### PR TITLE
Keep completion dots visible until the user types

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -36,6 +36,7 @@ function KannaLayout() {
       <KannaSidebar
         data={state.sidebarData}
         activeChatId={state.activeChatId}
+        unreadCompletedChatIds={state.unreadCompletedChatIds}
         connectionStatus={state.connectionStatus}
         ready={state.sidebarReady}
         open={state.sidebarOpen}

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -347,6 +347,7 @@ export function ChatPage() {
             ref={chatInputRef}
             key={state.activeChatId ?? "new-chat"}
             onSubmit={state.handleSend}
+            onInputActivity={state.handleComposerInputActivity}
             onCancel={() => {
               void state.handleCancel()
             }}

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -13,6 +13,7 @@ import { useProjectGroupOrderStore } from "../stores/projectGroupOrderStore"
 interface KannaSidebarProps {
   data: SidebarData
   activeChatId: string | null
+  unreadCompletedChatIds: ReadonlySet<string>
   connectionStatus: SocketStatus
   ready: boolean
   open: boolean
@@ -32,6 +33,7 @@ interface KannaSidebarProps {
 export function KannaSidebar({
   data,
   activeChatId,
+  unreadCompletedChatIds,
   connectionStatus,
   ready,
   open,
@@ -115,6 +117,7 @@ export function KannaSidebar({
       key={chat._id}
       chat={chat}
       activeChatId={activeChatId}
+      showCompletedMarker={unreadCompletedChatIds.has(chat.chatId)}
       nowMs={nowMs}
       onSelectChat={(chatId) => {
         navigate(`/chat/${chatId}`)
@@ -122,7 +125,7 @@ export function KannaSidebar({
       }}
       onDeleteChat={() => onDeleteChat(chat)}
     />
-  ), [activeChatId, navigate, nowMs, onClose, onDeleteChat])
+  ), [activeChatId, navigate, nowMs, onClose, onDeleteChat, unreadCompletedChatIds])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {

--- a/src/client/app/useKannaState.test.ts
+++ b/src/client/app/useKannaState.test.ts
@@ -3,10 +3,11 @@ import {
   getActiveChatSnapshot,
   getNewestRemainingChatId,
   getUiUpdateRestartReconnectAction,
+  reconcileUnreadCompletedChatIds,
   resolveComposeIntent,
   shouldAutoFollowTranscript,
 } from "./useKannaState"
-import type { ChatSnapshot, SidebarData } from "../../shared/types"
+import type { ChatSnapshot, SidebarChatRow, SidebarData } from "../../shared/types"
 
 function createSidebarData(): SidebarData {
   return {
@@ -200,5 +201,66 @@ describe("getActiveChatSnapshot", () => {
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-new")).toBeNull()
+  })
+})
+
+describe("reconcileUnreadCompletedChatIds", () => {
+  function createChat(chatId: string, status: SidebarChatRow["status"]): SidebarChatRow {
+    return {
+      _id: `row-${chatId}`,
+      _creationTime: 1,
+      chatId,
+      title: chatId,
+      status,
+      localPath: "/tmp/project-1",
+      provider: null,
+      lastMessageAt: 1,
+      hasAutomation: false,
+    }
+  }
+
+  test("marks a background chat when it finishes running", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "running"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(),
+    })
+
+    expect([...next]).toEqual(["chat-1"])
+  })
+
+  test("keeps the marker for an active chat until the composer clears it", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "running"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-1",
+      unreadCompletedChatIds: new Set(),
+    })
+
+    expect([...next]).toEqual(["chat-1"])
+  })
+
+  test("drops markers for chats that no longer exist", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>(),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-2", "idle")],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(["chat-1"]),
+    })
+
+    expect(next.size).toBe(0)
   })
 })

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -51,6 +51,46 @@ function logKannaState(message: string, details?: unknown) {
   console.info(`[useKannaState] ${message}`, details)
 }
 
