### PR TITLE
FEAT: Import chat history

### DIFF
--- a/src/server/recovery.test.ts
+++ b/src/server/recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import type { AgentProvider, TranscriptEntry } from "../shared/types"
@@ -91,7 +91,7 @@ class MemoryRecoveryStore {
 }
 
 describe("importProjectHistory", () => {
-  test("imports only the selected project's chats and picks the newest recovered chat", async () => {
+  test("imports only the selected project's chats and picks the newest imported chat", async () => {
     const homeDir = makeTempDir()
     const projectDir = path.join(homeDir, "workspace", "kanna")
     const otherDir = path.join(homeDir, "workspace", "other")
@@ -230,6 +230,7 @@ describe("importProjectHistory", () => {
     expect(firstImport.importedChats).toBe(1)
     expect(secondImport.importedChats).toBe(0)
     expect(store.chats.size).toBe(1)
+    expect(secondImport.newestChatId).toBeNull()
   })
 
   test("skips Claude sessions that have no real user-authored prompt", async () => {
@@ -277,5 +278,44 @@ describe("importProjectHistory", () => {
       importedMessages: 0,
       newestChatId: null,
     })
+  })
+
+  test("skips unreadable history files instead of failing the whole import", async () => {
+    const homeDir = makeTempDir()
+    const projectDir = path.join(homeDir, "workspace", "kanna")
+    const claudeProjectDir = path.join(homeDir, ".claude", "projects", encodeClaudeProjectPath(projectDir))
+    mkdirSync(projectDir, { recursive: true })
+    mkdirSync(claudeProjectDir, { recursive: true })
+
+    const unreadableFile = path.join(claudeProjectDir, "broken.jsonl")
+    const readableFile = path.join(claudeProjectDir, "good.jsonl")
+    writeFileSync(unreadableFile, "{\"type\":\"user\"}\n")
+    writeFileSync(readableFile, [
+      JSON.stringify({
+        type: "user",
+        uuid: "claude-user-1",
+        timestamp: "2026-03-21T06:07:40.619Z",
+        cwd: projectDir,
+        sessionId: "claude-session-1",
+        message: { role: "user", content: "Recover this Claude chat" },
+      }),
+    ].join("\n"))
+
+    chmodSync(unreadableFile, 0o000)
+
+    const store = new MemoryRecoveryStore()
+    try {
+      const result = await importProjectHistory({
+        store,
+        projectId: "project-1",
+        localPath: projectDir,
+        homeDir,
+      })
+
+      expect(result.importedChats).toBe(1)
+      expect(result.newestChatId).toBe("chat-1")
+    } finally {
+      chmodSync(unreadableFile, 0o644)
+    }
   })
 })

--- a/src/server/recovery.ts
+++ b/src/server/recovery.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import type { Dirent } from "node:fs"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import type { AgentProvider, TranscriptEntry } from "../shared/types"
@@ -47,16 +48,19 @@ function parseJsonRecord(line: string): Record<string, unknown> | null {
   }
 }
 
-function collectFiles(directory: string, extension: string): string[] {
-  if (!existsSync(directory)) {
+async function collectFiles(directory: string, extension: string): Promise<string[]> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(directory, { withFileTypes: true, encoding: "utf8" }) as Dirent[]
+  } catch {
     return []
   }
 
   const files: string[] = []
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+  for (const entry of entries) {
     const fullPath = path.join(directory, entry.name)
     if (entry.isDirectory()) {
-      files.push(...collectFiles(fullPath, extension))
+      files.push(...await collectFiles(fullPath, extension))
       continue
     }
     if (entry.isFile() && entry.name.endsWith(extension)) {
@@ -161,17 +165,33 @@ function firstLine(value: string, fallback: string) {
   return line.length > 80 ? `${line.slice(0, 77)}...` : line
 }
 
-function readClaudeProjectChats(homeDir: string, localPath: string): RecoveryChat[] {
-  const projectsDir = path.join(homeDir, ".claude", "projects")
-  const chats: RecoveryChat[] = []
-  const normalizedPath = path.normalize(localPath)
+function encodeClaudeProjectPath(localPath: string) {
+  return `-${localPath.replace(/\//g, "-")}`
+}
 
-  for (const sessionFile of collectFiles(projectsDir, ".jsonl")) {
-    const lines = readFileSync(sessionFile, "utf8").split("\n")
+async function readClaudeProjectChats(homeDir: string, localPath: string, log?: (message: string) => void): Promise<RecoveryChat[]> {
+  const projectsDir = path.join(homeDir, ".claude", "projects", encodeClaudeProjectPath(localPath))
+  const chats: RecoveryChat[] = []
+  const sessionFiles = await collectFiles(projectsDir, ".jsonl")
+
+  for (const sessionFile of sessionFiles) {
+    let lines: string[]
+    let modifiedAt = Date.now()
+    try {
+      const [fileText, fileStat] = await Promise.all([
+        readFile(sessionFile, "utf8"),
+        stat(sessionFile),
+      ])
+      lines = fileText.split("\n")
+      modifiedAt = fileStat.mtimeMs
+    } catch (error) {
+      log?.(`[kanna] Skipping unreadable Claude history file ${sessionFile}: ${String(error)}`)
+      continue
+    }
+
     const entries: TranscriptEntry[] = []
     let sessionToken: string | null = null
     let sessionLocalPath: string | null = null
-    let modifiedAt = statSync(sessionFile).mtimeMs
 
     for (const line of lines) {
       if (!line.trim()) continue
@@ -193,7 +213,7 @@ function readClaudeProjectChats(homeDir: string, localPath: string): RecoveryCha
       entries.push(...claudeEntriesFromRecord(record))
     }
 
-    if (!sessionToken || sessionLocalPath !== normalizedPath || entries.length === 0) {
+    if (!sessionToken || sessionLocalPath !== path.normalize(localPath) || entries.length === 0) {
       continue
     }
 
@@ -326,17 +346,29 @@ function codexEntriesFromRecord(record: Record<string, unknown>, index: number):
   return []
 }
 
-function readCodexProjectChats(homeDir: string, localPath: string): RecoveryChat[] {
+async function readCodexProjectChats(homeDir: string, localPath: string, log?: (message: string) => void): Promise<RecoveryChat[]> {
   const sessionsDir = path.join(homeDir, ".codex", "sessions")
   const chats: RecoveryChat[] = []
   const normalizedPath = path.normalize(localPath)
 
-  for (const sessionFile of collectFiles(sessionsDir, ".jsonl")) {
-    const lines = readFileSync(sessionFile, "utf8").split("\n")
+  for (const sessionFile of await collectFiles(sessionsDir, ".jsonl")) {
+    let lines: string[]
+    let modifiedAt = Date.now()
+    try {
+      const [fileText, fileStat] = await Promise.all([
+        readFile(sessionFile, "utf8"),
+        stat(sessionFile),
+      ])
+      lines = fileText.split("\n")
+      modifiedAt = fileStat.mtimeMs
+    } catch (error) {
+      log?.(`[kanna] Skipping unreadable Codex history file ${sessionFile}: ${String(error)}`)
+      continue
+    }
+
     const entries: TranscriptEntry[] = []
     let sessionToken: string | null = null
     let sessionLocalPath: string | null = null
-    let modifiedAt = statSync(sessionFile).mtimeMs
 
     lines.forEach((line, index) => {
       if (!line.trim()) return
@@ -385,10 +417,10 @@ function readCodexProjectChats(homeDir: string, localPath: string): RecoveryChat
   return chats
 }
 
-function collectProjectChats(homeDir: string, localPath: string) {
+async function collectProjectChats(homeDir: string, localPath: string, log?: (message: string) => void) {
   return [
-    ...readClaudeProjectChats(homeDir, localPath),
-    ...readCodexProjectChats(homeDir, localPath),
+    ...await readClaudeProjectChats(homeDir, localPath, log),
+    ...await readCodexProjectChats(homeDir, localPath, log),
   ]
 }
 
@@ -400,7 +432,7 @@ export async function importProjectHistory(args: {
   log?: (message: string) => void
 }): Promise<ProjectImportResult> {
   const normalizedPath = path.normalize(args.localPath)
-  const chats = collectProjectChats(args.homeDir ?? homedir(), normalizedPath)
+  const chats = await collectProjectChats(args.homeDir ?? homedir(), normalizedPath, args.log)
   const existingChats = args.store.listChatsByProject(args.projectId)
   const existingSessionKeys = new Set(
     existingChats
@@ -427,7 +459,12 @@ export async function importProjectHistory(args: {
     importedChatIds.push(createdChat.id)
   }
 
-  const newestChatId = args.store.listChatsByProject(args.projectId)[0]?.id ?? null
+  const importedNewestChatId = importedChatIds.length === 0
+    ? null
+    : args.store
+      .listChatsByProject(args.projectId)
+      .find((chat) => importedChatIds.includes(chat.id))
+      ?.id ?? null
   args.log?.(
     `[kanna] project import path=${normalizedPath} discovered=${chats.length} imported=${importedChatIds.length} messages=${importedMessages}`
   )
@@ -436,6 +473,6 @@ export async function importProjectHistory(args: {
     importedChatIds,
     importedChats: importedChatIds.length,
     importedMessages,
-    newestChatId,
+    newestChatId: importedNewestChatId,
   }
 }

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
 import type { KeybindingsSnapshot } from "../shared/types"
 import { PROTOCOL_VERSION } from "../shared/types"
 import { createEmptyState } from "./events"
@@ -14,6 +17,33 @@ class FakeWebSocket {
     this.sent.push(JSON.parse(message))
   }
 }
+
+async function waitForMessages(ws: FakeWebSocket, minimumCount = 1, timeoutMs = 500) {
+  const start = Date.now()
+  while (ws.sent.length < minimumCount) {
+    if (Date.now() - start > timeoutMs) {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+const originalHome = process.env.HOME
+const tempDirs: string[] = []
+
+function withTempHome() {
+  const directory = mkdtempSync(path.join(tmpdir(), "kanna-ws-router-"))
+  tempDirs.push(directory)
+  process.env.HOME = directory
+  return directory
+}
+
+afterEach(() => {
+  process.env.HOME = originalHome
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
 
 const DEFAULT_KEYBINDINGS_SNAPSHOT: KeybindingsSnapshot = {
   bindings: {
@@ -235,17 +265,173 @@ describe("ws-router", () => {
       v: PROTOCOL_VERSION,
       type: "ack",
       id: "keybindings-write-1",
-        result: {
-          bindings: {
-            toggleEmbeddedTerminal: ["cmd+k"],
-            toggleRightSidebar: ["ctrl+shift+b"],
-            openInFinder: ["cmd+shift+g"],
-            openInEditor: ["cmd+shift+p"],
-            addSplitTerminal: ["cmd+alt+j"],
-          },
-          warning: null,
-          filePathDisplay: "~/.kanna/keybindings.json",
+      result: {
+        bindings: {
+          toggleEmbeddedTerminal: ["cmd+k"],
+          toggleRightSidebar: ["ctrl+shift+b"],
+          openInFinder: ["cmd+shift+g"],
+          openInEditor: ["cmd+shift+p"],
+          addSplitTerminal: ["cmd+alt+j"],
         },
+        warning: null,
+        filePathDisplay: "~/.kanna/keybindings.json",
+      },
+    })
+  })
+
+  test("project.open does not reuse an existing local chat when no new history was imported", async () => {
+    withTempHome()
+    const chatState = new Map<string, {
+      id: string
+      projectId: string
+      provider: "claude" | "codex" | null
+      sessionToken: string | null
+      title: string
+      updatedAt: number
+      lastMessageAt?: number
+    }>()
+
+    chatState.set("chat-existing", {
+      id: "chat-existing",
+      projectId: "project-1",
+      provider: "claude",
+      sessionToken: "session-1",
+      title: "Recovered chat",
+      updatedAt: 10,
+      lastMessageAt: 10,
+    })
+
+    const store = {
+      state: createEmptyState(),
+      openProject: async () => ({ id: "project-1", localPath: "/tmp/project-1", title: "project-1" }),
+      listChatsByProject: () => [...chatState.values()].sort((a, b) => (b.lastMessageAt ?? b.updatedAt) - (a.lastMessageAt ?? a.updatedAt)),
+      createChat: async (projectId: string) => {
+        const next = {
+          id: `chat-${chatState.size + 1}`,
+          projectId,
+          provider: null,
+          sessionToken: null,
+          title: "New Chat",
+          updatedAt: chatState.size + 1,
+        }
+        chatState.set(next.id, next)
+        return next
+      },
+      renameChat: async (chatId: string, title: string) => {
+        const chat = chatState.get(chatId)
+        if (chat) chat.title = title
+      },
+      setChatProvider: async (chatId: string, provider: "claude" | "codex") => {
+        const chat = chatState.get(chatId)
+        if (chat) chat.provider = provider
+      },
+      setSessionToken: async (chatId: string, sessionToken: string | null) => {
+        const chat = chatState.get(chatId)
+        if (chat) chat.sessionToken = sessionToken
+      },
+      appendMessage: async (chatId: string, entry: any) => {
+        const chat = chatState.get(chatId)
+        if (!chat) return
+        chat.updatedAt = entry.createdAt
+        if (entry.kind === "user_prompt") {
+          chat.lastMessageAt = entry.createdAt
+        }
+      },
+    }
+
+    const router = createWsRouter({
+      store: store as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "project-open-1",
+        command: { type: "project.open", localPath: "/tmp/project-1" },
       })
+    )
+
+    await waitForMessages(ws)
+
+    expect(ws.sent).toEqual([
+      {
+        v: PROTOCOL_VERSION,
+        type: "ack",
+        id: "project-open-1",
+        result: {
+          projectId: "project-1",
+          chatId: null,
+          importedChats: 0,
+        },
+      },
+    ])
+  })
+
+  test("project.open still succeeds when history import throws", async () => {
+    withTempHome()
+    const store = {
+      state: createEmptyState(),
+      openProject: async () => ({ id: "project-1", localPath: "/tmp/project-1", title: "project-1" }),
+      listChatsByProject: () => {
+        throw new Error("boom")
+      },
+    }
+
+    const router = createWsRouter({
+      store: store as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "project-open-2",
+        command: { type: "project.open", localPath: "/tmp/project-1" },
+      })
+    )
+
+    await waitForMessages(ws)
+
+    expect(ws.sent).toEqual([
+      {
+        v: PROTOCOL_VERSION,
+        type: "ack",
+        id: "project-open-2",
+        result: {
+          projectId: "project-1",
+          chatId: null,
+          importedChats: 0,
+        },
+      },
+    ])
   })
 })

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -30,6 +30,20 @@ function send(ws: ServerWebSocket<ClientState>, message: ServerEnvelope) {
   ws.send(JSON.stringify(message))
 }
 
+async function importProjectHistorySafely(args: Parameters<typeof importProjectHistory>[0]) {
+  try {
+    return await importProjectHistory(args)
+  } catch (error) {
+    console.warn(`[kanna] Failed to import project history for ${args.localPath}:`, error)
+    return {
+      importedChatIds: [],
+      importedChats: 0,
+      importedMessages: 0,
+      newestChatId: null,
+    }
+  }
+}
+
 export function createWsRouter({
   store,
   agent,
@@ -172,7 +186,7 @@ export function createWsRouter({
         case "project.open": {
           await ensureProjectDirectory(command.localPath)
           const project = await store.openProject(command.localPath)
-          const imported = await importProjectHistory({
+          const imported = await importProjectHistorySafely({
             store,
             projectId: project.id,
             localPath: project.localPath,
@@ -193,7 +207,7 @@ export function createWsRouter({
         case "project.create": {
           await ensureProjectDirectory(command.localPath)
           const project = await store.openProject(command.localPath, command.title)
-          const imported = await importProjectHistory({
+          const imported = await importProjectHistorySafely({
             store,
             projectId: project.id,
             localPath: project.localPath,


### PR DESCRIPTION
Imports prior sessions only when a specific project is opened. That keeps initial load clean while still restoring meaningful history for projects the user actively works on.

The import flow scans provider session files for the selected project path, restores missing chats into Kanna, preserves provider session tokens for resume, and opens the newest recovered chat when history exists. It also avoids duplicate imports on reopen and skips invalid or prompt-less sessions, so placeholder chats are not created.

Included changes:

- Add scoped project history import for Claude and Codex sessions
- Trigger import during project open/create instead of global startup recovery
- Return an existing/imported chatId from project.open / project.create so the client can open the recovered history directly
- Improve Claude transcript parsing so real user prompts are recognised from both string and block-array content
- Add tests for selective import, dedupe behaviour, and invalid-session filtering