### PR TITLE
Virtualize the transcript and preload recent chat history

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@xterm/xterm": "^6.0.0",
         "default-shell": "^2.2.0",
         "react-resizable-panels": "^4.7.3",
+        "react-virtuoso": "^4.18.3",
       },
       "devDependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -657,6 +658,8 @@
     "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-virtuoso": ["react-virtuoso@4.18.3", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-fLz/peHAx4Eu0DLHurFEEI7Y6n5CqEoxBh04rgJM9yMuOJah2a9zWg/MUOmZLcp7zuWYorXq5+5bf3IRgkNvWg=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "@xterm/headless": "^6.0.0",
     "@xterm/xterm": "^6.0.0",
     "default-shell": "^2.2.0",
-    "react-resizable-panels": "^4.7.3"
+    "react-resizable-panels": "^4.7.3",
+    "react-virtuoso": "^4.18.3"
   },
   "devDependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { ArrowDown, Flower } from "lucide-react"
-import { useOutletContext } from "react-router-dom"
+import { useLocation, useNavigate, useOutletContext } from "react-router-dom"
 import { ChatInput } from "../components/chat-ui/ChatInput"
 import { ChatNavbar } from "../components/chat-ui/ChatNavbar"
 import { RightSidebar } from "../components/chat-ui/RightSidebar"
 import { TerminalWorkspace } from "../components/chat-ui/TerminalWorkspace"
 import { ProcessingMessage } from "../components/messages/ProcessingMessage"
+import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
 import { Card, CardContent } from "../components/ui/card"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable"
 import { ScrollArea } from "../components/ui/scroll-area"
@@ -25,19 +26,26 @@ import { useTerminalToggleAnimation } from "./useTerminalToggleAnimation"
 import type { KannaState } from "./useKannaState"
 import { KannaTranscript } from "./KannaTranscript"
 import { useStickyChatFocus } from "./useStickyChatFocus"
+import { shouldAutoScrollChatToBottom } from "../pwa"
+import type { HydratedTranscriptMessage } from "../../shared/types"
 
 const EMPTY_STATE_TEXT = "What are we building?"
-const EMPTY_STATE_TYPING_INTERVAL_MS = 19
 const CHAT_NAVBAR_OFFSET_PX = 72
 const SCROLL_BUTTON_BOTTOM_PX = 120
 
