### PR TITLE
Add installable PWA support and completion notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Kanna</title>
   </head>
   <body>

--- a/public/badge.svg
+++ b/public/badge.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <circle cx="48" cy="48" r="36" fill="#ffffff"/>
+</svg>

--- a/public/icon-maskable.svg
+++ b/public/icon-maskable.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="mask-bg" x1="72" y1="72" x2="440" y2="440" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f472b6"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+    <linearGradient id="mask-petal" x1="144" y1="120" x2="368" y2="392" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#ffe4f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="#0f172a"/>
+  <circle cx="256" cy="256" r="196" fill="url(#mask-bg)"/>
+  <g fill="url(#mask-petal)">
+    <ellipse cx="256" cy="150" rx="42" ry="76"/>
+    <ellipse cx="256" cy="362" rx="42" ry="76"/>
+    <ellipse cx="150" cy="256" rx="76" ry="42"/>
+    <ellipse cx="362" cy="256" rx="76" ry="42"/>
+    <ellipse cx="184" cy="184" rx="38" ry="66" transform="rotate(-45 184 184)"/>
+    <ellipse cx="328" cy="184" rx="38" ry="66" transform="rotate(45 328 184)"/>
+    <ellipse cx="184" cy="328" rx="38" ry="66" transform="rotate(45 184 328)"/>
+    <ellipse cx="328" cy="328" rx="38" ry="66" transform="rotate(-45 328 328)"/>
+  </g>
+  <circle cx="256" cy="256" r="38" fill="#0f172a"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="64" y1="48" x2="448" y2="464" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f472b6"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+    <linearGradient id="petal" x1="160" y1="128" x2="352" y2="384" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#ffe4f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="#0f172a"/>
+  <rect x="32" y="32" width="448" height="448" rx="112" fill="url(#bg)"/>
+  <g fill="url(#petal)">
+    <ellipse cx="256" cy="140" rx="46" ry="86"/>
+    <ellipse cx="256" cy="372" rx="46" ry="86"/>
+    <ellipse cx="140" cy="256" rx="86" ry="46"/>
+    <ellipse cx="372" cy="256" rx="86" ry="46"/>
+    <ellipse cx="176" cy="176" rx="42" ry="76" transform="rotate(-45 176 176)"/>
+    <ellipse cx="336" cy="176" rx="42" ry="76" transform="rotate(45 336 176)"/>
+    <ellipse cx="176" cy="336" rx="42" ry="76" transform="rotate(45 176 336)"/>
+    <ellipse cx="336" cy="336" rx="42" ry="76" transform="rotate(-45 336 336)"/>
+  </g>
+  <circle cx="256" cy="256" r="44" fill="#0f172a"/>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "id": "/",
+  "name": "Kanna",
+  "short_name": "Kanna",
+  "description": "A beautiful web UI for Claude Code and Codex with installable mobile access.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "kanna-pwa-v1"
+const CACHE_NAME = "kanna-pwa-v2"
 const APP_SHELL = [
   "/",
   "/index.html",
@@ -37,7 +37,7 @@ self.addEventListener("fetch", (event) => {
   }
 
   if (["script", "style", "image", "font"].includes(request.destination)) {
-    event.respondWith(staleWhileRevalidate(request))
+    event.respondWith(networkFirst(request))
   }
 })
 
@@ -60,20 +60,6 @@ async function networkFirst(request, fallbackCacheKey) {
   } catch {
     return (await cache.match(request)) || (fallbackCacheKey ? await cache.match(fallbackCacheKey) : undefined) || Response.error()
   }
-}
-
-async function staleWhileRevalidate(request) {
-  const cache = await caches.open(CACHE_NAME)
-  const cached = await cache.match(request)
-
-  const networkPromise = fetch(request).then((response) => {
-    if (response.ok) {
-      cache.put(request, response.clone())
-    }
-    return response
-  }).catch(() => undefined)
-
-  return cached || networkPromise || Response.error()
 }
 
 async function openOrFocusClient(targetUrl) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,98 @@
