### PR TITLE
Use HydratedTranscriptMessage and add providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dev:client": "vite --host 0.0.0.0 --port 5174",
     "dev:server": "bun run ./src/server/cli.ts --no-open --port 3211",
     "start": "bun run ./src/server/cli.ts",
+    "test": "bun test",
     "prepublishOnly": "vite build"
   },
   "dependencies": {

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -93,6 +93,8 @@ export function ChatPage() {
               disabled={!state.hasSelectedProject || state.runtime?.status === "waiting_for_user"}
               canCancel={state.canCancel}
               chatId={state.activeChatId}
+              activeProvider={state.runtime?.provider ?? null}
+              availableProviders={state.availableProviders}
             />
           </div>
         </div>

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react"
 import type { AskUserQuestionItem, ProcessedToolCall } from "../components/messages/types"
-import type { Message } from "../lib/parseTranscript"
+import type { HydratedTranscriptMessage } from "../../shared/types"
 import { UserMessage } from "../components/messages/UserMessage"
 import { RawJsonMessage } from "../components/messages/RawJsonMessage"
 import { SystemMessage } from "../components/messages/SystemMessage"
@@ -20,23 +20,23 @@ import { CollapsedToolGroup } from "../components/messages/CollapsedToolGroup"
 const SPECIAL_TOOL_NAMES = new Set(["AskUserQuestion", "ExitPlanMode", "TodoWrite"])
 
 type RenderItem =
-  | { type: "single"; message: Message; index: number }
-  | { type: "tool-group"; messages: Message[]; startIndex: number }
+  | { type: "single"; message: HydratedTranscriptMessage; index: number }
+  | { type: "tool-group"; messages: HydratedTranscriptMessage[]; startIndex: number }
 
-function isCollapsibleToolCall(message: Message) {
-  if (message.processed?.kind !== "tool") return false
-  const toolName = (message.processed as ProcessedToolCall).toolName
+function isCollapsibleToolCall(message: HydratedTranscriptMessage) {
+  if (message.kind !== "tool") return false
+  const toolName = (message as ProcessedToolCall).toolName
   return !SPECIAL_TOOL_NAMES.has(toolName)
 }
 
-function groupMessages(messages: Message[]): RenderItem[] {
+function groupMessages(messages: HydratedTranscriptMessage[]): RenderItem[] {
   const result: RenderItem[] = []
   let index = 0
 
   while (index < messages.length) {
     const message = messages[index]
     if (isCollapsibleToolCall(message)) {
-      const group: Message[] = [message]
+      const group: HydratedTranscriptMessage[] = [message]
       const startIndex = index
       index += 1
       while (index < messages.length && isCollapsibleToolCall(messages[index])) {
@@ -59,7 +59,7 @@ function groupMessages(messages: Message[]): RenderItem[] {
 }
 
 interface KannaTranscriptProps {
-  messages: Message[]
+  messages: HydratedTranscriptMessage[]
   isLoading: boolean
   localPath?: string
   latestToolIds: Record<string, string | null>
@@ -81,58 +81,53 @@ export function KannaTranscript({
 }: KannaTranscriptProps) {
   const renderItems = useMemo(() => groupMessages(messages), [messages])
 
-  function renderMessage(message: Message, index: number): React.ReactNode {
-    if (message.role === "user") {
+  function renderMessage(message: HydratedTranscriptMessage, index: number): React.ReactNode {
+    if (message.kind === "user_prompt") {
       return <UserMessage key={message.id} content={message.content} />
     }
 
-    const processed = message.processed
-    if (!processed) {
-      return <RawJsonMessage key={message.id} json={message.content} />
-    }
-
-    switch (processed.kind) {
-      case "system": {        
-        const isFirst = messages.findIndex((entry) => entry.processed?.kind === "system") === index
-        return isFirst ? <SystemMessage key={message.id} message={processed} rawJson={message.rawJson} /> : null
-        // return <SystemMessage key={message.id} message={processed} rawJson={message.rawJson} /> 
-
+    switch (message.kind) {
+      case "unknown":
+        return <RawJsonMessage key={message.id} json={message.json} />
+      case "system_init": {
+        const isFirst = messages.findIndex((entry) => entry.kind === "system_init") === index
+        return isFirst ? <SystemMessage key={message.id} message={message} rawJson={message.debugRaw} /> : null
       }
       case "account_info": {
-        const isFirst = messages.findIndex((entry) => entry.processed?.kind === "account_info") === index
-        return isFirst ? <AccountInfoMessage key={message.id} message={processed} /> : null
+        const isFirst = messages.findIndex((entry) => entry.kind === "account_info") === index
+        return isFirst ? <AccountInfoMessage key={message.id} message={message} /> : null
       }
-      case "text":
-        return <TextMessage key={message.id} message={processed} />
+      case "assistant_text":
+        return <TextMessage key={message.id} message={message} />
       case "tool":
-        if (processed.toolName === "AskUserQuestion") {
+        if (message.toolKind === "ask_user_question") {
           return (
             <AskUserQuestionMessage
               key={message.id}
-              message={processed}
+              message={message}
               onSubmit={onAskUserQuestionSubmit}
-              isLatest={processed.id === latestToolIds.AskUserQuestion}
+              isLatest={message.id === latestToolIds.AskUserQuestion}
             />
           )
         }
-        if (processed.toolName === "ExitPlanMode") {
+        if (message.toolKind === "exit_plan_mode") {
           return (
             <ExitPlanModeMessage
               key={message.id}
-              message={processed}
+              message={message}
               onConfirm={onExitPlanModeConfirm}
-              isLatest={processed.id === latestToolIds.ExitPlanMode}
+              isLatest={message.id === latestToolIds.ExitPlanMode}
             />
           )
         }
-        if (processed.toolName === "TodoWrite") {
-          if (processed.id !== latestToolIds.TodoWrite) return null
-          return <TodoWriteMessage key={message.id} message={processed} />
+        if (message.toolKind === "todo_write") {
+          if (message.id !== latestToolIds.TodoWrite) return null
+          return <TodoWriteMessage key={message.id} message={message} />
         }
         return (
           <ToolCallMessage
             key={message.id}
-            message={processed}
+            message={message}
             isLoading={isLoading}
             localPath={localPath}
           />
@@ -140,21 +135,21 @@ export function KannaTranscript({
       case "result": {
         const nextMessage = messages[index + 1]
         const previousMessage = messages[index - 1]
-        if (nextMessage?.processed?.kind === "context_cleared" || previousMessage?.processed?.kind === "context_cleared") {
+        if (nextMessage?.kind === "context_cleared" || previousMessage?.kind === "context_cleared") {
           return null
         }
-        return <ResultMessage key={message.id} message={processed} />
+        return <ResultMessage key={message.id} message={message} />
       }
       case "interrupted":
-        return <InterruptedMessage key={message.id} message={processed} />
+        return <InterruptedMessage key={message.id} message={message} />
       case "compact_boundary":
         return <CompactBoundaryMessage key={message.id} />
       case "context_cleared":
         return <ContextClearedMessage key={message.id} />
       case "compact_summary":
-        return <CompactSummaryMessage key={message.id} message={processed} />
+        return <CompactSummaryMessage key={message.id} message={message} />
       case "status":
-        return index === messages.length - 1 ? <StatusMessage key={message.id} message={processed} /> : null
+        return index === messages.length - 1 ? <StatusMessage key={message.id} message={message} /> : null
     }
   }
 

--- a/src/client/app/derived.ts
+++ b/src/client/app/derived.ts
@@ -1,14 +1,14 @@
-import type { Message } from "../lib/parseTranscript"
+import type { HydratedTranscriptMessage } from "../../shared/types"
 import type { ProcessedToolCall } from "../components/messages/types"
 
 const SPECIAL_TOOL_NAMES = ["AskUserQuestion", "ExitPlanMode", "TodoWrite"] as const
 const RESOLVED_TOOL_NAMES = new Set<string>(["TodoWrite"])
 
-function findLatestUnresolvedToolId(messages: Message[], toolName: string): string | null {
+function findLatestUnresolvedToolId(messages: HydratedTranscriptMessage[], toolName: string): string | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
-    if (message.processed?.kind !== "tool") continue
-    const toolCall = message.processed as ProcessedToolCall
+    if (message.kind !== "tool") continue
+    const toolCall = message as ProcessedToolCall
     if (toolCall.toolName === toolName && !toolCall.result) {
       return toolCall.id
     }
@@ -16,11 +16,11 @@ function findLatestUnresolvedToolId(messages: Message[], toolName: string): stri
   return null
 }
 
-function findLatestToolId(messages: Message[], toolName: string): string | null {
+function findLatestToolId(messages: HydratedTranscriptMessage[], toolName: string): string | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
-    if (message.processed?.kind !== "tool") continue
-    const toolCall = message.processed as ProcessedToolCall
+    if (message.kind !== "tool") continue
+    const toolCall = message as ProcessedToolCall
     if (toolCall.toolName === toolName) {
       return toolCall.id
     }
@@ -28,7 +28,7 @@ function findLatestToolId(messages: Message[], toolName: string): string | null 
   return null
 }
 
-export function getLatestToolIds(messages: Message[]) {
+export function getLatestToolIds(messages: HydratedTranscriptMessage[]) {
   const ids: Record<string, string | null> = {}
   for (const toolName of SPECIAL_TOOL_NAMES) {
     ids[toolName] = RESOLVED_TOOL_NAMES.has(toolName)

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react"
 import { useNavigate } from "react-router-dom"
 import { APP_NAME } from "../../shared/branding"
+import { PROVIDERS, type AgentProvider, type ModelOptions, type ProviderCatalogEntry } from "../../shared/types"
 import { useChatPreferencesStore } from "../stores/chatPreferencesStore"
 import type { ChatSnapshot, LocalProjectsSnapshot, SidebarChatRow, SidebarData } from "../../shared/types"
 import type { AskUserQuestionItem } from "../components/messages/types"
@@ -47,6 +48,7 @@ export interface KannaState {
   messages: ReturnType<typeof processTranscriptMessages>
   latestToolIds: ReturnType<typeof getLatestToolIds>
   runtime: ChatSnapshot["runtime"] | null
+  availableProviders: ProviderCatalogEntry[]
   isProcessing: boolean
   canCancel: boolean
   transcriptPaddingBottom: number
@@ -62,7 +64,7 @@ export interface KannaState {
   handleCreateChat: (projectId: string) => Promise<void>
   handleOpenLocalProject: (localPath: string) => Promise<void>
   handleCreateProject: (project: { mode: "new" | "existing"; localPath: string; title: string }) => Promise<void>
-  handleSend: (content: string, options?: { model?: string; effort?: string; planMode?: boolean }) => Promise<void>
+  handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
@@ -185,6 +187,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const messages = useMemo(() => processTranscriptMessages(chatSnapshot?.messages ?? []), [chatSnapshot?.messages])
   const latestToolIds = useMemo(() => getLatestToolIds(messages), [messages])
   const runtime = chatSnapshot?.runtime ?? null
+  const availableProviders = chatSnapshot?.availableProviders ?? PROVIDERS
   const isProcessing = isProcessingStatus(runtime?.status)
   const canCancel = canCancelStatus(runtime?.status)
   const transcriptPaddingBottom = inputHeight + 48
@@ -273,7 +276,10 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }
 
-  async function handleSend(content: string, options?: { model?: string; effort?: string; planMode?: boolean }) {
+  async function handleSend(
+    content: string,
+    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }
+  ) {
     try {
       let projectId = selectedProjectId ?? sidebarData.projectGroups[0]?.groupKey ?? null
       if (!activeChatId && !projectId && fallbackLocalProjectPath) {
@@ -293,9 +299,10 @@ export function useKannaState(activeChatId: string | null): KannaState {
         type: "chat.send",
         chatId: activeChatId ?? undefined,
         projectId: activeChatId ? undefined : projectId ?? undefined,
+        provider: options?.provider,
         content,
         model: options?.model,
-        effort: options?.effort,
+        modelOptions: options?.modelOptions,
         planMode: options?.planMode,
       })
 
@@ -446,6 +453,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     messages,
     latestToolIds,
     runtime,
+    availableProviders,
     isProcessing,
     canCancel,
     transcriptPaddingBottom,

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1,12 +1,21 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react"
-import { ArrowUp, Brain, Gauge, ListTodo, Sparkles, UnlockIcon, Zap } from "lucide-react"
+import { memo, useCallback, useEffect, useRef, useState, type ComponentType, type SVGProps } from "react"
+import { ArrowUp, Brain, Gauge, ListTodo, LockOpen, Sparkles, Zap } from "lucide-react"
+import {
+  CLAUDE_REASONING_OPTIONS,
+  CODEX_REASONING_OPTIONS,
+  type AgentProvider,
+  type ClaudeReasoningEffort,
+  type CodexReasoningEffort,
+  type ModelOptions,
+  type ProviderCatalogEntry,
+} from "../../../shared/types"
 import { Button } from "../ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover"
 import { Textarea } from "../ui/textarea"
 import { cn } from "../../lib/utils"
 import { useIsStandalone } from "../../hooks/useIsStandalone"
 import { useChatInputStore } from "../../stores/chatInputStore"
-import { useChatPreferencesStore, type ModelOption } from "../../stores/chatPreferencesStore"
+import { useChatPreferencesStore } from "../../stores/chatPreferencesStore"
 
 function PopoverMenuItem({
   onClick,
@@ -45,12 +54,28 @@ function PopoverMenuItem({
 function InputPopover({
   trigger,
   triggerClassName,
+  disabled = false,
   children,
 }: {
   trigger: React.ReactNode
   triggerClassName?: string
+  disabled?: boolean
   children: React.ReactNode
 }) {
+  if (disabled) {
+    return (
+      <button
+        disabled
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-1 text-sm rounded-md text-muted-foreground [&>svg]:shrink-0 opacity-70 cursor-default",
+          triggerClassName
+        )}
+      >
+        {trigger}
+      </button>
+    )
+  }
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -71,31 +96,61 @@ function InputPopover({
   )
 }
 
-const MODEL_ICONS: Record<ModelOption, typeof Sparkles> = {
-  opus: Sparkles,
-  sonnet: Zap,
-  haiku: Brain,
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>
+
+function AnthropicIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    </svg>
+  )
 }
 
-const MODEL_LABELS: Record<ModelOption, string> = {
-  opus: "Opus",
-  sonnet: "Sonnet",
-  haiku: "Haiku",
+function OpenAIIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 158.7128 157.296"
+      fill="currentColor"
+      aria-hidden="true"
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      <path d="M60.8734 57.2556V42.3124c0-1.2586.4722-2.2029 1.5728-2.8314l30.0443-17.3023c4.0899-2.3593 8.9662-3.4599 13.9988-3.4599 18.8759 0 30.8307 14.6289 30.8307 30.2006 0 1.1007 0 2.3593-.158 3.6178l-31.1446-18.2467c-1.8872-1.1006-3.7754-1.1006-5.6629 0L60.8734 57.2556Zm70.1542 58.2005V79.7487c0-2.2028-.9446-3.7756-2.8318-4.8763l-39.481-22.9651 12.8982-7.3934c1.1007-.6285 2.0453-.6285 3.1458 0l30.0441 17.3024c8.6523 5.0341 14.4708 15.7296 14.4708 26.1107 0 11.9539-7.0769 22.965-18.2461 27.527ZM51.593 83.9964l-12.8982-7.5497c-1.1007-.6285-1.5728-1.5728-1.5728-2.8314V39.0105c0-16.8303 12.8982-29.5722 30.3585-29.5722 6.607 0 12.7403 2.2029 17.9324 6.1349l-30.987 17.9324c-1.8871 1.1007-2.8314 2.6735-2.8314 4.8764v45.6159ZM79.3562 100.0403 60.8733 89.6592V67.6383l18.4829-10.3811 18.4812 10.3811v22.0209l-18.4812 10.3811Zm11.8757 47.8188c-6.607 0-12.7403-2.2031-17.9324-6.1344l30.9866-17.9333c1.8872-1.1005 2.8318-2.6728 2.8318-4.8759v-45.616l13.0564 7.5498c1.1005.6285 1.5723 1.5728 1.5723 2.8314v34.6051c0 16.8297-13.0564 29.5723-30.5147 29.5723ZM53.9522 112.7822 23.9079 95.4798c-8.652-5.0343-14.471-15.7296-14.471-26.1107 0-12.1119 7.2356-22.9652 18.403-27.5272v35.8634c0 2.2028.9443 3.7756 2.8314 4.8763l39.3248 22.8068-12.8982 7.3938c-1.1007.6287-2.045.6287-3.1456 0ZM52.2229 138.5791c-17.7745 0-30.8306-13.3713-30.8306-29.8871 0-1.2585.1578-2.5169.3143-3.7754l30.987 17.9323c1.8871 1.1005 3.7757 1.1005 5.6628 0l39.4811-22.807v14.9435c0 1.2585-.4721 2.2021-1.5728 2.8308l-30.0443 17.3025c-4.0898 2.359-8.9662 3.4605-13.9989 3.4605h.0014ZM91.2319 157.296c19.0327 0 34.9188-13.5272 38.5383-31.4594 17.6164-4.562 28.9425-21.0779 28.9425-37.908 0-11.0112-4.719-21.7066-13.2133-29.4143.7867-3.3035 1.2595-6.607 1.2595-9.909 0-22.4929-18.2471-39.3247-39.3251-39.3247-4.2461 0-8.3363.6285-12.4262 2.045-7.0792-6.9213-16.8318-11.3254-27.5271-11.3254-19.0331 0-34.9191 13.5268-38.5384 31.4591C11.3255 36.0212 0 52.5373 0 69.3675c0 11.0112 4.7184 21.7065 13.2125 29.4142-.7865 3.3035-1.2586 6.6067-1.2586 9.9092 0 22.4923 18.2466 39.3241 39.3248 39.3241 4.2462 0 8.3362-.6277 12.426-2.0441 7.0776 6.921 16.8302 11.3251 27.5271 11.3251Z" />
+    </svg>
+  )
 }
 
-const EFFORT_LABELS: Record<string, string> = {
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  max: "Max",
+const PROVIDER_ICONS: Record<AgentProvider, IconComponent> = {
+  claude: AnthropicIcon,
+  codex: OpenAIIcon,
+}
+
+const MODEL_ICON_BY_ID: Record<string, typeof Sparkles> = {
+  opus: Brain,
+  sonnet: Sparkles,
+  haiku: Zap,
+  "gpt-5.4": Brain,
+  "gpt-5.3-codex": Sparkles,
+  "gpt-5.3-codex-spark": Zap,
 }
 
 interface Props {
-  onSubmit: (value: string, options?: { model?: string; effort?: string; planMode?: boolean }) => Promise<void>
+  onSubmit: (
+    value: string,
+    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }
+  ) => Promise<void>
   onCancel?: () => void
   disabled: boolean
   canCancel?: boolean
   chatId?: string | null
+  activeProvider: AgentProvider | null
+  availableProviders: ProviderCatalogEntry[]
 }
 
 export const ChatInput = memo(function ChatInput({
@@ -104,12 +159,33 @@ export const ChatInput = memo(function ChatInput({
   disabled,
   canCancel,
   chatId,
+  activeProvider,
+  availableProviders,
 }: Props) {
   const { getDraft, setDraft, clearDraft } = useChatInputStore()
-  const { model, effort, planMode, setModel, setEffort, setPlanMode } = useChatPreferencesStore()
+  const {
+    provider: preferredProvider,
+    preferences,
+    planMode,
+    setProvider,
+    setModel,
+    setModelOptions,
+    setPlanMode,
+  } = useChatPreferencesStore()
   const [value, setValue] = useState(() => (chatId ? getDraft(chatId) : ""))
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const isStandalone = useIsStandalone()
+
+  const selectedProvider = activeProvider ?? preferredProvider
+  const providerConfig = availableProviders.find((provider) => provider.id === selectedProvider) ?? availableProviders[0]
+  const providerPrefs = preferences[selectedProvider]
+  const providerLocked = activeProvider !== null
+  const showPlanMode = providerConfig?.supportsPlanMode ?? false
+  const selectedReasoningEffort = selectedProvider === "claude"
+    ? preferences.claude.modelOptions.reasoningEffort
+    : preferences.codex.modelOptions.reasoningEffort
+  const codexFastMode = preferences.codex.modelOptions.fastMode
+  const reasoningOptions = selectedProvider === "claude" ? CLAUDE_REASONING_OPTIONS : CODEX_REASONING_OPTIONS
 
   const autoResize = useCallback(() => {
     const element = textareaRef.current
@@ -131,6 +207,15 @@ export const ChatInput = memo(function ChatInput({
     textareaRef.current?.focus()
   }, [chatId])
 
+  function setReasoningEffort(reasoningEffort: string) {
+    if (selectedProvider === "claude") {
+      setModelOptions("claude", { reasoningEffort: reasoningEffort as ClaudeReasoningEffort })
+      return
+    }
+
+    setModelOptions("codex", { reasoningEffort: reasoningEffort as CodexReasoningEffort })
+  }
+
   async function handleSubmit() {
     if (!value.trim()) return
     const nextValue = value
@@ -140,7 +225,14 @@ export const ChatInput = memo(function ChatInput({
     if (textareaRef.current) textareaRef.current.style.height = "auto"
 
     try {
-      await onSubmit(nextValue, { model, effort, planMode })
+      await onSubmit(nextValue, {
+        provider: selectedProvider,
+        model: providerPrefs.model,
+        modelOptions: selectedProvider === "claude"
+          ? { claude: { ...preferences.claude.modelOptions } }
+          : { codex: { ...preferences.codex.modelOptions } },
+        planMode: showPlanMode ? planMode : false,
+      })
     } catch (error) {
       console.error("[ChatInput] Submit failed:", error)
       setValue(nextValue)
@@ -149,7 +241,7 @@ export const ChatInput = memo(function ChatInput({
   }
 
   function handleKeyDown(event: React.KeyboardEvent) {
-    if (event.key === "Tab" && event.shiftKey) {
+    if (event.key === "Tab" && event.shiftKey && showPlanMode) {
       event.preventDefault()
       setPlanMode(!planMode)
       return
@@ -168,7 +260,8 @@ export const ChatInput = memo(function ChatInput({
     }
   }
 
-  const ModelIcon = MODEL_ICONS[model]
+  const ProviderIcon = PROVIDER_ICONS[selectedProvider]
+  const ModelIcon = MODEL_ICON_BY_ID[providerPrefs.model] ?? Sparkles
 
   return (
     <div className={cn("p-3 pt-0 md:pb-2", isStandalone && "px-5 pb-5")}>
@@ -212,108 +305,130 @@ export const ChatInput = memo(function ChatInput({
 
       <div className="flex justify-center items-center gap-0.5 max-w-[840px] mx-auto mt-2 animate-fade-in">
         <InputPopover
+          disabled={providerLocked}
           trigger={
             <>
-              <ModelIcon className="h-3.5 w-3.5" />
-              <span>{MODEL_LABELS[model]}</span>
+              <ProviderIcon className="h-3.5 w-3.5" />
+              <span>{providerConfig?.label ?? selectedProvider}</span>
             </>
           }
         >
-          <PopoverMenuItem
-            onClick={() => setModel("opus")}
-            selected={model === "opus"}
-            icon={<Sparkles className="h-4 w-4 text-muted-foreground" />}
-            label="Opus"
-            description="Highest capability, deep reasoning"
-          />
-          <PopoverMenuItem
-            onClick={() => setModel("sonnet")}
-            selected={model === "sonnet"}
-            icon={<Zap className="h-4 w-4 text-muted-foreground" />}
-            label="Sonnet"
-            description="Balanced speed and intelligence"
-          />
-          <PopoverMenuItem
-            onClick={() => setModel("haiku")}
-            selected={model === "haiku"}
-            icon={<Brain className="h-4 w-4 text-muted-foreground" />}
-            label="Haiku"
-            description="Fastest responses, lightweight tasks"
-          />
+          {availableProviders.map((provider) => {
+            const Icon = PROVIDER_ICONS[provider.id]
+            return (
+              <PopoverMenuItem
+                key={provider.id}
+                onClick={() => setProvider(provider.id)}
+                selected={selectedProvider === provider.id}
+                icon={<Icon className="h-4 w-4 text-muted-foreground" />}
+                label={provider.label}
+                description={provider.supportsPlanMode ? "Plan mode available" : "Fast local JSONL exec flow"}
+              />
+            )
+          })}
+        </InputPopover>
+
+        <InputPopover
+          trigger={
+            <>
+              <ModelIcon className="h-3.5 w-3.5" />
+              <span>{providerConfig.models.find((model) => model.id === providerPrefs.model)?.label ?? providerPrefs.model}</span>
+            </>
+          }
+        >
+          {providerConfig.models.map((model) => {
+            const Icon = MODEL_ICON_BY_ID[model.id] ?? Sparkles
+            return (
+              <PopoverMenuItem
+                key={model.id}
+                onClick={() => setModel(selectedProvider, model.id)}
+                selected={providerPrefs.model === model.id}
+                icon={<Icon className="h-4 w-4 text-muted-foreground" />}
+                label={model.label}
+                description={selectedProvider === "claude" ? "Claude model" : "Codex model"}
+              />
+            )
+          })}
         </InputPopover>
 
         <InputPopover
           trigger={
             <>
               <Gauge className="h-3.5 w-3.5" />
-              <span>{EFFORT_LABELS[effort]}</span>
+              <span>{reasoningOptions.find((effort) => effort.id === selectedReasoningEffort)?.label ?? selectedReasoningEffort}</span>
             </>
           }
-          triggerClassName={effort === "max" ? "text-amber-400 dark:text-amber-300" : undefined}
         >
-          <PopoverMenuItem
-            onClick={() => setEffort("low")}
-            selected={effort === "low"}
-            icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
-            label="Low"
-            description="Minimal thinking, fastest responses"
-          />
-          <PopoverMenuItem
-            onClick={() => setEffort("medium")}
-            selected={effort === "medium"}
-            icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
-            label="Medium"
-            description="Moderate thinking for typical tasks"
-          />
-          <PopoverMenuItem
-            onClick={() => setEffort("high")}
-            selected={effort === "high"}
-            icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
-            label="High"
-            description="Deep reasoning for complex problems"
-          />
-          <PopoverMenuItem
-            onClick={() => setEffort("max")}
-            selected={effort === "max"}
-            disabled={model !== "opus"}
-            icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
-            label="Max"
-            description={model !== "opus" ? "Only available with Opus" : "Maximum effort, deepest reasoning"}
-          />
+          {reasoningOptions.map((effort) => (
+            <PopoverMenuItem
+              key={effort.id}
+              onClick={() => setReasoningEffort(effort.id)}
+              selected={selectedReasoningEffort === effort.id}
+              icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
+              label={effort.label}
+              description={
+                selectedProvider === "claude"
+                  ? (effort.id === "max" ? "Maximum effort, deepest reasoning" : `${effort.label} reasoning effort`)
+                  : `${effort.label} reasoning effort`
+              }
+              disabled={selectedProvider === "claude" && effort.id === "max" && providerPrefs.model !== "opus"}
+            />
+          ))}
         </InputPopover>
 
-        <InputPopover
-          trigger={planMode ? (
-            <>
-              <ListTodo className="h-3.5 w-3.5" />
-              <span>Plan Mode</span>
-            </>
-          ) : (
-            <>
-              <UnlockIcon className="h-3.5 w-3.5" />
-              <span>Full Access</span>
-            </>
-          )}
-          triggerClassName={planMode ? "text-blue-400 dark:text-blue-300" : undefined}
-        >
-          <PopoverMenuItem
-            onClick={() => setPlanMode(false)}
-            selected={!planMode}
-            icon={<UnlockIcon className="h-4 w-4 text-muted-foreground" />}
-            label="Full Access"
-            description="Claude can read and edit files"
-          />
-          <PopoverMenuItem
-            onClick={() => setPlanMode(true)}
-            selected={planMode}
-            icon={<ListTodo className="h-4 w-4 text-muted-foreground" />}
-            label="Plan Mode"
-            description="Claude can only read, not edit"
-          />
-          <p className="text-xs text-muted-foreground/90 px-2 py-2">
-            Press <kbd className="px-1 mx-0.5 py-0.5 text-[12px] bg-muted/90 rounded font-mono">shift+tab</kbd> to toggle
-          </p>
-        </InputPopover>
+        {selectedProvider === "codex" ? (
+          <InputPopover
+            trigger={
+              <>
+                <Zap className="h-3.5 w-3.5" />
+                <span>{codexFastMode ? "Fast Mode" : "Standard"}</span>
+              </>
+            }
+            triggerClassName={codexFastMode ? "text-emerald-500 dark:text-emerald-400" : undefined}
+          >
+            <PopoverMenuItem
+              onClick={() => setModelOptions("codex", { fastMode: false })}
+              selected={!codexFastMode}
+              icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
+              label="Standard"
+              description="Use the default Codex service tier"
+            />
+            <PopoverMenuItem
+              onClick={() => setModelOptions("codex", { fastMode: true })}
+              selected={codexFastMode}
+              icon={<Zap className="h-4 w-4 text-muted-foreground" />}
+              label="Fast Mode"
+              description="Map to Codex serviceTier fast"
+            />
+          </InputPopover>
+        ) : null}
+
+        {showPlanMode ? (
+          <InputPopover
+            trigger={
+              <>
+                {planMode ? <ListTodo className="h-3.5 w-3.5" /> : <LockOpen className="h-3.5 w-3.5" />}
+                <span>{planMode ? "Plan Mode" : "Full Access"}</span>
+              </>
+            }
+            triggerClassName={planMode ? "text-blue-400 dark:text-blue-300" : undefined}
+          >
+            <PopoverMenuItem
+              onClick={() => setPlanMode(false)}
+              selected={!planMode}
+              icon={<LockOpen className="h-4 w-4 text-muted-foreground" />}
+              label="Full Access"
+              description="Execute immediately without plan approval"
+            />
+            <PopoverMenuItem
+              onClick={() => setPlanMode(true)}
+              selected={planMode}
+              icon={<ListTodo className="h-4 w-4 text-muted-foreground" />}
+              label="Plan Mode"
+              description="Review a plan before execution"
+            />
+          </InputPopover>
+        ) : null}
       </div>
     </div>
   )

--- a/src/client/components/messages/AskUserQuestionMessage.tsx
+++ b/src/client/components/messages/AskUserQuestionMessage.tsx
@@ -5,7 +5,7 @@ import { Button } from "../ui/button"
 import { cn } from "../../lib/utils"
 
 interface Props {
-  message: ProcessedToolCall
+  message: Extract<ProcessedToolCall, { toolKind: "ask_user_question" }>
   onSubmit: (toolUseId: string, questions: AskUserQuestionItem[], answers: Record<string, string>) => void
   isLatest: boolean
 }
@@ -135,19 +135,18 @@ function OptionRow({
   )
 }
 
-// Parse answers from result JSON if present
-function parseAnswersFromResult(result: string | undefined): Record<string, string> | undefined {
-  if (!result) return undefined
-  try {
-    const parsed = JSON.parse(result)
-    return parsed.answers
-  } catch {
-    return undefined
-  }
+function parseAnswersFromResult(
+  result: Extract<ProcessedToolCall, { toolKind: "ask_user_question" }>["result"]
+): Record<string, string> | undefined {
+  return result?.answers
+}
+
+function getQuestionKey(question: AskUserQuestionItem): string {
+  return question.id || question.question
 }
 
 export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
-  const questions = ((message.input as any)?.questions || []) as AskUserQuestionItem[]
+  const questions = message.input.questions
   const isComplete = !!message.result
   const savedAnswers = parseAnswersFromResult(message.result)
 
@@ -159,7 +158,7 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
   const getEffectiveAnswer = (questionKey: string, question?: AskUserQuestionItem) => {
     const custom = customInputs[questionKey]?.trim()
     const selectedAnswer = answers[questionKey] || ""
-    const q = question || questions.find(q => q.question === questionKey)
+    const q = question || questions.find((candidate) => getQuestionKey(candidate) === questionKey)
 
     if (q?.multiSelect) {
       const parts = [selectedAnswer, custom].filter(Boolean)
@@ -170,14 +169,14 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
   }
 
   const getSelectedOptions = (question: AskUserQuestionItem) => {
-    const answer = answers[question.question] || ""
+    const answer = answers[getQuestionKey(question)] || ""
     return question.multiSelect
       ? answer.split(", ").filter(Boolean)
       : [answer]
   }
 
   const handleOptionSelect = (question: AskUserQuestionItem, label: string) => {
-    const key = question.question
+    const key = getQuestionKey(question)
 
     if (question.multiSelect) {
       const current = answers[key] ? answers[key].split(", ").filter(Boolean) : []
@@ -196,7 +195,7 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
   }
 
   const handleCustomInputChange = (question: AskUserQuestionItem, value: string) => {
-    const key = question.question
+    const key = getQuestionKey(question)
     setCustomInputs({ ...customInputs, [key]: value })
     if (value && !question.multiSelect) {
       setAnswers({ ...answers, [key]: "" })
@@ -204,15 +203,17 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
   }
 
   const clearCustomInput = (question: AskUserQuestionItem) => {
-    if (question.multiSelect && customInputs[question.question]) {
-      setCustomInputs({ ...customInputs, [question.question]: "" })
+    const key = getQuestionKey(question)
+    if (question.multiSelect && customInputs[key]) {
+      setCustomInputs({ ...customInputs, [key]: "" })
     }
   }
 
-  const allQuestionsAnswered = questions.every((q) => getEffectiveAnswer(q.question).length > 0)
+  const allQuestionsAnswered = questions.every((question) => getEffectiveAnswer(getQuestionKey(question), question).length > 0)
   const currentQuestion = questions[currentIndex]
   const isLastQuestion = currentIndex === questions.length - 1
-  const currentHasAnswer = currentQuestion && getEffectiveAnswer(currentQuestion.question).length > 0
+  const currentHasAnswer = currentQuestion
+    && getEffectiveAnswer(getQuestionKey(currentQuestion), currentQuestion).length > 0
 
   const handleNext = () => {
     if (currentIndex < questions.length - 1) {
@@ -231,7 +232,8 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
 
     const finalAnswers: Record<string, string> = {}
     for (const q of questions) {
-      finalAnswers[q.question] = getEffectiveAnswer(q.question)
+      const key = getQuestionKey(q)
+      finalAnswers[key] = getEffectiveAnswer(key, q)
     }
     setAnswers(finalAnswers)
     setIsSubmitted(true)
@@ -250,12 +252,12 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
             <p className="">Answers</p>
           </div>
           {questions.map((question, index) => {
-            const answerValue = displayAnswers[question.question] || ""
+            const answerValue = displayAnswers[getQuestionKey(question)] || displayAnswers[question.question] || ""
             const isLast = index === questions.length - 1
 
             return (
               <div
-                key={question.question}
+                key={getQuestionKey(question)}
                 className={cn(
                   "w-full p-3 pt-2.5 pl-4 pr-5 bg-background flex items-center justify-between gap-3",
                   !isLast && "border-b border-border"
@@ -288,7 +290,7 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
   if (!currentQuestion) return null
 
   const selectedOptions = getSelectedOptions(currentQuestion)
-  const customInput = customInputs[currentQuestion.question] || ""
+  const customInput = customInputs[getQuestionKey(currentQuestion)] || ""
 
   return (
     <div className="w-full space-y-3">

--- a/src/client/components/messages/CollapsedToolGroup.tsx
+++ b/src/client/components/messages/CollapsedToolGroup.tsx
@@ -4,7 +4,7 @@ import { ToolCallMessage } from "./ToolCallMessage"
 import { MetaRow, MetaLabel } from "./shared"
 import { AnimatedShinyText } from "../ui/animated-shiny-text"
 import type { ProcessedToolCall } from "./types"
-import type { Message } from "../../lib/parseTranscript"
+import type { HydratedTranscriptMessage } from "../../../shared/types"
 
 interface ToolCategory {
   key: string
@@ -13,39 +13,31 @@ interface ToolCategory {
 }
 
 const TOOL_CATEGORIES: Record<string, ToolCategory> = {
-  Read: { key: "read", singular: "read", plural: "reads" },
-  Edit: { key: "edit", singular: "edit", plural: "edits" },
-  Write: { key: "write", singular: "write", plural: "writes" },
-  Bash: { key: "bash", singular: "command", plural: "commands" },
-  Grep: { key: "grep", singular: "search", plural: "searches" },
-  Glob: { key: "glob", singular: "glob", plural: "globs" },
-  Task: { key: "task", singular: "agent", plural: "agents" },
-  WebFetch: { key: "webfetch", singular: "fetch", plural: "fetches" },
-  WebSearch: { key: "websearch", singular: "web search", plural: "web searches" },
-  Skill: { key: "skill", singular: "skill", plural: "skills" },
-  TodoWrite: { key: "todo", singular: "todo update", plural: "todo updates" },
+  read_file: { key: "read", singular: "read", plural: "reads" },
+  edit_file: { key: "edit", singular: "edit", plural: "edits" },
+  write_file: { key: "write", singular: "write", plural: "writes" },
+  bash: { key: "bash", singular: "command", plural: "commands" },
+  grep: { key: "grep", singular: "search", plural: "searches" },
+  glob: { key: "glob", singular: "glob", plural: "globs" },
+  subagent_task: { key: "task", singular: "agent", plural: "agents" },
+  web_search: { key: "websearch", singular: "web search", plural: "web searches" },
+  skill: { key: "skill", singular: "skill", plural: "skills" },
+  todo_write: { key: "todo", singular: "todo update", plural: "todo updates" },
 }
 
-const DB_QUERY_CATEGORY: ToolCategory = { key: "dbquery", singular: "query", plural: "queries" }
 const OTHER_CATEGORY: ToolCategory = { key: "other", singular: "tool call", plural: "tool calls" }
 
-function getToolCategory(toolName: string): ToolCategory {
-  if (TOOL_CATEGORIES[toolName]) {
-    return TOOL_CATEGORIES[toolName]
-  }
-  if (/^mcp__db__.+_query$/.test(toolName)) {
-    return DB_QUERY_CATEGORY
-  }
-  return OTHER_CATEGORY
+function getToolCategory(toolKind: string): ToolCategory {
+  return TOOL_CATEGORIES[toolKind] ?? OTHER_CATEGORY
 }
 
-function getToolGroupLabel(messages: Message[]): string {
+function getToolGroupLabel(messages: HydratedTranscriptMessage[]): string {
   const counts = new Map<string, { category: ToolCategory; count: number }>()
   const order: string[] = []
 
   for (const msg of messages) {
-    const toolName = (msg.processed as ProcessedToolCall).toolName
-    const category = getToolCategory(toolName)
+    const toolKind = (msg as ProcessedToolCall).toolKind
+    const category = getToolCategory(toolKind)
 
     const existing = counts.get(category.key)
     if (existing) {
@@ -64,20 +56,19 @@ function getToolGroupLabel(messages: Message[]): string {
 }
 
 interface Props {
-  messages: Message[]
+  messages: HydratedTranscriptMessage[]
   isLoading: boolean
-  outputsUrl?: string | null
   localPath?: string | null
 }
 
-export function CollapsedToolGroup({ messages, isLoading, outputsUrl, localPath }: Props) {
+export function CollapsedToolGroup({ messages, isLoading, localPath }: Props) {
   const [expanded, setExpanded] = useState(false)
 
   const label = useMemo(() => getToolGroupLabel(messages), [messages])
 
   // Check if any tool in the group is still in progress
   const anyInProgress = messages.some(msg => {
-    const processed = msg.processed as ProcessedToolCall
+    const processed = msg as ProcessedToolCall
     return processed.result === undefined
   })
 
@@ -106,9 +97,8 @@ export function CollapsedToolGroup({ messages, isLoading, outputsUrl, localPath 
             {messages.map(msg => (
               <ToolCallMessage
                 key={msg.id}
-                message={msg.processed as ProcessedToolCall}
+                message={msg as ProcessedToolCall}
                 isLoading={isLoading}
-                outputsUrl={outputsUrl}
                 localPath={localPath}
               />
             ))}

--- a/src/client/components/messages/ExitPlanModeMessage.tsx
+++ b/src/client/components/messages/ExitPlanModeMessage.tsx
@@ -8,7 +8,7 @@ import { markdownWithHeadingsComponents } from "./shared"
 import { cn } from "../../lib/utils"
 
 interface Props {
-  message: ProcessedToolCall
+  message: Extract<ProcessedToolCall, { toolKind: "exit_plan_mode" }>
   onConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
   isLatest: boolean
 }
@@ -20,7 +20,7 @@ export function ExitPlanModeMessage({ message, onConfirm }: Props) {
   const [showEditInput, setShowEditInput] = useState(false)
   const [editMessage, setEditMessage] = useState("")
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const input = message.input as { plan?: string; summary?: string } | undefined
+  const input = message.input
 
   useEffect(() => {
     if (showEditInput && textareaRef.current) {
@@ -35,14 +35,7 @@ export function ExitPlanModeMessage({ message, onConfirm }: Props) {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const result = (() => {
-    if (!isComplete) return null
-    try {
-      return JSON.parse(message.result || "{}")
-    } catch {
-      return {}
-    }
-  })()
+  const result = isComplete ? message.result : null
 
   return (
     <div className="flex flex-col gap-3">

--- a/src/client/components/messages/FileContentView.tsx
+++ b/src/client/components/messages/FileContentView.tsx
@@ -99,7 +99,7 @@ function buildDiffLines(rawDiff: RawLine[]): DiffLine[] {
 export function FileContentView({ content, isDiff = false, oldString, newString }: FileContentViewProps) {
   // Diff mode
   const diffLines = useMemo(() => {
-    if (isDiff && oldString && newString) {
+    if (isDiff && oldString !== undefined && newString !== undefined) {
       return computeUnifiedDiff(oldString, newString)
     }
     return []

--- a/src/client/components/messages/TodoWriteMessage.tsx
+++ b/src/client/components/messages/TodoWriteMessage.tsx
@@ -2,12 +2,6 @@ import { Check, Circle, ListChecks, Loader2 } from "lucide-react"
 import { cn } from "../../lib/utils"
 import type { ProcessedToolCall } from "./types"
 
-interface TodoItem {
-  content: string
-  status: "pending" | "in_progress" | "completed"
-  activeForm: string
-}
-
 const STATUS_CONFIG = {
   completed:   { Icon: Check,   iconClass: "text-emerald-500",             textClass: "text-muted-foreground" },
   in_progress: { Icon: Loader2, iconClass: "text-foreground animate-spin", textClass: "text-foreground font-medium" },
@@ -15,11 +9,11 @@ const STATUS_CONFIG = {
 } as const
 
 interface Props {
-  message: ProcessedToolCall
+  message: Extract<ProcessedToolCall, { toolKind: "todo_write" }>
 }
 
 export function TodoWriteMessage({ message }: Props) {
-  const todos = (message.input.todos as TodoItem[] | undefined) ?? []
+  const todos = message.input.todos
 
   if (!todos.length) return null
 

--- a/src/client/components/messages/ToolCallMessage.tsx
+++ b/src/client/components/messages/ToolCallMessage.tsx
@@ -1,41 +1,32 @@
 import { UserRound, X } from "lucide-react"
-import Markdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 import type { ProcessedToolCall } from "./types"
-import { MetaRow, MetaLabel, MetaCodeBlock, ExpandableRow, VerticalLineContainer, getToolIcon, markdownWithHeadingsComponents } from "./shared"
+import { MetaRow, MetaLabel, MetaCodeBlock, ExpandableRow, VerticalLineContainer, getToolIcon } from "./shared"
 import { useMemo } from "react"
-import { stripWorkspacePath, stripOutputsPath } from "../../lib/pathUtils"
+import { stripWorkspacePath } from "../../lib/pathUtils"
 import { AnimatedShinyText } from "../ui/animated-shiny-text"
 import { toTitleCase } from "../../lib/formatters"
 import { FileContentView } from "./FileContentView"
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
-
 interface Props {
   message: ProcessedToolCall
   isLoading?: boolean
-  outputsUrl?: string | null
   localPath?: string | null
 }
 
-export function ToolCallMessage({ message, isLoading = false, outputsUrl, localPath }: Props) {
+export function ToolCallMessage({ message, isLoading = false, localPath }: Props) {
   const hasResult = message.result !== undefined
   const showLoadingState = !hasResult && isLoading
 
   const name = useMemo(() => {
-    if (message.toolName === "Skill") {
+    if (message.toolKind === "skill") {
       return message.input.skill
     }
-    if (message.toolName === "Glob") {
-      return `Search files ${message.input.pattern === '**/*' ? 'in all directories' : `matching ${message.input.pattern}`}`
+    if (message.toolKind === "glob") {
+      return `Search files ${message.input.pattern === "**/*" ? "in all directories" : `matching ${message.input.pattern}`}`
     }
-    if (message.toolName === "Grep") {
+    if (message.toolKind === "grep") {
       const pattern = message.input.pattern
-      const outputMode = (message.input as Record<string, unknown>).output_mode as string | undefined
+      const outputMode = message.input.outputMode
       if (outputMode === "count") {
         return `Count \`${pattern}\` occurrences`
       }
@@ -44,89 +35,62 @@ export function ToolCallMessage({ message, isLoading = false, outputsUrl, localP
       }
       return `Find \`${pattern}\` in files`
     }
-    if (message.toolName === "Bash") {
-      return `${message.input.description as string || message.input.command as string || "Bash"}`
+    if (message.toolKind === "bash") {
+      return message.input.description || message.input.command || "Bash"
     }
-    if (message.toolName === "WebSearch") {
-      return message.input.query as string || "Web Search"
+    if (message.toolKind === "web_search") {
+      return message.input.query || "Web Search"
     }
-    if (message.toolName === "Read") {
-      return `Read ${stripWorkspacePath(message.input.file_path as string, localPath)}`
+    if (message.toolKind === "read_file") {
+      return `Read ${stripWorkspacePath(message.input.filePath, localPath)}`
     }
-    if (message.toolName === "Write") {
-      return `Write ${stripWorkspacePath(message.input.file_path as string, localPath)}`
+    if (message.toolKind === "write_file") {
+      return `Write ${stripWorkspacePath(message.input.filePath, localPath)}`
     }
-    if (message.toolName === "Edit") {
-      return `Edit ${stripWorkspacePath(message.input.file_path as string, localPath)}`
+    if (message.toolKind === "edit_file") {
+      return `Edit ${stripWorkspacePath(message.input.filePath, localPath)}`
     }
-    // Context tools: read/edit/write
-    if (message.toolName === "mcp__lever__read_db_context") {
-      const connName = message.input.connection_name as string | undefined
-      return connName ? `Read ${toTitleCase(connName)} Context` : "Read DB Context"
+    if (message.toolKind === "mcp_generic") {
+      return `${toTitleCase(message.input.tool)} from ${toTitleCase(message.input.server)}`
     }
-    if (message.toolName === "mcp__lever__edit_db_context") {
-      const connName = message.input.connection_name as string | undefined
-      return connName ? `Edit ${toTitleCase(connName)} Context` : "Edit DB Context"
+    if (message.toolKind === "subagent_task") {
+      return message.input.subagentType || message.toolName
     }
-    if (message.toolName === "mcp__lever__write_db_context") {
-      const connName = message.input.connection_name as string | undefined
-      return connName ? `Update ${toTitleCase(connName)} Context` : "Update DB Context"
-    }
-    // Database query tools: mcp__db__{db}_query → Query {db} {description}
-    const dbMatch = message.toolName.match(/^mcp__db__(.+)_query$/)
-    if (dbMatch) {
-      const desc = message.input.description as string | undefined
-      return desc ? `${desc} from ${toTitleCase(dbMatch[1])}` : `Query ${dbMatch[1]}`
-    }
-    const mcpMatch = message.toolName.match(/^mcp__(.+?)__(.+)$/)
-    if (mcpMatch) {
-      return `${toTitleCase(mcpMatch[2])} from ${toTitleCase(mcpMatch[1])}`
-    }
-    return message.input.subagent_type || message.toolName
+    return message.toolName
   }, [message.input, message.toolName, localPath])
 
-  const isAgent = useMemo(() => message.input.subagent_type !== undefined, [message.input])
+  const isAgent = useMemo(() => message.toolKind === "subagent_task", [message.toolKind])
   const description = useMemo(() => {
-    if (message.toolName === "Skill") {
+    if (message.toolKind === "skill") {
       return message.input.skill
     }
-  }, [message.input, message.toolName])
+  }, [message.input, message.toolKind])
 
-  const isBashTool = message.toolName === "Bash";
-  const isDbQueryTool = /^mcp__db__.+_query$/.test(message.toolName);
-  const isWriteTool = message.toolName === "Write";
-  const isWriteContextTool = message.toolName === "mcp__lever__write_db_context";
-  const isEditContextTool = message.toolName === "mcp__lever__edit_db_context";
-  const isEditTool = message.toolName === "Edit";
-  const isReadTool = message.toolName === "Read";
-  const isReadContextTool = message.toolName === "mcp__lever__read_db_context";
+  const isBashTool = message.toolKind === "bash"
+  const isWriteTool = message.toolKind === "write_file"
+  const isEditTool = message.toolKind === "edit_file"
+  const isReadTool = message.toolKind === "read_file"
 
-  const { result, outputFile } = useMemo(() => {
-    let parsed: Record<string, unknown> = {}
-    if (typeof message.result === "string") {
-      try {
-        parsed = JSON.parse(message.result)
-      } catch {
-        // Result is not valid JSON (e.g., error string), wrap it
-        parsed = { output: message.result }
-      }
-    } else {
-      parsed = message.result ?? {}
+  const resultText = useMemo(() => {
+    if (typeof message.result === "string") return message.result
+    if (!message.result) return ""
+    if (typeof message.result === "object" && message.result !== null && "content" in message.result) {
+      const content = (message.result as { content?: unknown }).content
+      if (typeof content === "string") return content
     }
-    return {
-      result: parsed,
-      outputFile: stripOutputsPath(parsed['fullOutputFile'] as string | undefined, localPath),
-    }
-  }, [message.result, localPath])
+    return JSON.stringify(message.result, null, 2)
+  }, [message.result])
 
-  const contextResultText = useMemo(() => {
-    if (!isReadContextTool || !message.result) return ""
-    try {
-      const content = typeof message.result === "string" ? JSON.parse(message.result) : message.result
-      if (Array.isArray(content)) return content.map((c: any) => c.text).join("\n")
-    } catch { /* fall through */ }
-    return typeof message.result === "string" ? message.result : JSON.stringify(message.result, null, 2)
-  }, [message.result, isReadContextTool])
+  const inputText = useMemo(() => {
+    switch (message.toolKind) {
+      case "bash":
+        return message.input.command
+      case "write_file":
+        return message.input.content
+      default:
+        return JSON.stringify(message.input, null, 2)
+    }
+  }, [message])
 
   return (
     <MetaRow className="w-full">
@@ -134,100 +98,43 @@ export function ToolCallMessage({ message, isLoading = false, outputsUrl, localP
         expandedContent={
           <VerticalLineContainer className="my-4 text-sm">
             <div className="flex flex-col gap-2">
-              {isWriteContextTool ? (
-                <div>
-                  <span className="font-medium text-muted-foreground">Context ({((message.input.context as string).length / 1000).toFixed(1)}/20kb)</span>
-                  <div className="my-1 max-h-64 md:max-h-[50vh] overflow-auto rounded-lg border border-border bg-muted p-3 prose prose-sm dark:prose-invert max-w-none">
-                    <Markdown remarkPlugins={[remarkGfm]} components={markdownWithHeadingsComponents}>
-                      {message.input.context as string}
-                    </Markdown>
-                  </div>
-                </div>
-              ) : isEditTool ? (
+              {isEditTool ? (
                 <FileContentView
                   content=""
                   isDiff
-                  oldString={message.input.old_string as string}
-                  newString={message.input.new_string as string}
+                  oldString={message.input.oldString}
+                  newString={message.input.newString}
                 />
-              ) : isEditContextTool ? (
-                <div className="flex flex-col gap-2">
-                  <MetaCodeBlock label="Find" copyText={message.input.old_string as string}>
-                    {message.input.old_string as string}
-                  </MetaCodeBlock>
-                  <MetaCodeBlock label="Replace" copyText={message.input.new_string as string}>
-                    {message.input.new_string as string}
-                  </MetaCodeBlock>
-                </div>
               ) : !isReadTool && !isWriteTool && (
                 <MetaCodeBlock label={
                   isBashTool ? (
                     <span className="flex items-center gap-2 w-full">
                       <span>Command</span>
-                      {!!message.input.timeout && (
-                        <span className="text-muted-foreground">timeout: {String(message.input.timeout)}ms</span>
+                      {!!message.input.timeoutMs && (
+                        <span className="text-muted-foreground">timeout: {String(message.input.timeoutMs)}ms</span>
                       )}
-                      {!!message.input.run_in_background && (
+                      {!!message.input.runInBackground && (
                         <span className="text-muted-foreground">background</span>
                       )}
                     </span>
-                  ) : isDbQueryTool ? (
-                    <span className="flex items-center gap-2 w-full">
-                      <span>Query</span>
-                      {!!message.input.timeout && (
-                        <span className="text-muted-foreground">timeout: {String(message.input.timeout)}s</span>
-                      )}
-                    </span>
                   ) : isWriteTool ? "Contents" : "Input"
-                } copyText={isBashTool ? (message.input.command as string) : isDbQueryTool ? (message.input.query as string) : isWriteTool ? (message.input.content as string) : JSON.stringify(message.input, null, 2)}>
-                  {isBashTool ? (message.input.command as string) : isDbQueryTool ? message.input.query : isWriteTool ? (message.input.content as string) : JSON.stringify(message.input, null, 2)}
+                } copyText={inputText}>
+                  {inputText}
                 </MetaCodeBlock>
-              )}
-              {hasResult && isReadContextTool && (
-                <div>
-                  <span className="font-medium text-muted-foreground">Context ({(contextResultText.length / 1000).toFixed(1)}/20kb)</span>
-                  <div className="my-1 max-h-64 md:max-h-[50vh] overflow-auto rounded-lg border border-border bg-muted p-3 prose prose-sm dark:prose-invert max-w-none">
-                    <Markdown remarkPlugins={[remarkGfm]} components={markdownWithHeadingsComponents}>
-                      {contextResultText}
-                    </Markdown>
-                  </div>
-                </div>
               )}
               {hasResult && isReadTool && !message.isError && (
                 <FileContentView
-                  content={typeof message.result === "string" ? message.result : JSON.stringify(message.result, null, 2)}
+                  content={resultText}
                 />
               )}
               {isWriteTool && !message.isError && (
                 <FileContentView
-                  content={message.input.content as string}
+                  content={message.input.content}
                 />
               )}
-              {hasResult && !isDbQueryTool && !isReadContextTool && !isReadTool && !(isWriteTool && !message.isError) && !(isEditTool && !message.isError) && (
-                <MetaCodeBlock label={message.isError ? "Error" : "Result"} copyText={typeof message.result === "string" ? message.result : JSON.stringify(message.result, null, 2)}>
-                  {typeof message.result === "string" ? message.result : JSON.stringify(message.result, null, 2)}
-                </MetaCodeBlock>
-              )}
-              {hasResult && isDbQueryTool && (
-                <MetaCodeBlock label={
-                  message.isError ? "Error" : (
-                    <span className="flex items-center justify-between w-full">
-                      <span>Preview{result['isOutputTruncated'] ? " (~25kb)" : ""}</span>
-                      {outputFile && outputsUrl && (
-                        <a
-                          href={`${outputsUrl}/api/file?path=${encodeURIComponent(outputFile)}`}
-                          download
-                          onClick={(e) => e.stopPropagation()}
-                          target="_blank"
-                          className="text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          Download ({formatBytes(result['fullOutputLength'] as number)})
-                        </a>
-                      )}
-                    </span>
-                  )
-                } copyText={(result['output'] as string).replaceAll("\\n", "\n")}>
-                  {(result['output'] as string).replaceAll("\\n", "\n")}
+              {hasResult && !isReadTool && !(isWriteTool && !message.isError) && !(isEditTool && !message.isError) && (
+                <MetaCodeBlock label={message.isError ? "Error" : "Result"} copyText={resultText}>
+                  {resultText}
                 </MetaCodeBlock>
               )}
             </div>
@@ -251,7 +158,7 @@ export function ToolCallMessage({ message, isLoading = false, outputsUrl, localP
         <MetaLabel className="text-left transition-opacity duration-200 truncate">
           <AnimatedShinyText
             animate={showLoadingState}
-            shimmerWidth={Math.max(20, (description || name)?.length ?? 33 * 3)}
+            shimmerWidth={Math.max(20, ((description || name)?.length ?? 33) * 3)}
           >
             {description || name}
           </AnimatedShinyText>

--- a/src/client/components/messages/shared.tsx
+++ b/src/client/components/messages/shared.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, type ReactNode, type ComponentPropsWithoutRef } 
 import { Button } from "../ui/button"
 import {
   ArrowDownToLine,
-  BarChart3,
   CheckLine,
   ChevronRight,
   ListTodo,
@@ -10,7 +9,6 @@ import {
   MessageCircleQuestion,
   Pencil,
   Search,
-  Database,
   Sparkles,
   SquareX,
   Terminal,
@@ -47,19 +45,10 @@ export const toolIcons: Record<string, LucideIcon> = {
 
 export const defaultToolIcon: LucideIcon = ToyBrick
 
-// Get icon for a tool, handling dynamic patterns like database query tools
+// Get icon for a tool.
 export function getToolIcon(toolName: string): LucideIcon {
-  // Check static mapping first
   if (toolIcons[toolName]) {
     return toolIcons[toolName]
-  }
-  // Database query tools: mcp__db__{db}_query
-  if (/^mcp__db__.+_query$/.test(toolName)) {
-    return Database
-  }
-  // Chart tool
-  if (toolName === "mcp__lever__show_chart") {
-    return BarChart3
   }
   return defaultToolIcon
 }
@@ -300,4 +289,3 @@ export const markdownWithHeadingsComponents = {
     <h6 className="text-sm font-medium mt-3 mb-1 first:mt-0">{children}</h6>
   ),
 }
-

--- a/src/client/components/messages/types.ts
+++ b/src/client/components/messages/types.ts
@@ -1,197 +1,52 @@
-// Types for Claude Code transcript messages
+export type {
+  AccountInfo,
+  AskUserQuestionItem,
+  AskUserQuestionOption,
+  HydratedTranscriptMessage,
+  HydratedToolCall as ProcessedToolCall,
+} from "../../../shared/types"
 
-export interface SystemInitMessage {
-  type: "system"
-  subtype: "init"
-  cwd: string
-  session_id: string
-  tools: string[]
-  model: string
-}
+export type ProcessedTextMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "assistant_text" }
+>
 
-export interface TextContent {
-  type: "text"
-  text: string
-}
+export type ProcessedSystemMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "system_init" }
+>
 
-export interface ToolUseContent {
-  type: "tool_use"
-  id: string
-  name: string
-  input: Record<string, unknown>
-}
+export type ProcessedAccountInfoMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "account_info" }
+>
 
-export interface ToolResultContent {
-  type: "tool_result"
-  tool_use_id: string
-  content: string
-  is_error?: boolean
-}
+export type ProcessedResultMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "result" }
+>
 
-export interface AssistantMessage {
-  type: "assistant"
-  message: {
-    id: string
-    role: "assistant"
-    content: (TextContent | ToolUseContent)[]
-  }
-  session_id: string
-}
+export type ProcessedCompactBoundaryMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "compact_boundary" }
+>
 
-export interface UserToolResultMessage {
-  type: "user"
-  message: {
-    role: "user"
-    content: ToolResultContent[]
-  }
-  session_id: string
-}
+export type ProcessedCompactSummaryMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "compact_summary" }
+>
 
-export interface ResultMessage {
-  type: "result"
-  subtype: "success" | "error" | "cancelled"
-  is_error: boolean
-  duration_ms: number
-  result: string
-  session_id?: string
-  total_cost_usd?: number
-}
+export type ProcessedContextClearedMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "context_cleared" }
+>
 
-export type TranscriptMessage =
-  | SystemInitMessage
-  | AssistantMessage
-  | UserToolResultMessage
-  | ResultMessage
+export type ProcessedStatusMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "status" }
+>
 
-// Processed message types for display
-export interface ProcessedTextMessage {
-  id: string
-  kind: "text"
-  text: string
-  timestamp: string
-}
-
-export interface MessageInput {
-  [key: string]: unknown
-  subagent_type?: string
-  description?: string
-  url?: string
-  file_path?: string
-  skill?: string
-  args?: string
-  name?: string
-  pattern?: string
-  query?: string
-  result?: string
-}
-
-export interface ProcessedToolCall {
-  id: string
-  kind: "tool"
-  toolName: string
-  toolId: string
-  input: MessageInput
-  result?: string
-  isError?: boolean
-  timestamp: string
-}
-
-export interface McpServerInfo {
-  name: string
-  status: string
-  error?: string
-}
-
-export interface AccountInfo {
-  email?: string
-  organization?: string
-  subscriptionType?: string
-  tokenSource?: string
-  apiKeySource?: string
-}
-
-export interface ProcessedSystemMessage {
-  id: string
-  kind: "system"
-  model: string
-  tools: string[]
-  agents: string[]
-  slashCommands: string[]
-  mcpServers: McpServerInfo[]
-  timestamp: string
-}
-
-export interface ProcessedAccountInfoMessage {
-  id: string
-  kind: "account_info"
-  accountInfo: AccountInfo
-  timestamp: string
-}
-
-export interface ProcessedResultMessage {
-  id: string
-  kind: "result"
-  success: boolean
-  cancelled?: boolean
-  result: string
-  durationMs: number
-  costUsd?: number
-  timestamp: string
-}
-
-export interface ProcessedCompactBoundaryMessage {
-  id: string
-  kind: "compact_boundary"
-  timestamp: string
-}
-
-export interface ProcessedCompactSummaryMessage {
-  id: string
-  kind: "compact_summary"
-  summary: string
-  timestamp: string
-}
-
-export interface ProcessedContextClearedMessage {
-  id: string
-  kind: "context_cleared"
-  timestamp: string
-}
-
-export interface ProcessedStatusMessage {
-  id: string
-  kind: "status"
-  status: string
-  timestamp: string
-}
-
-export interface ProcessedInterruptedMessage {
-  id: string
-  kind: "interrupted"
-  timestamp: string
-}
-
-// AskUserQuestion types (used for parsing input/result of AskUserQuestion tool)
-export interface AskUserQuestionOption {
-  label: string
-  description?: string
-}
-
-export interface AskUserQuestionItem {
-  question: string
-  header?: string
-  options?: AskUserQuestionOption[]
-  multiSelect?: boolean
-}
-
-export type ProcessedMessage =
-  | ProcessedTextMessage
-  | ProcessedToolCall
-  | ProcessedSystemMessage
-  | ProcessedAccountInfoMessage
-  | ProcessedResultMessage
-  | ProcessedCompactBoundaryMessage
-  | ProcessedCompactSummaryMessage
-  | ProcessedContextClearedMessage
-  | ProcessedStatusMessage
-  | ProcessedInterruptedMessage
+export type ProcessedInterruptedMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "interrupted" }
+>

--- a/src/client/lib/parseTranscript.test.ts
+++ b/src/client/lib/parseTranscript.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test"
+import { processTranscriptMessages } from "./parseTranscript"
+import { getLatestToolIds } from "../app/derived"
+import type { TranscriptEntry } from "../../shared/types"
+
+function entry(partial: Omit<TranscriptEntry, "_id" | "createdAt">): TranscriptEntry {
+  return {
+    _id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    ...partial,
+  } as TranscriptEntry
+}
+
+describe("processTranscriptMessages", () => {
+  test("hydrates tool results onto prior tool calls", () => {
+    const messages = processTranscriptMessages([
+      entry({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "bash",
+          toolName: "Bash",
+          toolId: "tool-1",
+          input: { command: "pwd" },
+        },
+      }),
+      entry({
+        kind: "tool_result",
+        toolId: "tool-1",
+        content: "/Users/jake/Projects/kanna\n",
+      }),
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.kind).toBe("tool")
+    if (messages[0]?.kind !== "tool") throw new Error("unexpected message")
+    expect(messages[0].result).toBe("/Users/jake/Projects/kanna\n")
+  })
+
+  test("hydrates ask-user-question results with typed answers", () => {
+    const messages = processTranscriptMessages([
+      entry({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "ask_user_question",
+          toolName: "AskUserQuestion",
+          toolId: "tool-2",
+          input: {
+            questions: [{ question: "Provider?" }],
+          },
+        },
+      }),
+      entry({
+        kind: "tool_result",
+        toolId: "tool-2",
+        content: { answers: { "Provider?": "Codex" } },
+      }),
+    ])
+
+    expect(messages[0]?.kind).toBe("tool")
+    if (messages[0]?.kind !== "tool") throw new Error("unexpected message")
+    expect(messages[0].result).toEqual({ answers: { "Provider?": "Codex" } })
+  })
+
+  test("preserves structured Claude ask-user-question results when a later echoed tool result arrives", () => {
+    const messages = processTranscriptMessages([
+      entry({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "ask_user_question",
+          toolName: "AskUserQuestion",
+          toolId: "tool-3",
+          input: {
+            questions: [{ question: "Provider?" }],
+          },
+        },
+      }),
+      entry({
+        kind: "tool_result",
+        toolId: "tool-3",
+        content: { answers: { "Provider?": "Codex" } },
+      }),
+      entry({
+        kind: "tool_result",
+        toolId: "tool-3",
+        content: "User has answered your questions: \"Provider?\"=\"Codex\".",
+        debugRaw: JSON.stringify({
+          type: "user",
+          tool_use_result: {
+            questions: [{ question: "Provider?" }],
+            answers: { "Provider?": "Codex" },
+          },
+        }),
+      }),
+    ])
+
+    expect(messages[0]?.kind).toBe("tool")
+    if (messages[0]?.kind !== "tool") throw new Error("unexpected message")
+    expect(messages[0].result).toEqual({ answers: { "Provider?": "Codex" } })
+  })
+})
+
+describe("getLatestToolIds", () => {
+  test("returns the latest unresolved special tool ids", () => {
+    const messages = processTranscriptMessages([
+      entry({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "ask_user_question",
+          toolName: "AskUserQuestion",
+          toolId: "tool-1",
+          input: {
+            questions: [{ question: "Provider?" }],
+          },
+        },
+      }),
+      entry({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "todo_write",
+          toolName: "TodoWrite",
+          toolId: "tool-2",
+          input: {
+            todos: [{ content: "Implement adapter", status: "in_progress", activeForm: "Implementing adapter" }],
+          },
+        },
+      }),
+    ])
+
+    expect(getLatestToolIds(messages)).toEqual({
+      AskUserQuestion: messages[0]?.kind === "tool" ? messages[0].id : null,
+      ExitPlanMode: null,
+      TodoWrite: messages[1]?.kind === "tool" ? messages[1].id : null,
+    })
+  })
+})

--- a/src/client/lib/parseTranscript.ts
+++ b/src/client/lib/parseTranscript.ts
@@ -1,252 +1,157 @@
-import { generateUUID } from "./utils"
-import type { ProcessedMessage, ProcessedToolCall } from "../components/messages/types"
+import { hydrateToolResult } from "../../shared/tools"
+import type { HydratedToolCall, HydratedTranscriptMessage, NormalizedToolCall, TranscriptEntry } from "../../shared/types"
 
-export interface Message {
-  id: string
-  messageId?: string
-  role: "user" | "assistant"
-  content: string
-  timestamp: string
-  processed?: ProcessedMessage
-  rawJson?: string
-  hidden?: boolean
+function createTimestamp(createdAt: number): string {
+  return new Date(createdAt).toISOString()
 }
 
-interface ParsedTranscriptMessage {
-  processed: ProcessedMessage | null
-  rawJson: string
-  isUserMessage?: boolean
-  userContent?: string
-}
-
-function formatJsonPretty(jsonString: string): string {
-  try {
-    return JSON.stringify(JSON.parse(jsonString), null, 2)
-  } catch {
-    return jsonString
+function createBaseMessage(entry: TranscriptEntry) {
+  return {
+    id: entry._id,
+    messageId: entry.messageId,
+    timestamp: createTimestamp(entry.createdAt),
+    hidden: entry.hidden,
   }
 }
 
-function createTimestamp(): string {
-  return new Date().toISOString()
+function hydrateToolCall(entry: Extract<TranscriptEntry, { kind: "tool_call" }>): HydratedToolCall {
+  return {
+    id: entry._id,
+    messageId: entry.messageId,
+    hidden: entry.hidden,
+    kind: "tool",
+    toolKind: entry.tool.toolKind,
+    toolName: entry.tool.toolName,
+    toolId: entry.tool.toolId,
+    input: entry.tool.input as HydratedToolCall["input"],
+    timestamp: createTimestamp(entry.createdAt),
+  } as HydratedToolCall
 }
 
-function parseTranscriptMessage(
-  jsonStr: string,
-  pendingToolCalls: Map<string, ProcessedToolCall>
-): ParsedTranscriptMessage {
-  const rawJson = formatJsonPretty(jsonStr)
-  const emptyResult = { processed: null, rawJson }
+function getStructuredToolResultFromDebug(entry: Extract<TranscriptEntry, { kind: "tool_result" }>): unknown {
+  if (!entry.debugRaw) return undefined
 
   try {
-    const data = JSON.parse(jsonStr)
+    const parsed = JSON.parse(entry.debugRaw) as { tool_use_result?: unknown }
+    return parsed.tool_use_result
+  } catch {
+    return undefined
+  }
+}
 
-    // User prompt message (stored by worker)
-    if (data.type === "user_prompt" && data.content) {
-      return { ...emptyResult, isUserMessage: true, userContent: data.content }
-    }
+export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedTranscriptMessage[] {
+  const pendingToolCalls = new Map<string, { hydrated: HydratedToolCall; normalized: NormalizedToolCall }>()
+  const messages: HydratedTranscriptMessage[] = []
 
-    // System init message
-    if (data.type === "system" && data.subtype === "init") {
-      return {
-        processed: {
-          id: generateUUID(),
-          kind: "system",
-          model: data.model || "unknown",
-          tools: data.tools || [],
-          agents: data.agents || [],
-          slashCommands: data.slash_commands?.filter((e: string) => !e.startsWith("._")) || [],
-          mcpServers: data.mcp_servers || [],
-          timestamp: createTimestamp(),
-        },
-        rawJson,
-      }
-    }
-
-    // Account info message
-    if (data.type === "system" && data.subtype === "account_info") {
-      return {
-        processed: {
-          id: generateUUID(),
+  for (const entry of entries) {
+    switch (entry.kind) {
+      case "user_prompt":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "user_prompt",
+          content: entry.content,
+        })
+        break
+      case "system_init":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "system_init",
+          provider: entry.provider,
+          model: entry.model,
+          tools: entry.tools,
+          agents: entry.agents,
+          slashCommands: entry.slashCommands,
+          mcpServers: entry.mcpServers,
+          debugRaw: entry.debugRaw,
+        })
+        break
+      case "account_info":
+        messages.push({
+          ...createBaseMessage(entry),
           kind: "account_info",
-          accountInfo: data.accountInfo,
-          timestamp: createTimestamp(),
-        },
-        rawJson,
+          accountInfo: entry.accountInfo,
+        })
+        break
+      case "assistant_text":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "assistant_text",
+          text: entry.text,
+        })
+        break
+      case "tool_call": {
+        const toolCall = hydrateToolCall(entry)
+        pendingToolCalls.set(entry.tool.toolId, { hydrated: toolCall, normalized: entry.tool })
+        messages.push(toolCall)
+        break
       }
-    }
+      case "tool_result": {
+        const pendingCall = pendingToolCalls.get(entry.toolId)
+        if (pendingCall) {
+          const rawResult = (
+            pendingCall.normalized.toolKind === "ask_user_question" ||
+            pendingCall.normalized.toolKind === "exit_plan_mode"
+          )
+            ? getStructuredToolResultFromDebug(entry) ?? entry.content
+            : entry.content
 
-    // Assistant message with text or tool_use
-    if (data.type === "assistant" && data.message?.content) {
-      for (const content of data.message.content) {
-        if (content.type === "text" && content.text) {
-          return {
-            processed: {
-              id: generateUUID(),
-              kind: "text",
-              text: content.text,
-              timestamp: createTimestamp(),
-            },
-            rawJson,
-          }
+          pendingCall.hydrated.result = hydrateToolResult(pendingCall.normalized, rawResult) as never
+          pendingCall.hydrated.rawResult = rawResult
+          pendingCall.hydrated.isError = entry.isError
         }
-
-        if (content.type === "tool_use") {
-          const toolCall: ProcessedToolCall = {
-            id: generateUUID(),
-            kind: "tool",
-            toolName: content.name,
-            toolId: content.id,
-            input: content.input || {},
-            timestamp: createTimestamp(),
-          }
-          pendingToolCalls.set(content.id, toolCall)
-          return { processed: toolCall, rawJson }
-        }
+        break
       }
-    }
-
-    // User message with tool_result - update existing pending tool call
-    if (data.type === "user" && data.message?.content) {
-      for (const content of data.message.content) {
-        if (content.type === "tool_result" && content.tool_use_id) {
-          const pendingCall = pendingToolCalls.get(content.tool_use_id)
-          if (pendingCall) {
-            pendingCall.result = content.content || "(empty)"
-            pendingCall.isError = content.is_error || false
-            pendingToolCalls.delete(content.tool_use_id)
-            return emptyResult
-          }
-        }
-      }
-    }
-
-    // Result message
-    if (data.type === "result") {
-      // Cancelled/interrupted gets its own message type
-      if (data.subtype === "cancelled") {
-        return {
-          processed: {
-            id: generateUUID(),
-            kind: "interrupted",
-            timestamp: createTimestamp(),
-          },
-          rawJson,
-        }
-      }
-
-      return {
-        processed: {
-          id: generateUUID(),
+      case "result":
+        messages.push({
+          ...createBaseMessage(entry),
           kind: "result",
-          success: !data.is_error,
-          result: data.result || "",
-          durationMs: data.duration_ms || 0,
-          costUsd: data.total_cost_usd,
-          timestamp: createTimestamp(),
-        },
-        rawJson,
-      }
-    }
-
-    // Status message (e.g., compacting)
-    if (data.type === "system" && data.subtype === "status" && data.status) {
-      return {
-        processed: {
-          id: generateUUID(),
+          success: !entry.isError,
+          cancelled: entry.subtype === "cancelled",
+          result: entry.result,
+          durationMs: entry.durationMs,
+          costUsd: entry.costUsd,
+        })
+        break
+      case "status":
+        messages.push({
+          ...createBaseMessage(entry),
           kind: "status",
-          status: data.status,
-          timestamp: createTimestamp(),
-        },
-        rawJson,
-      }
-    }
-
-    // Compact boundary message
-    if (data.type === "system" && data.subtype === "compact_boundary") {
-      return {
-        processed: {
-          id: generateUUID(),
+          status: entry.status,
+        })
+        break
+      case "compact_boundary":
+        messages.push({
+          ...createBaseMessage(entry),
           kind: "compact_boundary",
-          timestamp: createTimestamp(),
-        },
-        rawJson,
-      }
-    }
-
-    // Context cleared boundary message
-    if (data.type === "system" && data.subtype === "context_cleared") {
-      return {
-        processed: {
-          id: generateUUID(),
+        })
+        break
+      case "compact_summary":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "compact_summary",
+          summary: entry.summary,
+        })
+        break
+      case "context_cleared":
+        messages.push({
+          ...createBaseMessage(entry),
           kind: "context_cleared",
-          timestamp: createTimestamp(),
-        },
-        rawJson,
-      }
+        })
+        break
+      case "interrupted":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "interrupted",
+        })
+        break
+      default:
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "unknown",
+          json: JSON.stringify(entry, null, 2),
+        })
+        break
     }
-
-    // User message that is a compact summary
-    if (data.type === "user" && data.message?.role === "user" && typeof data.message.content === "string") {
-      if (data.message.content.startsWith("This session is being continued")) {
-        return {
-          processed: {
-            id: generateUUID(),
-            kind: "compact_summary",
-            summary: data.message.content,
-            timestamp: createTimestamp(),
-          },
-          rawJson,
-        }
-      }
-    }
-
-    return emptyResult
-  } catch {
-    return emptyResult
-  }
-}
-
-/**
- * Process raw Convex messages into display-ready Message objects.
- * Encapsulates all transcript parsing logic including tool call pairing.
- */
-export function processTranscriptMessages(
-  convexMessages: { _id: string; message: string; messageId?: string; createdAt: number; hidden?: boolean }[]
-): Message[] {
-  const pendingToolCalls = new Map<string, ProcessedToolCall>()
-  const messages: Message[] = []
-
-  for (const convexMsg of convexMessages) {
-    const { processed, rawJson, isUserMessage, userContent } = parseTranscriptMessage(
-      convexMsg.message,
-      pendingToolCalls
-    )
-
-    if (isUserMessage && userContent) {
-      messages.push({
-        id: convexMsg._id,
-        messageId: convexMsg.messageId,
-        role: "user",
-        content: userContent,
-        timestamp: new Date(convexMsg.createdAt).toISOString(),
-        hidden: convexMsg.hidden,
-      })
-      continue
-    }
-
-    if (processed === null) continue
-
-    messages.push({
-      id: convexMsg._id,
-      messageId: convexMsg.messageId,
-      role: "assistant",
-      content: rawJson,
-      timestamp: new Date(convexMsg.createdAt).toISOString(),
-      processed,
-      rawJson,
-      hidden: convexMsg.hidden,
-    })
   }
 
   return messages

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -1,40 +1,138 @@
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
+import {
+  DEFAULT_CLAUDE_MODEL_OPTIONS,
+  DEFAULT_CODEX_MODEL_OPTIONS,
+  isClaudeReasoningEffort,
+  isCodexReasoningEffort,
+  type AgentProvider,
+  type ClaudeModelOptions,
+  type CodexModelOptions,
+  type ProviderModelOptionsByProvider,
+} from "../../shared/types"
 
-export type ModelOption = "opus" | "sonnet" | "haiku"
-export type EffortOption = "low" | "medium" | "high" | "max"
+export interface ProviderPreference<TModelOptions> {
+  model: string
+  modelOptions: TModelOptions
+}
+
+type ChatPreferences = {
+  claude: ProviderPreference<ClaudeModelOptions>
+  codex: ProviderPreference<CodexModelOptions>
+}
+
+function normalizeCodexModel(model?: string) {
+  return model === "gpt-5-codex" ? "gpt-5.3-codex" : (model ?? "gpt-5.4")
+}
+
+function normalizeClaudePreference(value?: {
+  model?: string
+  effort?: string
+  modelOptions?: Partial<ClaudeModelOptions>
+}): ProviderPreference<ClaudeModelOptions> {
+  const reasoningEffort = value?.modelOptions?.reasoningEffort
+  return {
+    model: value?.model ?? "opus",
+    modelOptions: {
+      reasoningEffort: isClaudeReasoningEffort(reasoningEffort)
+        ? reasoningEffort
+        : isClaudeReasoningEffort(value?.effort)
+          ? value.effort
+          : DEFAULT_CLAUDE_MODEL_OPTIONS.reasoningEffort,
+    },
+  }
+}
+
+function normalizeCodexPreference(value?: {
+  model?: string
+  effort?: string
+  modelOptions?: Partial<CodexModelOptions>
+}): ProviderPreference<CodexModelOptions> {
+  const reasoningEffort = value?.modelOptions?.reasoningEffort
+  return {
+    model: normalizeCodexModel(value?.model),
+    modelOptions: {
+      reasoningEffort: isCodexReasoningEffort(reasoningEffort)
+        ? reasoningEffort
+        : isCodexReasoningEffort(value?.effort)
+          ? value.effort
+          : DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort,
+      fastMode: typeof value?.modelOptions?.fastMode === "boolean"
+        ? value.modelOptions.fastMode
+        : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,
+    },
+  }
+}
+
+type PersistedChatPreferencesState = Pick<ChatPreferencesState, "provider" | "planMode" | "preferences">
 
 interface ChatPreferencesState {
-  model: ModelOption
-  effort: EffortOption
+  provider: AgentProvider
   planMode: boolean
-  setModel: (model: ModelOption) => void
-  setEffort: (effort: EffortOption) => void
+  preferences: ChatPreferences
+  setProvider: (provider: AgentProvider) => void
+  setModel: (provider: AgentProvider, model: string) => void
+  setModelOptions: <TProvider extends AgentProvider>(
+    provider: TProvider,
+    modelOptions: Partial<ProviderModelOptionsByProvider[TProvider]>
+  ) => void
   setPlanMode: (planMode: boolean) => void
 }
 
 export const useChatPreferencesStore = create<ChatPreferencesState>()(
   persist(
     (set) => ({
-      model: "opus",
-      effort: "high",
+      provider: "claude",
       planMode: false,
-
-      setModel: (model) =>
-        set((state) => {
-          // "max" effort is only available for Opus — downgrade to "high" when switching away
-          if (model !== "opus" && state.effort === "max") {
-            return { model, effort: "high" }
-          }
-          return { model }
-        }),
-
-      setEffort: (effort) => set({ effort }),
-
+      preferences: {
+        claude: { model: "opus", modelOptions: { ...DEFAULT_CLAUDE_MODEL_OPTIONS } },
+        codex: { model: "gpt-5.4", modelOptions: { ...DEFAULT_CODEX_MODEL_OPTIONS } },
+      },
+      setProvider: (provider) => set({ provider }),
+      setModel: (provider, model) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            [provider]: {
+              ...state.preferences[provider],
+              model,
+              modelOptions:
+                provider === "claude" && model !== "opus" && state.preferences.claude.modelOptions.reasoningEffort === "max"
+                  ? { reasoningEffort: "high" }
+                  : state.preferences[provider].modelOptions,
+            },
+          },
+        })),
+      setModelOptions: (provider, modelOptions) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            [provider]: {
+              ...state.preferences[provider],
+              modelOptions: {
+                ...state.preferences[provider].modelOptions,
+                ...modelOptions,
+              },
+            },
+          },
+        })),
       setPlanMode: (planMode) => set({ planMode }),
     }),
     {
       name: "chat-preferences",
+      version: 2,
+      migrate: (persistedState) => {
+        const state = persistedState as Partial<PersistedChatPreferencesState> | undefined
+
+        return {
+          provider: state?.provider ?? "claude",
+          planMode: state?.planMode ?? false,
+          preferences: {
+            claude: normalizeClaudePreference(state?.preferences?.claude),
+            codex: normalizeCodexPreference(state?.preferences?.codex),
+          },
+        }
+      },
     }
   )
 )

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test } from "bun:test"
+import { AgentCoordinator, normalizeClaudeStreamMessage } from "./agent"
+import type { HarnessTurn } from "./harness-types"
+import type { TranscriptEntry } from "../shared/types"
+
+function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry: T): TranscriptEntry {
+  return {
+    _id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    ...entry,
+  } as TranscriptEntry
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition")
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+describe("normalizeClaudeStreamMessage", () => {
+  test("normalizes assistant tool calls", () => {
+    const entries = normalizeClaudeStreamMessage({
+      type: "assistant",
+      uuid: "msg-1",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: {
+              command: "pwd",
+              timeout: 1000,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.kind).toBe("tool_call")
+    if (entries[0]?.kind !== "tool_call") throw new Error("unexpected entry")
+    expect(entries[0].tool.toolKind).toBe("bash")
+  })
+
+  test("normalizes result messages", () => {
+    const entries = normalizeClaudeStreamMessage({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 3210,
+      result: "done",
+    })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.kind).toBe("result")
+    if (entries[0]?.kind !== "result") throw new Error("unexpected entry")
+    expect(entries[0].durationMs).toBe(3210)
+  })
+})
+
+describe("AgentCoordinator codex integration", () => {
+  test("binds codex provider and reuses the session token on later turns", async () => {
+    const sessionCalls: Array<{ chatId: string; sessionToken: string | null }> = []
+    const fakeCodexManager = {
+      async startSession(args: { chatId: string; sessionToken: string | null }) {
+        sessionCalls.push({ chatId: args.chatId, sessionToken: args.sessionToken })
+      },
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield { type: "session_token" as const, sessionToken: "thread-1" }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "first",
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+    expect(store.chat.provider).toBe("codex")
+    expect(store.chat.sessionToken).toBe("thread-1")
+    expect(sessionCalls).toEqual([{ chatId: "chat-1", sessionToken: null }])
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      content: "second",
+    })
+
+    await waitFor(() => store.turnFinishedCount === 2)
+    expect(sessionCalls).toEqual([
+      { chatId: "chat-1", sessionToken: null },
+      { chatId: "chat-1", sessionToken: "thread-1" },
+    ])
+  })
+
+  test("maps codex model options into session and turn settings", async () => {
+    const sessionCalls: Array<{ chatId: string; sessionToken: string | null; serviceTier?: string }> = []
+    const turnCalls: Array<{ effort?: string; serviceTier?: string }> = []
+
+    const fakeCodexManager = {
+      async startSession(args: { chatId: string; sessionToken: string | null; serviceTier?: string }) {
+        sessionCalls.push({
+          chatId: args.chatId,
+          sessionToken: args.sessionToken,
+          serviceTier: args.serviceTier,
+        })
+      },
+      async startTurn(args: { effort?: string; serviceTier?: string }): Promise<HarnessTurn> {
+        turnCalls.push({
+          effort: args.effort,
+          serviceTier: args.serviceTier,
+        })
+
+        async function* stream() {
+          yield { type: "session_token" as const, sessionToken: "thread-1" }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "opt in",
+      modelOptions: {
+        codex: {
+          reasoningEffort: "xhigh",
+          fastMode: true,
+        },
+      },
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    expect(sessionCalls).toEqual([{ chatId: "chat-1", sessionToken: null, serviceTier: "fast" }])
+    expect(turnCalls).toEqual([{ effort: "xhigh", serviceTier: "fast" }])
+  })
+
+  test("approving synthetic codex ExitPlanMode starts a hidden follow-up turn and can clear context", async () => {
+    const sessionCalls: Array<{ chatId: string; sessionToken: string | null }> = []
+    const startTurnCalls: Array<{ content: string; planMode: boolean }> = []
+    let turnCount = 0
+
+    const fakeCodexManager = {
+      async startSession(args: { chatId: string; sessionToken: string | null }) {
+        sessionCalls.push({ chatId: args.chatId, sessionToken: args.sessionToken })
+      },
+      async startTurn(args: {
+        content: string
+        planMode: boolean
+        onToolRequest: (request: any) => Promise<unknown>
+      }): Promise<HarnessTurn> {
+        startTurnCalls.push({ content: args.content, planMode: args.planMode })
+        turnCount += 1
+
+        async function* firstStream() {
+          yield { type: "session_token" as const, sessionToken: "thread-1" }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "tool_call",
+              tool: {
+                kind: "tool",
+                toolKind: "exit_plan_mode",
+                toolName: "ExitPlanMode",
+                toolId: "exit-1",
+                input: {
+                  plan: "## Plan\n\n- [ ] Ship it",
+                  summary: "Plan summary",
+                },
+              },
+            }),
+          }
+          await args.onToolRequest({
+            tool: {
+              kind: "tool",
+              toolKind: "exit_plan_mode",
+              toolName: "ExitPlanMode",
+              toolId: "exit-1",
+              input: {
+                plan: "## Plan\n\n- [ ] Ship it",
+                summary: "Plan summary",
+              },
+            },
+          })
+        }
+
+        async function* secondStream() {
+          yield { type: "session_token" as const, sessionToken: "thread-2" }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: turnCount === 1 ? firstStream() : secondStream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "plan this",
+      planMode: true,
+    })
+
+    await waitFor(() => coordinator.getPendingTool("chat-1")?.toolKind === "exit_plan_mode")
+
+    await coordinator.respondTool({
+      type: "chat.respondTool",
+      chatId: "chat-1",
+      toolUseId: "exit-1",
+      result: {
+        confirmed: true,
+        clearContext: true,
+        message: "Use the fast path",
+      },
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    expect(startTurnCalls).toEqual([
+      { content: "plan this", planMode: true },
+      { content: "Proceed with the approved plan. Additional guidance: Use the fast path", planMode: false },
+    ])
+    expect(sessionCalls).toEqual([
+      { chatId: "chat-1", sessionToken: null },
+      { chatId: "chat-1", sessionToken: null },
+    ])
+    expect(store.messages.filter((entry) => entry.kind === "user_prompt")).toHaveLength(1)
+    expect(store.messages.some((entry) => entry.kind === "context_cleared")).toBe(true)
+    expect(store.chat.sessionToken).toBe("thread-2")
+  })
+})
+
+function createFakeStore() {
+  const chat = {
+    id: "chat-1",
+    projectId: "project-1",
+    title: "New Chat",
+    provider: null as "claude" | "codex" | null,
+    planMode: false,
+    sessionToken: null as string | null,
+  }
+  const project = {
+    id: "project-1",
+    localPath: "/tmp/project",
+  }
+  return {
+    chat,
+    turnFinishedCount: 0,
+    messages: [] as TranscriptEntry[],
+    requireChat(chatId: string) {
+      expect(chatId).toBe("chat-1")
+      return chat
+    },
+    getProject(projectId: string) {
+      expect(projectId).toBe("project-1")
+      return project
+    },
+    getMessages() {
+      return [] as TranscriptEntry[]
+    },
+    async setChatProvider(_chatId: string, provider: "claude" | "codex") {
+      chat.provider = provider
+    },
+    async setPlanMode(_chatId: string, planMode: boolean) {
+      chat.planMode = planMode
+    },
+    async renameChat(_chatId: string, title: string) {
+      chat.title = title
+    },
+    async appendMessage(_chatId: string, entry: TranscriptEntry) {
+      this.messages.push(entry)
+    },
+    async recordTurnStarted() {},
+    async recordTurnFinished() {
+      this.turnFinishedCount += 1
+    },
+    async recordTurnFailed() {
+      throw new Error("Did not expect turn failure")
+    },
+    async recordTurnCancelled() {},
+    async setSessionToken(_chatId: string, sessionToken: string | null) {
+      chat.sessionToken = sessionToken
+    },
+    async createChat() {
+      return chat
+    },
+  }
+}

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1,13 +1,25 @@
 import { query, type CanUseTool, type PermissionResult, type Query } from "@anthropic-ai/claude-agent-sdk"
+import type {
+  AgentProvider,
+  NormalizedToolCall,
+  PendingToolSnapshot,
+  KannaStatus,
+  TranscriptEntry,
+} from "../shared/types"
+import { normalizeToolCall } from "../shared/tools"
 import type { ClientCommand } from "../shared/protocol"
-
-import type { KannaStatus, PendingToolSnapshot } from "../shared/types"
 import { EventStore } from "./event-store"
-import { generateTitleForChat } from "./generate-title"
+import { CodexAppServerManager } from "./codex-app-server"
+import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
+import {
+  codexServiceTierFromModelOptions,
+  getServerProviderCatalog,
+  normalizeClaudeModelOptions,
+  normalizeCodexModelOptions,
+  normalizeServerModel,
+} from "./provider-catalog"
 
-const DEFAULT_MODEL = "opus"
-
-const TOOLSET = [
+const CLAUDE_TOOLSET = [
   "Skill",
   "WebFetch",
   "WebSearch",
@@ -28,16 +40,21 @@ const TOOLSET = [
 
 interface PendingToolRequest {
   toolUseId: string
-  toolName: "AskUserQuestion" | "ExitPlanMode"
-  input: Record<string, unknown>
-  resolve: (result: PermissionResult) => void
+  tool: NormalizedToolCall & { toolKind: "ask_user_question" | "exit_plan_mode" }
+  resolve: (result: unknown) => void
 }
 
 interface ActiveTurn {
   chatId: string
-  query: Query
+  provider: AgentProvider
+  turn: HarnessTurn
+  model: string
+  effort?: string
+  serviceTier?: "fast"
+  planMode: boolean
   status: KannaStatus
   pendingTool: PendingToolRequest | null
+  postToolFollowUp: { content: string; planMode: boolean } | null
   hasFinalResult: boolean
   cancelRequested: boolean
   cancelRecorded: boolean
@@ -46,46 +63,7 @@ interface ActiveTurn {
 interface AgentCoordinatorArgs {
   store: EventStore
   onStateChange: () => void
-}
-
-function buildUserPromptPayload(content: string) {
-  return JSON.stringify({ type: "user_prompt", content })
-}
-
-function buildToolResultPayload(toolUseId: string, body: unknown) {
-  return JSON.stringify({
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: JSON.stringify(body),
-        },
-      ],
-    },
-  })
-}
-
-function buildCancelledPayload() {
-  return JSON.stringify({
-    type: "result",
-    subtype: "cancelled",
-    is_error: false,
-    duration_ms: 0,
-    result: "Interrupted by user",
-  })
-}
-
-function buildErrorPayload(message: string) {
-  return JSON.stringify({
-    type: "result",
-    subtype: "error",
-    is_error: true,
-    duration_ms: 0,
-    result: message,
-  })
+  codexManager?: CodexAppServerManager
 }
 
 function deriveChatTitle(content: string) {
@@ -93,23 +71,262 @@ function deriveChatTitle(content: string) {
   return singleLine.slice(0, 60) || "New Chat"
 }
 
-function toTranscriptEntry(message: string, messageId?: string) {
+function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
+  entry: T,
+  createdAt = Date.now()
+): TranscriptEntry {
   return {
     _id: crypto.randomUUID(),
-    messageId,
-    message,
-    createdAt: Date.now(),
+    createdAt,
+    ...entry,
+  } as TranscriptEntry
+}
+
+function stringFromUnknown(value: unknown) {
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export function normalizeClaudeStreamMessage(message: any): TranscriptEntry[] {
+  const debugRaw = JSON.stringify(message)
+  const messageId = typeof message.uuid === "string" ? message.uuid : undefined
+
+  if (message.type === "system" && message.subtype === "init") {
+    return [
+      timestamped({
+        kind: "system_init",
+        messageId,
+        provider: "claude",
+        model: typeof message.model === "string" ? message.model : "unknown",
+        tools: Array.isArray(message.tools) ? message.tools : [],
+        agents: Array.isArray(message.agents) ? message.agents : [],
+        slashCommands: Array.isArray(message.slash_commands)
+          ? message.slash_commands.filter((entry: string) => !entry.startsWith("._"))
+          : [],
+        mcpServers: Array.isArray(message.mcp_servers) ? message.mcp_servers : [],
+        debugRaw,
+      }),
+    ]
+  }
+
+  if (message.type === "assistant" && Array.isArray(message.message?.content)) {
+    const entries: TranscriptEntry[] = []
+    for (const content of message.message.content) {
+      if (content.type === "text" && typeof content.text === "string") {
+        entries.push(timestamped({
+          kind: "assistant_text",
+          messageId,
+          text: content.text,
+          debugRaw,
+        }))
+      }
+      if (content.type === "tool_use" && typeof content.name === "string" && typeof content.id === "string") {
+        entries.push(timestamped({
+          kind: "tool_call",
+          messageId,
+          tool: normalizeToolCall({
+            toolName: content.name,
+            toolId: content.id,
+            input: (content.input ?? {}) as Record<string, unknown>,
+          }),
+          debugRaw,
+        }))
+      }
+    }
+    return entries
+  }
+
+  if (message.type === "user" && Array.isArray(message.message?.content)) {
+    const entries: TranscriptEntry[] = []
+    for (const content of message.message.content) {
+      if (content.type === "tool_result" && typeof content.tool_use_id === "string") {
+        entries.push(timestamped({
+          kind: "tool_result",
+          messageId,
+          toolId: content.tool_use_id,
+          content: content.content,
+          isError: Boolean(content.is_error),
+          debugRaw,
+        }))
+      }
+      if (message.message.role === "user" && typeof message.message.content === "string") {
+        entries.push(timestamped({
+          kind: "compact_summary",
+          messageId,
+          summary: message.message.content,
+          debugRaw,
+        }))
+      }
+    }
+    return entries
+  }
+
+  if (message.type === "result") {
+    if (message.subtype === "cancelled") {
+      return [timestamped({ kind: "interrupted", messageId, debugRaw })]
+    }
+    return [
+      timestamped({
+        kind: "result",
+        messageId,
+        subtype: message.is_error ? "error" : "success",
+        isError: Boolean(message.is_error),
+        durationMs: typeof message.duration_ms === "number" ? message.duration_ms : 0,
+        result: typeof message.result === "string" ? message.result : stringFromUnknown(message.result),
+        costUsd: typeof message.total_cost_usd === "number" ? message.total_cost_usd : undefined,
+        debugRaw,
+      }),
+    ]
+  }
+
+  if (message.type === "system" && message.subtype === "status" && typeof message.status === "string") {
+    return [timestamped({ kind: "status", messageId, status: message.status, debugRaw })]
+  }
+
+  if (message.type === "system" && message.subtype === "compact_boundary") {
+    return [timestamped({ kind: "compact_boundary", messageId, debugRaw })]
+  }
+
+  if (message.type === "system" && message.subtype === "context_cleared") {
+    return [timestamped({ kind: "context_cleared", messageId, debugRaw })]
+  }
+
+  if (
+    message.type === "user" &&
+    message.message?.role === "user" &&
+    typeof message.message.content === "string" &&
+    message.message.content.startsWith("This session is being continued")
+  ) {
+    return [timestamped({ kind: "compact_summary", messageId, summary: message.message.content, debugRaw })]
+  }
+
+  return []
+}
+
+async function* createClaudeHarnessStream(q: Query): AsyncGenerator<HarnessEvent> {
+  for await (const sdkMessage of q as AsyncIterable<any>) {
+    const sessionToken = typeof sdkMessage.session_id === "string" ? sdkMessage.session_id : null
+    if (sessionToken) {
+      yield { type: "session_token", sessionToken }
+    }
+    for (const entry of normalizeClaudeStreamMessage(sdkMessage)) {
+      yield { type: "transcript", entry }
+    }
+  }
+}
+
+async function startClaudeTurn(args: {
+  content: string
+  localPath: string
+  model: string
+  effort?: string
+  planMode: boolean
+  sessionToken: string | null
+  onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
+}): Promise<HarnessTurn> {
+  const canUseTool: CanUseTool = async (toolName, input, options) => {
+    if (toolName !== "AskUserQuestion" && toolName !== "ExitPlanMode") {
+      return {
+        behavior: "allow",
+        updatedInput: input,
+      }
+    }
+
+    const tool = normalizeToolCall({
+      toolName,
+      toolId: options.toolUseID,
+      input: (input ?? {}) as Record<string, unknown>,
+    })
+
+    if (tool.toolKind !== "ask_user_question" && tool.toolKind !== "exit_plan_mode") {
+      return {
+        behavior: "deny",
+        message: "Unsupported tool request",
+      }
+    }
+
+    const result = await args.onToolRequest({ tool })
+
+    if (tool.toolKind === "ask_user_question") {
+      const record = result && typeof result === "object" ? result as Record<string, unknown> : {}
+      return {
+        behavior: "allow",
+        updatedInput: {
+          ...(tool.rawInput ?? {}),
+          questions: record.questions ?? tool.input.questions,
+          answers: record.answers ?? result,
+        },
+      } satisfies PermissionResult
+    }
+
+    const record = result && typeof result === "object" ? result as Record<string, unknown> : {}
+    const confirmed = Boolean(record.confirmed)
+    if (confirmed) {
+      return {
+        behavior: "allow",
+        updatedInput: {
+          ...(tool.rawInput ?? {}),
+          ...record,
+        },
+      } satisfies PermissionResult
+    }
+
+    return {
+      behavior: "deny",
+      message: typeof record.message === "string"
+        ? `User wants to suggest edits to the plan: ${record.message}`
+        : "User wants to suggest edits to the plan before approving.",
+    } satisfies PermissionResult
+  }
+
+  const q = query({
+    prompt: args.content,
+    options: {
+      cwd: args.localPath,
+      model: args.model,
+      effort: args.effort as "low" | "medium" | "high" | "max" | undefined,
+      resume: args.sessionToken ?? undefined,
+      permissionMode: args.planMode ? "plan" : "acceptEdits",
+      canUseTool,
+      tools: [...CLAUDE_TOOLSET],
+      settingSources: ["user", "project", "local"],
+      env: { ...process.env },
+    },
+  })
+
+  return {
+    provider: "claude",
+    stream: createClaudeHarnessStream(q),
+    getAccountInfo: async () => {
+      try {
+        return await q.accountInfo()
+      } catch {
+        return null
+      }
+    },
+    interrupt: async () => {
+      await q.interrupt()
+    },
+    close: () => {
+      q.close()
+    },
   }
 }
 
 export class AgentCoordinator {
   private readonly store: EventStore
   private readonly onStateChange: () => void
+  private readonly codexManager: CodexAppServerManager
   readonly activeTurns = new Map<string, ActiveTurn>()
 
   constructor(args: AgentCoordinatorArgs) {
     this.store = args.store
     this.onStateChange = args.onStateChange
+    this.codexManager = args.codexManager ?? new CodexAppServerManager()
   }
 
   getActiveStatuses() {
@@ -123,7 +340,147 @@ export class AgentCoordinator {
   getPendingTool(chatId: string): PendingToolSnapshot | null {
     const pending = this.activeTurns.get(chatId)?.pendingTool
     if (!pending) return null
-    return { toolUseId: pending.toolUseId, toolName: pending.toolName }
+    return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
+  }
+
+  private resolveProvider(command: Extract<ClientCommand, { type: "chat.send" }>, currentProvider: AgentProvider | null) {
+    if (currentProvider) return currentProvider
+    return command.provider ?? "claude"
+  }
+
+  private getProviderSettings(provider: AgentProvider, command: Extract<ClientCommand, { type: "chat.send" }>) {
+    const catalog = getServerProviderCatalog(provider)
+    if (provider === "claude") {
+      const modelOptions = normalizeClaudeModelOptions(command.modelOptions, command.effort)
+      return {
+        model: normalizeServerModel(provider, command.model),
+        effort: modelOptions.reasoningEffort,
+        serviceTier: undefined,
+        planMode: catalog.supportsPlanMode ? Boolean(command.planMode) : false,
+      }
+    }
+
+    const modelOptions = normalizeCodexModelOptions(command.modelOptions, command.effort)
+    return {
+      model: normalizeServerModel(provider, command.model),
+      effort: modelOptions.reasoningEffort,
+      serviceTier: codexServiceTierFromModelOptions(modelOptions),
+      planMode: catalog.supportsPlanMode ? Boolean(command.planMode) : false,
+    }
+  }
+
+  private async startTurnForChat(args: {
+    chatId: string
+    provider: AgentProvider
+    content: string
+    model: string
+    effort?: string
+    serviceTier?: "fast"
+    planMode: boolean
+    appendUserPrompt: boolean
+  }) {
+    const chat = this.store.requireChat(args.chatId)
+    if (this.activeTurns.has(args.chatId)) {
+      throw new Error("Chat is already running")
+    }
+
+    if (!chat.provider) {
+      await this.store.setChatProvider(args.chatId, args.provider)
+    }
+    await this.store.setPlanMode(args.chatId, args.planMode)
+
+    const existingMessages = this.store.getMessages(args.chatId)
+    if (args.appendUserPrompt && chat.title === "New Chat" && existingMessages.length === 0) {
+      await this.store.renameChat(args.chatId, deriveChatTitle(args.content))
+    }
+
+    if (args.appendUserPrompt) {
+      await this.store.appendMessage(args.chatId, timestamped({ kind: "user_prompt", content: args.content }, Date.now()))
+    }
+    await this.store.recordTurnStarted(args.chatId)
+
+    const project = this.store.getProject(chat.projectId)
+    if (!project) {
+      throw new Error("Project not found")
+    }
+
+    const onToolRequest = async (request: HarnessToolRequest): Promise<unknown> => {
+      const active = this.activeTurns.get(args.chatId)
+      if (!active) {
+        throw new Error("Chat turn ended unexpectedly")
+      }
+
+      active.status = "waiting_for_user"
+      this.onStateChange()
+
+      return await new Promise<unknown>((resolve) => {
+        active.pendingTool = {
+          toolUseId: request.tool.toolId,
+          tool: request.tool,
+          resolve,
+        }
+      })
+    }
+
+    let turn: HarnessTurn
+    if (args.provider === "claude") {
+      turn = await startClaudeTurn({
+        content: args.content,
+        localPath: project.localPath,
+        model: args.model,
+        effort: args.effort,
+        planMode: args.planMode,
+        sessionToken: chat.sessionToken,
+        onToolRequest,
+      })
+    } else {
+      await this.codexManager.startSession({
+        chatId: args.chatId,
+        cwd: project.localPath,
+        model: args.model,
+        serviceTier: args.serviceTier,
+        sessionToken: chat.sessionToken,
+      })
+      turn = await this.codexManager.startTurn({
+        chatId: args.chatId,
+        content: args.content,
+        model: args.model,
+        effort: args.effort as any,
+        serviceTier: args.serviceTier,
+        planMode: args.planMode,
+        onToolRequest,
+      })
+    }
+
+    const active: ActiveTurn = {
+      chatId: args.chatId,
+      provider: args.provider,
+      turn,
+      model: args.model,
+      effort: args.effort,
+      serviceTier: args.serviceTier,
+      planMode: args.planMode,
+      status: "starting",
+      pendingTool: null,
+      postToolFollowUp: null,
+      hasFinalResult: false,
+      cancelRequested: false,
+      cancelRecorded: false,
+    }
+    this.activeTurns.set(args.chatId, active)
+    this.onStateChange()
+
+    if (turn.getAccountInfo) {
+      void turn.getAccountInfo()
+        .then(async (accountInfo) => {
+          if (!accountInfo) return
+          await this.store.appendMessage(args.chatId, timestamped({ kind: "account_info", accountInfo }))
+          this.onStateChange()
+        })
+        .catch(() => undefined)
+    }
+
+    void this.runTurn(active)
   }
 
   async send(command: Extract<ClientCommand, { type: "chat.send" }>) {
@@ -138,138 +495,42 @@ export class AgentCoordinator {
     }
 
     const chat = this.store.requireChat(chatId)
-    if (this.activeTurns.has(chatId)) {
-      throw new Error("Chat is already running")
-    }
-
-    const existingMessages = this.store.getMessages(chatId)
-    if (chat.title === "New Chat" && existingMessages.length === 0) {
-      // Immediate placeholder: truncated first message
-      await this.store.renameChat(chatId, deriveChatTitle(command.content))
-
-      // Fire-and-forget: generate a better title with Haiku in parallel
-      void generateTitleForChat(command.content)
-        .then(async (title) => {
-          if (title) {
-            await this.store.renameChat(chatId!, title)
-            this.onStateChange()
-          }
-        })
-        .catch(() => undefined)
-    }
-
-    await this.store.appendMessage(chatId, toTranscriptEntry(buildUserPromptPayload(command.content), crypto.randomUUID()))
-    await this.store.recordTurnStarted(chatId)
-
-    const canUseTool: CanUseTool = async (toolName, input, options) => {
-      if (toolName !== "AskUserQuestion" && toolName !== "ExitPlanMode") {
-        return {
-          behavior: "allow",
-          updatedInput: input,
-        }
-      }
-
-      const active = this.activeTurns.get(chatId!)
-      if (!active) {
-        return {
-          behavior: "deny",
-          message: "Chat turn ended unexpectedly",
-        }
-      }
-
-      active.status = "waiting_for_user"
-      this.onStateChange()
-
-      return await new Promise<PermissionResult>((resolve) => {
-        active.pendingTool = {
-          toolUseId: options.toolUseID,
-          toolName,
-          input,
-          resolve,
-        }
-      })
-    }
-
-    const project = this.store.getProject(chat.projectId)
-    if (!project) {
-      throw new Error("Project not found")
-    }
-
-    const resolvedModel = command.model || DEFAULT_MODEL
-    const resolvedEffort = (command.effort as "low" | "medium" | "high" | "max") || undefined
-    console.log(`[agent] query model=${resolvedModel} effort=${resolvedEffort} (command.model=${command.model})`)
-
-    const q = query({
-      prompt: command.content,
-      options: {
-        cwd: project.localPath,
-        model: resolvedModel,
-        effort: resolvedEffort,
-        resume: chat.resumeSessionId ?? undefined,
-        permissionMode: command.planMode ? "plan" : "acceptEdits",
-        canUseTool,
-        tools: [...TOOLSET],
-        settingSources: ["user", "project", "local"],
-        env: {
-          ...process.env,
-          // CLAUDE_AGENT_SDK_CLIENT_APP: SDK_CLIENT_APP,
-        },
-      },
-    })
-
-    const active: ActiveTurn = {
+    const provider = this.resolveProvider(command, chat.provider)
+    const settings = this.getProviderSettings(provider, command)
+    await this.startTurnForChat({
       chatId,
-      query: q,
-      status: "starting",
-      pendingTool: null,
-      hasFinalResult: false,
-      cancelRequested: false,
-      cancelRecorded: false,
-    }
-    this.activeTurns.set(chatId, active)
-    this.onStateChange()
-
-    void q.accountInfo()
-      .then(async (accountInfo) => {
-        await this.store.appendMessage(
-          chatId!,
-          toTranscriptEntry(JSON.stringify({ type: "system", subtype: "account_info", accountInfo }))
-        )
-        this.onStateChange()
-      })
-      .catch(() => undefined)
-
-    void this.runTurn(active)
+      provider,
+      content: command.content,
+      model: settings.model,
+      effort: settings.effort,
+      serviceTier: settings.serviceTier,
+      planMode: settings.planMode,
+      appendUserPrompt: true,
+    })
 
     return { chatId }
   }
 
   private async runTurn(active: ActiveTurn) {
     try {
-      for await (const sdkMessage of active.query) {
-        const raw = JSON.stringify(sdkMessage)
-        const maybeMessageId = "uuid" in sdkMessage && sdkMessage.uuid ? String(sdkMessage.uuid) : crypto.randomUUID()
-
-        await this.store.appendMessage(active.chatId, toTranscriptEntry(raw, maybeMessageId))
-
-        const sessionId = "session_id" in sdkMessage && typeof sdkMessage.session_id === "string"
-          ? sdkMessage.session_id
-          : null
-        if (sessionId) {
-          await this.store.setResumeSession(active.chatId, sessionId)
+      for await (const event of active.turn.stream) {
+        if (event.type === "session_token" && event.sessionToken) {
+          await this.store.setSessionToken(active.chatId, event.sessionToken)
+          this.onStateChange()
+          continue
         }
 
-        if (sdkMessage.type === "system" && sdkMessage.subtype === "init") {
+        if (!event.entry) continue
+        await this.store.appendMessage(active.chatId, event.entry)
+
+        if (event.entry.kind === "system_init") {
           active.status = "running"
         }
 
-        if (sdkMessage.type === "result") {
+        if (event.entry.kind === "result") {
           active.hasFinalResult = true
-          if (sdkMessage.is_error) {
-            const errorText = "errors" in sdkMessage && Array.isArray(sdkMessage.errors)
-              ? sdkMessage.errors.join("\n")
-              : "Turn failed"
-            await this.store.recordTurnFailed(active.chatId, errorText)
+          if (event.entry.isError) {
+            await this.store.recordTurnFailed(active.chatId, event.entry.result || "Turn failed")
           } else if (!active.cancelRequested) {
             await this.store.recordTurnFinished(active.chatId)
           }
@@ -280,16 +541,54 @@ export class AgentCoordinator {
     } catch (error) {
       if (!active.cancelRequested) {
         const message = error instanceof Error ? error.message : String(error)
-        await this.store.appendMessage(active.chatId, toTranscriptEntry(buildErrorPayload(message)))
+        await this.store.appendMessage(
+          active.chatId,
+          timestamped({
+            kind: "result",
+            subtype: "error",
+            isError: true,
+            durationMs: 0,
+            result: message,
+          })
+        )
         await this.store.recordTurnFailed(active.chatId, message)
       }
     } finally {
       if (active.cancelRequested && !active.cancelRecorded) {
         await this.store.recordTurnCancelled(active.chatId)
       }
-      active.query.close()
+      active.turn.close()
       this.activeTurns.delete(active.chatId)
       this.onStateChange()
+
+      if (active.postToolFollowUp && !active.cancelRequested) {
+        try {
+          await this.startTurnForChat({
+            chatId: active.chatId,
+            provider: active.provider,
+            content: active.postToolFollowUp.content,
+            model: active.model,
+            effort: active.effort,
+            serviceTier: active.serviceTier,
+            planMode: active.postToolFollowUp.planMode,
+            appendUserPrompt: false,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          await this.store.appendMessage(
+            active.chatId,
+            timestamped({
+              kind: "result",
+              subtype: "error",
+              isError: true,
+              durationMs: 0,
+              result: message,
+            })
+          )
+          await this.store.recordTurnFailed(active.chatId, message)
+          this.onStateChange()
+        }
+      }
     }
   }
 
@@ -300,15 +599,15 @@ export class AgentCoordinator {
     active.cancelRequested = true
     active.pendingTool = null
 
-    await this.store.appendMessage(chatId, toTranscriptEntry(buildCancelledPayload(), crypto.randomUUID()))
+    await this.store.appendMessage(chatId, timestamped({ kind: "interrupted" }))
     await this.store.recordTurnCancelled(chatId)
     active.cancelRecorded = true
     active.hasFinalResult = true
 
     try {
-      await active.query.interrupt()
+      await active.turn.interrupt()
     } catch {
-      active.query.close()
+      active.turn.close()
     }
 
     this.activeTurns.delete(chatId)
@@ -328,55 +627,45 @@ export class AgentCoordinator {
 
     await this.store.appendMessage(
       command.chatId,
-      toTranscriptEntry(buildToolResultPayload(command.toolUseId, command.result), crypto.randomUUID())
+      timestamped({
+        kind: "tool_result",
+        toolId: command.toolUseId,
+        content: command.result,
+      })
     )
 
     active.pendingTool = null
     active.status = "running"
 
-    if (pending.toolName === "AskUserQuestion") {
-      const result = command.result as { questions?: unknown; answers?: unknown }
-      pending.resolve({
-        behavior: "allow",
-        updatedInput: {
-          ...(pending.input ?? {}),
-          questions: result.questions ?? (pending.input.questions as unknown),
-          answers: result.answers ?? result,
-        },
-      })
-      this.onStateChange()
-      return
-    }
-
-    const result = (command.result ?? {}) as {
-      confirmed?: boolean
-      clearContext?: boolean
-      message?: string
-    }
-
-    if (result.confirmed) {
-      if (result.clearContext) {
-        await this.store.setResumeSession(command.chatId, null)
-        await this.store.appendMessage(
-          command.chatId,
-          toTranscriptEntry(JSON.stringify({ type: "system", subtype: "context_cleared" }), crypto.randomUUID())
-        )
+    if (pending.tool.toolKind === "exit_plan_mode") {
+      const result = (command.result ?? {}) as {
+        confirmed?: boolean
+        clearContext?: boolean
+        message?: string
       }
-      pending.resolve({
-        behavior: "allow",
-        updatedInput: {
-          ...(pending.input ?? {}),
-          ...result,
-        },
-      })
-    } else {
-      pending.resolve({
-        behavior: "deny",
-        message: result.message
-          ? `User wants to suggest edits to the plan: ${result.message}`
-          : "User wants to suggest edits to the plan before approving.",
-      })
+      if (result.confirmed && result.clearContext) {
+        await this.store.setSessionToken(command.chatId, null)
+        await this.store.appendMessage(command.chatId, timestamped({ kind: "context_cleared" }))
+      }
+
+      if (active.provider === "codex") {
+        active.postToolFollowUp = result.confirmed
+          ? {
+              content: result.message
+                ? `Proceed with the approved plan. Additional guidance: ${result.message}`
+                : "Proceed with the approved plan.",
+              planMode: false,
+            }
+          : {
+              content: result.message
+                ? `Revise the plan using this feedback: ${result.message}`
+                : "Revise the plan using this feedback.",
+              planMode: true,
+            }
+      }
     }
+
+    pending.resolve(command.result)
 
     this.onStateChange()
   }

--- a/src/server/codex-app-server-protocol.ts
+++ b/src/server/codex-app-server-protocol.ts
@@ -1,0 +1,440 @@
+// Minimal typed subset vendored from `codex app-server generate-ts`.
+// Keep names and field shapes aligned with the official app-server protocol.
+
+import type { CodexReasoningEffort, ServiceTier } from "../shared/types"
+
+export type CodexRequestId = string | number
+
+export interface JsonRpcResponse<TResult = unknown> {
+  id: CodexRequestId
+  result?: TResult
+  error?: {
+    code?: number
+    message?: string
+  }
+}
+
+export interface InitializeParams {
+  clientInfo: {
+    name: string
+    title: string
+    version: string
+  }
+  capabilities: {
+    experimentalApi: boolean
+  }
+}
+
+export interface ThreadStartParams {
+  model?: string | null
+  cwd?: string | null
+  serviceTier?: ServiceTier | null
+  approvalPolicy?: "never" | "on-request" | "on-failure" | "untrusted" | null
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access" | null
+  experimentalRawEvents: boolean
+  persistExtendedHistory: boolean
+}
+
+export interface ThreadResumeParams {
+  threadId: string
+  model?: string | null
+  cwd?: string | null
+  serviceTier?: ServiceTier | null
+  approvalPolicy?: "never" | "on-request" | "on-failure" | "untrusted" | null
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access" | null
+  persistExtendedHistory: boolean
+}
+
+export interface TextUserInput {
+  type: "text"
+  text: string
+  text_elements: []
+}
+
+export type CodexUserInput = TextUserInput
+
+export interface CollaborationMode {
+  mode: "default" | "plan"
+  settings: {
+    model: string | null
+    reasoning_effort: ReasoningEffort | null
+    developer_instructions: string | null
+  }
+}
+
+export type ReasoningEffort = CodexReasoningEffort
+
+export interface TurnStartParams {
+  threadId: string
+  input: CodexUserInput[]
+  approvalPolicy?: "never" | "on-request" | "on-failure" | "untrusted" | null
+  model?: string | null
+  effort?: ReasoningEffort | null
+  serviceTier?: ServiceTier | null
+  collaborationMode?: CollaborationMode | null
+}
+
+export interface TurnInterruptParams {
+  threadId: string
+  turnId: string
+}
+
+export interface ThreadSummary {
+  id: string
+}
+
+export interface ThreadStartResponse {
+  thread: ThreadSummary
+  model: string
+  reasoningEffort: ReasoningEffort | null
+}
+
+export type ThreadResumeResponse = ThreadStartResponse
+
+export interface TurnSummary {
+  id: string
+  status: "inProgress" | "completed" | "failed" | "interrupted"
+  error: {
+    message?: string
+  } | null
+}
+
+export interface TurnStartResponse {
+  turn: TurnSummary
+}
+
+export interface ThreadStartedNotification {
+  thread: ThreadSummary
+}
+
+export interface TurnStartedNotification {
+  threadId: string
+  turn: TurnSummary
+}
+
+export interface TurnCompletedNotification {
+  threadId: string
+  turn: TurnSummary
+}
+
+export interface TurnPlanStep {
+  step: string
+  status: "pending" | "inProgress" | "completed"
+}
+
+export interface TurnPlanUpdatedNotification {
+  threadId: string
+  turnId: string
+  explanation: string | null
+  plan: TurnPlanStep[]
+}
+
+export interface PlanDeltaNotification {
+  threadId: string
+  turnId: string
+  itemId: string
+  delta: string
+}
+
+export interface ContextCompactedNotification {
+  threadId: string
+  turnId: string
+}
+
+export interface ToolRequestUserInputOption {
+  label: string
+  description?: string | null
+}
+
+export interface ToolRequestUserInputQuestion {
+  id: string
+  header: string
+  question: string
+  isOther: boolean
+  isSecret: boolean
+  options: ToolRequestUserInputOption[] | null
+}
+
+export interface ToolRequestUserInputParams {
+  threadId: string
+  turnId: string
+  itemId: string
+  questions: ToolRequestUserInputQuestion[]
+}
+
+export interface ToolRequestUserInputResponse {
+  answers: Record<string, { answers: string[] }>
+}
+
+export interface CommandExecutionRequestApprovalParams {
+  threadId: string
+  turnId: string
+  itemId: string
+  approvalId?: string | null
+  reason?: string | null
+  command?: string | null
+  cwd?: string | null
+}
+
+export interface FileChangeRequestApprovalParams {
+  threadId: string
+  turnId: string
+  itemId: string
+  reason?: string | null
+  grantRoot?: string | null
+}
+
+export type CommandExecutionApprovalDecision =
+  | "accept"
+  | "acceptForSession"
+  | "decline"
+  | "cancel"
+
+export type FileChangeApprovalDecision =
+  | "accept"
+  | "acceptForSession"
+  | "decline"
+  | "cancel"
+
+export interface CommandExecutionRequestApprovalResponse {
+  decision: CommandExecutionApprovalDecision
+}
+
+export interface FileChangeRequestApprovalResponse {
+  decision: FileChangeApprovalDecision
+}
+
+export interface ToolRequestUserInputRequest {
+  id: CodexRequestId
+  method: "item/tool/requestUserInput"
+  params: ToolRequestUserInputParams
+}
+
+export interface DynamicToolCallParams {
+  threadId: string
+  turnId: string
+  callId: string
+  tool: string
+  arguments: Record<string, unknown> | unknown[] | string | number | boolean | null
+}
+
+export interface DynamicToolCallOutputContentItem {
+  type: "inputText" | "inputImage"
+  text?: string
+  imageUrl?: string
+}
+
+export interface DynamicToolCallResponse {
+  contentItems: DynamicToolCallOutputContentItem[]
+  success: boolean
+}
+
+export interface DynamicToolCallRequest {
+  id: CodexRequestId
+  method: "item/tool/call"
+  params: DynamicToolCallParams
+}
+
+export interface CommandExecutionRequestApprovalRequest {
+  id: CodexRequestId
+  method: "item/commandExecution/requestApproval"
+  params: CommandExecutionRequestApprovalParams
+}
+
+export interface FileChangeRequestApprovalRequest {
+  id: CodexRequestId
+  method: "item/fileChange/requestApproval"
+  params: FileChangeRequestApprovalParams
+}
+
+export type ServerRequest =
+  | ToolRequestUserInputRequest
+  | DynamicToolCallRequest
+  | CommandExecutionRequestApprovalRequest
+  | FileChangeRequestApprovalRequest
+
+export interface UserMessageItem {
+  type: "userMessage"
+  id: string
+  content: Array<{
+    type: "text"
+    text: string
+    text_elements: []
+  }>
+}
+
+export interface ReasoningItem {
+  type: "reasoning"
+  id: string
+  summary: unknown[]
+  content: unknown[]
+}
+
+export interface AgentMessageItem {
+  type: "agentMessage"
+  id: string
+  text: string
+  phase?: string
+}
+
+export interface PlanItem {
+  type: "plan"
+  id: string
+  text: string
+}
+
+export interface CommandExecutionItem {
+  type: "commandExecution"
+  id: string
+  command: string
+  cwd?: string
+  processId?: string
+  status: "inProgress" | "completed" | "failed" | "declined"
+  aggregatedOutput?: string | null
+  exitCode?: number | null
+  durationMs?: number | null
+}
+
+export interface McpToolCallItem {
+  type: "mcpToolCall"
+  id: string
+  server: string
+  tool: string
+  arguments?: Record<string, unknown> | null
+  result?: {
+    content?: unknown[]
+    structuredContent?: unknown
+  } | null
+  error?: {
+    message?: string
+  } | null
+  status: "inProgress" | "completed" | "failed"
+}
+
+export interface DynamicToolCallItem {
+  type: "dynamicToolCall"
+  id: string
+  tool: string
+  arguments?: Record<string, unknown> | unknown[] | string | number | boolean | null
+  status: "inProgress" | "completed" | "failed"
+  contentItems?: DynamicToolCallOutputContentItem[] | null
+  success?: boolean | null
+  durationMs?: number | null
+}
+
+export interface CollabAgentToolCallItem {
+  type: "collabAgentToolCall"
+  id: string
+  tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent"
+  status: "inProgress" | "completed" | "failed"
+  senderThreadId: string
+  receiverThreadIds: string[]
+  prompt?: string | null
+  agentsStates?: Record<string, { status: string; message: string | null }> | null
+}
+
+export interface WebSearchItem {
+  type: "webSearch"
+  id: string
+  query: string
+  action?: {
+    type?: string
+    query?: string
+    queries?: string[]
+  } | null
+}
+
+export interface FileChangeItem {
+  type: "fileChange"
+  id: string
+  changes: Array<{
+    path: string
+    kind:
+      | "add"
+      | "delete"
+      | "update"
+      | {
+          type: "add" | "delete" | "update"
+          move_path?: string | null
+        }
+    diff?: string | null
+  }>
+  status: "inProgress" | "completed" | "failed" | "declined"
+}
+
+export interface ErrorItem {
+  type: "error"
+  id: string
+  message: string
+}
+
+export type ThreadItem =
+  | UserMessageItem
+  | ReasoningItem
+  | AgentMessageItem
+  | PlanItem
+  | CommandExecutionItem
+  | McpToolCallItem
+  | DynamicToolCallItem
+  | CollabAgentToolCallItem
+  | WebSearchItem
+  | FileChangeItem
+  | ErrorItem
+
+export interface ItemStartedNotification {
+  item: ThreadItem
+  threadId: string
+  turnId: string
+}
+
+export interface ItemCompletedNotification {
+  item: ThreadItem
+  threadId: string
+  turnId: string
+}
+
+export interface ErrorNotification {
+  message: string
+}
+
+export type ServerNotification =
+  | { method: "thread/started"; params: ThreadStartedNotification }
+  | { method: "turn/started"; params: TurnStartedNotification }
+  | { method: "turn/completed"; params: TurnCompletedNotification }
+  | { method: "turn/plan/updated"; params: TurnPlanUpdatedNotification }
+  | { method: "item/started"; params: ItemStartedNotification }
+  | { method: "item/completed"; params: ItemCompletedNotification }
+  | { method: "item/plan/delta"; params: PlanDeltaNotification }
+  | { method: "thread/compacted"; params: ContextCompactedNotification }
+  | { method: "error"; params: ErrorNotification }
+
+export function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+  return Boolean(value) && typeof value === "object" && "id" in (value as Record<string, unknown>)
+    && ("result" in (value as Record<string, unknown>) || "error" in (value as Record<string, unknown>))
+    && !("method" in (value as Record<string, unknown>))
+}
+
+export function isServerRequest(value: unknown): value is ServerRequest {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.method !== "string" || !("id" in candidate)) return false
+  return candidate.method === "item/tool/requestUserInput"
+    || candidate.method === "item/tool/call"
+    || candidate.method === "item/commandExecution/requestApproval"
+    || candidate.method === "item/fileChange/requestApproval"
+}
+
+export function isServerNotification(value: unknown): value is ServerNotification {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.method !== "string" || "id" in candidate) return false
+  return candidate.method === "thread/started"
+    || candidate.method === "turn/started"
+    || candidate.method === "turn/completed"
+    || candidate.method === "turn/plan/updated"
+    || candidate.method === "item/started"
+    || candidate.method === "item/completed"
+    || candidate.method === "item/plan/delta"
+    || candidate.method === "thread/compacted"
+    || candidate.method === "error"
+}

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -1,0 +1,1303 @@
+import { describe, expect, test } from "bun:test"
+import { EventEmitter } from "node:events"
+import { PassThrough } from "node:stream"
+import { CodexAppServerManager } from "./codex-app-server"
+
+class FakeCodexProcess extends EventEmitter {
+  readonly stdin = new PassThrough()
+  readonly stdout = new PassThrough()
+  readonly stderr = new PassThrough()
+  readonly messages: unknown[] = []
+  killed = false
+
+  constructor(
+    private readonly onMessage?: (message: any, process: FakeCodexProcess) => void
+  ) {
+    super()
+    let buffer = ""
+    this.stdin.on("data", (chunk) => {
+      buffer += chunk.toString()
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        if (!line.trim()) continue
+        const message = JSON.parse(line)
+        this.messages.push(message)
+        this.onMessage?.(message, this)
+      }
+    })
+  }
+
+  kill() {
+    this.killed = true
+    this.emit("close", 0)
+  }
+
+  writeServerMessage(message: unknown) {
+    this.stdout.write(`${JSON.stringify(message)}\n`)
+  }
+
+  writeStderr(message: string) {
+    this.stderr.write(`${message}\n`)
+  }
+
+  closeWithCode(code: number) {
+    this.emit("close", code)
+  }
+}
+
+async function collectStream(stream: AsyncIterable<any>) {
+  const items: any[] = []
+  for await (const item of stream) {
+    items.push(item)
+  }
+  return items
+}
+
+describe("CodexAppServerManager", () => {
+  test("initializes app-server and starts a fresh thread", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    expect(process.messages).toHaveLength(3)
+    expect((process.messages[0] as any).method).toBe("initialize")
+    expect((process.messages[1] as any).method).toBe("initialized")
+    expect((process.messages[2] as any).method).toBe("thread/start")
+  })
+
+  test("falls back to thread/start when thread/resume is recoverably missing", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/resume") {
+        child.writeServerMessage({
+          id: message.id,
+          error: { message: "thread/resume failed: thread not found" },
+        })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-2" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: "missing-thread",
+    })
+
+    expect(process.messages.map((message: any) => message.method)).toEqual([
+      "initialize",
+      "initialized",
+      "thread/resume",
+      "thread/start",
+    ])
+  })
+
+  test("maps fast mode and reasoning into app-server params", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "completed", error: null } },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      serviceTier: "fast",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      effort: "xhigh",
+      serviceTier: "fast",
+      content: "Run pwd",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    await collectStream(turn.stream)
+
+    const threadStart = process.messages.find((message: any) => message.method === "thread/start") as
+      | { method: "thread/start"; params: { serviceTier?: string } }
+      | undefined
+    const turnStart = process.messages.find((message: any) => message.method === "turn/start") as
+      | { method: "turn/start"; params: { effort?: string; serviceTier?: string; collaborationMode?: { settings?: { reasoning_effort?: string | null } } } }
+      | undefined
+
+    expect(threadStart?.params.serviceTier).toBe("fast")
+    expect(turnStart?.params.effort).toBe("xhigh")
+    expect(turnStart?.params.serviceTier).toBe("fast")
+    expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBeNull()
+  })
+
+  test("maps command execution and agent output into the shared transcript stream", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "commandExecution",
+              id: "call-1",
+              command: "/bin/zsh -lc pwd",
+              status: "inProgress",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "commandExecution",
+              id: "call-1",
+              command: "/bin/zsh -lc pwd",
+              status: "completed",
+              aggregatedOutput: "/tmp/project\n",
+              exitCode: 0,
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "agentMessage",
+              id: "msg-1",
+              text: "/tmp/project",
+              phase: "final_answer",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "Run pwd",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const transcriptKinds = events
+      .filter((event) => event.type === "transcript")
+      .map((event) => event.entry.kind)
+
+    expect(events[0]).toEqual({ type: "session_token", sessionToken: "thread-1" })
+    expect(transcriptKinds).toEqual(["system_init", "tool_call", "tool_result", "assistant_text", "result"])
+  })
+
+  test("emits only a compact boundary when Codex reports thread compaction", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "thread/compacted",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "/compact",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const transcriptKinds = events
+      .filter((event) => event.type === "transcript")
+      .map((event) => event.entry.kind)
+
+    expect(transcriptKinds).toEqual(["system_init", "compact_boundary", "result"])
+    expect(transcriptKinds).not.toContain("context_cleared")
+  })
+
+  test("maps fileChange updates into edit_file tool calls", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "fileChange",
+              id: "call-1",
+              changes: [
+                {
+                  path: "/tmp/project/test.md",
+                  kind: {
+                    type: "update",
+                    move_path: null,
+                  },
+                  diff: "@@ -1,2 +1,2 @@\n-old line\n+new line",
+                },
+              ],
+              status: "inProgress",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "fileChange",
+              id: "call-1",
+              changes: [
+                {
+                  path: "/tmp/project/test.md",
+                  kind: {
+                    type: "update",
+                    move_path: null,
+                  },
+                  diff: "@@ -1,2 +1,2 @@\n-old line\n+new line",
+                },
+              ],
+              status: "completed",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "edit a file",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCall = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+
+    expect(toolCall?.entry.kind).toBe("tool_call")
+    if (!toolCall || toolCall.entry.kind !== "tool_call") throw new Error("missing tool call")
+    expect(toolCall.entry.tool.toolKind).toBe("edit_file")
+    expect(toolCall.entry.tool.toolName).toBe("Edit")
+    expect(toolCall.entry.tool.input).toEqual({
+      filePath: "/tmp/project/test.md",
+      oldString: "old line",
+      newString: "new line",
+    })
+  })
+
+  test("maps fileChange adds into write_file tool calls", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "fileChange",
+              id: "call-1",
+              changes: [
+                {
+                  path: "/tmp/project/test.md",
+                  kind: {
+                    type: "add",
+                    move_path: null,
+                  },
+                  diff: "@@ -0,0 +1,2 @@\n+hello\n+world",
+                },
+              ],
+              status: "inProgress",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "fileChange",
+              id: "call-1",
+              changes: [
+                {
+                  path: "/tmp/project/test.md",
+                  kind: {
+                    type: "add",
+                    move_path: null,
+                  },
+                  diff: "@@ -0,0 +1,2 @@\n+hello\n+world",
+                },
+              ],
+              status: "completed",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "write a file",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCall = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+
+    expect(toolCall?.entry.kind).toBe("tool_call")
+    if (!toolCall || toolCall.entry.kind !== "tool_call") throw new Error("missing tool call")
+    expect(toolCall.entry.tool.toolKind).toBe("write_file")
+    expect(toolCall.entry.tool.toolName).toBe("Write")
+    expect(toolCall.entry.tool.input).toEqual({
+      filePath: "/tmp/project/test.md",
+      content: "hello\nworld",
+    })
+  })
+
+  test("splits multi-change fileChange items into multiple tool calls and results", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "fileChange",
+              id: "call-1",
+              changes: [
+                {
+                  path: "/tmp/project/one.md",
+                  kind: {
+                    type: "add",
+                    move_path: null,
+                  },
+                  diff: "@@ -0,0 +1,2 @@\n+hello\n+world",
+                },
+                {
+                  path: "/tmp/project/two.md",
+                  kind: {
+                    type: "update",
+                    move_path: null,
+                  },
+                  diff: "@@ -1,2 +1,2 @@\n-old line\n+new line",
+                },
+              ],
+              status: "completed",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "change multiple files",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCalls = events.filter((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    const toolResults = events.filter((event) => event.type === "transcript" && event.entry.kind === "tool_result")
+
+    expect(toolCalls).toHaveLength(2)
+    expect(toolResults).toHaveLength(2)
+
+    expect(toolCalls[0]?.entry.kind).toBe("tool_call")
+    expect(toolCalls[1]?.entry.kind).toBe("tool_call")
+    if (toolCalls[0]?.entry.kind !== "tool_call" || toolCalls[1]?.entry.kind !== "tool_call") {
+      throw new Error("missing tool calls")
+    }
+
+    expect(toolCalls[0].entry.tool.toolKind).toBe("write_file")
+    expect(toolCalls[0].entry.tool.toolId).toBe("call-1:change:0")
+    expect(toolCalls[0].entry.tool.input).toEqual({
+      filePath: "/tmp/project/one.md",
+      content: "hello\nworld",
+    })
+
+    expect(toolCalls[1].entry.tool.toolKind).toBe("edit_file")
+    expect(toolCalls[1].entry.tool.toolId).toBe("call-1:change:1")
+    expect(toolCalls[1].entry.tool.input).toEqual({
+      filePath: "/tmp/project/two.md",
+      oldString: "old line",
+      newString: "new line",
+    })
+
+    expect(toolResults[0]?.entry.kind).toBe("tool_result")
+    expect(toolResults[1]?.entry.kind).toBe("tool_result")
+    if (toolResults[0]?.entry.kind !== "tool_result" || toolResults[1]?.entry.kind !== "tool_result") {
+      throw new Error("missing tool results")
+    }
+
+    expect(toolResults[0].entry.toolId).toBe("call-1:change:0")
+    expect(toolResults[1].entry.toolId).toBe("call-1:change:1")
+  })
+
+  test("maps plan updates into TodoWrite and synthesizes ExitPlanMode on successful plan turns", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "turn/plan/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            explanation: "Plan the work",
+            plan: [
+              { step: "Inspect repo", status: "completed" },
+              { step: "Implement changes", status: "inProgress" },
+            ],
+          },
+        })
+        child.writeServerMessage({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "plan",
+              id: "plan-1",
+              text: "",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/plan/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "plan-1",
+            delta: "## Plan\n\n- [x] Inspect repo\n- [ ] Implement changes",
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "make a plan",
+      planMode: true,
+      onToolRequest: async () => ({ confirmed: true }),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCalls = events
+      .filter((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+      .map((event) => event.entry.tool)
+
+    expect(toolCalls[0]?.toolKind).toBe("todo_write")
+    expect(toolCalls[1]?.toolKind).toBe("exit_plan_mode")
+    if (!toolCalls[1] || toolCalls[1].toolKind !== "exit_plan_mode") {
+      throw new Error("missing ExitPlanMode tool")
+    }
+    expect(toolCalls[1].input.summary).toBe("Plan the work")
+    expect(toolCalls[1].input.plan).toContain("## Plan")
+  })
+
+  test("maps collab agent tool calls into subagent_task", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "collabAgentToolCall",
+              id: "agent-1",
+              tool: "spawnAgent",
+              status: "completed",
+              senderThreadId: "thread-1",
+              receiverThreadIds: ["thread-2"],
+              prompt: "Inspect tests",
+              agentsStates: {
+                "thread-2": { status: "running", message: "Inspecting" },
+              },
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "spawn an agent",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCall = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+
+    expect(toolCall?.entry.kind).toBe("tool_call")
+    if (!toolCall || toolCall.entry.kind !== "tool_call") throw new Error("missing tool call")
+    expect(toolCall.entry.tool.toolKind).toBe("subagent_task")
+    expect(toolCall.entry.tool.input).toEqual({ subagentType: "spawnAgent" })
+  })
+
+  test("uses the completed webSearch query when the started item is empty", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "webSearch",
+              id: "ws-1",
+              query: "",
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "webSearch",
+              id: "ws-1",
+              query: "jake mor",
+              action: {
+                type: "search",
+                query: "jake mor",
+                queries: ["jake mor"],
+              },
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "search",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCalls = events.filter((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+
+    expect(toolCalls).toHaveLength(1)
+    const toolCall = toolCalls[0]
+    if (toolCall.entry.kind !== "tool_call") throw new Error("missing tool call")
+    expect(toolCall.entry.tool.toolKind).toBe("web_search")
+    expect(toolCall.entry.tool.input).toEqual({ query: "jake mor" })
+  })
+
+  test("responds to unsupported dynamic tool requests with a generic tool error", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "dyn-1",
+          method: "item/tool/call",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-1",
+            tool: "custom_tool",
+            arguments: { value: 1 },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "call tool",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const toolCall = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    const toolResult = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_result")
+    const response = process.messages.find((message: any) => message.id === "dyn-1")
+
+    expect(toolCall?.entry.kind).toBe("tool_call")
+    if (!toolCall || toolCall.entry.kind !== "tool_call") throw new Error("missing tool call")
+    expect(toolCall.entry.tool.toolKind).toBe("unknown_tool")
+    expect(toolCall.entry.tool.toolName).toBe("custom_tool")
+    expect(toolResult?.entry.kind).toBe("tool_result")
+    expect(response).toEqual({
+      id: "dyn-1",
+      result: {
+        contentItems: [{ type: "inputText", text: "Unsupported dynamic tool call: custom_tool" }],
+        success: false,
+      },
+    })
+  })
+
+  test("answers requestUserInput requests with the official JSON-RPC result payload", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "req-1",
+          method: "item/tool/requestUserInput",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "ask-1",
+            questions: [
+              {
+                id: "runtime",
+                header: "Runtime",
+                question: "Which runtime?",
+                isOther: false,
+                isSecret: false,
+                options: null,
+              },
+            ],
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "ask me",
+      planMode: false,
+      onToolRequest: async () => ({
+        questions: [{
+          id: "runtime",
+          question: "Which runtime?",
+        }],
+        answers: {
+          runtime: "bun",
+        },
+      }),
+    })
+
+    const events = await collectStream(turn.stream)
+    const askEntry = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    expect(askEntry?.entry.tool.toolKind).toBe("ask_user_question")
+
+    const response = process.messages.find((message: any) => message.id === "req-1")
+    expect(response).toEqual({
+      id: "req-1",
+      result: {
+        answers: {
+          runtime: {
+            answers: ["bun"],
+          },
+        },
+      },
+    })
+  })
+
+  test("falls back to question text when requestUserInput answers are keyed by prompt text", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "req-1",
+          method: "item/tool/requestUserInput",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "ask-1",
+            questions: [
+              {
+                id: "favorite_color",
+                header: "Color",
+                question: "What is your favorite color right now?",
+                isOther: true,
+                isSecret: false,
+                options: [
+                  { label: "Red", description: null },
+                  { label: "Blue", description: null },
+                ],
+              },
+            ],
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "ask me",
+      planMode: false,
+      onToolRequest: async () => ({
+        questions: [{
+          id: "favorite_color",
+          question: "What is your favorite color right now?",
+        }],
+        answers: {
+          "What is your favorite color right now?": "Red",
+        },
+      }),
+    })
+
+    await collectStream(turn.stream)
+
+    const response = process.messages.find((message: any) => message.id === "req-1")
+    expect(response).toEqual({
+      id: "req-1",
+      result: {
+        answers: {
+          favorite_color: {
+            answers: ["Red"],
+          },
+        },
+      },
+    })
+  })
+
+  test("sends approval decisions back to the app-server", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "approval-1",
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "call-1",
+            command: "rm -rf .",
+            cwd: "/tmp/project",
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "approve something",
+      planMode: false,
+      onToolRequest: async () => ({}),
+      onApprovalRequest: async () => "accept",
+    })
+
+    await collectStream(turn.stream)
+
+    const response = process.messages.find((message: any) => message.id === "approval-1")
+    expect(response).toEqual({
+      id: "approval-1",
+      result: {
+        decision: "accept",
+      },
+    })
+  })
+
+  test("interrupt sends turn/interrupt for the active turn", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+      } else if (message.method === "turn/interrupt") {
+        child.writeServerMessage({ id: message.id, result: {} })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "wait",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    await turn.interrupt()
+
+    const interruptRequest = process.messages.find((message: any) => message.method === "turn/interrupt") as
+      | { id: string; method: "turn/interrupt"; params: { threadId: string; turnId: string } }
+      | undefined
+    expect(interruptRequest).toBeDefined()
+    if (!interruptRequest) throw new Error("missing interrupt request")
+    expect(interruptRequest).toEqual({
+      id: interruptRequest.id,
+      method: "turn/interrupt",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    })
+  })
+
+  test("emits an error result when the app-server exits mid-turn", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeStderr("fatal: app-server crashed")
+        child.closeWithCode(1)
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "crash",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    const events = await collectStream(turn.stream)
+    const resultEvent = events.find((event) => event.type === "transcript" && event.entry.kind === "result")
+    expect(resultEvent?.entry.subtype).toBe("error")
+    expect(resultEvent?.entry.result).toContain("fatal: app-server crashed")
+  })
+})

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -1,0 +1,1277 @@
+import { spawn } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import { createInterface } from "node:readline"
+import type { Readable, Writable } from "node:stream"
+import type { AskUserQuestionItem, CodexReasoningEffort, ServiceTier, TodoItem, TranscriptEntry } from "../shared/types"
+import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
+import {
+  type CollabAgentToolCallItem,
+  type ContextCompactedNotification,
+  type CodexRequestId,
+  type CommandExecutionApprovalDecision,
+  type CommandExecutionRequestApprovalParams,
+  type CommandExecutionRequestApprovalResponse,
+  type DynamicToolCallOutputContentItem,
+  type DynamicToolCallResponse,
+  type FileChangeApprovalDecision,
+  type FileChangeRequestApprovalParams,
+  type FileChangeRequestApprovalResponse,
+  type InitializeParams,
+  type ItemCompletedNotification,
+  type ItemStartedNotification,
+  type JsonRpcResponse,
+  type McpToolCallItem,
+  type PlanDeltaNotification,
+  type ServerNotification,
+  type ServerRequest,
+  type ThreadItem,
+  type ThreadResumeParams,
+  type ThreadResumeResponse,
+  type ThreadStartParams,
+  type ThreadStartResponse,
+  type ToolRequestUserInputParams,
+  type ToolRequestUserInputResponse,
+  type TurnPlanStep,
+  type TurnPlanUpdatedNotification,
+  type TurnCompletedNotification,
+  type TurnInterruptParams,
+  type TurnStartParams,
+  type TurnStartResponse,
+  isJsonRpcResponse,
+  isServerNotification,
+  isServerRequest,
+} from "./codex-app-server-protocol"
+
+interface CodexAppServerProcess {
+  stdin: Writable
+  stdout: Readable
+  stderr: Readable
+  killed?: boolean
+  kill(signal?: NodeJS.Signals | number): void
+  on(event: "close", listener: (code: number | null) => void): this
+  on(event: "error", listener: (error: Error) => void): this
+  once(event: "close", listener: (code: number | null) => void): this
+  once(event: "error", listener: (error: Error) => void): this
+}
+
+type SpawnCodexAppServer = (cwd: string) => CodexAppServerProcess
+
+interface PendingRequest<TResult> {
+  method: string
+  resolve: (value: TResult) => void
+  reject: (error: Error) => void
+}
+
+interface PendingTurn {
+  turnId: string | null
+  model: string
+  planMode: boolean
+  queue: AsyncQueue<HarnessEvent>
+  startedToolIds: Set<string>
+  handledDynamicToolIds: Set<string>
+  latestPlanExplanation: string | null
+  latestPlanSteps: TurnPlanStep[]
+  latestPlanText: string | null
+  planTextByItemId: Map<string, string>
+  todoSequence: number
+  pendingWebSearchResultToolId: string | null
+  resolved: boolean
+  onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
+  onApprovalRequest?: (
+    request:
+      | {
+          requestId: CodexRequestId
+          kind: "command_execution"
+          params: CommandExecutionRequestApprovalParams
+        }
+      | {
+          requestId: CodexRequestId
+          kind: "file_change"
+          params: FileChangeRequestApprovalParams
+        }
+  ) => Promise<CommandExecutionApprovalDecision | FileChangeApprovalDecision>
+}
+
+interface SessionContext {
+  chatId: string
+  cwd: string
+  child: CodexAppServerProcess
+  pendingRequests: Map<CodexRequestId, PendingRequest<unknown>>
+  pendingTurn: PendingTurn | null
+  sessionToken: string | null
+  stderrLines: string[]
+  closed: boolean
+}
+
+export interface StartCodexSessionArgs {
+  chatId: string
+  cwd: string
+  model: string
+  serviceTier?: ServiceTier
+  sessionToken: string | null
+}
+
+export interface StartCodexTurnArgs {
+  chatId: string
+  model: string
+  effort?: CodexReasoningEffort
+  serviceTier?: ServiceTier
+  content: string
+  planMode: boolean
+  onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
+  onApprovalRequest?: PendingTurn["onApprovalRequest"]
+}
+
+function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
+  entry: T,
+  createdAt = Date.now()
+): TranscriptEntry {
+  return {
+    _id: randomUUID(),
+    createdAt,
+    ...entry,
+  } as TranscriptEntry
+}
+
+function codexSystemInitEntry(model: string): TranscriptEntry {
+  return timestamped({
+    kind: "system_init",
+    provider: "codex",
+    model,
+    tools: ["Bash", "Write", "Edit", "WebSearch", "TodoWrite", "AskUserQuestion", "ExitPlanMode"],
+    agents: ["spawnAgent", "sendInput", "resumeAgent", "wait", "closeAgent"],
+    slashCommands: [],
+    mcpServers: [],
+  })
+}
+
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message
+  return String(value)
+}
+
+function parseJsonLine(line: string): unknown | null {
+  try {
+    return JSON.parse(line)
+  } catch {
+    return null
+  }
+}
+
+function isRecoverableResumeError(error: unknown): boolean {
+  const message = errorMessage(error).toLowerCase()
+  if (!message.includes("thread/resume")) return false
+  return ["not found", "missing thread", "no such thread", "unknown thread", "does not exist"].some((snippet) =>
+    message.includes(snippet)
+  )
+}
+
+function toAskUserQuestionItems(params: ToolRequestUserInputParams): AskUserQuestionItem[] {
+  return params.questions.map((question) => ({
+    id: question.id,
+    question: question.question,
+    header: question.header || undefined,
+    options: question.options?.map((option) => ({
+      label: option.label,
+      description: option.description ?? undefined,
+    })),
+    multiSelect: false,
+  }))
+}
+
+function toToolRequestUserInputResponse(raw: unknown, questions: ToolRequestUserInputParams["questions"]): ToolRequestUserInputResponse {
+  const record = raw && typeof raw === "object" ? raw as Record<string, unknown> : {}
+  const answersValue = record.answers
+  const value = answersValue && typeof answersValue === "object" && !Array.isArray(answersValue)
+    ? answersValue as Record<string, unknown>
+    : record
+  const answers = Object.fromEntries(
+    questions.map((question) => {
+      const rawAnswer = value[question.id] ?? value[question.question]
+      if (Array.isArray(rawAnswer)) {
+        return [question.id, { answers: rawAnswer.map((entry) => String(entry)) }]
+      }
+      if (typeof rawAnswer === "string") {
+        return [question.id, { answers: [rawAnswer] }]
+      }
+      if (rawAnswer && typeof rawAnswer === "object" && Array.isArray((rawAnswer as { answers?: unknown }).answers)) {
+        return [question.id, { answers: ((rawAnswer as { answers: unknown[] }).answers).map((entry) => String(entry)) }]
+      }
+      return [question.id, { answers: [] }]
+    })
+  )
+  return { answers }
+}
+
+function contentFromMcpResult(item: McpToolCallItem): unknown {
+  if (item.error?.message) {
+    return { error: item.error.message }
+  }
+  return item.result?.structuredContent ?? item.result?.content ?? null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function todoStatus(status: TurnPlanStep["status"]): TodoItem["status"] {
+  if (status === "completed") return "completed"
+  if (status === "inProgress") return "in_progress"
+  return "pending"
+}
+
+function planStepsToTodos(steps: TurnPlanStep[]): TodoItem[] {
+  return steps.map((step) => ({
+    content: step.step,
+    status: todoStatus(step.status),
+    activeForm: step.step,
+  }))
+}
+
+function renderPlanMarkdownFromSteps(steps: TurnPlanStep[]): string {
+  return steps.map((step) => {
+    const checkbox = step.status === "completed" ? "[x]" : "[ ]"
+    return `- ${checkbox} ${step.step}`
+  }).join("\n")
+}
+
+function dynamicContentToText(contentItems: DynamicToolCallOutputContentItem[] | null | undefined): string {
+  if (!contentItems?.length) return ""
+  return contentItems
+    .map((item) => item.type === "inputText" ? item.text ?? "" : item.imageUrl ?? "")
+    .filter(Boolean)
+    .join("\n")
+}
+
+function dynamicToolPayload(value: Record<string, unknown> | unknown[] | string | number | boolean | null | undefined): Record<string, unknown> {
+  const record = asRecord(value)
+  if (record) return record
+  return { value }
+}
+
+function webSearchQuery(item: Extract<ThreadItem, { type: "webSearch" }>): string {
+  return item.query || item.action?.query || item.action?.queries?.find((query) => typeof query === "string") || ""
+}
+
+function genericDynamicToolCall(toolId: string, toolName: string, input: Record<string, unknown>): TranscriptEntry {
+  return timestamped({
+    kind: "tool_call",
+    tool: {
+      kind: "tool",
+      toolKind: "unknown_tool",
+      toolName,
+      toolId,
+      input: {
+        payload: input,
+      },
+      rawInput: input,
+    },
+  })
+}
+
+function collabToolCall(item: CollabAgentToolCallItem): TranscriptEntry {
+  return timestamped({
+    kind: "tool_call",
+    tool: {
+      kind: "tool",
+      toolKind: "subagent_task",
+      toolName: "Task",
+      toolId: item.id,
+      input: {
+        subagentType: item.tool,
+      },
+      rawInput: item as unknown as Record<string, unknown>,
+    },
+  })
+}
+
+function todoToolCall(toolId: string, steps: TurnPlanStep[]): TranscriptEntry {
+  return timestamped({
+    kind: "tool_call",
+    tool: {
+      kind: "tool",
+      toolKind: "todo_write",
+      toolName: "TodoWrite",
+      toolId,
+      input: {
+        todos: planStepsToTodos(steps),
+      },
+      rawInput: {
+        plan: steps,
+      },
+    },
+  })
+}
+
+function fileChangeKind(
+  kind: "add" | "delete" | "update" | { type: "add" | "delete" | "update"; move_path?: string | null }
+): { type: "add" | "delete" | "update"; movePath?: string | null } {
+  if (typeof kind === "string") {
+    return { type: kind }
+  }
+  return {
+    type: kind.type,
+    movePath: kind.move_path ?? null,
+  }
+}
+
+function fileChangeToolId(itemId: string, index: number, totalChanges: number): string {
+  if (totalChanges === 1) {
+    return itemId
+  }
+  return `${itemId}:change:${index}`
+}
+
+function fileChangePayload(
+  item: Extract<ThreadItem, { type: "fileChange" }>,
+  change: Extract<ThreadItem, { type: "fileChange" }>["changes"][number]
+): Record<string, unknown> {
+  return {
+    ...item,
+    changes: [change],
+  } as unknown as Record<string, unknown>
+}
+
+function parseUnifiedDiff(diff: string): { oldString: string; newString: string } {
+  const oldLines: string[] = []
+  const newLines: string[] = []
+
+  for (const line of diff.split(/\r?\n/)) {
+    if (!line) continue
+    if (line.startsWith("@@") || line.startsWith("---") || line.startsWith("+++")) continue
+    if (line === "\\ No newline at end of file") continue
+
+    const prefix = line[0]
+    const content = line.slice(1)
+
+    if (prefix === " ") {
+      oldLines.push(content)
+      newLines.push(content)
+      continue
+    }
+    if (prefix === "-") {
+      oldLines.push(content)
+      continue
+    }
+    if (prefix === "+") {
+      newLines.push(content)
+    }
+  }
+
+  return {
+    oldString: oldLines.join("\n"),
+    newString: newLines.join("\n"),
+  }
+}
+
+function fileChangeToToolCalls(item: Extract<ThreadItem, { type: "fileChange" }>): TranscriptEntry[] {
+  return item.changes.map((change, index) => {
+    const payload = fileChangePayload(item, change)
+    const toolId = fileChangeToolId(item.id, index, item.changes.length)
+    const normalizedKind = fileChangeKind(change.kind)
+
+    if (normalizedKind.movePath) {
+      return timestamped({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "unknown_tool",
+          toolName: "FileChange",
+          toolId,
+          input: {
+            payload,
+          },
+          rawInput: payload,
+        },
+      })
+    }
+
+    if (typeof change.diff === "string") {
+      const { oldString, newString } = parseUnifiedDiff(change.diff)
+
+      if (normalizedKind.type === "add") {
+        return timestamped({
+          kind: "tool_call",
+          tool: {
+            kind: "tool",
+            toolKind: "write_file",
+            toolName: "Write",
+            toolId,
+            input: {
+              filePath: change.path,
+              content: newString,
+            },
+            rawInput: payload,
+          },
+        })
+      }
+
+      if (normalizedKind.type === "update") {
+        return timestamped({
+          kind: "tool_call",
+          tool: {
+            kind: "tool",
+            toolKind: "edit_file",
+            toolName: "Edit",
+            toolId,
+            input: {
+              filePath: change.path,
+              oldString,
+              newString,
+            },
+            rawInput: payload,
+          },
+        })
+      }
+    }
+
+    return timestamped({
+      kind: "tool_call",
+      tool: {
+        kind: "tool",
+        toolKind: "unknown_tool",
+        toolName: "FileChange",
+        toolId,
+        input: {
+          payload,
+        },
+        rawInput: payload,
+      },
+    })
+  })
+}
+
+function fileChangeToToolResults(item: Extract<ThreadItem, { type: "fileChange" }>): TranscriptEntry[] {
+  return item.changes.map((change, index) => timestamped({
+    kind: "tool_result",
+    toolId: fileChangeToolId(item.id, index, item.changes.length),
+    content: fileChangePayload(item, change),
+    isError: item.status === "failed" || item.status === "declined",
+  }))
+}
+
+function itemToToolCalls(item: ThreadItem): TranscriptEntry[] {
+  switch (item.type) {
+    case "dynamicToolCall":
+      return [genericDynamicToolCall(item.id, item.tool, dynamicToolPayload(item.arguments))]
+    case "collabAgentToolCall":
+      return [collabToolCall(item)]
+    case "commandExecution":
+      return [timestamped({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "bash",
+          toolName: "Bash",
+          toolId: item.id,
+          input: {
+            command: item.command,
+          },
+          rawInput: item,
+        },
+      })]
+    case "webSearch":
+      return [timestamped({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "web_search",
+          toolName: "WebSearch",
+          toolId: item.id,
+          input: {
+            query: webSearchQuery(item),
+          },
+          rawInput: item,
+        },
+      })]
+    case "mcpToolCall":
+      return [timestamped({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "mcp_generic",
+          toolName: `mcp__${item.server}__${item.tool}`,
+          toolId: item.id,
+          input: {
+            server: item.server,
+            tool: item.tool,
+            payload: item.arguments ?? {},
+          },
+          rawInput: item.arguments ?? {},
+        },
+      })]
+    case "fileChange":
+      return fileChangeToToolCalls(item)
+    case "plan":
+      return []
+    case "error":
+      return [timestamped({
+        kind: "tool_call",
+        tool: {
+          kind: "tool",
+          toolKind: "unknown_tool",
+          toolName: "Error",
+          toolId: item.id,
+          input: {
+            payload: item as unknown as Record<string, unknown>,
+          },
+          rawInput: item as unknown as Record<string, unknown>,
+        },
+      })]
+    default:
+      return []
+  }
+}
+
+function itemToToolResults(item: ThreadItem): TranscriptEntry[] {
+  switch (item.type) {
+    case "dynamicToolCall":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: dynamicContentToText(item.contentItems) || item,
+        isError: item.status === "failed" || item.success === false,
+      })]
+    case "collabAgentToolCall":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: item,
+        isError: item.status === "failed",
+      })]
+    case "commandExecution":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: item.aggregatedOutput ?? item,
+        isError: (typeof item.exitCode === "number" && item.exitCode !== 0) || item.status === "failed" || item.status === "declined",
+      })]
+    case "webSearch":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: item,
+      })]
+    case "mcpToolCall":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: contentFromMcpResult(item),
+        isError: item.status === "failed",
+      })]
+    case "fileChange":
+      return fileChangeToToolResults(item)
+    case "plan":
+      return []
+    case "error":
+      return [timestamped({
+        kind: "tool_result",
+        toolId: item.id,
+        content: item.message,
+        isError: true,
+      })]
+    default:
+      return []
+  }
+}
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+  private values: T[] = []
+  private resolvers: Array<(value: IteratorResult<T>) => void> = []
+  private done = false
+
+  push(value: T) {
+    if (this.done) return
+    const resolver = this.resolvers.shift()
+    if (resolver) {
+      resolver({ value, done: false })
+      return
+    }
+    this.values.push(value)
+  }
+
+  finish() {
+    if (this.done) return
+    this.done = true
+    while (this.resolvers.length > 0) {
+      const resolver = this.resolvers.shift()
+      resolver?.({ value: undefined as T, done: true })
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.values.length > 0) {
+          return Promise.resolve({ value: this.values.shift() as T, done: false })
+        }
+        if (this.done) {
+          return Promise.resolve({ value: undefined as T, done: true })
+        }
+        return new Promise<IteratorResult<T>>((resolve) => {
+          this.resolvers.push(resolve)
+        })
+      },
+    }
+  }
+}
+
+export class CodexAppServerManager {
+  private readonly sessions = new Map<string, SessionContext>()
+  private readonly spawnProcess: SpawnCodexAppServer
+
+  constructor(args: { spawnProcess?: SpawnCodexAppServer } = {}) {
+    this.spawnProcess = args.spawnProcess ?? ((cwd) =>
+      spawn("codex", ["app-server"], {
+        cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+      }) as unknown as CodexAppServerProcess)
+  }
+
+  async startSession(args: StartCodexSessionArgs) {
+    const existing = this.sessions.get(args.chatId)
+    if (existing && !existing.closed && existing.cwd === args.cwd) {
+      return
+    }
+
+    if (existing) {
+      this.stopSession(args.chatId)
+    }
+
+    const child = this.spawnProcess(args.cwd)
+    const context: SessionContext = {
+      chatId: args.chatId,
+      cwd: args.cwd,
+      child,
+      pendingRequests: new Map(),
+      pendingTurn: null,
+      sessionToken: null,
+      stderrLines: [],
+      closed: false,
+    }
+    this.sessions.set(args.chatId, context)
+    this.attachListeners(context)
+
+    await this.sendRequest(context, "initialize", {
+      clientInfo: {
+        name: "kanna_desktop",
+        title: "Kanna",
+        version: "0.1.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+    } satisfies InitializeParams)
+    this.writeMessage(context, {
+      method: "initialized",
+    })
+
+    const threadParams = {
+      model: args.model,
+      cwd: args.cwd,
+      serviceTier: args.serviceTier,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+      experimentalRawEvents: false,
+      persistExtendedHistory: false,
+    } satisfies ThreadStartParams
+
+    let response: ThreadStartResponse | ThreadResumeResponse
+    if (args.sessionToken) {
+      try {
+        response = await this.sendRequest<ThreadResumeResponse>(context, "thread/resume", {
+          threadId: args.sessionToken,
+          model: args.model,
+          cwd: args.cwd,
+          serviceTier: args.serviceTier,
+          approvalPolicy: "never",
+          sandbox: "danger-full-access",
+          persistExtendedHistory: false,
+        } satisfies ThreadResumeParams)
+      } catch (error) {
+        if (!isRecoverableResumeError(error)) {
+          this.stopSession(args.chatId)
+          throw error
+        }
+        response = await this.sendRequest<ThreadStartResponse>(context, "thread/start", threadParams)
+      }
+    } else {
+      response = await this.sendRequest<ThreadStartResponse>(context, "thread/start", threadParams)
+    }
+
+    context.sessionToken = response.thread.id
+  }
+
+  async startTurn(args: StartCodexTurnArgs): Promise<HarnessTurn> {
+    const context = this.requireSession(args.chatId)
+    if (context.pendingTurn) {
+      throw new Error("Codex turn is already running")
+    }
+
+    const queue = new AsyncQueue<HarnessEvent>()
+    if (context.sessionToken) {
+      queue.push({ type: "session_token", sessionToken: context.sessionToken })
+    }
+    queue.push({ type: "transcript", entry: codexSystemInitEntry(args.model) })
+
+    const pendingTurn: PendingTurn = {
+      turnId: null,
+      model: args.model,
+      planMode: args.planMode,
+      queue,
+      startedToolIds: new Set(),
+      handledDynamicToolIds: new Set(),
+      latestPlanExplanation: null,
+      latestPlanSteps: [],
+      latestPlanText: null,
+      planTextByItemId: new Map(),
+      todoSequence: 0,
+      pendingWebSearchResultToolId: null,
+      resolved: false,
+      onToolRequest: args.onToolRequest,
+      onApprovalRequest: args.onApprovalRequest,
+    }
+    context.pendingTurn = pendingTurn
+
+    try {
+      const response = await this.sendRequest<TurnStartResponse>(context, "turn/start", {
+        threadId: context.sessionToken ?? "",
+        input: [
+          {
+            type: "text",
+            text: args.content,
+            text_elements: [],
+          },
+        ],
+        approvalPolicy: "never",
+        model: args.model,
+        effort: args.effort,
+        serviceTier: args.serviceTier,
+        collaborationMode: {
+          mode: args.planMode ? "plan" : "default",
+          settings: {
+            model: args.model,
+            reasoning_effort: null,
+            developer_instructions: null,
+          },
+        },
+      } satisfies TurnStartParams)
+      if (context.pendingTurn) {
+        context.pendingTurn.turnId = response.turn.id
+      } else {
+        pendingTurn.turnId = response.turn.id
+      }
+    } catch (error) {
+      context.pendingTurn = null
+      queue.finish()
+      throw error
+    }
+
+    return {
+      provider: "codex",
+      stream: queue,
+      interrupt: async () => {
+        const pendingTurn = context.pendingTurn
+        if (!pendingTurn?.turnId || !context.sessionToken) return
+        await this.sendRequest(context, "turn/interrupt", {
+          threadId: context.sessionToken,
+          turnId: pendingTurn.turnId,
+        } satisfies TurnInterruptParams)
+      },
+      close: () => {},
+    }
+  }
+
+  stopSession(chatId: string) {
+    const context = this.sessions.get(chatId)
+    if (!context) return
+    context.closed = true
+    context.pendingTurn?.queue.finish()
+    this.sessions.delete(chatId)
+    try {
+      context.child.kill("SIGKILL")
+    } catch {
+      // ignore kill failures
+    }
+  }
+
+  stopAll() {
+    for (const chatId of this.sessions.keys()) {
+      this.stopSession(chatId)
+    }
+  }
+
+  private requireSession(chatId: string) {
+    const context = this.sessions.get(chatId)
+    if (!context || context.closed) {
+      throw new Error("Codex session not started")
+    }
+    return context
+  }
+
+  private attachListeners(context: SessionContext) {
+    const lines = createInterface({ input: context.child.stdout })
+    void (async () => {
+      for await (const line of lines) {
+        const parsed = parseJsonLine(line)
+        if (!parsed) continue
+
+        if (isJsonRpcResponse(parsed)) {
+          this.handleResponse(context, parsed)
+          continue
+        }
+
+        if (isServerRequest(parsed)) {
+          void this.handleServerRequest(context, parsed)
+          continue
+        }
+
+        if (isServerNotification(parsed)) {
+          void this.handleNotification(context, parsed)
+        }
+      }
+    })()
+
+    const stderr = createInterface({ input: context.child.stderr })
+    void (async () => {
+      for await (const line of stderr) {
+        if (line.trim()) {
+          context.stderrLines.push(line.trim())
+        }
+      }
+    })()
+
+    context.child.on("error", (error) => {
+      this.failContext(context, error.message)
+    })
+
+    context.child.on("close", (code) => {
+      if (context.closed) return
+      queueMicrotask(() => {
+        if (context.closed) return
+        const message = context.stderrLines.at(-1) || `Codex app-server exited with code ${code ?? 1}`
+        this.failContext(context, message)
+      })
+    })
+  }
+
+  private handleResponse(context: SessionContext, response: JsonRpcResponse) {
+    const pending = context.pendingRequests.get(response.id)
+    if (!pending) return
+    context.pendingRequests.delete(response.id)
+    if (response.error) {
+      pending.reject(new Error(`${pending.method} failed: ${response.error.message ?? "Unknown error"}`))
+      return
+    }
+    pending.resolve(response.result)
+  }
+
+  private async handleServerRequest(context: SessionContext, request: ServerRequest) {
+    const pendingTurn = context.pendingTurn
+    if (!pendingTurn) {
+      this.writeMessage(context, {
+        id: request.id,
+        error: {
+          message: "No active turn",
+        },
+      })
+      return
+    }
+
+    if (request.method === "item/tool/requestUserInput") {
+      const questions = toAskUserQuestionItems(request.params)
+      const toolId = request.params.itemId
+      const toolRequest: HarnessToolRequest = {
+        tool: {
+          kind: "tool",
+          toolKind: "ask_user_question",
+          toolName: "AskUserQuestion",
+          toolId,
+          input: { questions },
+          rawInput: {
+            questions: request.params.questions,
+          },
+        },
+      }
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "tool_call",
+          tool: toolRequest.tool,
+        }),
+      })
+
+      const result = await pendingTurn.onToolRequest(toolRequest)
+      this.writeMessage(context, {
+        id: request.id,
+        result: toToolRequestUserInputResponse(result, request.params.questions),
+      })
+      return
+    }
+
+    if (request.method === "item/tool/call") {
+      pendingTurn.handledDynamicToolIds.add(request.params.callId)
+      if (request.params.tool === "update_plan") {
+        const args = asRecord(request.params.arguments)
+        const plan = Array.isArray(args?.plan) ? args.plan : []
+        const steps: TurnPlanStep[] = plan
+          .map((entry) => asRecord(entry))
+          .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+          .map((entry) => {
+            const status: TurnPlanStep["status"] =
+              entry.status === "completed"
+                ? "completed"
+                : entry.status === "inProgress" || entry.status === "in_progress"
+                  ? "inProgress"
+                  : "pending"
+            return {
+              step: typeof entry.step === "string" ? entry.step : "",
+              status,
+            }
+          })
+          .filter((step) => step.step.length > 0)
+
+        if (steps.length > 0) {
+          pendingTurn.latestPlanSteps = steps
+          pendingTurn.latestPlanExplanation = typeof args?.explanation === "string" ? args.explanation : pendingTurn.latestPlanExplanation
+          pendingTurn.queue.push({
+            type: "transcript",
+            entry: todoToolCall(request.params.callId, steps),
+          })
+          pendingTurn.queue.push({
+            type: "transcript",
+            entry: timestamped({
+              kind: "tool_result",
+              toolId: request.params.callId,
+              content: "",
+            }),
+          })
+        }
+
+        this.writeMessage(context, {
+          id: request.id,
+          result: {
+            contentItems: [],
+            success: true,
+          } satisfies DynamicToolCallResponse,
+        })
+        return
+      }
+
+      const payload = dynamicToolPayload(request.params.arguments)
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: genericDynamicToolCall(request.params.callId, request.params.tool, payload),
+      })
+      const errorMessage = `Unsupported dynamic tool call: ${request.params.tool}`
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "tool_result",
+          toolId: request.params.callId,
+          content: errorMessage,
+          isError: true,
+        }),
+      })
+      this.writeMessage(context, {
+        id: request.id,
+        result: {
+          contentItems: [{ type: "inputText", text: errorMessage }],
+          success: false,
+        } satisfies DynamicToolCallResponse,
+      })
+      return
+    }
+
+    if (request.method === "item/commandExecution/requestApproval") {
+      const decision = await pendingTurn.onApprovalRequest?.({
+        requestId: request.id,
+        kind: "command_execution",
+        params: request.params,
+      }) ?? "decline"
+      this.writeMessage(context, {
+        id: request.id,
+        result: {
+          decision,
+        } satisfies CommandExecutionRequestApprovalResponse,
+      })
+      return
+    }
+
+    const decision = await pendingTurn.onApprovalRequest?.({
+      requestId: request.id,
+      kind: "file_change",
+      params: request.params,
+    }) ?? "decline"
+    this.writeMessage(context, {
+      id: request.id,
+      result: {
+        decision,
+      } satisfies FileChangeRequestApprovalResponse,
+    })
+  }
+
+  private async handleNotification(context: SessionContext, notification: ServerNotification) {
+    if (notification.method === "thread/started") {
+      context.sessionToken = notification.params.thread.id
+      if (context.pendingTurn) {
+        context.pendingTurn.queue.push({
+          type: "session_token",
+          sessionToken: notification.params.thread.id,
+        })
+      }
+      return
+    }
+
+    const pendingTurn = context.pendingTurn
+    if (!pendingTurn) return
+
+    switch (notification.method) {
+      case "turn/plan/updated":
+        this.handlePlanUpdated(pendingTurn, notification.params)
+        return
+      case "item/started":
+        this.handleItemStarted(pendingTurn, notification.params)
+        return
+      case "item/completed":
+        this.handleItemCompleted(pendingTurn, notification.params)
+        return
+      case "item/plan/delta":
+        this.handlePlanDelta(pendingTurn, notification.params)
+        return
+      case "turn/completed":
+        await this.handleTurnCompleted(context, notification.params)
+        return
+      case "thread/compacted":
+        this.handleContextCompacted(pendingTurn, notification.params)
+        return
+      case "error":
+        this.failContext(context, notification.params.message)
+        return
+      default:
+        return
+    }
+  }
+
+  private handleItemStarted(pendingTurn: PendingTurn, notification: ItemStartedNotification) {
+    if (notification.item.type === "plan") {
+      pendingTurn.planTextByItemId.set(notification.item.id, notification.item.text)
+      pendingTurn.latestPlanText = notification.item.text
+      return
+    }
+
+    if (
+      notification.item.type === "commandExecution"
+      || notification.item.type === "webSearch"
+      || notification.item.type === "mcpToolCall"
+      || notification.item.type === "dynamicToolCall"
+      || notification.item.type === "collabAgentToolCall"
+      || notification.item.type === "fileChange"
+      || notification.item.type === "error"
+    ) {
+      if (pendingTurn.handledDynamicToolIds.has(notification.item.id)) {
+        return
+      }
+      if (notification.item.type === "webSearch" && !webSearchQuery(notification.item)) {
+        return
+      }
+    }
+
+    const entries = itemToToolCalls(notification.item)
+    for (const entry of entries) {
+      if (entry.kind === "tool_call") {
+        pendingTurn.startedToolIds.add(entry.tool.toolId)
+      }
+      pendingTurn.queue.push({ type: "transcript", entry })
+    }
+  }
+
+  private handleItemCompleted(pendingTurn: PendingTurn, notification: ItemCompletedNotification) {
+    if (notification.item.type === "agentMessage") {
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "assistant_text",
+          text: notification.item.text,
+        }),
+      })
+      if (pendingTurn.pendingWebSearchResultToolId && notification.item.text.trim()) {
+        pendingTurn.queue.push({
+          type: "transcript",
+          entry: timestamped({
+            kind: "tool_result",
+            toolId: pendingTurn.pendingWebSearchResultToolId,
+            content: notification.item.text,
+          }),
+        })
+        pendingTurn.pendingWebSearchResultToolId = null
+      }
+      return
+    }
+
+    if (notification.item.type === "plan") {
+      pendingTurn.planTextByItemId.set(notification.item.id, notification.item.text)
+      pendingTurn.latestPlanText = notification.item.text
+      return
+    }
+
+    if (pendingTurn.handledDynamicToolIds.has(notification.item.id)) {
+      return
+    }
+
+    const startedEntries = itemToToolCalls(notification.item)
+    for (const entry of startedEntries) {
+      if (entry.kind !== "tool_call") {
+        continue
+      }
+      if (pendingTurn.startedToolIds.has(entry.tool.toolId)) {
+        continue
+      }
+      pendingTurn.startedToolIds.add(entry.tool.toolId)
+      pendingTurn.queue.push({ type: "transcript", entry })
+    }
+
+    const resultEntries = itemToToolResults(notification.item)
+    for (const entry of resultEntries) {
+      pendingTurn.queue.push({ type: "transcript", entry })
+      if (notification.item.type === "webSearch" && entry.kind === "tool_result" && !entry.isError) {
+        pendingTurn.pendingWebSearchResultToolId = notification.item.id
+      }
+    }
+  }
+
+  private handlePlanUpdated(pendingTurn: PendingTurn, notification: TurnPlanUpdatedNotification) {
+    pendingTurn.latestPlanExplanation = notification.explanation ?? null
+    pendingTurn.latestPlanSteps = notification.plan
+    if (notification.plan.length === 0) {
+      return
+    }
+    pendingTurn.todoSequence += 1
+    pendingTurn.queue.push({
+      type: "transcript",
+      entry: todoToolCall(
+        `${notification.turnId}:todo-${pendingTurn.todoSequence}`,
+        notification.plan
+      ),
+    })
+  }
+
+  private handlePlanDelta(pendingTurn: PendingTurn, notification: PlanDeltaNotification) {
+    const current = pendingTurn.planTextByItemId.get(notification.itemId) ?? ""
+    const next = `${current}${notification.delta}`
+    pendingTurn.planTextByItemId.set(notification.itemId, next)
+    pendingTurn.latestPlanText = next
+  }
+
+  private handleContextCompacted(pendingTurn: PendingTurn, _notification: ContextCompactedNotification) {
+    pendingTurn.queue.push({
+      type: "transcript",
+      entry: timestamped({ kind: "compact_boundary" }),
+    })
+  }
+
+  private async handleTurnCompleted(context: SessionContext, notification: TurnCompletedNotification) {
+    const pendingTurn = context.pendingTurn
+    if (!pendingTurn) return
+    const status = notification.turn.status
+    const isCancelled = status === "interrupted"
+    const isError = status === "failed"
+    pendingTurn.pendingWebSearchResultToolId = null
+
+    if (!isCancelled && !isError && pendingTurn.planMode) {
+      const planText = pendingTurn.latestPlanText?.trim()
+        || renderPlanMarkdownFromSteps(pendingTurn.latestPlanSteps).trim()
+
+      if (planText) {
+        pendingTurn.turnId = null
+        const tool = {
+          kind: "tool" as const,
+          toolKind: "exit_plan_mode" as const,
+          toolName: "ExitPlanMode",
+          toolId: `${notification.turn.id}:exit-plan`,
+          input: {
+            plan: planText,
+            summary: pendingTurn.latestPlanExplanation ?? undefined,
+          },
+          rawInput: {
+            plan: planText,
+            summary: pendingTurn.latestPlanExplanation ?? undefined,
+          },
+        }
+        pendingTurn.queue.push({
+          type: "transcript",
+          entry: timestamped({
+            kind: "tool_call",
+            tool,
+          }),
+        })
+        await pendingTurn.onToolRequest({ tool })
+        pendingTurn.resolved = true
+        pendingTurn.queue.finish()
+        context.pendingTurn = null
+        return
+      }
+    }
+
+    pendingTurn.resolved = true
+    pendingTurn.queue.push({
+      type: "transcript",
+      entry: timestamped({
+        kind: "result",
+        subtype: isCancelled ? "cancelled" : isError ? "error" : "success",
+        isError,
+        durationMs: 0,
+        result: notification.turn.error?.message ?? "",
+      }),
+    })
+    pendingTurn.queue.finish()
+    context.pendingTurn = null
+  }
+
+  private failContext(context: SessionContext, message: string) {
+    const pendingTurn = context.pendingTurn
+    if (pendingTurn && !pendingTurn.resolved) {
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: message,
+        }),
+      })
+      pendingTurn.queue.finish()
+      context.pendingTurn = null
+    }
+
+    for (const pending of context.pendingRequests.values()) {
+      pending.reject(new Error(message))
+    }
+    context.pendingRequests.clear()
+    context.closed = true
+  }
+
+  private async sendRequest<TResult>(context: SessionContext, method: string, params: unknown): Promise<TResult> {
+    const id = randomUUID()
+    const promise = new Promise<TResult>((resolve, reject) => {
+      context.pendingRequests.set(id, {
+        method,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      })
+    })
+    this.writeMessage(context, {
+      id,
+      method,
+      params,
+    })
+    return await promise
+  }
+
+  private writeMessage(context: SessionContext, message: Record<string, unknown>) {
+    context.child.stdin.write(`${JSON.stringify(message)}\n`)
+  }
+}

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -2,7 +2,7 @@ import { appendFile, mkdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { getDataDir, LOG_PREFIX } from "../shared/branding"
-import type { TranscriptEntry } from "../shared/types"
+import type { AgentProvider, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
 import {
   type ChatEvent,
@@ -29,6 +29,7 @@ export class EventStore {
   readonly dataDir = DATA_DIR
   readonly state: StoreState = createEmptyState()
   private writeChain = Promise.resolve()
+  private storageReset = false
 
   async initialize() {
     await mkdir(DATA_DIR, { recursive: true })
@@ -50,14 +51,31 @@ export class EventStore {
     }
   }
 
+  private async clearStorage() {
+    if (this.storageReset) return
+    this.storageReset = true
+    this.resetState()
+    await Promise.all([
+      Bun.write(SNAPSHOT_PATH, ""),
+      Bun.write(PROJECTS_LOG, ""),
+      Bun.write(CHATS_LOG, ""),
+      Bun.write(MESSAGES_LOG, ""),
+      Bun.write(TURNS_LOG, ""),
+    ])
+  }
+
   private async loadSnapshot() {
     const file = Bun.file(SNAPSHOT_PATH)
     if (!(await file.exists())) return
 
     try {
-      const parsed = (await file.json()) as SnapshotFile
+      const text = await file.text()
+      if (!text.trim()) return
+      const parsed = JSON.parse(text) as SnapshotFile
       if (parsed.v !== STORE_VERSION) {
-        throw new Error(`Unsupported snapshot version ${String(parsed.v)}`)
+        console.warn(`${LOG_PREFIX} Resetting local chat history for store version ${STORE_VERSION}`)
+        await this.clearStorage()
+        return
       }
       for (const project of parsed.projects) {
         this.state.projectsById.set(project.id, { ...project })
@@ -70,8 +88,8 @@ export class EventStore {
         this.state.messagesByChatId.set(messageSet.chatId, cloneTranscriptEntries(messageSet.entries))
       }
     } catch (error) {
-      console.warn(`${LOG_PREFIX} Failed to load snapshot, rebuilding from logs:`, error)
-      this.resetState()
+      console.warn(`${LOG_PREFIX} Failed to load snapshot, resetting local history:`, error)
+      await this.clearStorage()
     }
   }
 
@@ -83,9 +101,13 @@ export class EventStore {
   }
 
   private async replayLogs() {
+    if (this.storageReset) return
     await this.replayLog<ProjectEvent>(PROJECTS_LOG)
+    if (this.storageReset) return
     await this.replayLog<ChatEvent>(CHATS_LOG)
+    if (this.storageReset) return
     await this.replayLog<MessageEvent>(MESSAGES_LOG)
+    if (this.storageReset) return
     await this.replayLog<TurnEvent>(TURNS_LOG)
   }
 
@@ -108,14 +130,21 @@ export class EventStore {
       const line = lines[index].trim()
       if (!line) continue
       try {
-        const event = JSON.parse(line) as TEvent
-        this.applyEvent(event)
+        const event = JSON.parse(line) as Partial<StoreEvent>
+        if (event.v !== STORE_VERSION) {
+          console.warn(`${LOG_PREFIX} Resetting local history from incompatible event log`)
+          await this.clearStorage()
+          return
+        }
+        this.applyEvent(event as StoreEvent)
       } catch (error) {
         if (index === lastNonEmpty) {
           console.warn(`${LOG_PREFIX} Ignoring corrupt trailing line in ${path.basename(filePath)}`)
           return
         }
-        throw error
+        console.warn(`${LOG_PREFIX} Failed to replay ${path.basename(filePath)}, resetting local history:`, error)
+        await this.clearStorage()
+        return
       }
     }
   }
@@ -150,8 +179,9 @@ export class EventStore {
           title: event.title,
           createdAt: event.timestamp,
           updatedAt: event.timestamp,
+          provider: null,
           planMode: false,
-          resumeSessionId: null,
+          sessionToken: null,
           lastTurnOutcome: null,
         }
         this.state.chatsById.set(chat.id, chat)
@@ -171,6 +201,13 @@ export class EventStore {
         chat.updatedAt = event.timestamp
         break
       }
+      case "chat_provider_set": {
+        const chat = this.state.chatsById.get(event.chatId)
+        if (!chat) break
+        chat.provider = event.provider
+        chat.updatedAt = event.timestamp
+        break
+      }
       case "chat_plan_mode_set": {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
@@ -181,15 +218,8 @@ export class EventStore {
       case "message_appended": {
         const chat = this.state.chatsById.get(event.chatId)
         if (chat) {
-          // Only update lastMessageAt for user-sent messages so the sidebar
-          // sorts by "last sent" rather than "last received".
-          try {
-            const parsed = JSON.parse(event.entry.message)
-            if (parsed.type === "user_prompt") {
-              chat.lastMessageAt = event.entry.createdAt
-            }
-          } catch {
-            // non-JSON entry, skip
+          if (event.entry.kind === "user_prompt") {
+            chat.lastMessageAt = event.entry.createdAt
           }
           chat.updatedAt = Math.max(chat.updatedAt, event.entry.createdAt)
         }
@@ -225,10 +255,10 @@ export class EventStore {
         chat.lastTurnOutcome = "cancelled"
         break
       }
-      case "resume_session_set": {
+      case "session_token_set": {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
-        chat.resumeSessionId = event.sessionId
+        chat.sessionToken = event.sessionToken
         chat.updatedAt = event.timestamp
         break
       }
@@ -326,6 +356,19 @@ export class EventStore {
     await this.append(CHATS_LOG, event)
   }
 
+  async setChatProvider(chatId: string, provider: AgentProvider) {
+    const chat = this.requireChat(chatId)
+    if (chat.provider === provider) return
+    const event: ChatEvent = {
+      v: STORE_VERSION,
+      type: "chat_provider_set",
+      timestamp: Date.now(),
+      chatId,
+      provider,
+    }
+    await this.append(CHATS_LOG, event)
+  }
+
   async setPlanMode(chatId: string, planMode: boolean) {
     const chat = this.requireChat(chatId)
     if (chat.planMode === planMode) return
@@ -396,15 +439,15 @@ export class EventStore {
     await this.append(TURNS_LOG, event)
   }
 
-  async setResumeSession(chatId: string, sessionId: string | null) {
+  async setSessionToken(chatId: string, sessionToken: string | null) {
     const chat = this.requireChat(chatId)
-    if (chat.resumeSessionId === sessionId) return
+    if (chat.sessionToken === sessionToken) return
     const event: TurnEvent = {
       v: STORE_VERSION,
-      type: "resume_session_set",
+      type: "session_token_set",
       timestamp: Date.now(),
       chatId,
-      sessionId,
+      sessionToken,
     }
     await this.append(TURNS_LOG, event)
   }
@@ -460,19 +503,23 @@ export class EventStore {
         entries: cloneTranscriptEntries(entries),
       })),
     }
+
     await Bun.write(SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2))
-    await Bun.write(PROJECTS_LOG, "")
-    await Bun.write(CHATS_LOG, "")
-    await Bun.write(MESSAGES_LOG, "")
-    await Bun.write(TURNS_LOG, "")
+    await Promise.all([
+      Bun.write(PROJECTS_LOG, ""),
+      Bun.write(CHATS_LOG, ""),
+      Bun.write(MESSAGES_LOG, ""),
+      Bun.write(TURNS_LOG, ""),
+    ])
   }
 
   private async shouldCompact() {
-    const files = [PROJECTS_LOG, CHATS_LOG, MESSAGES_LOG, TURNS_LOG]
-    let total = 0
-    for (const filePath of files) {
-      total += Bun.file(filePath).size
-    }
-    return total >= COMPACTION_THRESHOLD_BYTES
+    const sizes = await Promise.all([
+      Bun.file(PROJECTS_LOG).size,
+      Bun.file(CHATS_LOG).size,
+      Bun.file(MESSAGES_LOG).size,
+      Bun.file(TURNS_LOG).size,
+    ])
+    return sizes.reduce((total, size) => total + size, 0) >= COMPACTION_THRESHOLD_BYTES
   }
 }

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,4 +1,4 @@
-import type { ProjectSummary, TranscriptEntry } from "../shared/types"
+import type { AgentProvider, ProjectSummary, TranscriptEntry } from "../shared/types"
 
 export interface ProjectRecord extends ProjectSummary {
   deletedAt?: number
@@ -11,8 +11,9 @@ export interface ChatRecord {
   createdAt: number
   updatedAt: number
   deletedAt?: number
+  provider: AgentProvider | null
   planMode: boolean
-  resumeSessionId: string | null
+  sessionToken: string | null
   lastMessageAt?: number
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
 }
@@ -25,7 +26,7 @@ export interface StoreState {
 }
 
 export interface SnapshotFile {
-  v: 1
+  v: 2
   generatedAt: number
   projects: ProjectRecord[]
   chats: ChatRecord[]
@@ -33,14 +34,14 @@ export interface SnapshotFile {
 }
 
 export type ProjectEvent = {
-  v: 1
+  v: 2
   type: "project_opened"
   timestamp: number
   projectId: string
   localPath: string
   title: string
 } | {
-  v: 1
+  v: 2
   type: "project_removed"
   timestamp: number
   projectId: string
@@ -48,7 +49,7 @@ export type ProjectEvent = {
 
 export type ChatEvent =
   | {
-      v: 1
+      v: 2
       type: "chat_created"
       timestamp: number
       chatId: string
@@ -56,20 +57,27 @@ export type ChatEvent =
       title: string
     }
   | {
-      v: 1
+      v: 2
       type: "chat_renamed"
       timestamp: number
       chatId: string
       title: string
     }
   | {
-      v: 1
+      v: 2
       type: "chat_deleted"
       timestamp: number
       chatId: string
     }
   | {
-      v: 1
+      v: 2
+      type: "chat_provider_set"
+      timestamp: number
+      chatId: string
+      provider: AgentProvider
+    }
+  | {
+      v: 2
       type: "chat_plan_mode_set"
       timestamp: number
       chatId: string
@@ -77,7 +85,7 @@ export type ChatEvent =
     }
 
 export type MessageEvent = {
-  v: 1
+  v: 2
   type: "message_appended"
   timestamp: number
   chatId: string
@@ -86,36 +94,36 @@ export type MessageEvent = {
 
 export type TurnEvent =
   | {
-      v: 1
+      v: 2
       type: "turn_started"
       timestamp: number
       chatId: string
     }
   | {
-      v: 1
+      v: 2
       type: "turn_finished"
       timestamp: number
       chatId: string
     }
   | {
-      v: 1
+      v: 2
       type: "turn_failed"
       timestamp: number
       chatId: string
       error: string
     }
   | {
-      v: 1
+      v: 2
       type: "turn_cancelled"
       timestamp: number
       chatId: string
     }
   | {
-      v: 1
-      type: "resume_session_set"
+      v: 2
+      type: "session_token_set"
       timestamp: number
       chatId: string
-      sessionId: string | null
+      sessionToken: string | null
     }
 
 export type StoreEvent = ProjectEvent | ChatEvent | MessageEvent | TurnEvent

--- a/src/server/harness-types.ts
+++ b/src/server/harness-types.ts
@@ -1,0 +1,19 @@
+import type { AccountInfo, AgentProvider, NormalizedToolCall, TranscriptEntry } from "../shared/types"
+
+export interface HarnessEvent {
+  type: "transcript" | "session_token"
+  entry?: TranscriptEntry
+  sessionToken?: string
+}
+
+export interface HarnessToolRequest {
+  tool: NormalizedToolCall & { toolKind: "ask_user_question" | "exit_plan_mode" }
+}
+
+export interface HarnessTurn {
+  provider: AgentProvider
+  stream: AsyncIterable<HarnessEvent>
+  getAccountInfo?: () => Promise<AccountInfo | null>
+  interrupt: () => Promise<void>
+  close: () => void
+}

--- a/src/server/provider-catalog.test.ts
+++ b/src/server/provider-catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import {
+  codexServiceTierFromModelOptions,
+  normalizeClaudeModelOptions,
+  normalizeCodexModelOptions,
+} from "./provider-catalog"
+
+describe("provider catalog normalization", () => {
+  test("maps legacy Claude effort into shared model options", () => {
+    expect(normalizeClaudeModelOptions(undefined, "max")).toEqual({
+      reasoningEffort: "max",
+    })
+  })
+
+  test("normalizes Codex model options and fast mode defaults", () => {
+    expect(normalizeCodexModelOptions(undefined)).toEqual({
+      reasoningEffort: "high",
+      fastMode: false,
+    })
+
+    const normalized = normalizeCodexModelOptions({
+      codex: {
+        reasoningEffort: "xhigh",
+        fastMode: true,
+      },
+    })
+
+    expect(normalized).toEqual({
+      reasoningEffort: "xhigh",
+      fastMode: true,
+    })
+    expect(codexServiceTierFromModelOptions(normalized)).toBe("fast")
+  })
+})

--- a/src/server/provider-catalog.ts
+++ b/src/server/provider-catalog.ts
@@ -1,0 +1,77 @@
+import type {
+  AgentProvider,
+  ClaudeModelOptions,
+  CodexModelOptions,
+  ModelOptions,
+  ProviderCatalogEntry,
+  ProviderModelOption,
+  ServiceTier,
+} from "../shared/types"
+import {
+  DEFAULT_CLAUDE_MODEL_OPTIONS,
+  DEFAULT_CODEX_MODEL_OPTIONS,
+  PROVIDERS,
+  isClaudeReasoningEffort,
+  isCodexReasoningEffort,
+} from "../shared/types"
+
+const HARD_CODED_CODEX_MODELS: ProviderModelOption[] = [
+  { id: "gpt-5.4", label: "GPT-5.4", supportsEffort: false },
+  { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: false },
+  { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark", supportsEffort: false },
+]
+
+export const SERVER_PROVIDERS: ProviderCatalogEntry[] = PROVIDERS.map((provider) =>
+  provider.id === "codex"
+    ? {
+        ...provider,
+        defaultModel: "gpt-5.4",
+        models: HARD_CODED_CODEX_MODELS,
+      }
+    : provider
+)
+
+export function getServerProviderCatalog(provider: AgentProvider): ProviderCatalogEntry {
+  const entry = SERVER_PROVIDERS.find((candidate) => candidate.id === provider)
+  if (!entry) {
+    throw new Error(`Unknown provider: ${provider}`)
+  }
+  return entry
+}
+
+export function normalizeServerModel(provider: AgentProvider, model?: string): string {
+  const catalog = getServerProviderCatalog(provider)
+  if (model && catalog.models.some((candidate) => candidate.id === model)) {
+    return model
+  }
+  return catalog.defaultModel
+}
+
+export function normalizeClaudeModelOptions(modelOptions?: ModelOptions, legacyEffort?: string): ClaudeModelOptions {
+  const reasoningEffort = modelOptions?.claude?.reasoningEffort
+  return {
+    reasoningEffort: isClaudeReasoningEffort(reasoningEffort)
+      ? reasoningEffort
+      : isClaudeReasoningEffort(legacyEffort)
+        ? legacyEffort
+        : DEFAULT_CLAUDE_MODEL_OPTIONS.reasoningEffort,
+  }
+}
+
+export function normalizeCodexModelOptions(modelOptions?: ModelOptions, legacyEffort?: string): CodexModelOptions {
+  const reasoningEffort = modelOptions?.codex?.reasoningEffort
+  return {
+    reasoningEffort: isCodexReasoningEffort(reasoningEffort)
+      ? reasoningEffort
+      : isCodexReasoningEffort(legacyEffort)
+        ? legacyEffort
+        : DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort,
+    fastMode: typeof modelOptions?.codex?.fastMode === "boolean"
+      ? modelOptions.codex.fastMode
+      : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,
+  }
+}
+
+export function codexServiceTierFromModelOptions(modelOptions: CodexModelOptions): ServiceTier | undefined {
+  return modelOptions.fastMode ? "fast" : undefined
+}

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { deriveChatSnapshot, deriveSidebarData } from "./read-models"
+import { createEmptyState } from "./events"
+
+describe("read models", () => {
+  test("include provider data in sidebar rows", () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "codex",
+      planMode: false,
+      sessionToken: "thread-1",
+      lastTurnOutcome: null,
+    })
+
+    const sidebar = deriveSidebarData(state, new Map())
+    expect(sidebar.projectGroups[0]?.chats[0]?.provider).toBe("codex")
+  })
+
+  test("includes available providers in chat snapshots", () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "claude",
+      planMode: true,
+      sessionToken: "session-1",
+      lastTurnOutcome: null,
+    })
+
+    const chat = deriveChatSnapshot(state, new Map(), "chat-1")
+    expect(chat?.runtime.provider).toBe("claude")
+    expect(chat?.availableProviders.length).toBeGreaterThan(1)
+    expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
+      "gpt-5.4",
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+    ])
+  })
+})

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -10,6 +10,7 @@ import type {
 import type { ChatRecord, StoreState } from "./events"
 import { cloneTranscriptEntries } from "./events"
 import { resolveLocalPath } from "./paths"
+import { SERVER_PROVIDERS } from "./provider-catalog"
 
 export function deriveStatus(chat: ChatRecord, activeStatus?: KannaStatus): KannaStatus {
   if (activeStatus) return activeStatus
@@ -36,6 +37,7 @@ export function deriveSidebarData(
         title: chat.title,
         status: deriveStatus(chat, activeStatuses.get(chat.id)),
         localPath: project.localPath,
+        provider: chat.provider,
         lastMessageAt: chat.lastMessageAt,
         hasAutomation: false,
       }))
@@ -109,12 +111,14 @@ export function deriveChatSnapshot(
     localPath: project.localPath,
     title: chat.title,
     status: deriveStatus(chat, activeStatuses.get(chat.id)),
+    provider: chat.provider,
     planMode: chat.planMode,
-    resumeSessionId: chat.resumeSessionId,
+    sessionToken: chat.sessionToken,
   }
 
   return {
     runtime,
     messages: cloneTranscriptEntries(state.messagesByChatId.get(chat.id) ?? []),
+    availableProviders: [...SERVER_PROVIDERS],
   }
 }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1,4 +1,4 @@
-import type { ChatSnapshot, LocalProjectsSnapshot, SidebarData } from "./types"
+import type { AgentProvider, ChatSnapshot, LocalProjectsSnapshot, ModelOptions, SidebarData } from "./types"
 
 export type SubscriptionTopic =
   | { type: "sidebar" }
@@ -13,7 +13,17 @@ export type ClientCommand =
   | { type: "chat.create"; projectId: string }
   | { type: "chat.rename"; chatId: string; title: string }
   | { type: "chat.delete"; chatId: string }
-  | { type: "chat.send"; chatId?: string; projectId?: string; content: string; model?: string; effort?: string; planMode?: boolean }
+  | {
+      type: "chat.send"
+      chatId?: string
+      projectId?: string
+      provider?: AgentProvider
+      content: string
+      model?: string
+      modelOptions?: ModelOptions
+      effort?: string
+      planMode?: boolean
+    }
   | { type: "chat.cancel"; chatId: string }
   | { type: "chat.respondTool"; chatId: string; toolUseId: string; result: unknown }
 

--- a/src/shared/tools.test.ts
+++ b/src/shared/tools.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { hydrateToolResult, normalizeToolCall } from "./tools"
+
+describe("normalizeToolCall", () => {
+  test("maps AskUserQuestion input to typed questions", () => {
+    const tool = normalizeToolCall({
+      toolName: "AskUserQuestion",
+      toolId: "tool-1",
+      input: {
+        questions: [
+          {
+            question: "Which runtime?",
+            header: "Runtime",
+            options: [{ label: "Codex", description: "Use Codex" }],
+          },
+        ],
+      },
+    })
+
+    expect(tool.toolKind).toBe("ask_user_question")
+    if (tool.toolKind !== "ask_user_question") throw new Error("unexpected tool kind")
+    expect(tool.input.questions[0]?.question).toBe("Which runtime?")
+  })
+
+  test("maps Bash snake_case input to camelCase", () => {
+    const tool = normalizeToolCall({
+      toolName: "Bash",
+      toolId: "tool-2",
+      input: {
+        command: "pwd",
+        timeout: 5000,
+        run_in_background: true,
+      },
+    })
+
+    expect(tool.toolKind).toBe("bash")
+    if (tool.toolKind !== "bash") throw new Error("unexpected tool kind")
+    expect(tool.input.timeoutMs).toBe(5000)
+    expect(tool.input.runInBackground).toBe(true)
+  })
+
+  test("maps unknown MCP tools to mcp_generic", () => {
+    const tool = normalizeToolCall({
+      toolName: "mcp__sentry__search_issues",
+      toolId: "tool-3",
+      input: { query: "regression" },
+    })
+
+    expect(tool.toolKind).toBe("mcp_generic")
+    if (tool.toolKind !== "mcp_generic") throw new Error("unexpected tool kind")
+    expect(tool.input.server).toBe("sentry")
+    expect(tool.input.tool).toBe("search_issues")
+  })
+})
+
+describe("hydrateToolResult", () => {
+  test("hydrates AskUserQuestion answers", () => {
+    const tool = normalizeToolCall({
+      toolName: "AskUserQuestion",
+      toolId: "tool-1",
+      input: { questions: [] },
+    })
+
+    const result = hydrateToolResult(tool, JSON.stringify({ answers: { runtime: "codex" } }))
+    expect(result).toEqual({ answers: { runtime: "codex" } })
+  })
+
+  test("hydrates ExitPlanMode decisions", () => {
+    const tool = normalizeToolCall({
+      toolName: "ExitPlanMode",
+      toolId: "tool-2",
+      input: { plan: "Do the thing" },
+    })
+
+    const result = hydrateToolResult(tool, { confirmed: true, clearContext: true })
+    expect(result).toEqual({ confirmed: true, clearContext: true, message: undefined })
+  })
+
+  test("hydrates Read file text results", () => {
+    const tool = normalizeToolCall({
+      toolName: "Read",
+      toolId: "tool-3",
+      input: { file_path: "/tmp/example.ts" },
+    })
+
+    expect(hydrateToolResult(tool, "line 1\nline 2")).toBe("line 1\nline 2")
+  })
+})

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -1,0 +1,233 @@
+import type {
+  AskUserQuestionItem,
+  AskUserQuestionToolResult,
+  ExitPlanModeToolResult,
+  HydratedToolCall,
+  NormalizedToolCall,
+  ReadFileToolResult,
+  TodoItem,
+} from "./types"
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+export function normalizeToolCall(args: {
+  toolName: string
+  toolId: string
+  input: Record<string, unknown>
+}): NormalizedToolCall {
+  const { toolName, toolId, input } = args
+
+  switch (toolName) {
+    case "AskUserQuestion":
+      return {
+        kind: "tool",
+        toolKind: "ask_user_question",
+        toolName,
+        toolId,
+        input: {
+          questions: Array.isArray(input.questions) ? (input.questions as AskUserQuestionItem[]) : [],
+        },
+        rawInput: input,
+      }
+    case "ExitPlanMode":
+      return {
+        kind: "tool",
+        toolKind: "exit_plan_mode",
+        toolName,
+        toolId,
+        input: {
+          plan: typeof input.plan === "string" ? input.plan : undefined,
+          summary: typeof input.summary === "string" ? input.summary : undefined,
+        },
+        rawInput: input,
+      }
+    case "TodoWrite":
+      return {
+        kind: "tool",
+        toolKind: "todo_write",
+        toolName,
+        toolId,
+        input: {
+          todos: Array.isArray(input.todos) ? (input.todos as TodoItem[]) : [],
+        },
+        rawInput: input,
+      }
+    case "Skill":
+      return {
+        kind: "tool",
+        toolKind: "skill",
+        toolName,
+        toolId,
+        input: {
+          skill: typeof input.skill === "string" ? input.skill : "",
+        },
+        rawInput: input,
+      }
+    case "Glob":
+      return {
+        kind: "tool",
+        toolKind: "glob",
+        toolName,
+        toolId,
+        input: {
+          pattern: typeof input.pattern === "string" ? input.pattern : "",
+        },
+        rawInput: input,
+      }
+    case "Grep":
+      return {
+        kind: "tool",
+        toolKind: "grep",
+        toolName,
+        toolId,
+        input: {
+          pattern: typeof input.pattern === "string" ? input.pattern : "",
+          outputMode: typeof input.output_mode === "string" ? input.output_mode : undefined,
+        },
+        rawInput: input,
+      }
+    case "Bash":
+      return {
+        kind: "tool",
+        toolKind: "bash",
+        toolName,
+        toolId,
+        input: {
+          command: typeof input.command === "string" ? input.command : "",
+          description: typeof input.description === "string" ? input.description : undefined,
+          timeoutMs: typeof input.timeout === "number" ? input.timeout : undefined,
+          runInBackground: Boolean(input.run_in_background),
+        },
+        rawInput: input,
+      }
+    case "WebSearch":
+      return {
+        kind: "tool",
+        toolKind: "web_search",
+        toolName,
+        toolId,
+        input: {
+          query: typeof input.query === "string" ? input.query : "",
+        },
+        rawInput: input,
+      }
+    case "Read":
+      return {
+        kind: "tool",
+        toolKind: "read_file",
+        toolName,
+        toolId,
+        input: {
+          filePath: typeof input.file_path === "string" ? input.file_path : "",
+        },
+        rawInput: input,
+      }
+    case "Write":
+      return {
+        kind: "tool",
+        toolKind: "write_file",
+        toolName,
+        toolId,
+        input: {
+          filePath: typeof input.file_path === "string" ? input.file_path : "",
+          content: typeof input.content === "string" ? input.content : "",
+        },
+        rawInput: input,
+      }
+    case "Edit":
+      return {
+        kind: "tool",
+        toolKind: "edit_file",
+        toolName,
+        toolId,
+        input: {
+          filePath: typeof input.file_path === "string" ? input.file_path : "",
+          oldString: typeof input.old_string === "string" ? input.old_string : "",
+          newString: typeof input.new_string === "string" ? input.new_string : "",
+        },
+        rawInput: input,
+      }
+  }
+
+  const mcpMatch = toolName.match(/^mcp__(.+?)__(.+)$/)
+  if (mcpMatch) {
+    return {
+      kind: "tool",
+      toolKind: "mcp_generic",
+      toolName,
+      toolId,
+      input: {
+        server: mcpMatch[1],
+        tool: mcpMatch[2],
+        payload: input,
+      },
+      rawInput: input,
+    }
+  }
+
+  if (typeof input.subagent_type === "string") {
+    return {
+      kind: "tool",
+      toolKind: "subagent_task",
+      toolName,
+      toolId,
+      input: {
+        subagentType: input.subagent_type,
+      },
+      rawInput: input,
+    }
+  }
+
+  return {
+    kind: "tool",
+    toolKind: "unknown_tool",
+    toolName,
+    toolId,
+    input: {
+      payload: input,
+    },
+    rawInput: input,
+  }
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+export function hydrateToolResult(tool: NormalizedToolCall, raw: unknown): HydratedToolCall["result"] {
+  const parsed = parseJsonValue(raw)
+
+  switch (tool.toolKind) {
+    case "ask_user_question": {
+      const record = asRecord(parsed)
+      const answers = asRecord(record?.answers) ?? (record ? record : {})
+      return { answers: Object.fromEntries(Object.entries(answers).map(([key, value]) => [key, String(value)])) } satisfies AskUserQuestionToolResult
+    }
+    case "exit_plan_mode": {
+      const record = asRecord(parsed)
+      return {
+        confirmed: typeof record?.confirmed === "boolean" ? record.confirmed : undefined,
+        clearContext: typeof record?.clearContext === "boolean" ? record.clearContext : undefined,
+        message: typeof record?.message === "string" ? record.message : undefined,
+      } satisfies ExitPlanModeToolResult
+    }
+    case "read_file":
+      if (typeof parsed === "string") {
+        return parsed
+      }
+      const record = asRecord(parsed)
+      return {
+        content: typeof record?.content === "string" ? record.content : JSON.stringify(parsed, null, 2),
+      } satisfies ReadFileToolResult
+    default:
+      return parsed
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,118 @@
-export const STORE_VERSION = 1 as const
+export const STORE_VERSION = 2 as const
 export const PROTOCOL_VERSION = 1 as const
+
+export type AgentProvider = "claude" | "codex"
+
+export interface ProviderModelOption {
+  id: string
+  label: string
+  supportsEffort: boolean
+}
+
+export interface ProviderEffortOption {
+  id: string
+  label: string
+}
+
+export const CLAUDE_REASONING_OPTIONS = [
+  { id: "low", label: "Low" },
+  { id: "medium", label: "Medium" },
+  { id: "high", label: "High" },
+  { id: "max", label: "Max" },
+] as const satisfies readonly ProviderEffortOption[]
+
+export const CODEX_REASONING_OPTIONS = [
+  { id: "minimal", label: "Minimal" },
+  { id: "low", label: "Low" },
+  { id: "medium", label: "Medium" },
+  { id: "high", label: "High" },
+  { id: "xhigh", label: "XHigh" },
+] as const satisfies readonly ProviderEffortOption[]
+
+export type ClaudeReasoningEffort = (typeof CLAUDE_REASONING_OPTIONS)[number]["id"]
+export type CodexReasoningEffort = (typeof CODEX_REASONING_OPTIONS)[number]["id"]
+export type ServiceTier = "fast"
+
+export interface ClaudeModelOptions {
+  reasoningEffort: ClaudeReasoningEffort
+}
+
+export interface CodexModelOptions {
+  reasoningEffort: CodexReasoningEffort
+  fastMode: boolean
+}
+
+export interface ProviderModelOptionsByProvider {
+  claude: ClaudeModelOptions
+  codex: CodexModelOptions
+}
+
+export type ModelOptions = Partial<{
+  [K in AgentProvider]: Partial<ProviderModelOptionsByProvider[K]>
+}>
+
+export const DEFAULT_CLAUDE_MODEL_OPTIONS = {
+  reasoningEffort: "high",
+} as const satisfies ClaudeModelOptions
+
+export const DEFAULT_CODEX_MODEL_OPTIONS = {
+  reasoningEffort: "high",
+  fastMode: false,
+} as const satisfies CodexModelOptions
+
+export function isClaudeReasoningEffort(value: unknown): value is ClaudeReasoningEffort {
+  return CLAUDE_REASONING_OPTIONS.some((option) => option.id === value)
+}
+
+export function isCodexReasoningEffort(value: unknown): value is CodexReasoningEffort {
+  return CODEX_REASONING_OPTIONS.some((option) => option.id === value)
+}
+
+export interface ProviderCatalogEntry {
+  id: AgentProvider
+  label: string
+  defaultModel: string
+  defaultEffort?: string
+  supportsPlanMode: boolean
+  models: ProviderModelOption[]
+  efforts: ProviderEffortOption[]
+}
+
+export const PROVIDERS: ProviderCatalogEntry[] = [
+  {
+    id: "claude",
+    label: "Claude",
+    defaultModel: "opus",
+    defaultEffort: "high",
+    supportsPlanMode: true,
+    models: [
+      { id: "opus", label: "Opus", supportsEffort: true },
+      { id: "sonnet", label: "Sonnet", supportsEffort: true },
+      { id: "haiku", label: "Haiku", supportsEffort: true },
+    ],
+    efforts: [...CLAUDE_REASONING_OPTIONS],
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    defaultModel: "gpt-5.4",
+    supportsPlanMode: true,
+    models: [
+      { id: "gpt-5.4", label: "GPT-5.4", supportsEffort: false },
+      { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: false },
+      { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark", supportsEffort: false },
+    ],
+    efforts: [],
+  },
+]
+
+export function getProviderCatalog(provider: AgentProvider): ProviderCatalogEntry {
+  const entry = PROVIDERS.find((candidate) => candidate.id === provider)
+  if (!entry) {
+    throw new Error(`Unknown provider: ${provider}`)
+  }
+  return entry
+}
 
 export type KannaStatus =
   | "idle"
@@ -23,6 +136,7 @@ export interface SidebarChatRow {
   title: string
   status: KannaStatus
   localPath: string
+  provider: AgentProvider | null
   lastMessageAt?: number
   hasAutomation: boolean
 }
@@ -53,13 +167,296 @@ export interface LocalProjectsSnapshot {
   projects: LocalProjectSummary[]
 }
 
-export interface TranscriptEntry {
+export interface McpServerInfo {
+  name: string
+  status: string
+  error?: string
+}
+
+export interface AccountInfo {
+  email?: string
+  organization?: string
+  subscriptionType?: string
+  tokenSource?: string
+  apiKeySource?: string
+}
+
+export interface AskUserQuestionOption {
+  label: string
+  description?: string
+}
+
+export interface AskUserQuestionItem {
+  id?: string
+  question: string
+  header?: string
+  options?: AskUserQuestionOption[]
+  multiSelect?: boolean
+}
+
+export interface TodoItem {
+  content: string
+  status: "pending" | "in_progress" | "completed"
+  activeForm: string
+}
+
+interface TranscriptEntryBase {
   _id: string
   messageId?: string
-  message: string
   createdAt: number
   hidden?: boolean
+  debugRaw?: string
 }
+
+interface ToolCallBase<TKind extends string, TInput> {
+  kind: "tool"
+  toolKind: TKind
+  toolName: string
+  toolId: string
+  input: TInput
+  rawInput?: Record<string, unknown>
+}
+
+export interface AskUserQuestionToolCall
+  extends ToolCallBase<"ask_user_question", { questions: AskUserQuestionItem[] }> {}
+
+export interface ExitPlanModeToolCall
+  extends ToolCallBase<"exit_plan_mode", { plan?: string; summary?: string }> {}
+
+export interface TodoWriteToolCall
+  extends ToolCallBase<"todo_write", { todos: TodoItem[] }> {}
+
+export interface SkillToolCall
+  extends ToolCallBase<"skill", { skill: string }> {}
+
+export interface GlobToolCall
+  extends ToolCallBase<"glob", { pattern: string }> {}
+
+export interface GrepToolCall
+  extends ToolCallBase<"grep", { pattern: string; outputMode?: string }> {}
+
+export interface BashToolCall
+  extends ToolCallBase<"bash", { command: string; description?: string; timeoutMs?: number; runInBackground?: boolean }> {}
+
+export interface WebSearchToolCall
+  extends ToolCallBase<"web_search", { query: string }> {}
+
+export interface ReadFileToolCall
+  extends ToolCallBase<"read_file", { filePath: string }> {}
+
+export interface WriteFileToolCall
+  extends ToolCallBase<"write_file", { filePath: string; content: string }> {}
+
+export interface EditFileToolCall
+  extends ToolCallBase<"edit_file", { filePath: string; oldString: string; newString: string }> {}
+
+export interface SubagentTaskToolCall
+  extends ToolCallBase<"subagent_task", { subagentType?: string }> {}
+
+export interface McpGenericToolCall
+  extends ToolCallBase<"mcp_generic", { server: string; tool: string; payload: Record<string, unknown> }> {}
+
+export interface UnknownToolCall
+  extends ToolCallBase<"unknown_tool", { payload: Record<string, unknown> }> {}
+
+export type NormalizedToolCall =
+  | AskUserQuestionToolCall
+  | ExitPlanModeToolCall
+  | TodoWriteToolCall
+  | SkillToolCall
+  | GlobToolCall
+  | GrepToolCall
+  | BashToolCall
+  | WebSearchToolCall
+  | ReadFileToolCall
+  | WriteFileToolCall
+  | EditFileToolCall
+  | SubagentTaskToolCall
+  | McpGenericToolCall
+  | UnknownToolCall
+
+export interface ToolResultEntry extends TranscriptEntryBase {
+  kind: "tool_result"
+  toolId: string
+  content: unknown
+  isError?: boolean
+}
+
+export interface UserPromptEntry extends TranscriptEntryBase {
+  kind: "user_prompt"
+  content: string
+}
+
+export interface SystemInitEntry extends TranscriptEntryBase {
+  kind: "system_init"
+  provider: AgentProvider
+  model: string
+  tools: string[]
+  agents: string[]
+  slashCommands: string[]
+  mcpServers: McpServerInfo[]
+}
+
+export interface AccountInfoEntry extends TranscriptEntryBase {
+  kind: "account_info"
+  accountInfo: AccountInfo
+}
+
+export interface AssistantTextEntry extends TranscriptEntryBase {
+  kind: "assistant_text"
+  text: string
+}
+
+export interface ToolCallEntry extends TranscriptEntryBase {
+  kind: "tool_call"
+  tool: NormalizedToolCall
+}
+
+export interface ResultEntry extends TranscriptEntryBase {
+  kind: "result"
+  subtype: "success" | "error" | "cancelled"
+  isError: boolean
+  durationMs: number
+  result: string
+  costUsd?: number
+}
+
+export interface StatusEntry extends TranscriptEntryBase {
+  kind: "status"
+  status: string
+}
+
+export interface CompactBoundaryEntry extends TranscriptEntryBase {
+  kind: "compact_boundary"
+}
+
+export interface CompactSummaryEntry extends TranscriptEntryBase {
+  kind: "compact_summary"
+  summary: string
+}
+
+export interface ContextClearedEntry extends TranscriptEntryBase {
+  kind: "context_cleared"
+}
+
+export interface InterruptedEntry extends TranscriptEntryBase {
+  kind: "interrupted"
+}
+
+export type TranscriptEntry =
+  | UserPromptEntry
+  | SystemInitEntry
+  | AccountInfoEntry
+  | AssistantTextEntry
+  | ToolCallEntry
+  | ToolResultEntry
+  | ResultEntry
+  | StatusEntry
+  | CompactBoundaryEntry
+  | CompactSummaryEntry
+  | ContextClearedEntry
+  | InterruptedEntry
+
+export interface HydratedToolCallBase<TKind extends string, TInput, TResult> {
+  id: string
+  messageId?: string
+  hidden?: boolean
+  kind: "tool"
+  toolKind: TKind
+  toolName: string
+  toolId: string
+  input: TInput
+  result?: TResult
+  rawResult?: unknown
+  isError?: boolean
+  timestamp: string
+}
+
+export interface AskUserQuestionToolResult {
+  answers: Record<string, string>
+}
+
+export interface ExitPlanModeToolResult {
+  confirmed?: boolean
+  clearContext?: boolean
+  message?: string
+}
+
+export type HydratedAskUserQuestionToolCall =
+  HydratedToolCallBase<"ask_user_question", AskUserQuestionToolCall["input"], AskUserQuestionToolResult>
+
+export type HydratedExitPlanModeToolCall =
+  HydratedToolCallBase<"exit_plan_mode", ExitPlanModeToolCall["input"], ExitPlanModeToolResult>
+
+export type HydratedTodoWriteToolCall =
+  HydratedToolCallBase<"todo_write", TodoWriteToolCall["input"], unknown>
+
+export type HydratedSkillToolCall =
+  HydratedToolCallBase<"skill", SkillToolCall["input"], unknown>
+
+export type HydratedGlobToolCall =
+  HydratedToolCallBase<"glob", GlobToolCall["input"], unknown>
+
+export type HydratedGrepToolCall =
+  HydratedToolCallBase<"grep", GrepToolCall["input"], unknown>
+
+export type HydratedBashToolCall =
+  HydratedToolCallBase<"bash", BashToolCall["input"], unknown>
+
+export type HydratedWebSearchToolCall =
+  HydratedToolCallBase<"web_search", WebSearchToolCall["input"], unknown>
+
+export interface ReadFileToolResult {
+  content: string
+}
+
+export type HydratedReadFileToolCall =
+  HydratedToolCallBase<"read_file", ReadFileToolCall["input"], ReadFileToolResult | string>
+
+export type HydratedWriteFileToolCall =
+  HydratedToolCallBase<"write_file", WriteFileToolCall["input"], unknown>
+
+export type HydratedEditFileToolCall =
+  HydratedToolCallBase<"edit_file", EditFileToolCall["input"], unknown>
+
+export type HydratedSubagentTaskToolCall =
+  HydratedToolCallBase<"subagent_task", SubagentTaskToolCall["input"], unknown>
+
+export type HydratedMcpGenericToolCall =
+  HydratedToolCallBase<"mcp_generic", McpGenericToolCall["input"], unknown>
+
+export type HydratedUnknownToolCall =
+  HydratedToolCallBase<"unknown_tool", UnknownToolCall["input"], unknown>
+
+export type HydratedToolCall =
+  | HydratedAskUserQuestionToolCall
+  | HydratedExitPlanModeToolCall
+  | HydratedTodoWriteToolCall
+  | HydratedSkillToolCall
+  | HydratedGlobToolCall
+  | HydratedGrepToolCall
+  | HydratedBashToolCall
+  | HydratedWebSearchToolCall
+  | HydratedReadFileToolCall
+  | HydratedWriteFileToolCall
+  | HydratedEditFileToolCall
+  | HydratedSubagentTaskToolCall
+  | HydratedMcpGenericToolCall
+  | HydratedUnknownToolCall
+
+export type HydratedTranscriptMessage =
+  | ({ kind: "user_prompt"; content: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "system_init"; model: string; tools: string[]; agents: string[]; slashCommands: string[]; mcpServers: McpServerInfo[]; provider: AgentProvider; id: string; messageId?: string; timestamp: string; hidden?: boolean; debugRaw?: string })
+  | ({ kind: "account_info"; accountInfo: AccountInfo; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "assistant_text"; text: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "result"; success: boolean; cancelled?: boolean; result: string; durationMs: number; costUsd?: number; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "status"; status: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "compact_boundary"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "compact_summary"; summary: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "context_cleared"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "interrupted"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "unknown"; json: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ id: string; messageId?: string; hidden?: boolean } & HydratedToolCall)
 
 export interface ChatRuntime {
   chatId: string
@@ -67,13 +464,15 @@ export interface ChatRuntime {
   localPath: string
   title: string
   status: KannaStatus
+  provider: AgentProvider | null
   planMode: boolean
-  resumeSessionId: string | null
+  sessionToken: string | null
 }
 
 export interface ChatSnapshot {
   runtime: ChatRuntime
   messages: TranscriptEntry[]
+  availableProviders: ProviderCatalogEntry[]
 }
 
 export interface KannaSnapshot {
@@ -83,5 +482,5 @@ export interface KannaSnapshot {
 
 export interface PendingToolSnapshot {
   toolUseId: string
-  toolName: "AskUserQuestion" | "ExitPlanMode"
+  toolKind: "ask_user_question" | "exit_plan_mode"
 }


### PR DESCRIPTION
Replace legacy Message/processed shapes with HydratedTranscriptMessage across the client (KannaTranscript, derived helpers, collapsed tool groups, tool messages and various message components). Migrate toolName -> toolKind and normalize input/result field names, update message grouping/rendering logic, and adjust message-specific parsing (AskUserQuestion, TodoWrite, ExitPlanMode, ToolCallMessage, FileContentView, etc.).

Add multi-provider support in the chat input and state: expose availableProviders/activeProvider from useKannaState, update ChatInput to select providers/models, reasoning effort and fast mode, pass provider and modelOptions in chat.send payload, and wire provider icons and UI behaviors. Also add a test script to package.json and introduce several new tests and server/shared protocol/type files. These changes align the UI with the new hydrated transcript types and enable provider-aware model selection and options.