### PR TITLE
Stream chat updates and recover interrupted turns

### DIFF
--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -651,16 +651,100 @@ describe("AgentCoordinator codex integration", () => {
     expect(discardedResult.content).toEqual({ discarded: true })
     expect(startTurnCalls).toEqual(["plan this"])
   })
+
+  test("recovers an interrupted turn after restart using the saved session token", async () => {
+    const sessionCalls: Array<{ chatId: string; sessionToken: string | null }> = []
+    const startTurnCalls: Array<{ content: string; planMode: boolean }> = []
+
+    const fakeCodexManager = {
+      async startSession(args: { chatId: string; sessionToken: string | null }) {
+        sessionCalls.push({ chatId: args.chatId, sessionToken: args.sessionToken })
+      },
+      async startTurn(args: { content: string; planMode: boolean }): Promise<HarnessTurn> {
+        startTurnCalls.push({ content: args.content, planMode: args.planMode })
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore({
+      provider: "codex",
+      sessionToken: "thread-1",
+      activeTurn: {
+        provider: "codex",
+        content: "finish this task",
+        model: "gpt-5.4",
+        planMode: false,
+      },
+    })
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.recoverInterruptedTurns()
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    expect(sessionCalls).toEqual([{ chatId: "chat-1", sessionToken: "thread-1" }])
+    expect(startTurnCalls).toEqual([{
+      content: "The previous response was interrupted because the Kanna server restarted. Continue from where you left off without repeating completed work unless necessary.",
+      planMode: false,
+    }])
+    expect(store.messages.some((entry) => entry.kind === "user_prompt")).toBe(false)
+  })
 })
 