+function isTodoWriteMessage(
+  message: HydratedTranscriptMessage
+): message is Extract<HydratedTranscriptMessage, { kind: "tool"; toolKind: "todo_write" }> {
+  return message.kind === "tool" && message.toolKind === "todo_write"
+}
+
 export function ChatPage() {
   const state = useOutletContext<KannaState>()
+  const location = useLocation()
+  const navigate = useNavigate()
   const layoutRootRef = useRef<HTMLDivElement>(null)
   const chatCardRef = useRef<HTMLDivElement>(null)
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
-  const [typedEmptyStateText, setTypedEmptyStateText] = useState("")
-  const [isEmptyStateTypingComplete, setIsEmptyStateTypingComplete] = useState(false)
   const [fixedTerminalHeight, setFixedTerminalHeight] = useState(0)
   const projectId = state.runtime?.projectId ?? null
   const projectTerminalLayout = useTerminalLayoutStore((store) => (projectId ? store.projects[projectId] : undefined))
@@ -55,6 +63,18 @@ export function ChatPage() {
   const minColumnWidth = useTerminalPreferencesStore((store) => store.minColumnWidth)
   const keybindings = state.keybindings
   const resolvedKeybindings = useMemo(() => getResolvedKeybindings(keybindings), [keybindings])
+  const pinnedTodoMessage = useMemo(() => {
+    const latestTodoId = state.latestToolIds.TodoWrite
+    if (!latestTodoId) return null
+
+    for (let index = state.messages.length - 1; index >= 0; index -= 1) {
+      const message = state.messages[index]
+      if (message.id !== latestTodoId) continue
+      return isTodoWriteMessage(message) ? message : null
+    }
+
+    return null
+  }, [state.latestToolIds.TodoWrite, state.messages])
 
   const hasTerminals = terminalLayout.terminals.length > 0
   const showTerminalPane = Boolean(projectId && terminalLayout.isVisible && hasTerminals)
@@ -92,26 +112,6 @@ export function ChatPage() {
     enabled: state.hasSelectedProject && state.runtime?.status !== "waiting_for_user",
     canCancel: state.canCancel,
   })
-
-  useEffect(() => {
-    if (state.messages.length !== 0) return
-
-    setTypedEmptyStateText("")
-    setIsEmptyStateTypingComplete(false)
-
-    let characterIndex = 0
-    const interval = window.setInterval(() => {
-      characterIndex += 1
-      setTypedEmptyStateText(EMPTY_STATE_TEXT.slice(0, characterIndex))
-
-      if (characterIndex >= EMPTY_STATE_TEXT.length) {
-        window.clearInterval(interval)
-        setIsEmptyStateTypingComplete(true)
-      }
-    }, EMPTY_STATE_TYPING_INTERVAL_MS)
-
-    return () => window.clearInterval(interval)
-  }, [state.activeChatId, state.messages.length])
 
   useEffect(() => {
     function handleGlobalKeydown(event: KeyboardEvent) {
@@ -156,18 +156,6 @@ export function ChatPage() {
   }, [addTerminal, hasTerminals, projectId, resolvedKeybindings, toggleRightSidebar, toggleVisibility])
 
   useEffect(() => {
-    if (state.messages.length === 0) return
-
-    const frameId = window.requestAnimationFrame(() => {
-      const element = state.scrollRef.current
-      if (!element) return
-      element.scrollTo({ top: element.scrollHeight, behavior: "auto" })
-    })
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [state.messages.length, state.scrollRef])
-
-  useEffect(() => {
     const frameId = window.requestAnimationFrame(() => {
       state.updateScrollState()
     })
@@ -208,6 +196,24 @@ export function ChatPage() {
 
     return () => observer.disconnect()
   }, [projectId, shouldRenderTerminalLayout, terminalLayout.mainSizes])
+
+  useEffect(() => {
+    if (!shouldAutoScrollChatToBottom(location.search)) return
+    if (!state.activeChatId || !state.runtime) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      state.scrollToBottom()
+    })
+    const timeoutId = window.setTimeout(() => {
+      state.scrollToBottom()
+      navigate({ pathname: location.pathname, search: "" }, { replace: true })
+    }, 150)
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [location.pathname, location.search, navigate, state.activeChatId, state.runtime, state.scrollToBottom])
 
   const clampRightSidebarSize = (size: number) => {
     if (!Number.isFinite(size)) {
@@ -253,14 +259,20 @@ export function ChatPage() {
           onScroll={state.updateScrollState}
           className="flex-1 min-h-0 px-4 scroll-pt-[72px]"
         >
+          {state.loadingOlderMessages ? (
+            <div className="pt-[72px] pb-3 max-w-[800px] mx-auto text-xs text-muted-foreground">
+              Loading older messages...
+            </div>
+          ) : null}
           {state.messages.length === 0 ? <div style={{ height: state.transcriptPaddingBottom }} aria-hidden="true" /> : null}
           {state.messages.length > 0 ? (
             <>
-              <div className="animate-fade-in space-y-5 pt-[72px] max-w-[800px] mx-auto">
+              <div className="space-y-5 pt-[72px] max-w-[800px] mx-auto">
                 <KannaTranscript
                   messages={state.messages}
                   isLoading={state.isProcessing}
                   localPath={state.runtime?.localPath}
+                  scrollParent={state.scrollRef.current}
                   latestToolIds={state.latestToolIds}
                   onOpenLocalLink={state.handleOpenLocalLink}
                   onAskUserQuestionSubmit={state.handleAskUserQuestion}
@@ -281,7 +293,7 @@ export function ChatPage() {
         {state.messages.length === 0 ? (
           <div
             key={state.activeChatId ?? "new-chat"}
-            className="pointer-events-none absolute inset-x-4 animate-fade-in"
+            className="pointer-events-none absolute inset-x-4"
             style={{
               top: CHAT_NAVBAR_OFFSET_PX,
               bottom: state.transcriptPaddingBottom,
@@ -289,26 +301,12 @@ export function ChatPage() {
           >
             <div className="mx-auto flex h-full max-w-[800px] items-center justify-center">
               <div className="flex flex-col items-center justify-center text-muted-foreground gap-4 opacity-70">
-                <Flower strokeWidth={1.5} className="size-8 text-muted-foreground kanna-empty-state-flower"></Flower>
+                <Flower strokeWidth={1.5} className="size-8 text-muted-foreground" />
                 <div
-                  className="text-base font-normal text-muted-foreground text-center max-w-xs flex items-center kanna-empty-state-text"
+                  className="text-base font-normal text-muted-foreground text-center max-w-xs flex items-center"
                   aria-label={EMPTY_STATE_TEXT}
                 >
-                  <span className="relative inline-grid place-items-start">
-                    <span className="invisible col-start-1 row-start-1 whitespace-pre flex items-center">
-                      <span>{EMPTY_STATE_TEXT}</span>
-                      <span className="kanna-typewriter-cursor-slot" aria-hidden="true" />
-                    </span>
-                    <span className="col-start-1 row-start-1 whitespace-pre flex items-center">
-                      <span>{typedEmptyStateText}</span>
-                      <span className="kanna-typewriter-cursor-slot" aria-hidden="true">
-                        <span
-                          className="kanna-typewriter-cursor"
-                          data-typing-complete={isEmptyStateTypingComplete ? "true" : "false"}
-                        />
-                      </span>
-                    </span>
-                  </span>
+                  <span>{EMPTY_STATE_TEXT}</span>
                 </div>
               </div>
             </div>
@@ -335,6 +333,14 @@ export function ChatPage() {
 
       <div className="absolute bottom-0 left-0 right-0 z-20 pointer-events-none">
         <div className="bg-gradient-to-t from-background via-background pointer-events-auto" ref={state.inputRef}>
+          {pinnedTodoMessage ? (
+            <div className="mx-auto max-w-[840px] px-3 pt-3 md:px-5">
+              <TodoWriteMessage
+                message={pinnedTodoMessage}
+                className="rounded-2xl shadow-lg shadow-black/5"
+              />
+            </div>
+          ) : null}
           <ChatInput
             ref={chatInputRef}
             key={state.activeChatId ?? "new-chat"}

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react"
+import { Virtuoso } from "react-virtuoso"
 import type { AskUserQuestionItem, ProcessedToolCall } from "../components/messages/types"
 import type { AskUserQuestionAnswerMap, HydratedTranscriptMessage } from "../../shared/types"
 import { UserMessage } from "../components/messages/UserMessage"
@@ -8,7 +9,6 @@ import { AccountInfoMessage } from "../components/messages/AccountInfoMessage"
 import { TextMessage } from "../components/messages/TextMessage"
 import { AskUserQuestionMessage } from "../components/messages/AskUserQuestionMessage"
 import { ExitPlanModeMessage } from "../components/messages/ExitPlanModeMessage"
-import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
 import { ToolCallMessage } from "../components/messages/ToolCallMessage"
 import { ResultMessage } from "../components/messages/ResultMessage"
 import { InterruptedMessage } from "../components/messages/InterruptedMessage"
@@ -64,6 +64,7 @@ interface KannaTranscriptProps {
   messages: HydratedTranscriptMessage[]
   isLoading: boolean
   localPath?: string
+  scrollParent?: HTMLElement | null
   latestToolIds: Record<string, string | null>
   onOpenLocalLink: (target: { path: string; line?: number; column?: number }) => void
   onAskUserQuestionSubmit: (
@@ -74,16 +75,19 @@ interface KannaTranscriptProps {
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
 }
 
-export function KannaTranscript({
+export const KannaTranscript = React.memo(function KannaTranscript({
   messages,
   isLoading,
   localPath,
+  scrollParent,
   latestToolIds,
   onOpenLocalLink,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
 }: KannaTranscriptProps) {
   const renderItems = useMemo(() => groupMessages(messages), [messages])
+  const firstSystemInitIndex = useMemo(() => messages.findIndex((entry) => entry.kind === "system_init"), [messages])
+  const firstAccountInfoIndex = useMemo(() => messages.findIndex((entry) => entry.kind === "account_info"), [messages])
 
   function renderMessage(message: HydratedTranscriptMessage, index: number): React.ReactNode {
     if (message.kind === "user_prompt") {
@@ -94,11 +98,11 @@ export function KannaTranscript({
       case "unknown":
         return <RawJsonMessage key={message.id} json={message.json} />
       case "system_init": {
-        const isFirst = messages.findIndex((entry) => entry.kind === "system_init") === index
+        const isFirst = firstSystemInitIndex === index
         return isFirst ? <SystemMessage key={message.id} message={message} rawJson={message.debugRaw} /> : null
       }
       case "account_info": {
-        const isFirst = messages.findIndex((entry) => entry.kind === "account_info") === index
+        const isFirst = firstAccountInfoIndex === index
         return isFirst ? <AccountInfoMessage key={message.id} message={message} /> : null
       }
       case "assistant_text":
@@ -125,8 +129,7 @@ export function KannaTranscript({
           )
         }
         if (message.toolKind === "todo_write") {
-          if (message.id !== latestToolIds.TodoWrite) return null
-          return <TodoWriteMessage key={message.id} message={message} />
+          return null
         }
         return (
           <ToolCallMessage
@@ -157,34 +160,49 @@ export function KannaTranscript({
     }
   }
 
+  function renderItem(item: RenderItem) {
+    if (item.type === "tool-group") {
+      return (
+        <div
+          key={`group-${item.startIndex}`}
+          className="group relative pb-5"
+          {...{ [CHAT_SELECTION_ZONE_ATTRIBUTE]: "" }}
+        >
+          <CollapsedToolGroup messages={item.messages} isLoading={isLoading} localPath={localPath} />
+        </div>
+      )
+    }
+
+    const rendered = renderMessage(item.message, item.index)
+    if (!rendered) return null
+    return (
+      <div
+        key={item.message.id}
+        id={`msg-${item.message.id}`}
+        className="group relative pb-5"
+        {...{ [CHAT_SELECTION_ZONE_ATTRIBUTE]: "" }}
+      >
+        {rendered}
+      </div>
+    )
+  }
+
   return (
     <OpenLocalLinkProvider onOpenLocalLink={onOpenLocalLink}>
-      {renderItems.map((item) => {
-        if (item.type === "tool-group") {
-          return (
-            <div
-              key={`group-${item.startIndex}`}
-              className="group relative"
-              {...{ [CHAT_SELECTION_ZONE_ATTRIBUTE]: "" }}
-            >
-              <CollapsedToolGroup messages={item.messages} isLoading={isLoading} localPath={localPath} />
-            </div>
-          )
-        }
-
-        const rendered = renderMessage(item.message, item.index)
-        if (!rendered) return null
-        return (
-          <div
-            key={item.message.id}
-            id={`msg-${item.message.id}`}
-            className="group relative"
-            {...{ [CHAT_SELECTION_ZONE_ATTRIBUTE]: "" }}
-          >
-            {rendered}
-          </div>
-        )
-      })}
+      <Virtuoso
+        customScrollParent={scrollParent ?? undefined}
+        data={renderItems}
+        increaseViewportBy={{ top: 600, bottom: 1200 }}
+        overscan={400}
+        computeItemKey={(index, item) => item.type === "tool-group" ? `group-${item.startIndex}` : item.message.id}
+        itemContent={(index, item) => renderItem(item)}
+      />
     </OpenLocalLinkProvider>
   )
-}
+}, (previous, next) => (
+  previous.messages === next.messages
+  && previous.isLoading === next.isLoading
+  && previous.localPath === next.localPath
+  && previous.scrollParent === next.scrollParent
+  && previous.latestToolIds === next.latestToolIds
+))

--- a/src/client/app/useKannaState.test.ts
+++ b/src/client/app/useKannaState.test.ts
@@ -3,10 +3,12 @@ import {
   getActiveChatSnapshot,
   getNewestRemainingChatId,
   getUiUpdateRestartReconnectAction,
+  reconcileUnreadCompletedChatIds,
   resolveComposeIntent,
+  shouldAutoFollowTranscript,
   shouldPinTranscriptToBottom,
 } from "./useKannaState"
-import type { ChatSnapshot, SidebarData } from "../../shared/types"
+import type { ChatSnapshot, SidebarChatRow, SidebarData } from "../../shared/types"
 
 function createSidebarData(): SidebarData {
   return {
@@ -177,6 +179,8 @@ describe("getActiveChatSnapshot", () => {
         sessionToken: null,
       },
       messages: [],
+      hasOlderMessages: false,
+      oldestLoadedMessageId: null,
       availableProviders: [],
     }
 
@@ -196,9 +200,140 @@ describe("getActiveChatSnapshot", () => {
         sessionToken: null,
       },
       messages: [],
+      hasOlderMessages: false,
+      oldestLoadedMessageId: null,
       availableProviders: [],
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-new")).toBeNull()
+  })
+})
+
+describe("shouldAutoFollowTranscript", () => {
+  test("returns true when the transcript is still pinned to the bottom", () => {
+    expect(shouldAutoFollowTranscript(0)).toBe(true)
+  })
+
+  test("returns true when the transcript is only slightly above the bottom", () => {
+    expect(shouldAutoFollowTranscript(23)).toBe(true)
+  })
+
+  test("returns false when the reader has scrolled away from the bottom", () => {
+    expect(shouldAutoFollowTranscript(24)).toBe(false)
+  })
+})
+
+describe("reconcileUnreadCompletedChatIds", () => {
+  function createChat(chatId: string, status: SidebarChatRow["status"]): SidebarChatRow {
+    return {
+      _id: `row-${chatId}`,
+      _creationTime: 1,
+      chatId,
+      title: chatId,
+      status,
+      localPath: "/tmp/project-1",
+      provider: null,
+      lastMessageAt: 1,
+      hasAutomation: false,
+    }
+  }
+
+  test("marks background chats when they finish running", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "running"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(),
+    })
+
+    expect([...next]).toEqual(["chat-1"])
+  })
+
+  test("marks background chats when a pending sent turn has completed", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "idle"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(),
+      pendingCompletionChatIds: new Set(["chat-1"]),
+      observedRunningPendingChatIds: new Set(["chat-1"]),
+    })
+
+    expect([...next]).toEqual(["chat-1"])
+  })
+
+  test("does not mark a pending chat until it has been seen running", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "idle"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(),
+      pendingCompletionChatIds: new Set(["chat-1"]),
+      observedRunningPendingChatIds: new Set(),
+      lastSeenMessageAtByChatId: new Map([["chat-1", 1]]),
+    })
+
+    expect(next.size).toBe(0)
+  })
+
+  test("marks chats with unseen newer messages after reopening the app", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "idle"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [{
+          ...createChat("chat-1", "idle"),
+          lastCompletedTurnAt: 10,
+        }],
+      }],
+      activeChatId: "chat-2",
+      unreadCompletedChatIds: new Set(),
+      lastSeenMessageAtByChatId: new Map([["chat-1", 5]]),
+    })
+
+    expect([...next]).toEqual(["chat-1"])
+  })
+
+  test("does not mark the active chat when it finishes", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "running"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-1",
+      unreadCompletedChatIds: new Set(),
+    })
+
+    expect(next.size).toBe(0)
+  })
+
+  test("clears markers for the chat that becomes active", () => {
+    const next = reconcileUnreadCompletedChatIds({
+      previousStatuses: new Map<string, SidebarChatRow["status"]>([["chat-1", "idle"]]),
+      projectGroups: [{
+        groupKey: "project-1",
+        localPath: "/tmp/project-1",
+        chats: [createChat("chat-1", "idle")],
+      }],
+      activeChatId: "chat-1",
+      unreadCompletedChatIds: new Set(["chat-1"]),
+    })
+
+    expect(next.size).toBe(0)
   })
 })

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react"
+import { startTransition, useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react"
 import { useNavigate } from "react-router-dom"
 import { APP_NAME } from "../../shared/branding"
 import { PROVIDERS, type AgentProvider, type AskUserQuestionAnswerMap, type KeybindingsSnapshot, type ModelOptions, type ProviderCatalogEntry, type UpdateInstallResult, type UpdateSnapshot } from "../../shared/types"
@@ -10,8 +10,64 @@ import type { ChatSnapshot, LocalProjectsSnapshot, SidebarChatRow, SidebarData }
 import type { AskUserQuestionItem } from "../components/messages/types"
 import { useAppDialog } from "../components/ui/app-dialog"
 import { processTranscriptMessages } from "../lib/parseTranscript"
+import { requestNotificationPermissionOnUserAction, shouldShowCompletionNotification, showChatCompletionNotification } from "../pwa"
 import { canCancelStatus, getLatestToolIds, isProcessingStatus } from "./derived"
 import { KannaSocket, type SocketStatus } from "./socket"
+import type { ChatEvent } from "../../shared/protocol"
+
+function getSidebarChatStatusMap(projectGroups: SidebarData["projectGroups"]) {
+  const statuses = new Map<string, SidebarChatRow["status"]>()
+  for (const group of projectGroups) {
+    for (const chat of group.chats) {
+      statuses.set(chat.chatId, chat.status)
+    }
+  }
+  return statuses
+}
+
+export function reconcileUnreadCompletedChatIds(params: {
+  previousStatuses: ReadonlyMap<string, SidebarChatRow["status"]>
+  projectGroups: SidebarData["projectGroups"]
+  activeChatId: string | null
+  unreadCompletedChatIds: ReadonlySet<string>
+  pendingCompletionChatIds?: ReadonlySet<string>
+  observedRunningPendingChatIds?: ReadonlySet<string>
+  lastSeenMessageAtByChatId?: ReadonlyMap<string, number>
+}) {
+  const nextUnreadCompletedChatIds = new Set(params.unreadCompletedChatIds)
+  const currentChatIds = new Set<string>()
+
+  for (const group of params.projectGroups) {
+    for (const chat of group.chats) {
+      currentChatIds.add(chat.chatId)
+
+      const previousStatus = params.previousStatuses.get(chat.chatId)
+      const completedInBackground = (previousStatus === "starting" || previousStatus === "running") && chat.status === "idle"
+      const completedPendingTurn = params.pendingCompletionChatIds?.has(chat.chatId)
+        && params.observedRunningPendingChatIds?.has(chat.chatId)
+        && chat.status === "idle"
+      const seenMessageAt = params.lastSeenMessageAtByChatId?.get(chat.chatId) ?? 0
+      const hasUnreadCompletedTurnsSinceLastOpen = chat.status === "idle"
+        && typeof chat.lastCompletedTurnAt === "number"
+        && chat.lastCompletedTurnAt > seenMessageAt
+      if ((completedInBackground || completedPendingTurn || hasUnreadCompletedTurnsSinceLastOpen) && chat.chatId !== params.activeChatId) {
+        nextUnreadCompletedChatIds.add(chat.chatId)
+      }
+
+      if (chat.chatId === params.activeChatId) {
+        nextUnreadCompletedChatIds.delete(chat.chatId)
+      }
+    }
+  }
+
+  for (const chatId of nextUnreadCompletedChatIds) {
+    if (!currentChatIds.has(chatId)) {
+      nextUnreadCompletedChatIds.delete(chatId)
+    }
+  }
+
+  return nextUnreadCompletedChatIds
+}
 
 export function getNewestRemainingChatId(projectGroups: SidebarData["projectGroups"], activeChatId: string): string | null {
   const projectGroup = projectGroups.find((group) => group.chats.some((chat) => chat.chatId === activeChatId))
@@ -70,8 +126,13 @@ export function getUiUpdateRestartReconnectAction(
   return "none"
 }
 
-const FIXED_TRANSCRIPT_PADDING_BOTTOM = 320
+export function shouldAutoFollowTranscript(distanceFromBottom: number) {
+  return distanceFromBottom < 24
+}
+
+const MIN_TRANSCRIPT_PADDING_BOTTOM = 320
 const UI_UPDATE_RESTART_STORAGE_KEY = "kanna:ui-update-restart"
+const CHAT_LAST_SEEN_STORAGE_KEY = "kanna:chat-last-seen-completed-turn-at"
 
 function getUiUpdateRestartPhase() {
   return window.sessionStorage.getItem(UI_UPDATE_RESTART_STORAGE_KEY)
@@ -83,6 +144,33 @@ function setUiUpdateRestartPhase(phase: "awaiting_disconnect" | "awaiting_reconn
 
 function clearUiUpdateRestartPhase() {
   window.sessionStorage.removeItem(UI_UPDATE_RESTART_STORAGE_KEY)
+}
+
+function readLastSeenMessageAtByChatId() {
+  if (typeof window === "undefined") return new Map<string, number>()
+
+  try {
+    const raw = window.localStorage.getItem(CHAT_LAST_SEEN_STORAGE_KEY)
+    if (!raw) return new Map<string, number>()
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const entries = Object.entries(parsed).filter((entry): entry is [string, number] => typeof entry[1] === "number")
+    return new Map(entries)
+  } catch {
+    return new Map<string, number>()
+  }
+}
+
+function writeLastSeenMessageAtByChatId(lastSeenMessageAtByChatId: ReadonlyMap<string, number>) {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.setItem(
+      CHAT_LAST_SEEN_STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(lastSeenMessageAtByChatId.entries()))
+    )
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 export interface ProjectRequest {
@@ -127,6 +215,113 @@ export function getActiveChatSnapshot(chatSnapshot: ChatSnapshot | null, activeC
   return chatSnapshot
 }
 
+function upsertChatSnapshot(
+  previous: Record<string, ChatSnapshot>,
+  chatId: string,
+  snapshot: ChatSnapshot | null
+): Record<string, ChatSnapshot> {
+  if (!snapshot) {
+    if (!(chatId in previous)) return previous
+    const { [chatId]: _removed, ...rest } = previous
+    return rest
+  }
+
+  if (previous[chatId] === snapshot) return previous
+  return {
+    ...previous,
+    [chatId]: snapshot,
+  }
+}
+
+function applyChatEventToCache(
+  previous: Record<string, ChatSnapshot>,
+  activeChatId: string,
+  event: ChatEvent
+): Record<string, ChatSnapshot> {
+  const current = previous[activeChatId]
+  if (!current) {
+    if (event.type === "chat.reset") {
+      return upsertChatSnapshot(previous, activeChatId, event.snapshot)
+    }
+    return previous
+  }
+
+  switch (event.type) {
+    case "chat.reset":
+      return upsertChatSnapshot(previous, activeChatId, event.snapshot)
+    case "chat.runtime":
+      return {
+        ...previous,
+        [activeChatId]: {
+          ...current,
+          runtime: event.runtime,
+        },
+      }
+    case "chat.messageAppended":
+      return {
+        ...previous,
+        [activeChatId]: {
+          ...current,
+          messages: [...current.messages, event.entry],
+          oldestLoadedMessageId: current.oldestLoadedMessageId ?? event.entry._id,
+        },
+      }
+  }
+}
+
+function prependChatSnapshotChunk(
+  previous: Record<string, ChatSnapshot>,
+  chatId: string,
+  snapshot: ChatSnapshot | null
+): Record<string, ChatSnapshot> {
+  if (!snapshot) return previous
+  const current = previous[chatId]
+  if (!current) {
+    return upsertChatSnapshot(previous, chatId, snapshot)
+  }
+
+  if (snapshot.messages.length === 0) {
+    return {
+      ...previous,
+      [chatId]: {
+        ...current,
+        hasOlderMessages: snapshot.hasOlderMessages,
+        oldestLoadedMessageId: current.oldestLoadedMessageId,
+      },
+    }
+  }
+
+  const existingIds = new Set(current.messages.map((entry) => entry._id))
+  const prepended = snapshot.messages.filter((entry) => !existingIds.has(entry._id))
+  if (prepended.length === 0 && current.hasOlderMessages === snapshot.hasOlderMessages) {
+    return previous
+  }
+
+  return {
+    ...previous,
+    [chatId]: {
+      ...current,
+      runtime: snapshot.runtime,
+      messages: [...prepended, ...current.messages],
+      hasOlderMessages: snapshot.hasOlderMessages,
+      oldestLoadedMessageId: snapshot.oldestLoadedMessageId ?? current.oldestLoadedMessageId,
+      availableProviders: snapshot.availableProviders,
+    },
+  }
+}
+
+function getRecentSidebarChatIds(projectGroups: SidebarData["projectGroups"], limit: number): string[] {
+  return projectGroups
+    .flatMap((group) => group.chats)
+    .sort((a, b) => {
+      const aTime = a.lastMessageAt ?? a._creationTime
+      const bTime = b.lastMessageAt ?? b._creationTime
+      return bTime - aTime
+    })
+    .slice(0, limit)
+    .map((chat) => chat.chatId)
+}
+
 export interface KannaState {
   socket: KannaSocket
   activeChatId: string | null
@@ -148,8 +343,11 @@ export interface KannaState {
   latestToolIds: ReturnType<typeof getLatestToolIds>
   runtime: ChatSnapshot["runtime"] | null
   availableProviders: ProviderCatalogEntry[]
+  unreadCompletedChatIds: ReadonlySet<string>
   isProcessing: boolean
   canCancel: boolean
+  hasOlderMessages: boolean
+  loadingOlderMessages: boolean
   transcriptPaddingBottom: number
   showScrollButton: boolean
   navbarLocalPath?: string
@@ -168,6 +366,7 @@ export interface KannaState {
   handleInstallUpdate: () => Promise<void>
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
+  handleLoadOlderMessages: () => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
@@ -195,12 +394,13 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const [sidebarData, setSidebarData] = useState<SidebarData>({ projectGroups: [] })
   const [localProjects, setLocalProjects] = useState<LocalProjectsSnapshot | null>(null)
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null)
-  const [chatSnapshot, setChatSnapshot] = useState<ChatSnapshot | null>(null)
+  const [chatSnapshotsById, setChatSnapshotsById] = useState<Record<string, ChatSnapshot>>({})
   const [keybindings, setKeybindings] = useState<KeybindingsSnapshot | null>(null)
   const [connectionStatus, setConnectionStatus] = useState<SocketStatus>("connecting")
   const [sidebarReady, setSidebarReady] = useState(false)
   const [localProjectsReady, setLocalProjectsReady] = useState(false)
   const [chatReady, setChatReady] = useState(false)
+  const [loadingOlderMessages, setLoadingOlderMessages] = useState(false)
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
@@ -209,18 +409,153 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const [commandError, setCommandError] = useState<string | null>(null)
   const [startingLocalPath, setStartingLocalPath] = useState<string | null>(null)
   const [pendingChatId, setPendingChatId] = useState<string | null>(null)
+  const [unreadCompletedChatIds, setUnreadCompletedChatIds] = useState<Set<string>>(new Set())
   const editorLabel = getEditorPresetLabel(useTerminalPreferencesStore((store) => store.editorPreset))
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLDivElement>(null)
+  const pendingPrependScrollHeightRef = useRef<number | null>(null)
+  const autoFollowTranscriptRef = useRef(true)
+  const initialScrollCompletedRef = useRef(false)
+  const initialScrollFrameRef = useRef<number | null>(null)
+  const initialScrollTimeoutRef = useRef<number | null>(null)
+  const previousSidebarStatusesRef = useRef<ReadonlyMap<string, SidebarChatRow["status"]>>(new Map())
+  const activeChatIdRef = useRef<string | null>(activeChatId)
+  const pendingNotificationChatIdsRef = useRef<Set<string>>(new Set())
+  const observedRunningPendingChatIdsRef = useRef<Set<string>>(new Set())
+  const lastSeenMessageAtByChatIdRef = useRef<ReadonlyMap<string, number>>(readLastSeenMessageAtByChatId())
+  const processedTranscriptCacheRef = useRef(new Map<string, {
+    source: ChatSnapshot["messages"]
+    messages: ReturnType<typeof processTranscriptMessages>
+    latestToolIds: ReturnType<typeof getLatestToolIds>
+  }>())
+  const prewarmingChatIdsRef = useRef(new Set<string>())
+
+  function updatePendingNotificationChatIds(updater: (previous: Set<string>) => Set<string>) {
+    const next = updater(new Set(pendingNotificationChatIdsRef.current))
+    pendingNotificationChatIdsRef.current = next
+  }
+
+  function updateObservedRunningPendingChatIds(updater: (previous: Set<string>) => Set<string>) {
+    const next = updater(new Set(observedRunningPendingChatIdsRef.current))
+    observedRunningPendingChatIdsRef.current = next
+  }
+
+  function markChatSeen(chatId: string, lastCompletedTurnAt?: number) {
+    if (typeof lastCompletedTurnAt !== "number") return
+
+    const previous = lastSeenMessageAtByChatIdRef.current.get(chatId) ?? 0
+    if (lastCompletedTurnAt <= previous) return
+
+    const next = new Map(lastSeenMessageAtByChatIdRef.current)
+    next.set(chatId, lastCompletedTurnAt)
+    lastSeenMessageAtByChatIdRef.current = next
+    writeLastSeenMessageAtByChatId(next)
+  }
+
+  function warmProcessedTranscriptCache(chatId: string, snapshot: ChatSnapshot | null) {
+    if (!snapshot) return
+    const cached = processedTranscriptCacheRef.current.get(chatId)
+    if (cached?.source === snapshot.messages) return
+
+    const messages = processTranscriptMessages(snapshot.messages)
+    const latestToolIds = getLatestToolIds(messages)
+    processedTranscriptCacheRef.current.set(chatId, {
+      source: snapshot.messages,
+      messages,
+      latestToolIds,
+    })
+  }
+
+  useEffect(() => {
+    activeChatIdRef.current = activeChatId
+  }, [activeChatId])
 
   useEffect(() => socket.onStatus(setConnectionStatus), [socket])
 
   useEffect(() => {
     return socket.subscribe<SidebarData>({ type: "sidebar" }, (snapshot) => {
+      const chatById = new Map(snapshot.projectGroups.flatMap((group) => group.chats.map((chat) => [chat.chatId, chat] as const)))
+      const completedChatIds: string[] = []
+
+      updateObservedRunningPendingChatIds((previous) => {
+        const next = new Set(previous)
+        for (const chat of chatById.values()) {
+          if (!pendingNotificationChatIdsRef.current.has(chat.chatId)) continue
+          if (chat.status === "starting" || chat.status === "running") {
+            next.add(chat.chatId)
+          }
+        }
+        for (const chatId of next) {
+          if (!chatById.has(chatId) || !pendingNotificationChatIdsRef.current.has(chatId)) {
+            next.delete(chatId)
+          }
+        }
+        return next
+      })
+
+      for (const chat of chatById.values()) {
+        const previousStatus = previousSidebarStatusesRef.current.get(chat.chatId)
+        if ((previousStatus === "starting" || previousStatus === "running") && chat.status === "idle") {
+          completedChatIds.push(chat.chatId)
+        }
+      }
+
+      setUnreadCompletedChatIds((previous) => reconcileUnreadCompletedChatIds({
+        previousStatuses: previousSidebarStatusesRef.current,
+        projectGroups: snapshot.projectGroups,
+        activeChatId: activeChatIdRef.current,
+        unreadCompletedChatIds: previous,
+        pendingCompletionChatIds: pendingNotificationChatIdsRef.current,
+        observedRunningPendingChatIds: observedRunningPendingChatIdsRef.current,
+        lastSeenMessageAtByChatId: lastSeenMessageAtByChatIdRef.current,
+      }))
+      updatePendingNotificationChatIds((previous) => {
+        if (previous.size === 0 || completedChatIds.length === 0) return previous
+        const next = new Set(previous)
+        for (const chatId of completedChatIds) {
+          next.delete(chatId)
+        }
+        return next
+      })
+      updateObservedRunningPendingChatIds((previous) => {
+        if (previous.size === 0 || completedChatIds.length === 0) return previous
+        const next = new Set(previous)
+        for (const chatId of completedChatIds) {
+          next.delete(chatId)
+        }
+        return next
+      })
+      previousSidebarStatusesRef.current = getSidebarChatStatusMap(snapshot.projectGroups)
+      const activeChat = activeChatIdRef.current ? chatById.get(activeChatIdRef.current) : null
+      if (activeChat) {
+        markChatSeen(activeChat.chatId, activeChat.lastCompletedTurnAt)
+      }
       setSidebarData(snapshot)
       setSidebarReady(true)
       setCommandError(null)
+
+      for (const chatId of completedChatIds) {
+        if (!pendingNotificationChatIdsRef.current.has(chatId)) {
+          continue
+        }
+        if (!shouldShowCompletionNotification({
+          chatId,
+          activeChatId: activeChatIdRef.current,
+          documentVisibilityState: document.visibilityState,
+        })) {
+          continue
+        }
+
+        const chat = chatById.get(chatId)
+        if (!chat) {
+          continue
+        }
+        void showChatCompletionNotification({
+          chatId,
+          chatTitle: chat.title,
+        })
+      }
     })
   }, [socket])
 
@@ -283,27 +618,70 @@ export function useKannaState(activeChatId: string | null): KannaState {
   }, [socket])
 
   useEffect(() => {
+    const prewarmChatIds = getRecentSidebarChatIds(sidebarData.projectGroups, 4)
+    for (const chatId of prewarmChatIds) {
+      if (chatId === activeChatId) continue
+
+      const existingSnapshot = chatSnapshotsById[chatId]
+      if (existingSnapshot) {
+        warmProcessedTranscriptCache(chatId, existingSnapshot)
+        continue
+      }
+      if (prewarmingChatIdsRef.current.has(chatId)) continue
+
+      prewarmingChatIdsRef.current.add(chatId)
+      void socket.command<ChatSnapshot | null>({ type: "chat.prefetch", chatId })
+        .then((snapshot) => {
+          if (!snapshot) return
+          startTransition(() => {
+            setChatSnapshotsById((previous) => upsertChatSnapshot(previous, chatId, snapshot))
+          })
+          warmProcessedTranscriptCache(chatId, snapshot)
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          prewarmingChatIdsRef.current.delete(chatId)
+        })
+    }
+  }, [activeChatId, chatSnapshotsById, sidebarData.projectGroups, socket])
+
+  useEffect(() => {
     if (!activeChatId) {
-      logKannaState("clearing chat snapshot for non-chat route")
-      setChatSnapshot(null)
+      logKannaState("clearing active chat route")
       setChatReady(true)
       return
     }
 
     logKannaState("subscribing to chat", { activeChatId })
-    setChatSnapshot(null)
-    setChatReady(false)
-    return socket.subscribe<ChatSnapshot | null>({ type: "chat", chatId: activeChatId }, (snapshot) => {
-      logKannaState("chat snapshot received", {
-        activeChatId,
-        snapshotChatId: snapshot?.runtime.chatId ?? null,
-        snapshotProvider: snapshot?.runtime.provider ?? null,
-        snapshotStatus: snapshot?.runtime.status ?? null,
-      })
-      setChatSnapshot(snapshot)
-      setChatReady(true)
-      setCommandError(null)
-    })
+    setChatReady(Boolean(chatSnapshotsById[activeChatId]))
+    return socket.subscribe<ChatSnapshot | null, ChatEvent>(
+      { type: "chat", chatId: activeChatId },
+      (snapshot) => {
+        logKannaState("chat snapshot received", {
+          activeChatId,
+          snapshotChatId: snapshot?.runtime.chatId ?? null,
+          snapshotProvider: snapshot?.runtime.provider ?? null,
+          snapshotStatus: snapshot?.runtime.status ?? null,
+        })
+        warmProcessedTranscriptCache(activeChatId, snapshot)
+        startTransition(() => {
+          setChatSnapshotsById((previous) => upsertChatSnapshot(previous, activeChatId, snapshot))
+          setChatReady(true)
+          setCommandError(null)
+        })
+      },
+      (event) => {
+        if (event.chatId !== activeChatId) return
+        startTransition(() => {
+          setChatSnapshotsById((previous) => {
+            const next = applyChatEventToCache(previous, activeChatId, event)
+            warmProcessedTranscriptCache(activeChatId, next[activeChatId] ?? null)
+            return next
+          })
+          setChatReady(true)
+        })
+      }
+    )
   }, [activeChatId, socket])
 
   useEffect(() => {
@@ -330,6 +708,11 @@ export function useKannaState(activeChatId: string | null): KannaState {
     navigate("/")
   }, [activeChatId, chatReady, navigate, pendingChatId, sidebarData.projectGroups, sidebarReady])
 
+  const chatSnapshot = useMemo(
+    () => (activeChatId ? chatSnapshotsById[activeChatId] ?? null : null),
+    [activeChatId, chatSnapshotsById]
+  )
+
   useEffect(() => {
     if (!chatSnapshot) return
     setSelectedProjectId(chatSnapshot.runtime.projectId)
@@ -337,6 +720,54 @@ export function useKannaState(activeChatId: string | null): KannaState {
       setPendingChatId(null)
     }
   }, [chatSnapshot, pendingChatId])
+
+  useEffect(() => {
+    autoFollowTranscriptRef.current = true
+    initialScrollCompletedRef.current = false
+    if (initialScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(initialScrollFrameRef.current)
+      initialScrollFrameRef.current = null
+    }
+    if (initialScrollTimeoutRef.current !== null) {
+      window.clearTimeout(initialScrollTimeoutRef.current)
+      initialScrollTimeoutRef.current = null
+    }
+    setIsAtBottom(true)
+    if (!activeChatId) return
+    const activeChat = sidebarData.projectGroups.flatMap((group) => group.chats).find((chat) => chat.chatId === activeChatId)
+    if (activeChat) {
+      markChatSeen(activeChat.chatId, activeChat.lastCompletedTurnAt)
+    }
+    setUnreadCompletedChatIds((previous) => {
+      if (!previous.has(activeChatId)) return previous
+      const next = new Set(previous)
+      next.delete(activeChatId)
+      return next
+    })
+    updatePendingNotificationChatIds((previous) => {
+      if (!previous.has(activeChatId)) return previous
+      const next = new Set(previous)
+      next.delete(activeChatId)
+      return next
+    })
+    updateObservedRunningPendingChatIds((previous) => {
+      if (!previous.has(activeChatId)) return previous
+      const next = new Set(previous)
+      next.delete(activeChatId)
+      return next
+    })
+  }, [activeChatId, sidebarData.projectGroups])
+
+  useEffect(() => {
+    return () => {
+      if (initialScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(initialScrollFrameRef.current)
+      }
+      if (initialScrollTimeoutRef.current !== null) {
+        window.clearTimeout(initialScrollTimeoutRef.current)
+      }
+    }
+  }, [])
 
   useLayoutEffect(() => {
     const element = inputRef.current
@@ -364,13 +795,37 @@ export function useKannaState(activeChatId: string | null): KannaState {
       pendingChatId,
     })
   }, [activeChatId, activeChatSnapshot, chatSnapshot, pendingChatId])
-  const messages = useMemo(() => processTranscriptMessages(activeChatSnapshot?.messages ?? []), [activeChatSnapshot?.messages])
-  const latestToolIds = useMemo(() => getLatestToolIds(messages), [messages])
+  const processedTranscript = useMemo(() => {
+    if (!activeChatSnapshot || !activeChatId) {
+      return {
+        messages: [] as ReturnType<typeof processTranscriptMessages>,
+        latestToolIds: getLatestToolIds([]),
+      }
+    }
+
+    const cached = processedTranscriptCacheRef.current.get(activeChatId)
+    if (cached?.source === activeChatSnapshot.messages) {
+      return cached
+    }
+
+    const messages = processTranscriptMessages(activeChatSnapshot.messages)
+    const latestToolIds = getLatestToolIds(messages)
+    const next = {
+      source: activeChatSnapshot.messages,
+      messages,
+      latestToolIds,
+    }
+    processedTranscriptCacheRef.current.set(activeChatId, next)
+    return next
+  }, [activeChatId, activeChatSnapshot])
+  const messages = processedTranscript.messages
+  const latestToolIds = processedTranscript.latestToolIds
   const runtime = activeChatSnapshot?.runtime ?? null
+  const hasOlderMessages = activeChatSnapshot?.hasOlderMessages ?? false
   const availableProviders = activeChatSnapshot?.availableProviders ?? PROVIDERS
   const isProcessing = isProcessingStatus(runtime?.status)
   const canCancel = canCancelStatus(runtime?.status)
-  const transcriptPaddingBottom = FIXED_TRANSCRIPT_PADDING_BOTTOM
+  const transcriptPaddingBottom = Math.max(MIN_TRANSCRIPT_PADDING_BOTTOM, inputHeight + 24)
   const showScrollButton = !isAtBottom && messages.length > 0
   const fallbackLocalProjectPath = localProjects?.projects[0]?.localPath ?? null
   const navbarLocalPath =
@@ -384,27 +839,117 @@ export function useKannaState(activeChatId: string | null): KannaState {
     ?? fallbackLocalProjectPath
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (initialScrollCompletedRef.current) return
+
     const element = scrollRef.current
     if (!element) return
-    const distance = element.scrollHeight - element.scrollTop - element.clientHeight
-    if (shouldPinTranscriptToBottom(distance)) {
-      element.scrollTo({ top: element.scrollHeight, behavior: "smooth" })
+    if (activeChatId && !runtime) return
+
+    const scrollToLatestMessage = () => {
+      const currentElement = scrollRef.current
+      if (!currentElement) return
+      currentElement.scrollTo({ top: currentElement.scrollHeight, behavior: "auto" })
     }
+
+    scrollToLatestMessage()
+    if (initialScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(initialScrollFrameRef.current)
+    }
+    initialScrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollToLatestMessage()
+      initialScrollFrameRef.current = null
+    })
+    if (initialScrollTimeoutRef.current !== null) {
+      window.clearTimeout(initialScrollTimeoutRef.current)
+    }
+    initialScrollTimeoutRef.current = window.setTimeout(() => {
+      scrollToLatestMessage()
+      initialScrollTimeoutRef.current = null
+    }, 60)
+    initialScrollCompletedRef.current = true
+  }, [activeChatId, inputHeight, messages.length, runtime])
+
+  useEffect(() => {
+    if (!initialScrollCompletedRef.current || !autoFollowTranscriptRef.current) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      const element = scrollRef.current
+      if (!element || !autoFollowTranscriptRef.current) return
+      element.scrollTo({ top: element.scrollHeight, behavior: "auto" })
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
   }, [activeChatId, inputHeight, messages.length, runtime?.status])
 
   function updateScrollState() {
     const element = scrollRef.current
     if (!element) return
     const distance = element.scrollHeight - element.scrollTop - element.clientHeight
-    setIsAtBottom(distance < 24)
+    const nextIsAtBottom = shouldAutoFollowTranscript(distance)
+    autoFollowTranscriptRef.current = nextIsAtBottom
+    setIsAtBottom(nextIsAtBottom)
+    if (initialScrollCompletedRef.current && !loadingOlderMessages && hasOlderMessages && element.scrollTop <= 160) {
+      void handleLoadOlderMessages()
+    }
   }
 
   function scrollToBottom() {
     const element = scrollRef.current
     if (!element) return
+    autoFollowTranscriptRef.current = true
+    setIsAtBottom(true)
     element.scrollTo({ top: element.scrollHeight, behavior: "smooth" })
   }
+
+  async function handleLoadOlderMessages() {
+    if (!activeChatId || loadingOlderMessages) return
+    const snapshot = chatSnapshotsById[activeChatId]
+    if (!snapshot?.hasOlderMessages) return
+
+    const beforeMessageId = snapshot.oldestLoadedMessageId ?? snapshot.messages[0]?._id
+    if (!beforeMessageId) return
+
+    const element = scrollRef.current
+    pendingPrependScrollHeightRef.current = element?.scrollHeight ?? null
+    setLoadingOlderMessages(true)
+    try {
+      const olderSnapshot = await socket.command<ChatSnapshot | null>({
+        type: "chat.loadMore",
+        chatId: activeChatId,
+        beforeMessageId,
+        limit: 200,
+      })
+      startTransition(() => {
+        setChatSnapshotsById((previous) => prependChatSnapshotChunk(previous, activeChatId, olderSnapshot))
+      })
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+      pendingPrependScrollHeightRef.current = null
+    } finally {
+      setLoadingOlderMessages(false)
+    }
+  }
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => {
+      updateScrollState()
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [inputHeight, messages.length, runtime?.status])
+
+  useLayoutEffect(() => {
+    const previousHeight = pendingPrependScrollHeightRef.current
+    if (previousHeight === null) return
+
+    const element = scrollRef.current
+    if (!element) return
+
+    const nextHeight = element.scrollHeight
+    element.scrollTop += nextHeight - previousHeight
+    pendingPrependScrollHeightRef.current = null
+  }, [messages.length])
 
   async function createChatForProject(projectId: string) {
     useChatPreferencesStore.getState().initializeComposerForNewChat()
@@ -509,6 +1054,8 @@ export function useKannaState(activeChatId: string | null): KannaState {
     options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }
   ) {
     try {
+      requestNotificationPermissionOnUserAction()
+
       let projectId = selectedProjectId ?? sidebarData.projectGroups[0]?.groupKey ?? null
       if (!activeChatId && !projectId && fallbackLocalProjectPath) {
         const project = await socket.command<{ projectId: string }>({
@@ -536,7 +1083,18 @@ export function useKannaState(activeChatId: string | null): KannaState {
 
       if (!activeChatId && result.chatId) {
         setPendingChatId(result.chatId)
+        updatePendingNotificationChatIds((previous) => {
+          const next = new Set(previous)
+          next.add(result.chatId!)
+          return next
+        })
         navigate(`/chat/${result.chatId}`)
+      } else if (activeChatId) {
+        updatePendingNotificationChatIds((previous) => {
+          const next = new Set(previous)
+          next.add(activeChatId)
+          return next
+        })
       }
       setCommandError(null)
     } catch (error) {
@@ -729,8 +1287,11 @@ export function useKannaState(activeChatId: string | null): KannaState {
     latestToolIds,
     runtime,
     availableProviders,
+    unreadCompletedChatIds,
     isProcessing,
     canCancel,
+    hasOlderMessages,
+    loadingOlderMessages,
     transcriptPaddingBottom,
     showScrollButton,
     navbarLocalPath,
@@ -749,6 +1310,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleInstallUpdate,
     handleSend,
     handleCancel,
+    handleLoadOlderMessages,
     handleDeleteChat,
     handleRemoveProject,
     handleOpenExternal,

--- a/src/client/components/messages/CollapsedToolGroup.tsx
+++ b/src/client/components/messages/CollapsedToolGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { memo, useState, useMemo } from "react"
 import { ChevronRight } from "lucide-react"
 import { ToolCallMessage } from "./ToolCallMessage"
 import { MetaRow, MetaLabel } from "./shared"
@@ -61,7 +61,7 @@ interface Props {
   localPath?: string | null
 }
 
-export function CollapsedToolGroup({ messages, isLoading, localPath }: Props) {
+export const CollapsedToolGroup = memo(function CollapsedToolGroup({ messages, isLoading, localPath }: Props) {
   const [expanded, setExpanded] = useState(false)
 
   const label = useMemo(() => getToolGroupLabel(messages), [messages])
@@ -120,4 +120,4 @@ export function CollapsedToolGroup({ messages, isLoading, localPath }: Props) {
       </div>
     </MetaRow>
   )
-}
+})

--- a/src/client/components/messages/TextMessage.tsx
+++ b/src/client/components/messages/TextMessage.tsx
@@ -1,18 +1,19 @@
+import { memo } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import type { ProcessedTextMessage } from "./types"
 import { createMarkdownComponents } from "./shared"
 
+const markdownComponents = createMarkdownComponents()
+
 interface Props {
   message: ProcessedTextMessage
 }
 
-export function TextMessage({ message }: Props) {
+export const TextMessage = memo(function TextMessage({ message }: Props) {
   return (
-    // <VerticalLineContainer className="w-full">
-      <div className="text-pretty prose prose-sm dark:prose-invert px-0.5 w-full max-w-full space-y-4">
-        <Markdown remarkPlugins={[remarkGfm]} components={createMarkdownComponents()}>{message.text}</Markdown>
-      </div>
-    // </VerticalLineContainer>
+    <div className="text-pretty prose prose-sm dark:prose-invert px-0.5 w-full max-w-full space-y-4">
+      <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{message.text}</Markdown>
+    </div>
   )
-}
+})

--- a/src/client/components/messages/TodoWriteMessage.tsx
+++ b/src/client/components/messages/TodoWriteMessage.tsx
@@ -10,15 +10,16 @@ const STATUS_CONFIG = {
 
 interface Props {
   message: Extract<ProcessedToolCall, { toolKind: "todo_write" }>
+  className?: string
 }
 
-export function TodoWriteMessage({ message }: Props) {
+export function TodoWriteMessage({ message, className }: Props) {
   const todos = message.input.todos
 
   if (!todos.length) return null
 
   return (
-    <div className="w-full">
+    <div className={cn("w-full", className)}>
       <div className="rounded-2xl border border-border overflow-hidden">
         <h3 className="font-medium text-foreground text-sm p-3 px-4 bg-card border-b border-border flex items-center gap-2">
           <ListChecks className="h-4 w-4 text-muted-foreground" />

--- a/src/client/components/messages/ToolCallMessage.tsx
+++ b/src/client/components/messages/ToolCallMessage.tsx
@@ -1,7 +1,7 @@
 import { UserRound, X } from "lucide-react"
 import type { ProcessedToolCall } from "./types"
 import { MetaRow, MetaLabel, MetaCodeBlock, ExpandableRow, VerticalLineContainer, getToolIcon } from "./shared"
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import { stripWorkspacePath } from "../../lib/pathUtils"
 import { AnimatedShinyText } from "../ui/animated-shiny-text"
 import { formatBashCommandTitle, toTitleCase } from "../../lib/formatters"
@@ -13,7 +13,7 @@ interface Props {
   localPath?: string | null
 }
 
-export function ToolCallMessage({ message, isLoading = false, localPath }: Props) {
+export const ToolCallMessage = memo(function ToolCallMessage({ message, isLoading = false, localPath }: Props) {
   const hasResult = message.result !== undefined
   const showLoadingState = !hasResult && isLoading
 
@@ -71,75 +71,79 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
   const isEditTool = message.toolKind === "edit_file"
   const isReadTool = message.toolKind === "read_file"
 
-  const resultText = useMemo(() => {
-    if (typeof message.result === "string") return message.result
-    if (!message.result) return ""
-    if (typeof message.result === "object" && message.result !== null && "content" in message.result) {
-      const content = (message.result as { content?: unknown }).content
-      if (typeof content === "string") return content
-    }
-    return JSON.stringify(message.result, null, 2)
-  }, [message.result])
-
-  const inputText = useMemo(() => {
-    switch (message.toolKind) {
-      case "bash":
-        return message.input.command
-      case "write_file":
-        return message.input.content
-      default:
-        return JSON.stringify(message.input, null, 2)
-    }
-  }, [message])
-
   return (
     <MetaRow className="w-full">
       <ExpandableRow
-        expandedContent={
-          <VerticalLineContainer className="my-4 text-sm">
-            <div className="flex flex-col gap-2">
-              {isEditTool ? (
-                <FileContentView
-                  content=""
-                  isDiff
-                  oldString={message.input.oldString}
-                  newString={message.input.newString}
-                />
-              ) : !isReadTool && !isWriteTool && (
-                <MetaCodeBlock label={
-                  isBashTool ? (
-                    <span className="flex items-center gap-2 w-full">
-                      <span>Command</span>
-                      {!!message.input.timeoutMs && (
-                        <span className="text-muted-foreground">timeout: {String(message.input.timeoutMs)}ms</span>
-                      )}
-                      {!!message.input.runInBackground && (
-                        <span className="text-muted-foreground">background</span>
-                      )}
-                    </span>
-                  ) : isWriteTool ? "Contents" : "Input"
-                } copyText={inputText}>
-                  {inputText}
-                </MetaCodeBlock>
-              )}
-              {hasResult && isReadTool && !message.isError && (
-                <FileContentView
-                  content={resultText}
-                />
-              )}
-              {isWriteTool && !message.isError && (
-                <FileContentView
-                  content={message.input.content}
-                />
-              )}
-              {hasResult && !isReadTool && !(isWriteTool && !message.isError) && !(isEditTool && !message.isError) && (
-                <MetaCodeBlock label={message.isError ? "Error" : "Result"} copyText={resultText}>
-                  {resultText}
-                </MetaCodeBlock>
-              )}
-            </div>
-          </VerticalLineContainer>
-        }
+        expandedContent={(expanded) => {
+          if (!expanded) return null
+
+          const resultText = (() => {
+            if (typeof message.result === "string") return message.result
+            if (!message.result) return ""
+            if (typeof message.result === "object" && message.result !== null && "content" in message.result) {
+              const content = (message.result as { content?: unknown }).content
+              if (typeof content === "string") return content
+            }
+            return JSON.stringify(message.result, null, 2)
+          })()
+
+          const inputText = (() => {
+            switch (message.toolKind) {
+              case "bash":
+                return message.input.command
+              case "write_file":
+                return message.input.content
+              default:
+                return JSON.stringify(message.input, null, 2)
+            }
+          })()
+
+          return (
+            <VerticalLineContainer className="my-4 text-sm">
+              <div className="flex flex-col gap-2">
+                {isEditTool ? (
+                  <FileContentView
+                    content=""
+                    isDiff
+                    oldString={message.input.oldString}
+                    newString={message.input.newString}
+                  />
+                ) : !isReadTool && !isWriteTool && (
+                  <MetaCodeBlock label={
+                    isBashTool ? (
+                      <span className="flex items-center gap-2 w-full">
+                        <span>Command</span>
+                        {!!message.input.timeoutMs && (
+                          <span className="text-muted-foreground">timeout: {String(message.input.timeoutMs)}ms</span>
+                        )}
+                        {!!message.input.runInBackground && (
+                          <span className="text-muted-foreground">background</span>
+                        )}
+                      </span>
+                    ) : isWriteTool ? "Contents" : "Input"
+                  } copyText={inputText}>
+                    {inputText}
+                  </MetaCodeBlock>
+                )}
+                {hasResult && isReadTool && !message.isError && (
+                  <FileContentView
+                    content={resultText}
+                  />
+                )}
+                {isWriteTool && !message.isError && (
+                  <FileContentView
+                    content={message.input.content}
+                  />
+                )}
+                {hasResult && !isReadTool && !(isWriteTool && !message.isError) && !(isEditTool && !message.isError) && (
+                  <MetaCodeBlock label={message.isError ? "Error" : "Result"} copyText={resultText}>
+                    {resultText}
+                  </MetaCodeBlock>
+                )}
+              </div>
+            </VerticalLineContainer>
+          )
+        }}
       >
 
         <div className={`w-5 h-5 relative flex items-center justify-center`}>
@@ -169,4 +173,4 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
       </ExpandableRow>
     </MetaRow>
   )
-}
+})

--- a/src/client/components/messages/shared.tsx
+++ b/src/client/components/messages/shared.tsx
@@ -120,13 +120,19 @@ export function MetaText({ children }: { children: ReactNode }) {
 
 // Expandable row with chevron
 interface ExpandableRowProps {
-  children: ReactNode
-  expandedContent: ReactNode
+  children: ReactNode | ((expanded: boolean) => ReactNode)
+  expandedContent: ReactNode | ((expanded: boolean) => ReactNode)
   defaultExpanded?: boolean
 }
 
 export function ExpandableRow({ children, expandedContent, defaultExpanded = false }: ExpandableRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded)
+  const resolvedChildren = typeof children === "function"
+    ? (children as (expanded: boolean) => ReactNode)(expanded)
+    : children
+  const resolvedExpandedContent = typeof expandedContent === "function"
+    ? (expandedContent as (expanded: boolean) => ReactNode)(expanded)
+    : expandedContent
 
   return (
     <div className="flex flex-col w-full">
@@ -136,13 +142,13 @@ export function ExpandableRow({ children, expandedContent, defaultExpanded = fal
         className={`group/expandable-row cursor-pointer grid grid-cols-[auto_1fr] items-center gap-1 text-sm ${!expanded ? "hover:opacity-60 transition-opacity" : ""}`}
       >
         <div className="grid grid-cols-[auto_1fr] items-center gap-1.5">
-          {children}
+          {resolvedChildren}
         </div>
         <ChevronRight
           className={`h-4.5 w-4.5 text-muted-icon translate-y-[0.5px] transition-all duration-200 opacity-0 group-hover/expandable-row:opacity-100 ${expanded ? "rotate-90 opacity-100" : ""}`}
         />
       </button>
-      {expanded && expandedContent}
+      {expanded && resolvedExpandedContent}
     </div>
   )
 }

--- a/src/client/pwa.ts
+++ b/src/client/pwa.ts
@@ -1,0 +1,38 @@
+export function shouldAutoScrollChatToBottom(search: string) {
+  const params = new URLSearchParams(search)
+  return params.get("autoscroll") === "1"
+}
+
+export function requestNotificationPermissionOnUserAction() {
+  if (typeof window === "undefined" || typeof Notification === "undefined") return
+  if (Notification.permission !== "default") return
+  void Notification.requestPermission().catch(() => undefined)
+}
+
+export function shouldShowCompletionNotification(params: {
+  chatId: string
+  activeChatId: string | null
+  documentVisibilityState: DocumentVisibilityState
+}) {
+  if (typeof Notification === "undefined") return false
+  if (Notification.permission !== "granted") return false
+  if (params.documentVisibilityState === "visible" && params.activeChatId === params.chatId) return false
+  return true
+}
+
+export async function showChatCompletionNotification(params: {
+  chatId: string
+  chatTitle: string
+}) {
+  if (typeof ServiceWorkerRegistration === "undefined") return
+  const registration = await navigator.serviceWorker?.getRegistration()
+  if (!registration) return
+
+  await registration.showNotification(`Kanna: ${params.chatTitle}`, {
+    body: "Chat completed",
+    tag: `chat-complete:${params.chatId}`,
+    data: {
+      url: `/chat/${params.chatId}?autoscroll=1`,
+    },
+  })
+}

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -651,16 +651,100 @@ describe("AgentCoordinator codex integration", () => {
     expect(discardedResult.content).toEqual({ discarded: true })
     expect(startTurnCalls).toEqual(["plan this"])
   })
+
+  test("recovers an interrupted turn after restart using the saved session token", async () => {
+    const sessionCalls: Array<{ chatId: string; sessionToken: string | null }> = []
+    const startTurnCalls: Array<{ content: string; planMode: boolean }> = []
+
+    const fakeCodexManager = {
+      async startSession(args: { chatId: string; sessionToken: string | null }) {
+        sessionCalls.push({ chatId: args.chatId, sessionToken: args.sessionToken })
+      },
+      async startTurn(args: { content: string; planMode: boolean }): Promise<HarnessTurn> {
+        startTurnCalls.push({ content: args.content, planMode: args.planMode })
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore({
+      provider: "codex",
+      sessionToken: "thread-1",
+      activeTurn: {
+        provider: "codex",
+        content: "finish this task",
+        model: "gpt-5.4",
+        planMode: false,
+      },
+    })
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.recoverInterruptedTurns()
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    expect(sessionCalls).toEqual([{ chatId: "chat-1", sessionToken: "thread-1" }])
+    expect(startTurnCalls).toEqual([{
+      content: "The previous response was interrupted because the Kanna server restarted. Continue from where you left off without repeating completed work unless necessary.",
+      planMode: false,
+    }])
+    expect(store.messages.some((entry) => entry.kind === "user_prompt")).toBe(false)
+  })
 })
 
-function createFakeStore() {
+function createFakeStore(overrides?: {
+  provider?: "claude" | "codex" | null
+  sessionToken?: string | null
+  activeTurn?: {
+    provider: "claude" | "codex"
+    content: string
+    model: string
+    effort?: string
+    serviceTier?: "fast"
+    planMode: boolean
+  } | null
+}) {
   const chat = {
     id: "chat-1",
     projectId: "project-1",
     title: "New Chat",
-    provider: null as "claude" | "codex" | null,
+    provider: overrides?.provider ?? null as "claude" | "codex" | null,
     planMode: false,
-    sessionToken: null as string | null,
+    sessionToken: overrides?.sessionToken ?? null as string | null,
+    activeTurn: overrides?.activeTurn ?? null,
   }
   const project = {
     id: "project-1",
@@ -678,6 +762,9 @@ function createFakeStore() {
       expect(projectId).toBe("project-1")
       return project
     },
+    listChatsWithActiveTurn() {
+      return chat.activeTurn ? [chat] : []
+    },
     getMessages() {
       return this.messages
     },
@@ -693,14 +780,23 @@ function createFakeStore() {
     async appendMessage(_chatId: string, entry: TranscriptEntry) {
       this.messages.push(entry)
     },
-    async recordTurnStarted() {},
+    async recordTurnStarted(
+      _chatId: string,
+      recovery: NonNullable<typeof chat.activeTurn>
+    ) {
+      chat.activeTurn = recovery
+    },
     async recordTurnFinished() {
       this.turnFinishedCount += 1
+      chat.activeTurn = null
     },
     async recordTurnFailed() {
+      chat.activeTurn = null
       throw new Error("Did not expect turn failure")
     },
-    async recordTurnCancelled() {},
+    async recordTurnCancelled() {
+      chat.activeTurn = null
+    },
     async setSessionToken(_chatId: string, sessionToken: string | null) {
       chat.sessionToken = sessionToken
     },

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -59,14 +59,21 @@ interface ActiveTurn {
   hasFinalResult: boolean
   cancelRequested: boolean
   cancelRecorded: boolean
+  abandonRequested: boolean
 }
 
 interface AgentCoordinatorArgs {
   store: EventStore
-  onStateChange: () => void
+  onStateChange: (change: AgentStateChange) => void
   codexManager?: CodexAppServerManager
   generateTitle?: (messageContent: string, cwd: string) => Promise<string | null>
 }
+
+export type AgentStateChange =
+  | { type: "sidebar" }
+  | { type: "chat-runtime"; chatId: string }
+  | { type: "chat-reset"; chatId: string }
+  | { type: "chat-message"; chatId: string; entry: TranscriptEntry }
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
   entry: T,
@@ -331,7 +338,7 @@ async function startClaudeTurn(args: {
 
 export class AgentCoordinator {
   private readonly store: EventStore
-  private readonly onStateChange: () => void
+  private readonly onStateChange: (change: AgentStateChange) => void
   private readonly codexManager: CodexAppServerManager
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<string | null>
   readonly activeTurns = new Map<string, ActiveTurn>()
@@ -355,6 +362,15 @@ export class AgentCoordinator {
     const pending = this.activeTurns.get(chatId)?.pendingTool
     if (!pending) return null
     return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
+  }
+
+  private buildRecoveryPrompt(chatId: string, originalContent: string) {
+    const chat = this.store.requireChat(chatId)
+    if (chat.sessionToken) {
+      return "The previous response was interrupted because the Kanna server restarted. Continue from where you left off without repeating completed work unless necessary."
+    }
+
+    return `The previous turn was interrupted by a Kanna server restart before a resumable session was fully established. Please continue by handling the user's pending request.\n\nPending request:\n${originalContent}`
   }
 
   private resolveProvider(command: Extract<ClientCommand, { type: "chat.send" }>, currentProvider: AgentProvider | null) {
@@ -407,9 +423,18 @@ export class AgentCoordinator {
     const shouldGenerateTitle = args.appendUserPrompt && chat.title === "New Chat" && existingMessages.length === 0
 
     if (args.appendUserPrompt) {
-      await this.store.appendMessage(args.chatId, timestamped({ kind: "user_prompt", content: args.content }, Date.now()))
+      const entry = timestamped({ kind: "user_prompt", content: args.content }, Date.now())
+      await this.store.appendMessage(args.chatId, entry)
+      this.onStateChange({ type: "chat-message", chatId: args.chatId, entry })
     }
-    await this.store.recordTurnStarted(args.chatId)
+    await this.store.recordTurnStarted(args.chatId, {
+      provider: args.provider,
+      content: args.content,
+      model: args.model,
+      effort: args.effort,
+      serviceTier: args.serviceTier,
+      planMode: args.planMode,
+    })
 
     const project = this.store.getProject(chat.projectId)
     if (!project) {
@@ -427,7 +452,8 @@ export class AgentCoordinator {
       }
 
       active.status = "waiting_for_user"
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId: args.chatId })
+      this.onStateChange({ type: "sidebar" })
 
       return await new Promise<unknown>((resolve) => {
         active.pendingTool = {
@@ -482,16 +508,19 @@ export class AgentCoordinator {
       hasFinalResult: false,
       cancelRequested: false,
       cancelRecorded: false,
+      abandonRequested: false,
     }
     this.activeTurns.set(args.chatId, active)
-    this.onStateChange()
+    this.onStateChange({ type: "chat-runtime", chatId: args.chatId })
+    this.onStateChange({ type: "sidebar" })
 
     if (turn.getAccountInfo) {
       void turn.getAccountInfo()
         .then(async (accountInfo) => {
           if (!accountInfo) return
-          await this.store.appendMessage(args.chatId, timestamped({ kind: "account_info", accountInfo }))
-          this.onStateChange()
+          const entry = timestamped({ kind: "account_info", accountInfo })
+          await this.store.appendMessage(args.chatId, entry)
+          this.onStateChange({ type: "chat-message", chatId: args.chatId, entry })
         })
         .catch(() => undefined)
     }
@@ -536,7 +565,8 @@ export class AgentCoordinator {
       if (chat.title !== "New Chat") return
 
       await this.store.renameChat(chatId, title)
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId })
+      this.onStateChange({ type: "sidebar" })
     } catch {
       // Ignore background title generation failures.
     }
@@ -545,9 +575,13 @@ export class AgentCoordinator {
   private async runTurn(active: ActiveTurn) {
     try {
       for await (const event of active.turn.stream) {
+        if (active.abandonRequested) {
+          break
+        }
+
         if (event.type === "session_token" && event.sessionToken) {
           await this.store.setSessionToken(active.chatId, event.sessionToken)
-          this.onStateChange()
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
           continue
         }
 
@@ -567,22 +601,27 @@ export class AgentCoordinator {
           }
         }
 
-        this.onStateChange()
+        this.onStateChange({ type: "chat-message", chatId: active.chatId, entry: event.entry })
+        if (event.entry.kind === "system_init" || event.entry.kind === "result" || event.entry.kind === "status") {
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+          this.onStateChange({ type: "sidebar" })
+        }
       }
     } catch (error) {
-      if (!active.cancelRequested) {
+      if (!active.cancelRequested && !active.abandonRequested) {
         const message = error instanceof Error ? error.message : String(error)
-        await this.store.appendMessage(
-          active.chatId,
-          timestamped({
-            kind: "result",
-            subtype: "error",
-            isError: true,
-            durationMs: 0,
-            result: message,
-          })
-        )
+        const entry = timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: message,
+        })
+        await this.store.appendMessage(active.chatId, entry)
         await this.store.recordTurnFailed(active.chatId, message)
+        this.onStateChange({ type: "chat-message", chatId: active.chatId, entry })
+        this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+        this.onStateChange({ type: "sidebar" })
       }
     } finally {
       if (active.cancelRequested && !active.cancelRecorded) {
@@ -590,9 +629,10 @@ export class AgentCoordinator {
       }
       active.turn.close()
       this.activeTurns.delete(active.chatId)
-      this.onStateChange()
+      this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+      this.onStateChange({ type: "sidebar" })
 
-      if (active.postToolFollowUp && !active.cancelRequested) {
+      if (active.postToolFollowUp && !active.cancelRequested && !active.abandonRequested) {
         try {
           await this.startTurnForChat({
             chatId: active.chatId,
@@ -606,18 +646,18 @@ export class AgentCoordinator {
           })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
-          await this.store.appendMessage(
-            active.chatId,
-            timestamped({
-              kind: "result",
-              subtype: "error",
-              isError: true,
-              durationMs: 0,
-              result: message,
-            })
-          )
+          const entry = timestamped({
+            kind: "result",
+            subtype: "error",
+            isError: true,
+            durationMs: 0,
+            result: message,
+          })
+          await this.store.appendMessage(active.chatId, entry)
           await this.store.recordTurnFailed(active.chatId, message)
-          this.onStateChange()
+          this.onStateChange({ type: "chat-message", chatId: active.chatId, entry })
+          this.onStateChange({ type: "chat-runtime", chatId: active.chatId })
+          this.onStateChange({ type: "sidebar" })
         }
       }
     }
@@ -634,20 +674,20 @@ export class AgentCoordinator {
 
     if (pendingTool) {
       const result = discardedToolResult(pendingTool.tool)
-      await this.store.appendMessage(
-        chatId,
-        timestamped({
-          kind: "tool_result",
-          toolId: pendingTool.toolUseId,
-          content: result,
-        })
-      )
+      const entry = timestamped({
+        kind: "tool_result",
+        toolId: pendingTool.toolUseId,
+        content: result,
+      })
+      await this.store.appendMessage(chatId, entry)
+      this.onStateChange({ type: "chat-message", chatId, entry })
       if (active.provider === "codex" && pendingTool.tool.toolKind === "exit_plan_mode") {
         pendingTool.resolve(result)
       }
     }
 
-    await this.store.appendMessage(chatId, timestamped({ kind: "interrupted" }))
+    const interruptedEntry = timestamped({ kind: "interrupted" })
+    await this.store.appendMessage(chatId, interruptedEntry)
     await this.store.recordTurnCancelled(chatId)
     active.cancelRecorded = true
     active.hasFinalResult = true
@@ -659,7 +699,55 @@ export class AgentCoordinator {
     }
 
     this.activeTurns.delete(chatId)
-    this.onStateChange()
+    this.onStateChange({ type: "chat-message", chatId, entry: interruptedEntry })
+    this.onStateChange({ type: "chat-runtime", chatId })
+    this.onStateChange({ type: "sidebar" })
+  }
+
+  async recoverInterruptedTurns() {
+    for (const chat of this.store.listChatsWithActiveTurn()) {
+      if (!chat.activeTurn || this.activeTurns.has(chat.id)) continue
+
+      try {
+        await this.startTurnForChat({
+          chatId: chat.id,
+          provider: chat.activeTurn.provider,
+          content: this.buildRecoveryPrompt(chat.id, chat.activeTurn.content),
+          model: chat.activeTurn.model,
+          effort: chat.activeTurn.effort,
+          serviceTier: chat.activeTurn.serviceTier,
+          planMode: chat.activeTurn.planMode,
+          appendUserPrompt: false,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const entry = timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: `Failed to recover interrupted turn after server restart: ${message}`,
+        })
+        await this.store.appendMessage(chat.id, entry)
+        await this.store.recordTurnFailed(chat.id, message)
+        this.onStateChange({ type: "chat-message", chatId: chat.id, entry })
+        this.onStateChange({ type: "chat-runtime", chatId: chat.id })
+        this.onStateChange({ type: "sidebar" })
+      }
+    }
+  }
+
+  shutdown() {
+    for (const active of this.activeTurns.values()) {
+      active.abandonRequested = true
+      const pendingTool = active.pendingTool
+      active.pendingTool = null
+      if (pendingTool) {
+        pendingTool.resolve(discardedToolResult(pendingTool.tool))
+      }
+      active.turn.close()
+    }
+    this.codexManager.stopAll()
   }
 
   async respondTool(command: Extract<ClientCommand, { type: "chat.respondTool" }>) {
@@ -673,14 +761,13 @@ export class AgentCoordinator {
       throw new Error("Tool response does not match active request")
     }
 
-    await this.store.appendMessage(
-      command.chatId,
-      timestamped({
-        kind: "tool_result",
-        toolId: command.toolUseId,
-        content: command.result,
-      })
-    )
+    const resultEntry = timestamped({
+      kind: "tool_result",
+      toolId: command.toolUseId,
+      content: command.result,
+    })
+    await this.store.appendMessage(command.chatId, resultEntry)
+    const extraEntries: TranscriptEntry[] = []
 
     active.pendingTool = null
     active.status = "running"
@@ -693,7 +780,9 @@ export class AgentCoordinator {
       }
       if (result.confirmed && result.clearContext) {
         await this.store.setSessionToken(command.chatId, null)
-        await this.store.appendMessage(command.chatId, timestamped({ kind: "context_cleared" }))
+        const clearEntry = timestamped({ kind: "context_cleared" })
+        await this.store.appendMessage(command.chatId, clearEntry)
+        extraEntries.push(clearEntry)
       }
 
       if (active.provider === "codex") {
@@ -715,6 +804,11 @@ export class AgentCoordinator {
 
     pending.resolve(command.result)
 
-    this.onStateChange()
+    this.onStateChange({ type: "chat-message", chatId: command.chatId, entry: resultEntry })
+    for (const entry of extraEntries) {
+      this.onStateChange({ type: "chat-message", chatId: command.chatId, entry })
+    }
+    this.onStateChange({ type: "chat-runtime", chatId: command.chatId })
+    this.onStateChange({ type: "sidebar" })
   }
 }

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -5,6 +5,7 @@ import { getDataDir, LOG_PREFIX } from "../shared/branding"
 import type { AgentProvider, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
 import {
+  type ActiveTurnRecovery,
   type ChatEvent,
   type MessageEvent,
   type ProjectEvent,
@@ -90,7 +91,10 @@ export class EventStore {
         this.state.projectIdsByPath.set(project.localPath, project.id)
       }
       for (const chat of parsed.chats) {
-        this.state.chatsById.set(chat.id, { ...chat })
+        this.state.chatsById.set(chat.id, {
+          ...chat,
+          activeTurn: chat.activeTurn ?? null,
+        })
       }
       for (const messageSet of parsed.messages) {
         this.state.messagesByChatId.set(messageSet.chatId, cloneTranscriptEntries(messageSet.entries))
@@ -191,6 +195,7 @@ export class EventStore {
           planMode: false,
           sessionToken: null,
           lastTurnOutcome: null,
+          activeTurn: null,
         }
         this.state.chatsById.set(chat.id, chat)
         break
@@ -240,13 +245,16 @@ export class EventStore {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.updatedAt = event.timestamp
+        chat.activeTurn = { ...event.recovery }
         break
       }
       case "turn_finished": {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.updatedAt = event.timestamp
+        chat.lastCompletedTurnAt = event.timestamp
         chat.lastTurnOutcome = "success"
+        chat.activeTurn = null
         break
       }
       case "turn_failed": {
@@ -254,6 +262,7 @@ export class EventStore {
         if (!chat) break
         chat.updatedAt = event.timestamp
         chat.lastTurnOutcome = "failed"
+        chat.activeTurn = null
         break
       }
       case "turn_cancelled": {
@@ -261,6 +270,7 @@ export class EventStore {
         if (!chat) break
         chat.updatedAt = event.timestamp
         chat.lastTurnOutcome = "cancelled"
+        chat.activeTurn = null
         break
       }
       case "session_token_set": {
@@ -402,13 +412,14 @@ export class EventStore {
     await this.append(this.messagesLogPath, event)
   }
 
-  async recordTurnStarted(chatId: string) {
+  async recordTurnStarted(chatId: string, recovery: ActiveTurnRecovery) {
     this.requireChat(chatId)
     const event: TurnEvent = {
       v: STORE_VERSION,
       type: "turn_started",
       timestamp: Date.now(),
       chatId,
+      recovery,
     }
     await this.append(this.turnsLogPath, event)
   }
@@ -478,6 +489,12 @@ export class EventStore {
     const chat = this.state.chatsById.get(chatId)
     if (!chat || chat.deletedAt) return null
     return chat
+  }
+
+  listChatsWithActiveTurn() {
+    return [...this.state.chatsById.values()]
+      .filter((chat) => !chat.deletedAt && chat.activeTurn)
+      .sort((a, b) => a.updatedAt - b.updatedAt)
   }
 
   getMessages(chatId: string) {

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -15,7 +15,18 @@ export interface ChatRecord {
   planMode: boolean
   sessionToken: string | null
   lastMessageAt?: number
+  lastCompletedTurnAt?: number
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
+  activeTurn: ActiveTurnRecovery | null
+}
+
+export interface ActiveTurnRecovery {
+  provider: AgentProvider
+  content: string
+  model: string
+  effort?: string
+  serviceTier?: "fast"
+  planMode: boolean
 }
 
 export interface StoreState {
@@ -98,6 +109,7 @@ export type TurnEvent =
       type: "turn_started"
       timestamp: number
       chatId: string
+      recovery: ActiveTurnRecovery
     }
   | {
       v: 2

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -23,6 +23,7 @@ describe("read models", () => {
       planMode: false,
       sessionToken: "thread-1",
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const sidebar = deriveSidebarData(state, new Map())
@@ -49,10 +50,13 @@ describe("read models", () => {
       planMode: true,
       sessionToken: "session-1",
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const chat = deriveChatSnapshot(state, new Map(), "chat-1")
     expect(chat?.runtime.provider).toBe("claude")
+    expect(chat?.hasOlderMessages).toBe(false)
+    expect(chat?.oldestLoadedMessageId).toBeNull()
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
       "gpt-5.4",
@@ -82,6 +86,7 @@ describe("read models", () => {
       sessionToken: null,
       lastMessageAt: 100,
       lastTurnOutcome: null,
+      activeTurn: null,
     })
 
     const snapshot = deriveLocalProjectsSnapshot(state, [
@@ -101,5 +106,43 @@ describe("read models", () => {
         chatCount: 1,
       },
     ])
+  })
+
+  test("returns only the latest chunk of chat history by default", () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "claude",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+    state.messagesByChatId.set("chat-1", Array.from({ length: 250 }, (_, index) => ({
+      _id: `msg-${index + 1}`,
+      createdAt: index + 1,
+      kind: "assistant_text" as const,
+      text: `message ${index + 1}`,
+    })))
+
+    const chat = deriveChatSnapshot(state, new Map(), "chat-1")
+
+    expect(chat?.messages).toHaveLength(200)
+    expect(chat?.messages[0]?._id).toBe("msg-51")
+    expect(chat?.messages.at(-1)?._id).toBe("msg-250")
+    expect(chat?.hasOlderMessages).toBe(true)
+    expect(chat?.oldestLoadedMessageId).toBe("msg-51")
   })
 })

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -12,6 +12,8 @@ import { cloneTranscriptEntries } from "./events"
 import { resolveLocalPath } from "./paths"
 import { SERVER_PROVIDERS } from "./provider-catalog"
 
+const DEFAULT_CHAT_SNAPSHOT_LIMIT = 200
+
 export function deriveStatus(chat: ChatRecord, activeStatus?: KannaStatus): KannaStatus {
   if (activeStatus) return activeStatus
   if (chat.lastTurnOutcome === "failed") return "failed"
@@ -39,6 +41,7 @@ export function deriveSidebarData(
         localPath: project.localPath,
         provider: chat.provider,
         lastMessageAt: chat.lastMessageAt,
+        lastCompletedTurnAt: chat.lastCompletedTurnAt,
         hasAutomation: false,
       }))
 
@@ -98,14 +101,68 @@ export function deriveLocalProjectsSnapshot(
 export function deriveChatSnapshot(
   state: StoreState,
   activeStatuses: Map<string, KannaStatus>,
-  chatId: string
+  chatId: string,
+  options?: {
+    beforeMessageId?: string | null
+    limit?: number
+  }
 ): ChatSnapshot | null {
   const chat = state.chatsById.get(chatId)
   if (!chat || chat.deletedAt) return null
   const project = state.projectsById.get(chat.projectId)
   if (!project || project.deletedAt) return null
 
-  const runtime: ChatRuntime = {
+  const runtime = deriveChatRuntime(state, activeStatuses, chatId)
+  if (!runtime) return null
+
+  const allMessages = state.messagesByChatId.get(chatId) ?? []
+  const { entries, hasOlderMessages, oldestLoadedMessageId } = sliceChatMessages(allMessages, options)
+
+  return {
+    runtime,
+    messages: entries,
+    hasOlderMessages,
+    oldestLoadedMessageId,
+    availableProviders: [...SERVER_PROVIDERS],
+  }
+}
+
+export function sliceChatMessages(
+  allMessages: readonly (ReturnType<typeof cloneTranscriptEntries>[number])[],
+  options?: {
+    beforeMessageId?: string | null
+    limit?: number
+  }
+) {
+  const limit = Math.max(1, options?.limit ?? DEFAULT_CHAT_SNAPSHOT_LIMIT)
+  let endExclusive = allMessages.length
+
+  if (options?.beforeMessageId) {
+    const beforeIndex = allMessages.findIndex((entry) => entry._id === options.beforeMessageId)
+    endExclusive = beforeIndex >= 0 ? beforeIndex : allMessages.length
+  }
+
+  const start = Math.max(0, endExclusive - limit)
+  const entries = cloneTranscriptEntries(allMessages.slice(start, endExclusive))
+
+  return {
+    entries,
+    hasOlderMessages: start > 0,
+    oldestLoadedMessageId: entries[0]?._id ?? null,
+  }
+}
+
+export function deriveChatRuntime(
+  state: StoreState,
+  activeStatuses: Map<string, KannaStatus>,
+  chatId: string
+): ChatRuntime | null {
+  const chat = state.chatsById.get(chatId)
+  if (!chat || chat.deletedAt) return null
+  const project = state.projectsById.get(chat.projectId)
+  if (!project || project.deletedAt) return null
+
+  return {
     chatId: chat.id,
     projectId: project.id,
     localPath: project.localPath,
@@ -114,11 +171,5 @@ export function deriveChatSnapshot(
     provider: chat.provider,
     planMode: chat.planMode,
     sessionToken: chat.sessionToken,
-  }
-
-  return {
-    runtime,
-    messages: cloneTranscriptEntries(state.messagesByChatId.get(chat.id) ?? []),
-    availableProviders: [...SERVER_PROVIDERS],
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -52,8 +52,24 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     : null
   const agent = new AgentCoordinator({
     store,
-    onStateChange: () => {
-      router.broadcastSnapshots()
+    onStateChange: (change) => {
+      if (change.type === "sidebar") {
+        router.pushSidebarSnapshots()
+        return
+      }
+      if (change.type === "chat-runtime") {
+        router.pushChatRuntime(change.chatId)
+        return
+      }
+      if (change.type === "chat-reset") {
+        router.pushChatReset(change.chatId)
+        return
+      }
+      router.pushChatEvent(change.chatId, {
+        type: "chat.messageAppended",
+        chatId: change.chatId,
+        entry: change.entry,
+      })
     },
   })
   router = createWsRouter({
@@ -66,6 +82,8 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     machineDisplayName,
     updateManager,
   })
+
+  await agent.recoverInterruptedTurns()
 
   const distDir = path.join(import.meta.dir, "..", "..", "dist", "client")
 
@@ -120,9 +138,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   }
 
   const shutdown = async () => {
-    for (const chatId of [...agent.activeTurns.keys()]) {
-      await agent.cancel(chatId)
-    }
+    agent.shutdown()
     router.dispose()
     keybindings.dispose()
     terminals.closeAll()

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -176,6 +176,154 @@ describe("ws-router", () => {
     })
   })
 
+  test("loads older chat history chunks through chat.loadMore", async () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "codex",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+    state.messagesByChatId.set("chat-1", Array.from({ length: 4 }, (_, index) => ({
+      _id: `msg-${index + 1}`,
+      createdAt: index + 1,
+      kind: "assistant_text" as const,
+      text: `message ${index + 1}`,
+    })))
+
+    const router = createWsRouter({
+      store: { state } as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "chat-load-1",
+        command: {
+          type: "chat.loadMore",
+          chatId: "chat-1",
+          beforeMessageId: "msg-4",
+          limit: 2,
+        },
+      })
+    )
+
+    await Promise.resolve()
+    expect(ws.sent[0]).toEqual({
+      v: PROTOCOL_VERSION,
+      type: "ack",
+      id: "chat-load-1",
+      result: {
+        runtime: {
+          chatId: "chat-1",
+          projectId: "project-1",
+          localPath: "/tmp/project",
+          title: "Chat",
+          status: "idle",
+          provider: "codex",
+          planMode: false,
+          sessionToken: null,
+        },
+        messages: [
+          { _id: "msg-2", createdAt: 2, kind: "assistant_text", text: "message 2" },
+          { _id: "msg-3", createdAt: 3, kind: "assistant_text", text: "message 3" },
+        ],
+        hasOlderMessages: true,
+        oldestLoadedMessageId: "msg-2",
+        availableProviders: expect.any(Array),
+      },
+    })
+  })
+
+  test("prefetches chat snapshots without opening a live subscription", async () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      provider: "claude",
+      planMode: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+      activeTurn: null,
+    })
+
+    const router = createWsRouter({
+      store: { state } as never,
+      agent: { getActiveStatuses: () => new Map() } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "chat-prefetch-1",
+        command: {
+          type: "chat.prefetch",
+          chatId: "chat-1",
+        },
+      })
+    )
+
+    await Promise.resolve()
+    expect((ws.sent[0] as any).type).toBe("ack")
+    expect((ws.sent[0] as any).result.runtime.chatId).toBe("chat-1")
+  })
+
   test("subscribes to keybindings snapshots and writes keybindings through the router", async () => {
     const initialSnapshot: KeybindingsSnapshot = DEFAULT_KEYBINDINGS_SNAPSHOT
     const keybindings = {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun"
 import { PROTOCOL_VERSION } from "../shared/types"
-import type { ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
+import type { ChatEvent, ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
 import { isClientEnvelope } from "../shared/protocol"
 import type { AgentCoordinator } from "./agent"
 import type { DiscoveredProject } from "./discovery"
@@ -10,7 +10,7 @@ import { KeybindingsManager } from "./keybindings"
 import { ensureProjectDirectory } from "./paths"
 import { TerminalManager } from "./terminal-manager"
 import type { UpdateManager } from "./update-manager"
-import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
+import { deriveChatRuntime, deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
 
 export interface ClientState {
   subscriptions: Map<string, SubscriptionTopic>
@@ -138,6 +138,56 @@ export function createWsRouter({
     }
   }
 
+  function broadcastTopic(predicate: (topic: SubscriptionTopic) => boolean) {
+    for (const ws of sockets) {
+      for (const [id, topic] of ws.data.subscriptions.entries()) {
+        if (!predicate(topic)) continue
+        send(ws, createEnvelope(id, topic))
+      }
+    }
+  }
+
+  function pushSidebarSnapshots() {
+    broadcastTopic((topic) => topic.type === "sidebar")
+  }
+
+  function pushChatReset(chatId: string) {
+    const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), chatId)
+    const event: ChatEvent = {
+      type: "chat.reset",
+      chatId,
+      snapshot,
+    }
+    pushChatEvent(chatId, event)
+  }
+
+  function pushChatRuntime(chatId: string) {
+    const runtime = deriveChatRuntime(store.state, agent.getActiveStatuses(), chatId)
+    if (!runtime) {
+      pushChatReset(chatId)
+      return
+    }
+    pushChatEvent(chatId, {
+      type: "chat.runtime",
+      chatId,
+      runtime,
+    })
+  }
+
+  function pushChatEvent(chatId: string, event: ChatEvent) {
+    for (const ws of sockets) {
+      for (const [id, topic] of ws.data.subscriptions.entries()) {
+        if (topic.type !== "chat" || topic.chatId !== chatId) continue
+        send(ws, {
+          v: PROTOCOL_VERSION,
+          type: "event",
+          id,
+          event,
+        })
+      }
+    }
+  }
+
   function pushTerminalSnapshot(terminalId: string) {
     for (const ws of sockets) {
       for (const [id, topic] of ws.data.subscriptions.entries()) {
@@ -185,6 +235,7 @@ export function createWsRouter({
 
   async function handleCommand(ws: ServerWebSocket<ClientState>, message: Extract<ClientEnvelope, { type: "command" }>) {
     const { command, id } = message
+    let shouldBroadcastSnapshots = true
     try {
       switch (command.type) {
         case "system.ping": {
@@ -275,19 +326,37 @@ export function createWsRouter({
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
         }
+        case "chat.prefetch": {
+          const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), command.chatId)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: snapshot })
+          shouldBroadcastSnapshots = false
+          break
+        }
         case "chat.send": {
           const result = await agent.send(command)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
+          shouldBroadcastSnapshots = false
           break
         }
         case "chat.cancel": {
           await agent.cancel(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          shouldBroadcastSnapshots = false
           break
         }
         case "chat.respondTool": {
           await agent.respondTool(command)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          shouldBroadcastSnapshots = false
+          break
+        }
+        case "chat.loadMore": {
+          const snapshot = deriveChatSnapshot(store.state, agent.getActiveStatuses(), command.chatId, {
+            beforeMessageId: command.beforeMessageId ?? null,
+            limit: command.limit,
+          })
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: snapshot })
+          shouldBroadcastSnapshots = false
           break
         }
         case "terminal.create": {
@@ -323,7 +392,9 @@ export function createWsRouter({
         }
       }
 
-      broadcastSnapshots()
+      if (shouldBroadcastSnapshots) {
+        broadcastSnapshots()
+      }
     } catch (error) {
       const messageText = error instanceof Error ? error.message : String(error)
       send(ws, { v: PROTOCOL_VERSION, type: "error", id, message: messageText })
@@ -338,6 +409,10 @@ export function createWsRouter({
       sockets.delete(ws)
     },
     broadcastSnapshots,
+    pushSidebarSnapshots,
+    pushChatReset,
+    pushChatRuntime,
+    pushChatEvent,
     handleMessage(ws: ServerWebSocket<ClientState>, raw: string | Buffer | ArrayBuffer | Uint8Array) {
       let parsed: unknown
       try {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1,10 +1,12 @@
 import type {
   AgentProvider,
+  ChatRuntime,
   ChatSnapshot,
   KeybindingsSnapshot,
   LocalProjectsSnapshot,
   ModelOptions,
   SidebarData,
+  TranscriptEntry,
   UpdateSnapshot,
 } from "./types"
 
@@ -41,6 +43,11 @@ export type TerminalEvent =
   | { type: "terminal.output"; terminalId: string; data: string }
   | { type: "terminal.exit"; terminalId: string; exitCode: number; signal?: number }
 
+export type ChatEvent =
+  | { type: "chat.runtime"; chatId: string; runtime: ChatRuntime }
+  | { type: "chat.messageAppended"; chatId: string; entry: TranscriptEntry }
+  | { type: "chat.reset"; chatId: string; snapshot: ChatSnapshot | null }
+
 export type ClientCommand =
   | { type: "project.open"; localPath: string }
   | { type: "project.create"; localPath: string; title: string }
@@ -61,6 +68,7 @@ export type ClientCommand =
   | { type: "chat.create"; projectId: string }
   | { type: "chat.rename"; chatId: string; title: string }
   | { type: "chat.delete"; chatId: string }
+  | { type: "chat.prefetch"; chatId: string }
   | {
       type: "chat.send"
       chatId?: string
@@ -74,6 +82,7 @@ export type ClientCommand =
     }
   | { type: "chat.cancel"; chatId: string }
   | { type: "chat.respondTool"; chatId: string; toolUseId: string; result: unknown }
+  | { type: "chat.loadMore"; chatId: string; beforeMessageId?: string; limit?: number }
   | { type: "terminal.create"; projectId: string; terminalId: string; cols: number; rows: number; scrollback: number }
   | { type: "terminal.input"; terminalId: string; data: string }
   | { type: "terminal.resize"; terminalId: string; cols: number; rows: number }
@@ -94,7 +103,7 @@ export type ServerSnapshot =
 
 export type ServerEnvelope =
   | { v: 1; type: "snapshot"; id: string; snapshot: ServerSnapshot }
-  | { v: 1; type: "event"; id: string; event: TerminalEvent }
+  | { v: 1; type: "event"; id: string; event: TerminalEvent | ChatEvent }
   | { v: 1; type: "ack"; id: string; result?: unknown }
   | { v: 1; type: "error"; id?: string; message: string }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,6 +138,7 @@ export interface SidebarChatRow {
   localPath: string
   provider: AgentProvider | null
   lastMessageAt?: number
+  lastCompletedTurnAt?: number
   hasAutomation: boolean
 }
 
@@ -529,6 +530,8 @@ export interface ChatRuntime {
 export interface ChatSnapshot {
   runtime: ChatRuntime
   messages: TranscriptEntry[]
+  hasOlderMessages: boolean
+  oldestLoadedMessageId: string | null
   availableProviders: ProviderCatalogEntry[]
 }
 


### PR DESCRIPTION
## Summary
- virtualize transcript rendering to keep large chats responsive
- preload recent chat history so opening a chat feels faster
- improve large message/tool rendering paths on the client

## Notes
- this branch is intentionally stacked on top of #26 ()
- once #26 lands, this PR should narrow to the loading/virtualization delta

## Verification
- originally validated in the working branch before splitting for upstream PRs