+function getSidebarChatStatusMap(projectGroups: SidebarData["projectGroups"]) {
+  const statuses = new Map<string, SidebarChatRow["status"]>()
+  for (const group of projectGroups) {
+    for (const chat of group.chats) {
+      statuses.set(chat.chatId, chat.status)
+    }
+  }
+  return statuses
+}
+
+export function reconcileUnreadCompletedChatIds(params: {
+  previousStatuses: ReadonlyMap<string, SidebarChatRow["status"]>
+  projectGroups: SidebarData["projectGroups"]
+  activeChatId: string | null
+  unreadCompletedChatIds: ReadonlySet<string>
+}) {
+  const nextUnreadCompletedChatIds = new Set(params.unreadCompletedChatIds)
+  const currentChatIds = new Set<string>()
+
+  for (const group of params.projectGroups) {
+    for (const chat of group.chats) {
+      currentChatIds.add(chat.chatId)
+
+      const previousStatus = params.previousStatuses.get(chat.chatId)
+      const completedInBackground = (previousStatus === "starting" || previousStatus === "running") && chat.status === "idle"
+      if (completedInBackground) {
+        nextUnreadCompletedChatIds.add(chat.chatId)
+      }
+    }
+  }
+
+  for (const chatId of nextUnreadCompletedChatIds) {
+    if (!currentChatIds.has(chatId)) {
+      nextUnreadCompletedChatIds.delete(chatId)
+    }
+  }
+
+  return nextUnreadCompletedChatIds
+}
+
 export function shouldAutoFollowTranscript(distanceFromBottom: number) {
   return distanceFromBottom < 24
 }
