### PR TITLE
Add print preview mode for PDF export

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom"
 import { AppDialogProvider } from "../components/ui/app-dialog"
 import { TooltipProvider } from "../components/ui/tooltip"
 import { SDK_CLIENT_APP } from "../../shared/branding"
+import { cn } from "../lib/utils"
 import { KannaSidebar } from "./KannaSidebar"
 import { ChatPage } from "./ChatPage"
 import { LocalProjectsPage } from "./LocalProjectsPage"
@@ -20,6 +21,7 @@ function KannaLayout() {
   const navigate = useNavigate()
   const params = useParams()
   const state = useKannaState(params.chatId ?? null)
+  const [isPrintPreview, setIsPrintPreview] = useState(false)
   const showMobileOpenButton = location.pathname === "/" || location.pathname.startsWith("/settings")
   const currentVersion = SDK_CLIENT_APP.split("/")[1] ?? "unknown"
 
@@ -31,35 +33,48 @@ function KannaLayout() {
     navigate("/settings/changelog", { replace: true })
   }, [currentVersion, location.pathname, navigate])
 
+  useEffect(() => {
+    if (location.pathname.startsWith("/chat/")) return
+    setIsPrintPreview(false)
+  }, [location.pathname])
+
   return (
-    <div className="flex h-[100dvh] min-h-[100dvh] overflow-hidden">
-      <KannaSidebar
-        data={state.sidebarData}
-        activeChatId={state.activeChatId}
-        connectionStatus={state.connectionStatus}
-        ready={state.sidebarReady}
-        open={state.sidebarOpen}
-        collapsed={state.sidebarCollapsed}
-        showMobileOpenButton={showMobileOpenButton}
-        onOpen={state.openSidebar}
-        onClose={state.closeSidebar}
-        onCollapse={state.collapseSidebar}
-        onExpand={state.expandSidebar}
-        onCreateChat={(projectId) => {
-          void state.handleCreateChat(projectId)
-        }}
-        onDeleteChat={(chat) => {
-          void state.handleDeleteChat(chat)
-        }}
-        onRemoveProject={(projectId) => {
-          void state.handleRemoveProject(projectId)
-        }}
-        updateSnapshot={state.updateSnapshot}
-        onInstallUpdate={() => {
-          void state.handleInstallUpdate()
-        }}
-      />
-      <Outlet context={state} />
+    <div
+      className={cn(
+        isPrintPreview
+          ? "block min-h-0 overflow-visible"
+          : "flex h-[100dvh] min-h-[100dvh] overflow-hidden"
+      )}
+    >
+      {!isPrintPreview ? (
+        <KannaSidebar
+          data={state.sidebarData}
+          activeChatId={state.activeChatId}
+          connectionStatus={state.connectionStatus}
+          ready={state.sidebarReady}
+          open={state.sidebarOpen}
+          collapsed={state.sidebarCollapsed}
+          showMobileOpenButton={showMobileOpenButton}
+          onOpen={state.openSidebar}
+          onClose={state.closeSidebar}
+          onCollapse={state.collapseSidebar}
+          onExpand={state.expandSidebar}
+          onCreateChat={(projectId) => {
+            void state.handleCreateChat(projectId)
+          }}
+          onDeleteChat={(chat) => {
+            void state.handleDeleteChat(chat)
+          }}
+          onRemoveProject={(projectId) => {
+            void state.handleRemoveProject(projectId)
+          }}
+          updateSnapshot={state.updateSnapshot}
+          onInstallUpdate={() => {
+            void state.handleInstallUpdate()
+          }}
+        />
+      ) : null}
+      <Outlet context={{ ...state, isPrintPreview, setIsPrintPreview }} />
     </div>
   )
 }

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -199,7 +199,7 @@ export function ChatPage() {
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [isPrintMode, state])
+  }, [isPrintMode, state.setIsPrintPreview])
 
   useEffect(() => {
     const frameId = window.requestAnimationFrame(() => {

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type Dispatch, type SetStateAction } from "react"
 import { ArrowDown, Flower } from "lucide-react"
 import { useOutletContext } from "react-router-dom"
 import { ChatInput } from "../components/chat-ui/ChatInput"
@@ -10,6 +10,7 @@ import { Card, CardContent } from "../components/ui/card"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable"
 import { ScrollArea } from "../components/ui/scroll-area"
 import { actionMatchesEvent, getResolvedKeybindings } from "../lib/keybindings"
+import { buildChatPdfFilename } from "../lib/pdf"
 import { cn } from "../lib/utils"
 import {
   DEFAULT_PROJECT_RIGHT_SIDEBAR_LAYOUT,
@@ -31,14 +32,20 @@ const EMPTY_STATE_TYPING_INTERVAL_MS = 19
 const CHAT_NAVBAR_OFFSET_PX = 72
 const SCROLL_BUTTON_BOTTOM_PX = 120
 
+type ChatPageOutletContext = KannaState & {
+  isPrintPreview: boolean
+  setIsPrintPreview: Dispatch<SetStateAction<boolean>>
+}
+
 export function ChatPage() {
-  const state = useOutletContext<KannaState>()
+  const state = useOutletContext<ChatPageOutletContext>()
   const layoutRootRef = useRef<HTMLDivElement>(null)
   const chatCardRef = useRef<HTMLDivElement>(null)
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
   const [typedEmptyStateText, setTypedEmptyStateText] = useState("")
   const [isEmptyStateTypingComplete, setIsEmptyStateTypingComplete] = useState(false)
   const [fixedTerminalHeight, setFixedTerminalHeight] = useState(0)
+  const isPrintMode = state.isPrintPreview
   const projectId = state.runtime?.projectId ?? null
   const projectTerminalLayout = useTerminalLayoutStore((store) => (projectId ? store.projects[projectId] : undefined))
   const terminalLayout = projectTerminalLayout ?? DEFAULT_PROJECT_TERMINAL_LAYOUT
@@ -168,6 +175,33 @@ export function ChatPage() {
   }, [state.messages.length, state.scrollRef])
 
   useEffect(() => {
+    const previousTitle = document.title
+    if (isPrintMode) {
+      document.title = buildChatPdfFilename({
+        title: state.runtime?.title,
+        localPath: state.runtime?.localPath,
+      })
+    }
+
+    return () => {
+      document.title = previousTitle
+    }
+  }, [isPrintMode, state.runtime?.localPath, state.runtime?.title])
+
+  useEffect(() => {
+    if (!isPrintMode) return
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return
+      event.preventDefault()
+      state.setIsPrintPreview(false)
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [isPrintMode, state])
+
+  useEffect(() => {
     const frameId = window.requestAnimationFrame(() => {
       state.updateScrollState()
     })
@@ -218,67 +252,91 @@ export function ChatPage() {
   }
 
   const chatCard = (
-    <Card ref={chatCardRef} className="bg-background h-full flex flex-col overflow-hidden border-0 rounded-none relative">
-      <CardContent className="flex flex-1 min-h-0 flex-col p-0 overflow-hidden relative">
-        <ChatNavbar
-          sidebarCollapsed={state.sidebarCollapsed}
-          onOpenSidebar={state.openSidebar}
-          onExpandSidebar={state.expandSidebar}
-          onNewChat={state.handleCompose}
-          localPath={state.navbarLocalPath}
-          embeddedTerminalVisible={showTerminalPane}
-          onToggleEmbeddedTerminal={projectId
-            ? () => {
-              if (hasTerminals) {
-                toggleVisibility(projectId)
-                return
+    <Card
+      ref={chatCardRef}
+      className={cn(
+        "bg-background h-full flex flex-col overflow-hidden border-0 rounded-none relative",
+        isPrintMode && "h-auto overflow-visible bg-transparent"
+      )}
+    >
+      <CardContent
+        className={cn(
+          "flex flex-1 min-h-0 flex-col p-0 overflow-hidden relative",
+          isPrintMode && "overflow-visible"
+        )}
+      >
+        {!isPrintMode ? (
+          <ChatNavbar
+            sidebarCollapsed={state.sidebarCollapsed}
+            onOpenSidebar={state.openSidebar}
+            onExpandSidebar={state.expandSidebar}
+            onNewChat={state.handleCompose}
+            localPath={state.navbarLocalPath}
+            embeddedTerminalVisible={showTerminalPane}
+            onToggleEmbeddedTerminal={projectId
+              ? () => {
+                if (hasTerminals) {
+                  toggleVisibility(projectId)
+                  return
+                }
+                addTerminal(projectId)
               }
-              addTerminal(projectId)
-            }
-            : undefined}
-          rightSidebarVisible={showRightSidebar}
-          onToggleRightSidebar={projectId ? () => toggleRightSidebar(projectId) : undefined}
-          onOpenExternal={(action) => {
-            void state.handleOpenExternal(action)
-          }}
-          editorLabel={state.editorLabel}
-          finderShortcut={resolvedKeybindings.bindings.openInFinder}
-          editorShortcut={resolvedKeybindings.bindings.openInEditor}
-          terminalShortcut={resolvedKeybindings.bindings.toggleEmbeddedTerminal}
-          rightSidebarShortcut={resolvedKeybindings.bindings.toggleRightSidebar}
-        />
+              : undefined}
+            rightSidebarVisible={showRightSidebar}
+            onToggleRightSidebar={projectId ? () => toggleRightSidebar(projectId) : undefined}
+            onOpenExternal={(action) => {
+              void state.handleOpenExternal(action)
+            }}
+            onExportPdf={() => {
+              if (state.messages.length > 0) {
+                state.setIsPrintPreview((current) => !current)
+              }
+            }}
+            canExportPdf={state.messages.length > 0}
+            editorLabel={state.editorLabel}
+            finderShortcut={resolvedKeybindings.bindings.openInFinder}
+            editorShortcut={resolvedKeybindings.bindings.openInEditor}
+            terminalShortcut={resolvedKeybindings.bindings.toggleEmbeddedTerminal}
+            rightSidebarShortcut={resolvedKeybindings.bindings.toggleRightSidebar}
+          />
+        ) : null}
 
         <ScrollArea
           ref={state.scrollRef}
           onScroll={state.updateScrollState}
-          className="flex-1 min-h-0 px-4 scroll-pt-[72px]"
+          className={cn(
+            "flex-1 min-h-0 px-4 scroll-pt-[72px]",
+            isPrintMode && "overflow-visible px-0"
+          )}
         >
           {state.messages.length === 0 ? <div style={{ height: state.transcriptPaddingBottom }} aria-hidden="true" /> : null}
           {state.messages.length > 0 ? (
             <>
-              <div className="animate-fade-in space-y-5 pt-[72px] max-w-[800px] mx-auto">
-                <KannaTranscript
-                  messages={state.messages}
-                  isLoading={state.isProcessing}
-                  localPath={state.runtime?.localPath}
-                  latestToolIds={state.latestToolIds}
-                  onOpenLocalLink={state.handleOpenLocalLink}
-                  onAskUserQuestionSubmit={state.handleAskUserQuestion}
-                  onExitPlanModeConfirm={state.handleExitPlanMode}
-                />
-                {state.isProcessing ? <ProcessingMessage status={state.runtime?.status} /> : null}
-                {state.commandError ? (
-                  <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-xl px-4 py-3">
-                    {state.commandError}
-                  </div>
-                ) : null}
+              <div className={cn("animate-fade-in space-y-5 max-w-[800px] mx-auto", isPrintMode ? "pt-0" : "pt-[72px]")}>
+                <div>
+                  <KannaTranscript
+                    messages={state.messages}
+                    isLoading={state.isProcessing}
+                    localPath={state.runtime?.localPath}
+                    latestToolIds={state.latestToolIds}
+                    onOpenLocalLink={state.handleOpenLocalLink}
+                    onAskUserQuestionSubmit={state.handleAskUserQuestion}
+                    onExitPlanModeConfirm={state.handleExitPlanMode}
+                  />
+                  {state.commandError ? (
+                    <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-xl px-4 py-3">
+                      {state.commandError}
+                    </div>
+                  ) : null}
+                </div>
+                {!isPrintMode && state.isProcessing ? <ProcessingMessage status={state.runtime?.status} /> : null}
               </div>
-              <div style={{ height: 250 }} aria-hidden="true" />
+              {!isPrintMode ? <div style={{ height: 250 }} aria-hidden="true" /> : null}
             </>
           ) : null}
         </ScrollArea>
 
-        {state.messages.length === 0 ? (
+        {state.messages.length === 0 && !isPrintMode ? (
           <div
             key={state.activeChatId ?? "new-chat"}
             className="pointer-events-none absolute inset-x-4 animate-fade-in"
@@ -315,43 +373,78 @@ export function ChatPage() {
           </div>
         ) : null}
 
-        <div
-          style={{ bottom: SCROLL_BUTTON_BOTTOM_PX }}
-          className={cn(
-            "absolute left-1/2 -translate-x-1/2 z-10 transition-all",
-            state.showScrollButton
-              ? "scale-100 duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
-              : "scale-60 duration-300 ease-out pointer-events-none blur-sm opacity-0"
-          )}
-        >
-          <button
-            onClick={state.scrollToBottom}
-            className="flex items-center transition-colors gap-1.5 px-2 bg-white hover:bg-muted border border-border rounded-full aspect-square cursor-pointer text-sm text-primary hover:text-foreground dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100 dark:border-slate-600"
+        {!isPrintMode ? (
+          <div
+            data-scroll-bottom-button
+            style={{ bottom: SCROLL_BUTTON_BOTTOM_PX }}
+            className={cn(
+              "absolute left-1/2 -translate-x-1/2 z-10 transition-all",
+              state.showScrollButton
+                ? "scale-100 duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+                : "scale-60 duration-300 ease-out pointer-events-none blur-sm opacity-0"
+            )}
           >
-            <ArrowDown className="h-5 w-5" />
-          </button>
-        </div>
+            <button
+              onClick={state.scrollToBottom}
+              className="flex items-center transition-colors gap-1.5 px-2 bg-white hover:bg-muted border border-border rounded-full aspect-square cursor-pointer text-sm text-primary hover:text-foreground dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100 dark:border-slate-600"
+            >
+              <ArrowDown className="h-5 w-5" />
+            </button>
+          </div>
+        ) : null}
       </CardContent>
 
-      <div className="absolute bottom-0 left-0 right-0 z-20 pointer-events-none">
-        <div className="bg-gradient-to-t from-background via-background pointer-events-auto" ref={state.inputRef}>
-          <ChatInput
-            ref={chatInputRef}
-            key={state.activeChatId ?? "new-chat"}
-            onSubmit={state.handleSend}
-            onCancel={() => {
-              void state.handleCancel()
-            }}
-            disabled={!state.hasSelectedProject || state.runtime?.status === "waiting_for_user"}
-            canCancel={state.canCancel}
-            chatId={state.activeChatId}
-            activeProvider={state.runtime?.provider ?? null}
-            availableProviders={state.availableProviders}
-          />
+      {!isPrintMode ? (
+        <div data-chat-input-shell className="absolute bottom-0 left-0 right-0 z-20 pointer-events-none">
+          <div className="bg-gradient-to-t from-background via-background pointer-events-auto" ref={state.inputRef}>
+            <ChatInput
+              ref={chatInputRef}
+              key={state.activeChatId ?? "new-chat"}
+              onSubmit={state.handleSend}
+              onCancel={() => {
+                void state.handleCancel()
+              }}
+              disabled={!state.hasSelectedProject || state.runtime?.status === "waiting_for_user"}
+              canCancel={state.canCancel}
+              chatId={state.activeChatId}
+              activeProvider={state.runtime?.provider ?? null}
+              availableProviders={state.availableProviders}
+            />
+          </div>
         </div>
-      </div>
+      ) : null}
     </Card>
   )
+
+  if (isPrintMode) {
+    return (
+      <div ref={layoutRootRef} className="flex-1 min-w-0 relative overflow-visible bg-background px-6 py-8">
+        <button
+          type="button"
+          onClick={() => state.setIsPrintPreview(false)}
+          className="fixed top-4 right-4 z-50 rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground focus:outline-none print:hidden"
+        >
+          Exit
+        </button>
+        <div className="mx-auto max-w-[800px] space-y-5">
+          <KannaTranscript
+            messages={state.messages}
+            isLoading={false}
+            localPath={state.runtime?.localPath}
+            latestToolIds={state.latestToolIds}
+            onOpenLocalLink={state.handleOpenLocalLink}
+            onAskUserQuestionSubmit={state.handleAskUserQuestion}
+            onExitPlanModeConfirm={state.handleExitPlanMode}
+          />
+          {state.commandError ? (
+            <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-xl px-4 py-3">
+              {state.commandError}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div ref={layoutRootRef} className="flex-1 flex flex-col min-w-0 relative">

--- a/src/client/components/chat-ui/ChatNavbar.tsx
+++ b/src/client/components/chat-ui/ChatNavbar.tsx
@@ -1,6 +1,7 @@
-import { Flower, Code, FolderOpen, Menu, PanelLeft, PanelRight, SquarePen, Terminal } from "lucide-react"
+import { Flower, Code, Ellipsis, FileOutput, FolderOpen, Menu, PanelLeft, PanelRight, SquarePen, Terminal } from "lucide-react"
 import { Button } from "../ui/button"
 import { CardHeader } from "../ui/card"
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover"
 import { HotkeyTooltip, HotkeyTooltipContent, HotkeyTooltipTrigger } from "../ui/tooltip"
 import { cn } from "../../lib/utils"
 
@@ -15,6 +16,8 @@ interface Props {
   rightSidebarVisible?: boolean
   onToggleRightSidebar?: () => void
   onOpenExternal?: (action: "open_finder" | "open_editor") => void
+  onExportPdf?: () => void
+  canExportPdf?: boolean
   editorLabel?: string
   finderShortcut?: string[]
   editorShortcut?: string[]
@@ -33,6 +36,8 @@ export function ChatNavbar({
   rightSidebarVisible = false,
   onToggleRightSidebar,
   onOpenExternal,
+  onExportPdf,
+  canExportPdf = false,
   editorLabel = "Editor",
   finderShortcut,
   editorShortcut,
@@ -140,6 +145,36 @@ export function ChatNavbar({
               ) : null}
             </>
           )}
+          {onExportPdf ? (
+            <Popover>
+              <HotkeyTooltip>
+                <HotkeyTooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="More actions"
+                      className="border border-border/0"
+                    >
+                      <Ellipsis className="h-4.5 w-4.5" />
+                    </Button>
+                  </PopoverTrigger>
+                </HotkeyTooltipTrigger>
+                <HotkeyTooltipContent side="bottom">More actions</HotkeyTooltipContent>
+              </HotkeyTooltip>
+              <PopoverContent align="end" className="w-56 p-1.5">
+                <button
+                  type="button"
+                  onClick={onExportPdf}
+                  disabled={!canExportPdf}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-left text-foreground transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+                >
+                  <FileOutput className="h-4 w-4 text-muted-foreground" />
+                  <span>Preview PDF</span>
+                </button>
+              </PopoverContent>
+            </Popover>
+          ) : null}
           {onToggleRightSidebar ? (
             <HotkeyTooltip>
               <HotkeyTooltipTrigger asChild>

--- a/src/client/lib/pdf.test.ts
+++ b/src/client/lib/pdf.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { buildChatPdfFilename } from "./pdf"
 
 describe("buildChatPdfFilename", () => {
-  const exportedAt = new Date(Date.UTC(2026, 2, 26, 18, 45, 0))
-
-  test("uses the chat title when available", () => {
-    expect(buildChatPdfFilename({ title: "Fix auth race condition", exportedAt })).toBe("fix-auth-race-condition-2026-03-26.pdf")
+  const exportedAt = new Date(Date.UTC(2026, 2, 26, 12, 0, 0))
   })
 
   test("falls back to the project folder name", () => {

--- a/src/client/lib/pdf.test.ts
+++ b/src/client/lib/pdf.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { buildChatPdfFilename } from "./pdf"
+
+describe("buildChatPdfFilename", () => {
+  const exportedAt = new Date(Date.UTC(2026, 2, 26, 18, 45, 0))
+
+  test("uses the chat title when available", () => {
+    expect(buildChatPdfFilename({ title: "Fix auth race condition", exportedAt })).toBe("fix-auth-race-condition-2026-03-26.pdf")
+  })
+
+  test("falls back to the project folder name", () => {
+    expect(buildChatPdfFilename({ localPath: "/Users/brian/superwall/kanna", exportedAt })).toBe("kanna-2026-03-26.pdf")
+  })
+
+  test("falls back to a generic label when no title or path is available", () => {
+    expect(buildChatPdfFilename({ exportedAt })).toBe("chat-history-2026-03-26.pdf")
+  })
+})

--- a/src/client/lib/pdf.ts
+++ b/src/client/lib/pdf.ts
@@ -1,0 +1,26 @@
+function sanitizeFilenameSegment(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+function formatDateSegment(exportedAt: Date) {
+  const year = exportedAt.getFullYear()
+  const month = String(exportedAt.getMonth() + 1).padStart(2, "0")
+  const day = String(exportedAt.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+export function buildChatPdfFilename(params: {
+  title?: string | null
+  localPath?: string | null
+  exportedAt?: Date
+}) {
+  const exportedAt = params.exportedAt ?? new Date()
+  const primaryLabel = params.title?.trim()
+    || params.localPath?.split("/").filter(Boolean).pop()
+    || "chat-history"
+  const safeLabel = sanitizeFilenameSegment(primaryLabel) || "chat-history"
+  return `${safeLabel}-${formatDateSegment(exportedAt)}.pdf`
+}

--- a/src/index.css
+++ b/src/index.css
@@ -193,6 +193,7 @@
     overscroll-behavior-y: contain;
   }
 
+
   /* Safe area insets for notched devices */
   .safe-area-inset-bottom {
     padding-bottom: env(safe-area-inset-bottom);


### PR DESCRIPTION
## Motivation

I wanted a simple way to share a chat and since this is all local, I thought a simple print function would be the easiest thing to do. 

## Summary
- Adds a **Preview PDF** option in the navbar's "more actions" menu (⋯) that enters a clean, full-page print preview layout
- Hides sidebar, navbar, chat input, scroll button, and processing indicator so the browser's native print / save-as-PDF produces a clean transcript
- Sets the document title to a smart filename (e.g. `fix-auth-race-condition-2026-03-26.pdf`) based on the chat title or project folder name
- Exit print preview via the floating **Exit** button or the **Escape** key

### Open the Preview

<img width="3024" height="1410" alt="CleanShot 2026-03-26 at 11 34 12@2x" src="https://github.com/user-attachments/assets/a6b882cd-700e-4e6c-8030-5497ef1ba446" />

### View Preview
<img width="3016" height="1678" alt="CleanShot 2026-03-26 at 11 34 23@2x" src="https://github.com/user-attachments/assets/782c8374-fcc4-49cd-8178-b7cb14d435c9" />

### Print View

<img width="2098" height="1390" alt="CleanShot 2026-03-26 at 11 34 30@2x" src="https://github.com/user-attachments/assets/a3812428-0cc3-4b90-968d-63fc7af8b536" />

## Test plan
- [ ] Open a chat with messages, click ⋯ → Preview PDF — verify clean layout with only transcript visible
- [ ] Use browser print (⌘P) while in preview — verify the Exit button is hidden in the printed output
- [ ] Press Escape — verify it exits print preview and returns to normal chat
- [ ] Click the Exit button — same behavior
- [ ] Navigate away from the chat route while in preview — verify it resets
- [ ] Verify the "Preview PDF" option is disabled when a chat has no messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)