-function createFakeStore() {
+function createFakeStore(overrides?: {
+  provider?: "claude" | "codex" | null
+  sessionToken?: string | null
+  activeTurn?: {
+    provider: "claude" | "codex"
+    content: string
+    model: string
+    effort?: string
+    serviceTier?: "fast"
+    planMode: boolean
+  } | null
+}) {
   const chat = {
     id: "chat-1",
     projectId: "project-1",
     title: "New Chat",
-    provider: null as "claude" | "codex" | null,
+    provider: overrides?.provider ?? null as "claude" | "codex" | null,
     planMode: false,
-    sessionToken: null as string | null,
+    sessionToken: overrides?.sessionToken ?? null as string | null,
+    activeTurn: overrides?.activeTurn ?? null,
   }
   const project = {
     id: "project-1",
@@ -678,6 +762,9 @@ function createFakeStore() {
       expect(projectId).toBe("project-1")
       return project
     },
+    listChatsWithActiveTurn() {
+      return chat.activeTurn ? [chat] : []
+    },
     getMessages() {
       return this.messages
     },
@@ -693,14 +780,23 @@ function createFakeStore() {
     async appendMessage(_chatId: string, entry: TranscriptEntry) {
       this.messages.push(entry)
     },
-    async recordTurnStarted() {},
+    async recordTurnStarted(
+      _chatId: string,
+      recovery: NonNullable<typeof chat.activeTurn>
+    ) {
+      chat.activeTurn = recovery
+    },
     async recordTurnFinished() {
       this.turnFinishedCount += 1
+      chat.activeTurn = null
     },
     async recordTurnFailed() {
+      chat.activeTurn = null
       throw new Error("Did not expect turn failure")
     },
-    async recordTurnCancelled() {},
+    async recordTurnCancelled() {
+      chat.activeTurn = null
+    },
     async setSessionToken(_chatId: string, sessionToken: string | null) {
       chat.sessionToken = sessionToken
     },

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -59,14 +59,21 @@ interface ActiveTurn {
   hasFinalResult: boolean
   cancelRequested: boolean
   cancelRecorded: boolean
+  abandonRequested: boolean
 }
 
 interface AgentCoordinatorArgs {
   store: EventStore
-  onStateChange: () => void
+  onStateChange: (change: AgentStateChange) => void
   codexManager?: CodexAppServerManager
   generateTitle?: (messageContent: string, cwd: string) => Promise<string | null>
 }
+
+export type AgentStateChange =
+  | { type: "sidebar" }
+  | { type: "chat-runtime"; chatId: string }
+  | { type: "chat-reset"; chatId: string }
+  | { type: "chat-message"; chatId: string; entry: TranscriptEntry }
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
   entry: T,
@@ -331,7 +338,7 @@ async function startClaudeTurn(args: {
 
 export class AgentCoordinator {
   private readonly store: EventStore
-  private readonly onStateChange: () => void
+  private readonly onStateChange: (change: AgentStateChange) => void
   private readonly codexManager: CodexAppServerManager
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<string | null>
   readonly activeTurns = new Map<string, ActiveTurn>()
@@ -355,6 +362,15 @@ export class AgentCoordinator {
     const pending = this.activeTurns.get(chatId)?.pendingTool
     if (!pending) return null
     return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
+  }
+
+  private buildRecoveryPrompt(chatId: string, originalContent: string) {
+    const chat = this.store.requireChat(chatId)
+    if (chat.sessionToken) {
+      return "The previous response was interrupted because the Kanna server restarted. Continue from where you left off without repeating completed work unless necessary."
+    }
+
+    return `The previous turn was interrupted by a Kanna server restart before a resumable session was fully established. Please continue by handling the user's pending request.\n\nPending request:\n${originalContent}`
   }
 
   private resolveProvider(command: Extract<ClientCommand, { type: "chat.send" }>, currentProvider: AgentProvider | null) {
@@ -407,9 +423,18 @@ export class AgentCoordinator {
     const shouldGenerateTitle = args.appendUserPrompt && chat.title === "New Chat" && existingMessages.length === 0
 
     if (args.appendUserPrompt) {
-      await this.store.appendMessage(args.chatId, timestamped({ kind: "user_prompt", content: args.content }, Date.now()))
+      const entry = timestamped({ kind: "user_prompt", content: args.content }, Date.now())
+      await this.store.appendMessage(args.chatId, entry)
+      this.onStateChange({ type: "chat-message", chatId: args.chatId, entry })
     }
-    await this.store.recordTurnStarted(args.chatId)
+    await this.store.recordTurnStarted(args.chatId, {
+      provider: args.provider,
+      content: args.content,
+      model: args.model,
+      effort: args.effort,
+      serviceTier: args.serviceTier,
+      planMode: args.planMode,
+    })
 
     const project = this.store.getProject(chat.projectId)
     if (!project) {
@@ -427,7 +452,8 @@ export class AgentCoordinator {
       }
 
       active.status = "waiting_for_user"
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId: args.chatId })
+      this.onStateChange({ type: "sidebar" })
 
       return await new Promise<unknown>((resolve) => {
         active.pendingTool = {
@@ -482,16 +508,19 @@ export class AgentCoordinator {
       hasFinalResult: false,
       cancelRequested: false,
       cancelRecorded: false,
+      abandonRequested: false,
     }
     this.activeTurns.set(args.chatId, active)
-    this.onStateChange()
+    this.onStateChange({ type: "chat-runtime", chatId: args.chatId })
+    this.onStateChange({ type: "sidebar" })
 
     if (turn.getAccountInfo) {
       void turn.getAccountInfo()
         .then(async (accountInfo) => {
           if (!accountInfo) return
-          await this.store.appendMessage(args.chatId, timestamped({ kind: "account_info", accountInfo }))
-          this.onStateChange()
+          const entry = timestamped({ kind: "account_info", accountInfo })
+          await this.store.appendMessage(args.chatId, entry)
+          this.onStateChange({ type: "chat-message", chatId: args.chatId, entry })
         })
         .catch(() => undefined)
     }
@@ -536,7 +565,8 @@ export class AgentCoordinator {
       if (chat.title !== "New Chat") return
 
       await this.store.renameChat(chatId, title)
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId })
+      this.onStateChange({ type: "sidebar" })
     } catch {
       // Ignore background title generation failures.
     }
@@ -545,9 +575,13 @@ export class AgentCoordinator {
   private async runTurn(active: ActiveTurn) {
     try {
       for await (const event of active.turn.stream) {
+        if (active.abandonRequested) {
+          break
+        }
+
         if (event.type === "session_token" && event.sessionToken) {
           await this.store.setSessionToken(active.chatId, event.sessionToken)
-          this.onStateChange()
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
           continue
         }
 
@@ -567,22 +601,27 @@ export class AgentCoordinator {
           }
         }
 
-        this.onStateChange()
+        this.onStateChange({ type: "chat-message", chatId: active.chatId, entry: event.entry })
+        if (event.entry.kind === "system_init" || event.entry.kind === "result" || event.entry.kind === "status") {
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+          this.onStateChange({ type: "sidebar" })
+        }
       }
     } catch (error) {
-      if (!active.cancelRequested) {
+      if (!active.cancelRequested && !active.abandonRequested) {
         const message = error instanceof Error ? error.message : String(error)
-        await this.store.appendMessage(
-          active.chatId,
-          timestamped({
-            kind: "result",
-            subtype: "error",
-            isError: true,
-            durationMs: 0,
-            result: message,
-          })
-        )
+        const entry = timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: message,
+        })
+        await this.store.appendMessage(active.chatId, entry)
         await this.store.recordTurnFailed(active.chatId, message)
+        this.onStateChange({ type: "chat-message", chatId: active.chatId, entry })
+        this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+        this.onStateChange({ type: "sidebar" })
       }
     } finally {
       if (active.cancelRequested && !active.cancelRecorded) {
@@ -590,9 +629,10 @@ export class AgentCoordinator {
       }
       active.turn.close()
       this.activeTurns.delete(active.chatId)
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+      this.onStateChange({ type: "sidebar" })
 
-      if (active.postToolFollowUp && !active.cancelRequested) {
+      if (active.postToolFollowUp && !active.cancelRequested && !active.abandonRequested) {
         try {
           await this.startTurnForChat({
             chatId: active.chatId,
@@ -606,18 +646,18 @@ export class AgentCoordinator {
           })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
-          await this.store.appendMessage(
-            active.chatId,
-            timestamped({
-              kind: "result",
-              subtype: "error",
-              isError: true,
-              durationMs: 0,
-              result: message,
-            })
-          )
+          const entry = timestamped({
+            kind: "result",
+            subtype: "error",
+            isError: true,
+            durationMs: 0,
+            result: message,
+          })
+          await this.store.appendMessage(active.chatId, entry)
           await this.store.recordTurnFailed(active.chatId, message)
-          this.onStateChange()
+          this.onStateChange({ type: "chat-message", chatId: active.chatId, entry })
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+          this.onStateChange({ type: "sidebar" })
         }
       }
     }
@@ -634,20 +674,20 @@ export class AgentCoordinator {
 
     if (pendingTool) {
       const result = discardedToolResult(pendingTool.tool)
-      await this.store.appendMessage(
-        chatId,
-        timestamped({
-          kind: "tool_result",
-          toolId: pendingTool.toolUseId,
-          content: result,
-        })
-      )
+      const entry = timestamped({
+        kind: "tool_result",
+        toolId: pendingTool.toolUseId,
+        content: result,
+      })
+      await this.store.appendMessage(chatId, entry)
+      this.onStateChange({ type: "chat-message", chatId, entry })
       if (active.provider === "codex" && pendingTool.tool.toolKind === "exit_plan_mode") {
         pendingTool.resolve(result)
       }
     }
 
-    await this.store.appendMessage(chatId, timestamped({ kind: "interrupted" }))
+    const interruptedEntry = timestamped({ kind: "interrupted" })
+    await this.store.appendMessage(chatId, interruptedEntry)
     await this.store.recordTurnCancelled(chatId)
     active.cancelRecorded = true
     active.hasFinalResult = true
@@ -659,7 +699,55 @@ export class AgentCoordinator {
     }
 
     this.activeTurns.delete(chatId)
-    this.onStateChange()
+    this.onStateChange({ type: "chat-message", chatId, entry: interruptedEntry })
+    this.onStateChange({ type: "chat-runtime", chatId })
+    this.onStateChange({ type: "sidebar" })
+  }
+
+  async recoverInterruptedTurns() {
+    for (const chat of this.store.listChatsWithActiveTurn()) {
+      if (!chat.activeTurn || this.activeTurns.has(chat.id)) continue
+
+      try {
+        await this.startTurnForChat({
+          chatId: chat.id,
+          provider: chat.activeTurn.provider,
+          content: this.buildRecoveryPrompt(chat.id, chat.activeTurn.content),
+          model: chat.activeTurn.model,
+          effort: chat.activeTurn.effort,
+          serviceTier: chat.activeTurn.serviceTier,
+          planMode: chat.activeTurn.planMode,
+          appendUserPrompt: false,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const entry = timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: `Failed to recover interrupted turn after server restart: ${message}`,
+        })
+        await this.store.appendMessage(chat.id, entry)
+        await this.store.recordTurnFailed(chat.id, message)
+        this.onStateChange({ type: "chat-message", chatId: chat.id, entry })
+        this.onStateChange({ type: "chat-runtime", chatId: chat.id })
+        this.onStateChange({ type: "sidebar" })
+      }
+    }
+  }
+
+  shutdown() {
+    for (const active of this.activeTurns.values()) {
+      active.abandonRequested = true
+      const pendingTool = active.pendingTool
+      active.pendingTool = null
+      if (pendingTool) {
+        pendingTool.resolve(discardedToolResult(pendingTool.tool))
+      }
+      active.turn.close()
+    }
+    this.codexManager.stopAll()
   }
 
   async respondTool(command: Extract<ClientCommand, { type: "chat.respondTool" }>) {
@@ -673,14 +761,13 @@ export class AgentCoordinator {
       throw new Error("Tool response does not match active request")
     }
 
-    await this.store.appendMessage(
-      command.chatId,
-      timestamped({
-        kind: "tool_result",
-        toolId: command.toolUseId,
-        content: command.result,
-      })
-    )
+    const resultEntry = timestamped({
+      kind: "tool_result",
+      toolId: command.toolUseId,
+      content: command.result,
+    })
+    await this.store.appendMessage(command.chatId, resultEntry)
+    const extraEntries: TranscriptEntry[] = []
 
     active.pendingTool = null
     active.status = "running"
@@ -693,7 +780,9 @@ export class AgentCoordinator {
       }
       if (result.confirmed && result.clearContext) {
         await this.store.setSessionToken(command.chatId, null)
-        await this.store.appendMessage(command.chatId, timestamped({ kind: "context_cleared" }))
+        const clearEntry = timestamped({ kind: "context_cleared" })
+        await this.store.appendMessage(command.chatId, clearEntry)
+        extraEntries.push(clearEntry)
       }
 
       if (active.provider === "codex") {
@@ -715,6 +804,11 @@ export class AgentCoordinator {
 
     pending.resolve(command.result)
 
-    this.onStateChange()
+    this.onStateChange({ type: "chat-message", chatId: command.chatId, entry: resultEntry })
+    for (const entry of extraEntries) {
+      this.onStateChange({ type: "chat-message", chatId: command.chatId, entry })
+    }
+    this.onStateChange({ type: "chat-runtime", chatId: command.chatId })
+    this.onStateChange({ type: "sidebar" })
   }
 }

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -5,6 +5,7 @@ import { getDataDir, LOG_PREFIX } from "../shared/branding"
 import type { AgentProvider, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
 import {
+  type ActiveTurnRecovery,
   type ChatEvent,
   type MessageEvent,
   type ProjectEvent,
@@ -90,7 +91,10 @@ export class EventStore {
         this.state.projectIdsByPath.set(project.localPath, project.id)
       }
       for (const chat of parsed.chats) {
-        this.state.chatsById.set(chat.id, { ...chat })
+        this.state.chatsById.set(chat.id, {
+          ...chat,
+          activeTurn: chat.activeTurn ?? null,
+        })
       }
       for (const messageSet of parsed.messages) {
         this.state.messagesByChatId.set(messageSet.chatId, cloneTranscriptEntries(messageSet.entries))
@@ -191,6 +195,7 @@ export class EventStore {
           planMode: false,
           sessionToken: null,
           lastTurnOutcome: null,
+          activeTurn: null,
         }
         this.state.chatsById.set(chat.id, chat)
         break
@@ -240,13 +245,16 @@ export class EventStore {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.updatedAt = event.timestamp
+        chat.activeTurn = { ...event.recovery }
         break
       }
       case "turn_finished": {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.updatedAt = event.timestamp
+        chat.lastCompletedTurnAt = event.timestamp
         chat.lastTurnOutcome = "success"
+        chat.activeTurn = null
         break
       }
       case "turn_failed": {
@@ -254,6 +262,7 @@ export class EventStore {
         if (!chat) break
         chat.updatedAt = event.timestamp
         chat.lastTurnOutcome = "failed"
+        chat.activeTurn = null
         break
       }
       case "turn_cancelled": {
@@ -261,6 +270,7 @@ export class EventStore {
         if (!chat) break
         chat.updatedAt = event.timestamp
         chat.lastTurnOutcome = "cancelled"
+        chat.activeTurn = null
         break
       }
       case "session_token_set": {
@@ -402,13 +412,14 @@ export class EventStore {
     await this.append(this.messagesLogPath, event)
   }
 
-  async recordTurnStarted(chatId: string) {
+  async recordTurnStarted(chatId: string, recovery: ActiveTurnRecovery) {
     this.requireChat(chatId)
     const event: TurnEvent = {
       v: STORE_VERSION,
       type: "turn_started",
       timestamp: Date.now(),
       chatId,
+      recovery,
     }
     await this.append(this.turnsLogPath, event)
   }
@@ -478,6 +489,12 @@ export class EventStore {
     const chat = this.state.chatsById.get(chatId)
     if (!chat || chat.deletedAt) return null
     return chat
+  }
+
+  listChatsWithActiveTurn() {
+    return [...this.state.chatsById.values()]
+      .filter((chat) => !chat.deletedAt && chat.activeTurn)
+      .sort((a, b) => a.updatedAt - b.updatedAt)
   }
 
   getMessages(chatId: string) {

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -15,7 +15,18 @@ export interface ChatRecord {
   planMode: boolean
   sessionToken: string | null
   lastMessageAt?: number
+  lastCompletedTurnAt?: number
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
+  activeTurn: ActiveTurnRecovery | null
+}
+
+export interface ActiveTurnRecovery {
+  provider: AgentProvider
+  content: string
+  model: string
+  effort?: string
+  serviceTier?: "fast"
+  planMode: boolean
 }
 
 export interface StoreState {
@@ -98,6 +109,7 @@ export type TurnEvent =
       type: "turn_started"
       timestamp: number
       chatId: string
+      recovery: ActiveTurnRecovery
     }
   | {
       v: 2

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -23,6 +23,7 @@ describe("read models", () => {
       planMode: false,
       sessionToken: "thread-1",
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const sidebar = deriveSidebarData(state, new Map())
@@ -49,10 +50,13 @@ describe("read models", () => {
       planMode: true,
       sessionToken: "session-1",
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const chat = deriveChatSnapshot(state, new Map(), "chat-1")
     expect(chat?.runtime.provider).toBe("claude")
+    expect(chat?.hasOlderMessages).toBe(false)
+    expect(chat?.oldestLoadedMessageId).toBeNull()
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
       "gpt-5.4",
@@ -82,6 +86,7 @@ describe("read models", () => {
       sessionToken: null,
       lastMessageAt: 100,
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const snapshot = deriveLocalProjectsSnapshot(state, [
@@ -101,5 +106,43 @@ describe("read models", () => {
         chatCount: 1,
       },
     ])
+  })
+
+  test("returns only the latest chunk of chat history by default", () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "claude",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+    state.messagesByChatId.set("chat-1", Array.from({ length: 250 }, (_, index) => ({
+      _id: `msg-${index + 1}`,
+      createdAt: index + 1,
+      kind: "assistant_text" as const,
+      text: `message ${index + 1}`,
+    })))
+
+    const chat = deriveChatSnapshot(state, new Map(), "chat-1")
+
+    expect(chat?.messages).toHaveLength(200)
+    expect(chat?.messages[0]?._id).toBe("msg-51")
+    expect(chat?.messages.at(-1)?._id).toBe("msg-250")
+    expect(chat?.hasOlderMessages).toBe(true)
+    expect(chat?.oldestLoadedMessageId).toBe("msg-51")
   })
 })

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -12,6 +12,8 @@ import { cloneTranscriptEntries } from "./events"
 import { resolveLocalPath } from "./paths"
 import { SERVER_PROVIDERS } from "./provider-catalog"
 
+const DEFAULT_CHAT_SNAPSHOT_LIMIT = 200
+
 export function deriveStatus(chat: ChatRecord, activeStatus?: KannaStatus): KannaStatus {
   if (activeStatus) return activeStatus
   if (chat.lastTurnOutcome === "failed") return "failed"
@@ -39,6 +41,7 @@ export function deriveSidebarData(
         localPath: project.localPath,
         provider: chat.provider,
         lastMessageAt: chat.lastMessageAt,
+        lastCompletedTurnAt: chat.lastCompletedTurnAt,
         hasAutomation: false,
       }))
 
@@ -98,14 +101,68 @@ export function deriveLocalProjectsSnapshot(
 export function deriveChatSnapshot(
   state: StoreState,
   activeStatuses: Map<string, KannaStatus>,
-  chatId: string
+  chatId: string,
+  options?: {
+    beforeMessageId?: string | null
+    limit?: number
+  }
 ): ChatSnapshot | null {
   const chat = state.chatsById.get(chatId)
   if (!chat || chat.deletedAt) return null
   const project = state.projectsById.get(chat.projectId)
   if (!project || project.deletedAt) return null
 
-  const runtime: ChatRuntime = {
+  const runtime = deriveChatRuntime(state, activeStatuses, chatId)
+  if (!runtime) return null
+
+  const allMessages = state.messagesByChatId.get(chatId) ?? []
+  const { entries, hasOlderMessages, oldestLoadedMessageId } = sliceChatMessages(allMessages, options)
+
+  return {
+    runtime,
+    messages: entries,
+    hasOlderMessages,
+    oldestLoadedMessageId,
+    availableProviders: [...SERVER_PROVIDERS],
+  }
+}
+
+export function sliceChatMessages(
+  allMessages: readonly (ReturnType<typeof cloneTranscriptEntries>[number])[],
+  options?: {
+    beforeMessageId?: string | null
+    limit?: number
+  }
+) {
+  const limit = Math.max(1, options?.limit ?? DEFAULT_CHAT_SNAPSHOT_LIMIT)
+  let endExclusive = allMessages.length
+
+  if (options?.beforeMessageId) {
+    const beforeIndex = allMessages.findIndex((entry) => entry._id === options.beforeMessageId)
+    endExclusive = beforeIndex >= 0 ? beforeIndex : allMessages.length
+  }
+
+  const start = Math.max(0, endExclusive - limit)
+  const entries = cloneTranscriptEntries(allMessages.slice(start, endExclusive))
+
+  return {
+    entries,
+    hasOlderMessages: start > 0,
+    oldestLoadedMessageId: entries[0]?._id ?? null,
+  }
+}
+
+export function deriveChatRuntime(
+  state: StoreState,
+  activeStatuses: Map<string, KannaStatus>,
+  chatId: string
+): ChatRuntime | null {
+  const chat = state.chatsById.get(chatId)
+  if (!chat || chat.deletedAt) return null
+  const project = state.projectsById.get(chat.projectId)
+  if (!project || project.deletedAt) return null
+
+  return {
     chatId: chat.id,
     projectId: project.id,
     localPath: project.localPath,
@@ -114,11 +171,5 @@ export function deriveChatSnapshot(
     provider: chat.provider,
     planMode: chat.planMode,
     sessionToken: chat.sessionToken,
-  }
-
-  return {
-    runtime,
-    messages: cloneTranscriptEntries(state.messagesByChatId.get(chat.id) ?? []),
-    availableProviders: [...SERVER_PROVIDERS],
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -52,8 +52,24 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     : null
   const agent = new AgentCoordinator({
     store,
-    onStateChange: () => {
-      router.broadcastSnapshots()
+    onStateChange: (change) => {
+      if (change.type === "sidebar") {
+        router.pushSidebarSnapshots()
+        return
+      }
+      if (change.type === "chat-runtime") {
+        router.pushChatRuntime(change.chatId)
+        return
+      }
+      if (change.type === "chat-reset") {
+        router.pushChatReset(change.chatId)
+        return
+      }
+      router.pushChatEvent(change.chatId, {
+        type: "chat.messageAppended",
+        chatId: change.chatId,
+        entry: change.entry,
+      })
     },
   })
   router = createWsRouter({
@@ -66,6 +82,8 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     machineDisplayName,
     updateManager,
   })
+
+  await agent.recoverInterruptedTurns()
 
   const distDir = path.join(import.meta.dir, "..", "..", "dist", "client")
 
@@ -120,9 +138,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   }
 
   const shutdown = async () => {
-    for (const chatId of [...agent.activeTurns.keys()]) {
-      await agent.cancel(chatId)
-    }
+    agent.shutdown()
     router.dispose()
     keybindings.dispose()
     terminals.closeAll()

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -176,6 +176,154 @@ describe("ws-router", () => {
     })
   })
 
+  test("loads older chat history chunks through chat.loadMore", async () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "codex",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+    state.messagesByChatId.set("chat-1", Array.from({ length: 4 }, (_, index) => ({
+      _id: `msg-${index + 1}`,
+      createdAt: index + 1,
+      kind: "assistant_text" as const,
+      text: `message ${index + 1}`,
+    })))
+
+    const router = createWsRouter({
+      store: { state } as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "chat-load-1",
+        command: {
+          type: "chat.loadMore",
+          chatId: "chat-1",
+          beforeMessageId: "msg-4",
+          limit: 2,
+        },
+      })
+    )
+
+    await Promise.resolve()
+    expect(ws.sent[0]).toEqual({
+      v: PROTOCOL_VERSION,
+      type: "ack",
+      id: "chat-load-1",
+      result: {
+        runtime: {
+          chatId: "chat-1",
+          projectId: "project-1",
+          localPath: "/tmp/project",
+          title: "Chat",
+          status: "idle",
+          provider: "codex",
+          planMode: false,
+          sessionToken: null,
+        },
+        messages: [
+          { _id: "msg-2", createdAt: 2, kind: "assistant_text", text: "message 2" },
+          { _id: "msg-3", createdAt: 3, kind: "assistant_text", text: "message 3" },
+        ],
+        hasOlderMessages: true,
+        oldestLoadedMessageId: "msg-2",
+        availableProviders: expect.any(Array),
+      },
+    })
+  })
+
+  test("prefetches chat snapshots without opening a live subscription", async () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "claude",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+
+    const router = createWsRouter({
+      store: { state } as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "chat-prefetch-1",
+        command: {
+          type: "chat.prefetch",
+          chatId: "chat-1",
+        },
+      })
+    )
+
+    await Promise.resolve()
+    expect((ws.sent[0] as any).type).toBe("ack")
+    expect((ws.sent[0] as any).result.runtime.chatId).toBe("chat-1")
+  })
+
   test("subscribes to keybindings snapshots and writes keybindings through the router", async () => {
     const initialSnapshot: KeybindingsSnapshot = DEFAULT_KEYBINDINGS_SNAPSHOT
     const keybindings = {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun"
 import { PROTOCOL_VERSION } from "../shared/types"
-import type { ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
+import type { ChatEvent, ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
 import { isClientEnvelope } from "../shared/protocol"
 import type { AgentCoordinator } from "./agent"
 import type { DiscoveredProject } from "./discovery"
@@ -10,7 +10,7 @@ import { KeybindingsManager } from "./keybindings"
 import { ensureProjectDirectory } from "./paths"
 import { TerminalManager } from "./terminal-manager"
 import type { UpdateManager } from "./update-manager"
-import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
+import { deriveChatRuntime, deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
 
 export interface ClientState {
   subscriptions: Map<string, SubscriptionTopic>
@@ -138,6 +138,56 @@ export function createWsRouter({
     }
   }
 
+  function broadcastTopic(predicate: (topic: SubscriptionTopic) => boolean) {
+    for (const ws of sockets) {
+      for (const [id, topic] of ws.data.subscriptions.entries()) {
+        if (!predicate(topic)) continue
+        send(ws, createEnvelope(id, topic))
+      }
+    }
+  }
+
+  function pushSidebarSnapshots() {
+    broadcastTopic((topic) => topic.type === "sidebar")
+  }
+
+  function pushChatReset(chatId: string) {
+    const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), chatId)
+    const event: ChatEvent = {
+      type: "chat.reset",
+      chatId,
+      snapshot,
+    }
+    pushChatEvent(chatId, event)
+  }
+
+  function pushChatRuntime(chatId: string) {
+    const runtime = deriveChatRuntime(store.state, agent.getActiveStatuses(), chatId)
+    if (!runtime) {
+      pushChatReset(chatId)
+      return
+    }
+    pushChatEvent(chatId, {
+      type: "chat.runtime",
+      chatId,
+      runtime,
+    })
+  }
+
+  function pushChatEvent(chatId: string, event: ChatEvent) {
+    for (const ws of sockets) {
+      for (const [id, topic] of ws.data.subscriptions.entries()) {
+        if (topic.type !== "chat" || topic.chatId !== chatId) continue
+        send(ws, {
+          v: PROTOCOL_VERSION,
+          type: "event",
+          id,
+          event,
+        })
+      }
+    }
+  }
+
   function pushTerminalSnapshot(terminalId: string) {
     for (const ws of sockets) {
       for (const [id, topic] of ws.data.subscriptions.entries()) {
@@ -185,6 +235,7 @@ export function createWsRouter({
 
   async function handleCommand(ws: ServerWebSocket<ClientState>, message: Extract<ClientEnvelope, { type: "command" }>) {
     const { command, id } = message
+    let shouldBroadcastSnapshots = true
     try {
       switch (command.type) {
         case "system.ping": {
@@ -275,19 +326,37 @@ export function createWsRouter({
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
         }
+        case "chat.prefetch": {
+          const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), command.chatId)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: snapshot })
+          shouldBroadcastSnapshots = false
+          break
+        }
         case "chat.send": {
           const result = await agent.send(command)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
+          shouldBroadcastSnapshots = false
           break
         }
         case "chat.cancel": {
           await agent.cancel(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          shouldBroadcastSnapshots = false
           break
         }
         case "chat.respondTool": {
           await agent.respondTool(command)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          shouldBroadcastSnapshots = false
+          break
+        }
+        case "chat.loadMore": {
+          const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), command.chatId, {
+            beforeMessageId: command.beforeMessageId ?? null,
+            limit: command.limit,
+          })
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: snapshot })
+          shouldBroadcastSnapshots = false
           break
         }
         case "terminal.create": {
@@ -323,7 +392,9 @@ export function createWsRouter({
         }
       }
 
-      broadcastSnapshots()
+      if (shouldBroadcastSnapshots) {
+        broadcastSnapshots()
+      }
     } catch (error) {
       const messageText = error instanceof Error ? error.message : String(error)
       send(ws, { v: PROTOCOL_VERSION, type: "error", id, message: messageText })
@@ -338,6 +409,10 @@ export function createWsRouter({
       sockets.delete(ws)
     },
     broadcastSnapshots,
+    pushSidebarSnapshots,
+    pushChatReset,
+    pushChatRuntime,
+    pushChatEvent,
     handleMessage(ws: ServerWebSocket<ClientState>, raw: string | Buffer | ArrayBuffer | Uint8Array) {
       let parsed: unknown
       try {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1,10 +1,12 @@
 import type {
   AgentProvider,
+  ChatRuntime,
   ChatSnapshot,
   KeybindingsSnapshot,
   LocalProjectsSnapshot,
   ModelOptions,
   SidebarData,
+  TranscriptEntry,
   UpdateSnapshot,
 } from "./types"
 
@@ -41,6 +43,11 @@ export type TerminalEvent =
   | { type: "terminal.output"; terminalId: string; data: string }
   | { type: "terminal.exit"; terminalId: string; exitCode: number; signal?: number }
 
+export type ChatEvent =
+  | { type: "chat.runtime"; chatId: string; runtime: ChatRuntime }
+  | { type: "chat.messageAppended"; chatId: string; entry: TranscriptEntry }
+  | { type: "chat.reset"; chatId: string; snapshot: ChatSnapshot | null }
+
 export type ClientCommand =
   | { type: "project.open"; localPath: string }
   | { type: "project.create"; localPath: string; title: string }
@@ -61,6 +68,7 @@ export type ClientCommand =
   | { type: "chat.create"; projectId: string }
   | { type: "chat.rename"; chatId: string; title: string }
   | { type: "chat.delete"; chatId: string }
+  | { type: "chat.prefetch"; chatId: string }
   | {
       type: "chat.send"
       chatId?: string
@@ -74,6 +82,7 @@ export type ClientCommand =
     }
   | { type: "chat.cancel"; chatId: string }
   | { type: "chat.respondTool"; chatId: string; toolUseId: string; result: unknown }
+  | { type: "chat.loadMore"; chatId: string; beforeMessageId?: string; limit?: number }
   | { type: "terminal.create"; projectId: string; terminalId: string; cols: number; rows: number; scrollback: number }
   | { type: "terminal.input"; terminalId: string; data: string }
   | { type: "terminal.resize"; terminalId: string; cols: number; rows: number }
@@ -94,7 +103,7 @@ export type ServerSnapshot =
 
 export type ServerEnvelope =
   | { v: 1; type: "snapshot"; id: string; snapshot: ServerSnapshot }
-  | { v: 1; type: "event"; id: string; event: TerminalEvent }
+  | { v: 1; type: "event"; id: string; event: TerminalEvent | ChatEvent }
   | { v: 1; type: "ack"; id: string; result?: unknown }
   | { v: 1; type: "error"; id?: string; message: string }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,6 +138,7 @@ export interface SidebarChatRow {
   localPath: string
   provider: AgentProvider | null
   lastMessageAt?: number
+  lastCompletedTurnAt?: number
   hasAutomation: boolean
 }
 
@@ -529,6 +530,8 @@ export interface ChatRuntime {
 export interface ChatSnapshot {
   runtime: ChatRuntime
   messages: TranscriptEntry[]
+  hasOlderMessages: boolean
+  oldestLoadedMessageId: string | null
   availableProviders: ProviderCatalogEntry[]
 }
 


### PR DESCRIPTION
## Summary
- stream chat runtime and message updates over websocket events instead of rebroadcasting full snapshots
- persist active turn recovery metadata and resume interrupted turns after server restart
- add chat prefetch/load-more protocol support and coverage for recovery/read-model router paths

## Verification
- rtk /root/.bun/bin/bun run check
- rtk /root/.bun/bin/bun test src/server/agent.test.ts src/server/read-models.test.ts src/server/ws-router.test.ts src/client/app/useKannaState.test.ts