+const CACHE_NAME = "kanna-pwa-v1"
+const APP_SHELL = [
+  "/",
+  "/index.html",
+  "/manifest.webmanifest",
+  "/favicon.png",
+  "/icon.svg",
+  "/icon-maskable.svg",
+  "/badge.svg",
+]
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting()
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)).catch(() => undefined)
+  )
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys()
+    await Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    await self.clients.claim()
+  })())
+})
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request
+  if (request.method !== "GET") return
+
+  const url = new URL(request.url)
+  if (url.origin !== self.location.origin) return
+
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirst(request, "/index.html"))
+    return
+  }
+
+  if (["script", "style", "image", "font"].includes(request.destination)) {
+    event.respondWith(staleWhileRevalidate(request))
+  }
+})
+
+self.addEventListener("notificationclick", (event) => {
+  const targetUrl = typeof event.notification.data?.url === "string" ? event.notification.data.url : "/"
+  event.notification.close()
+  event.waitUntil(openOrFocusClient(targetUrl))
+})
+
+async function networkFirst(request, fallbackCacheKey) {
+  const cache = await caches.open(CACHE_NAME)
+
+  try {
+    const response = await fetch(request)
+    cache.put(request, response.clone())
+    if (fallbackCacheKey && response.ok) {
+      cache.put(fallbackCacheKey, response.clone())
+    }
+    return response
+  } catch {
+    return (await cache.match(request)) || (fallbackCacheKey ? await cache.match(fallbackCacheKey) : undefined) || Response.error()
+  }
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE_NAME)
+  const cached = await cache.match(request)
+
+  const networkPromise = fetch(request).then((response) => {
+    if (response.ok) {
+      cache.put(request, response.clone())
+    }
+    return response
+  }).catch(() => undefined)
+
+  return cached || networkPromise || Response.error()
+}
+
+async function openOrFocusClient(targetUrl) {
+  const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true })
+
+  for (const client of clients) {
+    const clientUrl = new URL(client.url)
+    if (clientUrl.origin !== self.location.origin) continue
+
+    if ("focus" in client) {
+      await client.focus()
+    }
+    if ("navigate" in client) {
+      await client.navigate(targetUrl)
+    }
+    return
+  }
+
+  if (self.clients.openWindow) {
+    await self.clients.openWindow(targetUrl)
+  }
+}

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { ArrowDown, Flower } from "lucide-react"
-import { useOutletContext } from "react-router-dom"
+import { useLocation, useNavigate, useOutletContext } from "react-router-dom"
 import { ChatInput } from "../components/chat-ui/ChatInput"
 import { ChatNavbar } from "../components/chat-ui/ChatNavbar"
 import { RightSidebar } from "../components/chat-ui/RightSidebar"
@@ -26,6 +26,7 @@ import { useTerminalToggleAnimation } from "./useTerminalToggleAnimation"
 import type { KannaState } from "./useKannaState"
 import { KannaTranscript } from "./KannaTranscript"
 import { useStickyChatFocus } from "./useStickyChatFocus"
+import { shouldAutoScrollChatToBottom } from "../pwa"
 
 const EMPTY_STATE_TEXT = "What are we building?"
 const EMPTY_STATE_TYPING_INTERVAL_MS = 19
@@ -34,6 +35,8 @@ const SCROLL_BUTTON_BOTTOM_PX = 120
 
 export function ChatPage() {
   const state = useOutletContext<KannaState>()
+  const location = useLocation()
+  const navigate = useNavigate()
   const layoutRootRef = useRef<HTMLDivElement>(null)
   const chatCardRef = useRef<HTMLDivElement>(null)
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
@@ -224,6 +227,24 @@ export function ChatPage() {
 
     return () => observer.disconnect()
   }, [projectId, shouldRenderTerminalLayout, terminalLayout.mainSizes])