@@ -148,6 +188,7 @@ export interface KannaState {
   latestToolIds: ReturnType<typeof getLatestToolIds>
   runtime: ChatSnapshot["runtime"] | null
   availableProviders: ProviderCatalogEntry[]
+  unreadCompletedChatIds: ReadonlySet<string>
   isProcessing: boolean
   canCancel: boolean
   transcriptPaddingBottom: number
@@ -168,6 +209,7 @@ export interface KannaState {
   handleInstallUpdate: () => Promise<void>
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
+  handleComposerInputActivity: (value: string) => void
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
@@ -209,22 +251,31 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const [commandError, setCommandError] = useState<string | null>(null)
   const [startingLocalPath, setStartingLocalPath] = useState<string | null>(null)
   const [pendingChatId, setPendingChatId] = useState<string | null>(null)
+  const [unreadCompletedChatIds, setUnreadCompletedChatIds] = useState<Set<string>>(new Set())
   const editorLabel = getEditorPresetLabel(useTerminalPreferencesStore((store) => store.editorPreset))
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLDivElement>(null)
   const initialScrollCompletedRef = useRef(false)
   const initialScrollFrameRef = useRef<number | null>(null)
+  const previousSidebarStatusesRef = useRef<ReadonlyMap<string, SidebarChatRow["status"]>>(new Map())
 
   useEffect(() => socket.onStatus(setConnectionStatus), [socket])
 
   useEffect(() => {
     return socket.subscribe<SidebarData>({ type: "sidebar" }, (snapshot) => {
+      setUnreadCompletedChatIds((previous) => reconcileUnreadCompletedChatIds({
+        previousStatuses: previousSidebarStatusesRef.current,
+        projectGroups: snapshot.projectGroups,
+        activeChatId,
+        unreadCompletedChatIds: previous,
+      }))
+      previousSidebarStatusesRef.current = getSidebarChatStatusMap(snapshot.projectGroups)
       setSidebarData(snapshot)
       setSidebarReady(true)
       setCommandError(null)
     })
-  }, [socket])
+  }, [activeChatId, socket])
 
   useEffect(() => {
     return socket.subscribe<LocalProjectsSnapshot>({ type: "local-projects" }, (snapshot) => {
@@ -451,6 +502,17 @@ export function useKannaState(activeChatId: string | null): KannaState {
 
   function scrollToBottom() {
     enableAutoFollow("smooth")
+  }
+
+  function handleComposerInputActivity(value: string) {
+    if (!activeChatId) return
+    if (!value) return
+    setUnreadCompletedChatIds((previous) => {
+      if (!previous.has(activeChatId)) return previous
+      const next = new Set(previous)
+      next.delete(activeChatId)
+      return next
+    })
   }
 
   async function createChatForProject(projectId: string) {
@@ -778,6 +840,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     latestToolIds,
     runtime,
     availableProviders,
+    unreadCompletedChatIds,
     isProcessing,
     canCancel,
     transcriptPaddingBottom,
@@ -798,6 +861,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleInstallUpdate,
     handleSend,
     handleCancel,
+    handleComposerInputActivity,
     handleDeleteChat,
     handleRemoveProject,
     handleOpenExternal,

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -24,6 +24,7 @@ interface Props {
     options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }
   ) => Promise<void>
   onCancel?: () => void
+  onInputActivity?: (value: string) => void
   disabled: boolean
   canCancel?: boolean
   chatId?: string | null
@@ -110,6 +111,7 @@ export function resolvePlanModeState(args: {
 const ChatInputInner = forwardRef<HTMLTextAreaElement, Props>(function ChatInput({
   onSubmit,
   onCancel,
+  onInputActivity,
   disabled,
   canCancel,
   chatId,
@@ -340,11 +342,12 @@ const ChatInputInner = forwardRef<HTMLTextAreaElement, Props>(function ChatInput
             autoFocus
             {...{ [CHAT_INPUT_ATTRIBUTE]: "" }}
             rows={1}
-            onChange={(event) => {
-              setValue(event.target.value)
-              if (chatId) setDraft(chatId, event.target.value)
-              autoResize()
-            }}
+          onChange={(event) => {
+            setValue(event.target.value)
+            if (chatId) setDraft(chatId, event.target.value)
+            onInputActivity?.(event.target.value)
+            autoResize()
+          }}
             onKeyDown={handleKeyDown}
             disabled={disabled}
             className="flex-1 text-base p-3 md:p-4 pl-4.5 md:pl-6 resize-none max-h-[200px] outline-none bg-transparent border-0 shadow-none"

--- a/src/client/components/chat-ui/sidebar/ChatRow.tsx
+++ b/src/client/components/chat-ui/sidebar/ChatRow.tsx
@@ -10,6 +10,7 @@ const loadingStatuses = new Set(["starting", "running"])
 interface Props {
   chat: SidebarChatRow
   activeChatId: string | null
+  showCompletedMarker: boolean
   nowMs: number
   onSelectChat: (chatId: string) => void
   onDeleteChat: (chatId: string) => void
@@ -18,6 +19,7 @@ interface Props {
 export function ChatRow({
   chat,
   activeChatId,
+  showCompletedMarker,
   nowMs,
   onSelectChat,
   onDeleteChat,
@@ -43,6 +45,8 @@ export function ChatRow({
             <div className=" rounded-full z-0 size-2.5 bg-blue-400 ring-2 ring-muted/20 dark:ring-muted/50" />
           </div>
         </div>
+      ) : showCompletedMarker ? (
+        <span className="size-2.5 rounded-full bg-emerald-500 ring-2 ring-muted/20 dark:ring-muted/50" />
       ) : null}
       <span className="text-sm truncate flex-1 translate-y-[-0.5px]">
         {chat.status !== "idle" && chat.status !== "waiting_for_user" ? (


### PR DESCRIPTION
## Summary
- show a completion marker when a chat finishes, including when that chat is currently active
- keep the marker visible until the user starts typing in the composer instead of clearing it on open
- add coverage for the unread-completion reconciliation helper

## Notes
- this PR is intentionally scoped to sidebar completion marker behavior only
- notification/service-worker behavior is tracked separately in #30

## Verification
- rtk bash -lc '/root/.bun/bin/bun run check'