+
+  useEffect(() => {
+    if (!shouldAutoScrollChatToBottom(location.search)) return
+    if (!state.activeChatId || !state.runtime) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      state.scrollToBottom()
+    })
+    const timeoutId = window.setTimeout(() => {
+      state.scrollToBottom()
+      navigate({ pathname: location.pathname, search: "" }, { replace: true })
+    }, 150)
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [location.pathname, location.search, navigate, state.activeChatId, state.runtime, state.scrollToBottom])
 
   const clampRightSidebarSize = (size: number) => {
     if (!Number.isFinite(size)) {

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -10,6 +10,7 @@ import type { ChatSnapshot, LocalProjectsSnapshot, SidebarChatRow, SidebarData }
 import type { AskUserQuestionItem } from "../components/messages/types"
 import { useAppDialog } from "../components/ui/app-dialog"
 import { processTranscriptMessages } from "../lib/parseTranscript"
+import { requestNotificationPermissionOnUserAction, shouldShowCompletionNotification, showChatCompletionNotification } from "../pwa"
 import { canCancelStatus, getLatestToolIds, isProcessingStatus } from "./derived"
 import { KannaSocket, type SocketStatus } from "./socket"
 
@@ -49,6 +50,16 @@ function logKannaState(message: string, details?: unknown) {
   }
 
   console.info(`[useKannaState] ${message}`, details)
+}
+
+function getSidebarChatStatusMap(projectGroups: SidebarData["projectGroups"]) {
+  const statuses = new Map<string, SidebarChatRow["status"]>()
+  for (const group of projectGroups) {
+    for (const chat of group.chats) {
+      statuses.set(chat.chatId, chat.status)
+    }
+  }
+  return statuses
 }
 
 export function shouldAutoFollowTranscript(distanceFromBottom: number) {
@@ -209,20 +220,69 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const [commandError, setCommandError] = useState<string | null>(null)
   const [startingLocalPath, setStartingLocalPath] = useState<string | null>(null)
   const [pendingChatId, setPendingChatId] = useState<string | null>(null)
+  const [pendingNotificationChatIds, setPendingNotificationChatIds] = useState<Set<string>>(new Set())
   const editorLabel = getEditorPresetLabel(useTerminalPreferencesStore((store) => store.editorPreset))
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLDivElement>(null)
   const initialScrollCompletedRef = useRef(false)
   const initialScrollFrameRef = useRef<number | null>(null)
+  const previousSidebarStatusesRef = useRef<ReadonlyMap<string, SidebarChatRow["status"]>>(new Map())
+  const pendingNotificationChatIdsRef = useRef<ReadonlySet<string>>(new Set())
+
+  useEffect(() => {
+    pendingNotificationChatIdsRef.current = pendingNotificationChatIds
+  }, [pendingNotificationChatIds])
 
   useEffect(() => socket.onStatus(setConnectionStatus), [socket])
 
   useEffect(() => {
     return socket.subscribe<SidebarData>({ type: "sidebar" }, (snapshot) => {
+      const chatById = new Map(snapshot.projectGroups.flatMap((group) => group.chats.map((chat) => [chat.chatId, chat] as const)))
+      const completedChatIds: string[] = []
+      for (const chat of chatById.values()) {
+        const previousStatus = previousSidebarStatusesRef.current.get(chat.chatId)
+        if ((previousStatus === "starting" || previousStatus === "running") && chat.status === "idle") {
+          completedChatIds.push(chat.chatId)
+        }
+      }
+
+      setPendingNotificationChatIds((previous) => {
+        if (previous.size === 0 || completedChatIds.length === 0) {
+          return previous
+        }
+        const next = new Set(previous)
+        for (const chatId of completedChatIds) {
+          next.delete(chatId)
+        }
+        return next
+      })
+      previousSidebarStatusesRef.current = getSidebarChatStatusMap(snapshot.projectGroups)
       setSidebarData(snapshot)
       setSidebarReady(true)
       setCommandError(null)
+
+      for (const chatId of completedChatIds) {
+        if (!pendingNotificationChatIdsRef.current.has(chatId)) {
+          continue
+        }
+        if (!shouldShowCompletionNotification({
+          chatId,
+          activeChatId,
+          documentVisibilityState: document.visibilityState,
+        })) {
+          continue
+        }
+
+        const chat = chatById.get(chatId)
+        if (!chat) {
+          continue
+        }
+        void showChatCompletionNotification({
+          chatId,
+          chatTitle: chat.title,
+        })
+      }
     })
   }, [socket])
 
@@ -347,6 +407,13 @@ export function useKannaState(activeChatId: string | null): KannaState {
       initialScrollFrameRef.current = null
     }
     setIsAtBottom(true)
+    if (!activeChatId) return
+    setPendingNotificationChatIds((previous) => {
+      if (!previous.has(activeChatId)) return previous
+      const next = new Set(previous)
+      next.delete(activeChatId)
+      return next
+    })
   }, [activeChatId])
 
   useEffect(() => {
@@ -556,6 +623,8 @@ export function useKannaState(activeChatId: string | null): KannaState {
     options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }
   ) {
     try {
+      requestNotificationPermissionOnUserAction()
+
       let projectId = selectedProjectId ?? sidebarData.projectGroups[0]?.groupKey ?? null
       if (!activeChatId && !projectId && fallbackLocalProjectPath) {
         const project = await socket.command<{ projectId: string }>({
@@ -585,7 +654,18 @@ export function useKannaState(activeChatId: string | null): KannaState {
 
       if (!activeChatId && result.chatId) {
         setPendingChatId(result.chatId)
+        setPendingNotificationChatIds((previous) => {
+          const next = new Set(previous)
+          next.add(result.chatId!)
+          return next
+        })
         navigate(`/chat/${result.chatId}`)
+      } else if (activeChatId) {
+        setPendingNotificationChatIds((previous) => {
+          const next = new Set(previous)
+          next.add(activeChatId)
+          return next
+        })
       }
       setCommandError(null)
     } catch (error) {

--- a/src/client/pwa.test.ts
+++ b/src/client/pwa.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildChatDeepLink,
+  CHAT_SCROLL_TO_BOTTOM_QUERY_PARAM,
+  shouldAutoScrollChatToBottom,
+  shouldShowCompletionNotification,
+} from "./pwa"
+
+describe("buildChatDeepLink", () => {
+  test("builds a deep link to the chat and requests bottom scrolling", () => {
+    const url = buildChatDeepLink("https://kanna.example", "chat-123")
+
+    expect(url).toBe(`https://kanna.example/chat/chat-123?${CHAT_SCROLL_TO_BOTTOM_QUERY_PARAM}=1`)
+  })
+})
+
+describe("shouldAutoScrollChatToBottom", () => {
+  test("returns true when the deep link requests bottom scroll", () => {
+    expect(shouldAutoScrollChatToBottom("?scrollToBottom=1")).toBe(true)
+  })
+
+  test("returns false when the query param is absent", () => {
+    expect(shouldAutoScrollChatToBottom("?foo=bar")).toBe(false)
+  })
+})
+
+describe("shouldShowCompletionNotification", () => {
+  test("does not notify when the active chat is visible", () => {
+    expect(shouldShowCompletionNotification({
+      chatId: "chat-1",
+      activeChatId: "chat-1",
+      documentVisibilityState: "visible",
+    })).toBe(false)
+  })
+
+  test("notifies when the app is hidden", () => {
+    expect(shouldShowCompletionNotification({
+      chatId: "chat-1",
+      activeChatId: "chat-1",
+      documentVisibilityState: "hidden",
+    })).toBe(true)
+  })
+
+  test("notifies when a different chat is open", () => {
+    expect(shouldShowCompletionNotification({
+      chatId: "chat-1",
+      activeChatId: "chat-2",
+      documentVisibilityState: "visible",
+    })).toBe(true)
+  })
+})

--- a/src/client/pwa.ts
+++ b/src/client/pwa.ts
@@ -1,0 +1,102 @@
+import { APP_NAME } from "../shared/branding"
+
+const NOTIFICATION_PERMISSION_REQUESTED_STORAGE_KEY = "kanna:notifications:permission-requested"
+export const CHAT_SCROLL_TO_BOTTOM_QUERY_PARAM = "scrollToBottom"
+
+export function buildChatDeepLink(origin: string, chatId: string) {
+  const url = new URL(`/chat/${chatId}`, origin)
+  url.searchParams.set(CHAT_SCROLL_TO_BOTTOM_QUERY_PARAM, "1")
+  return url.toString()
+}
+
+export function shouldAutoScrollChatToBottom(search: string) {
+  const params = new URLSearchParams(search)
+  return params.get(CHAT_SCROLL_TO_BOTTOM_QUERY_PARAM) === "1"
+}
+
+export function shouldShowCompletionNotification(params: {
+  chatId: string
+  activeChatId: string | null
+  documentVisibilityState: DocumentVisibilityState
+}) {
+  return params.documentVisibilityState !== "visible" || params.activeChatId !== params.chatId
+}
+
+export async function registerPwaServiceWorker() {
+  if (!("serviceWorker" in navigator)) {
+    return null
+  }
+
+  try {
+    return await navigator.serviceWorker.register("/sw.js")
+  } catch (error) {
+    console.warn("[pwa] service worker registration failed", error)
+    return null
+  }
+}
+
+export function requestNotificationPermissionOnUserAction() {
+  if (typeof window === "undefined" || !("Notification" in window)) {
+    return
+  }
+
+  if (Notification.permission !== "default") {
+    return
+  }
+
+  try {
+    if (window.localStorage.getItem(NOTIFICATION_PERMISSION_REQUESTED_STORAGE_KEY) === "1") {
+      return
+    }
+    window.localStorage.setItem(NOTIFICATION_PERMISSION_REQUESTED_STORAGE_KEY, "1")
+  } catch {
+    // Ignore storage failures and still try the permission request.
+  }
+
+  void Notification.requestPermission().catch((error) => {
+    console.warn("[pwa] notification permission request failed", error)
+  })
+}
+
+export async function showChatCompletionNotification(params: {
+  chatId: string
+  chatTitle: string
+}) {
+  if (typeof window === "undefined" || !("Notification" in window) || Notification.permission !== "granted") {
+    return false
+  }
+
+  const body = "Agent finished working. Tap to open the chat."
+  const url = buildChatDeepLink(window.location.origin, params.chatId)
+  const notificationTitle = `${APP_NAME}: ${params.chatTitle}`
+  const options: NotificationOptions = {
+    body,
+    icon: "/icon.svg",
+    badge: "/badge.svg",
+    tag: `chat-complete:${params.chatId}`,
+    data: {
+      chatId: params.chatId,
+      url,
+    },
+  }
+
+  try {
+    if ("serviceWorker" in navigator) {
+      const registration = await navigator.serviceWorker.getRegistration()
+      if (registration) {
+        await registration.showNotification(notificationTitle, options)
+        return true
+      }
+    }
+
+    const notification = new Notification(notificationTitle, options)
+    notification.onclick = () => {
+      window.focus()
+      window.location.assign(url)
+    }
+    return true
+  } catch (error) {
+    console.warn("[pwa] chat completion notification failed", error)
+    return false
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client"
 import { BrowserRouter } from "react-router-dom"
 import { App } from "./client/app/App"
 import { ThemeProvider } from "./client/hooks/useTheme"
+import { registerPwaServiceWorker } from "./client/pwa"
 import "@xterm/xterm/css/xterm.css"
 import "./index.css"
 
@@ -11,6 +12,8 @@ const container = document.getElementById("root")
 if (!container) {
   throw new Error("Missing #root")
 }
+
+void registerPwaServiceWorker()
 
 createRoot(container).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- register a service worker and ship manifest/icon assets so Kanna can be installed as a PWA
- add notification helpers and chat deep links for completed turns
- prefer fresh navigations in the service worker while still caching the app shell

## Notes
- this is intentionally scoped to PWA/install/notification behavior and kept separate from unread completion dot UI changes
- there is partial topical overlap with #15, but this branch is focused on service worker install/notification flow rather than mobile layout work

## Verification
- rtk bash -lc '/root/.bun/bin/bun run check'