### PR TITLE
Inject current user device context into agent runtime

### DIFF
--- a/src/client/app/socket.test.ts
+++ b/src/client/app/socket.test.ts
@@ -117,6 +117,7 @@ describe("KannaSocket", () => {
   const originalWindow = globalThis.window
   const originalDocument = globalThis.document
   const originalWebSocket = globalThis.WebSocket
+  const originalNavigator = globalThis.navigator
 
   let windowTarget: FakeEventTarget
   let documentTarget: FakeEventTarget & { visibilityState: "visible" | "hidden" }
@@ -137,12 +138,18 @@ describe("KannaSocket", () => {
     })
     ;(globalThis as any).document = documentTarget
     ;(globalThis as any).WebSocket = FakeWebSocket
+    ;(globalThis as any).navigator = {
+      userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/123.0 Mobile Safari/537.36",
+      platform: "Linux armv8l",
+      maxTouchPoints: 5,
+    }
   })
 
   afterEach(() => {
     ;(globalThis as any).window = originalWindow
     ;(globalThis as any).document = originalDocument
     ;(globalThis as any).WebSocket = originalWebSocket
+    ;(globalThis as any).navigator = originalNavigator
   })
 
   test("does not ping when the connection is already fresh", async () => {
@@ -153,7 +160,16 @@ describe("KannaSocket", () => {
 
     await socket.ensureHealthyConnection()
 
-    expect(ws.sent).toHaveLength(0)
+    expect(ws.sent[0]).toMatchObject({
+      type: "command",
+      command: {
+        type: "system.setClientContext",
+        context: {
+          currentUserDevice: "pixel",
+          currentUserDeviceLabel: "pixel",
+        },
+      },
+    })
     socket.dispose()
   })
 
@@ -166,7 +182,7 @@ describe("KannaSocket", () => {
     ;(socket as any).lastMessageAt = Date.now() - 30_000
 
     const healthCheck = socket.ensureHealthyConnection()
-    const ping = ws.sent[0]
+    const ping = ws.sent[1]
 
     expect(ping?.type).toBe("command")
     expect(ping?.command).toEqual({ type: "system.ping" })

--- a/src/client/app/socket.ts
+++ b/src/client/app/socket.ts
@@ -7,6 +7,7 @@ import type {
   TerminalSnapshot,
 } from "../../shared/protocol"
 import { LOG_PREFIX } from "../../shared/branding"
+import { detectClientContext } from "../lib/current-user-device"
 import { generateUUID } from "../lib/utils"
 
 type SnapshotListener<T> = (value: T) => void
@@ -176,6 +177,15 @@ export class KannaSocket {
       this.lastMessageAt = this.lastOpenAt
       this.emitStatus("connected")
       this.startHeartbeat()
+      this.sendNow({
+        v: 1,
+        type: "command",
+        id: generateUUID(),
+        command: {
+          type: "system.setClientContext",
+          context: detectClientContext(),
+        },
+      })
       for (const [id, subscription] of this.subscriptions.entries()) {
         this.sendNow({ v: 1, type: "subscribe", id, topic: subscription.topic })
       }

--- a/src/client/lib/current-user-device.test.ts
+++ b/src/client/lib/current-user-device.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { detectClientContext, detectCurrentUserDevice } from "./current-user-device"
+
+describe("current-user-device", () => {
+  test("detects Pixel Android devices", () => {
+    expect(detectCurrentUserDevice({
+      userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/123.0 Mobile Safari/537.36",
+      platform: "Linux armv8l",
+      maxTouchPoints: 5,
+    } as Navigator)).toBe("pixel")
+  })
+
+  test("detects macOS devices", () => {
+    expect(detectCurrentUserDevice({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15",
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+    } as Navigator)).toBe("macbook")
+  })
+
+  test("returns a matching client context label", () => {
+    expect(detectClientContext({
+      userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/123.0 Mobile Safari/537.36",
+      platform: "Linux armv8l",
+      maxTouchPoints: 5,
+    } as Navigator)).toEqual({
+      currentUserDevice: "pixel",
+      currentUserDeviceLabel: "pixel",
+    })
+  })
+})

--- a/src/client/lib/current-user-device.ts
+++ b/src/client/lib/current-user-device.ts
@@ -1,0 +1,35 @@
+import type { ClientContext, CurrentUserDevice } from "../../shared/protocol"
+
+type NavigatorLike = Pick<Navigator, "userAgent" | "platform" | "maxTouchPoints"> & {
+  userAgentData?: {
+    platform?: string
+    mobile?: boolean
+    brands?: Array<{ brand?: string; version?: string }>
+  }
+}
+
+function normalizedUserAgent(navigatorValue: NavigatorLike | undefined) {
+  return `${navigatorValue?.userAgentData?.platform ?? ""} ${navigatorValue?.platform ?? ""} ${navigatorValue?.userAgent ?? ""}`
+    .trim()
+    .toLowerCase()
+}
+
+export function detectCurrentUserDevice(navigatorValue: NavigatorLike | undefined): CurrentUserDevice {
+  const userAgent = normalizedUserAgent(navigatorValue)
+  if (!userAgent) return "unknown"
+  if (userAgent.includes("pixel")) return "pixel"
+  if (userAgent.includes("android")) return "android"
+  if (userAgent.includes("iphone") || userAgent.includes("ipad") || userAgent.includes("ios")) return "ios"
+  if (userAgent.includes("macintosh") || userAgent.includes("mac os") || userAgent.includes("macos")) return "macbook"
+  if (userAgent.includes("windows")) return "windows"
+  if (userAgent.includes("linux")) return "linux"
+  return "unknown"
+}
+
+export function detectClientContext(navigatorValue = globalThis.navigator): ClientContext {
+  const currentUserDevice = detectCurrentUserDevice(navigatorValue)
+  return {
+    currentUserDevice,
+    currentUserDeviceLabel: currentUserDevice,
+  }
+}

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -7,7 +7,7 @@ import type {
   TranscriptEntry,
 } from "../shared/types"
 import { normalizeToolCall } from "../shared/tools"
-import type { ClientCommand } from "../shared/protocol"
+import type { ClientCommand, ClientContext } from "../shared/protocol"
 import { EventStore } from "./event-store"
 import { CodexAppServerManager } from "./codex-app-server"
 import { generateTitleForChat } from "./generate-title"
@@ -69,6 +69,23 @@ interface AgentCoordinatorArgs {
   generateTitle?: (messageContent: string, cwd: string) => Promise<string | null>
 }
 
+function buildRuntimeContextInstruction(clientContext?: ClientContext) {
+  const currentUserDevice = clientContext?.currentUserDevice ?? "unknown"
+  return [
+    "Runtime context:",
+    "- You are running on the VPS host, not on the user's local device.",
+    `- The user's current device tag is \`${currentUserDevice}\`.`,
+    "- If you need to mention the current device, use that exact tag unless later tool output proves otherwise.",
+    `- If the user asks for CURRENT_USER_DEVICE or CURRENT_USER_DEVICE_LABEL, answer with \`${currentUserDevice}\` directly.`,
+    "- Do not run shell commands just to read CURRENT_USER_DEVICE or CURRENT_USER_DEVICE_LABEL.",
+  ].join("\n")
+}
+
+export type AgentStateChange =
+  | { type: "sidebar" }
+  | { type: "chat-runtime"; chatId: string }
+  | { type: "chat-reset"; chatId: string }
+  | { type: "chat-message"; chatId: string; entry: TranscriptEntry }
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
   entry: T,
   createdAt = Date.now()
@@ -239,6 +256,8 @@ async function startClaudeTurn(args: {
   effort?: string
   planMode: boolean
   sessionToken: string | null
+  envOverrides?: Record<string, string>
+  systemPrompt?: string
   onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
 }): Promise<HarnessTurn> {
   const canUseTool: CanUseTool = async (toolName, input, options) => {
@@ -307,7 +326,14 @@ async function startClaudeTurn(args: {
       canUseTool,
       tools: [...CLAUDE_TOOLSET],
       settingSources: ["user", "project", "local"],
-      env: (() => { const { CLAUDECODE: _, ...env } = process.env; return env })(),
+      systemPrompt: args.systemPrompt ?? "",
+      env: (() => {
+        const { CLAUDECODE: _, ...env } = process.env
+        return {
+          ...env,
+          ...args.envOverrides,
+        }
+      })(),
     },
   })
 
@@ -385,6 +411,13 @@ export class AgentCoordinator {
     }
   }
 
+  private buildAgentEnv(clientContext?: ClientContext) {
+    return {
+      CURRENT_USER_DEVICE: clientContext?.currentUserDevice ?? "unknown",
+      CURRENT_USER_DEVICE_LABEL: clientContext?.currentUserDeviceLabel ?? clientContext?.currentUserDevice ?? "unknown",
+    }
+  }
+
   private async startTurnForChat(args: {
     chatId: string
     provider: AgentProvider
@@ -394,6 +427,7 @@ export class AgentCoordinator {
     serviceTier?: "fast"
     planMode: boolean
     appendUserPrompt: boolean
+    clientContext?: ClientContext
   }) {
     const chat = this.store.requireChat(args.chatId)
     if (this.activeTurns.has(args.chatId)) {
@@ -449,6 +483,8 @@ export class AgentCoordinator {
         effort: args.effort,
         planMode: args.planMode,
         sessionToken: chat.sessionToken,
+        envOverrides: this.buildAgentEnv(args.clientContext),
+        systemPrompt: buildRuntimeContextInstruction(args.clientContext),
         onToolRequest,
       })
     } else {
@@ -458,6 +494,7 @@ export class AgentCoordinator {
         model: args.model,
         serviceTier: args.serviceTier,
         sessionToken: chat.sessionToken,
+        envOverrides: this.buildAgentEnv(args.clientContext),
       })
       turn = await this.codexManager.startTurn({
         chatId: args.chatId,
@@ -466,6 +503,7 @@ export class AgentCoordinator {
         effort: args.effort as any,
         serviceTier: args.serviceTier,
         planMode: args.planMode,
+        developerInstructions: buildRuntimeContextInstruction(args.clientContext),
         onToolRequest,
       })
     }
@@ -501,7 +539,7 @@ export class AgentCoordinator {
     void this.runTurn(active)
   }
 
-  async send(command: Extract<ClientCommand, { type: "chat.send" }>) {
+  async send(command: Extract<ClientCommand, { type: "chat.send" }>, clientContext?: ClientContext) {
     let chatId = command.chatId
 
     if (!chatId) {
@@ -524,6 +562,7 @@ export class AgentCoordinator {
       serviceTier: settings.serviceTier,
       planMode: settings.planMode,
       appendUserPrompt: true,
+      clientContext,
     })
 
     return { chatId }

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -181,6 +181,59 @@ describe("CodexAppServerManager", () => {
     expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBeNull()
   })
 
+  test("passes developer instructions into collaboration mode", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "completed", error: null } },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "Where am I running?",
+      planMode: false,
+      developerInstructions: "Current device tag: pixel",
+      onToolRequest: async () => ({}),
+    })
+
+    await collectStream(turn.stream)
+
+    const turnStart = process.messages.find((message: any) => message.method === "turn/start") as
+      | { method: "turn/start"; params: { collaborationMode?: { settings?: { developer_instructions?: string | null } } } }
+      | undefined
+
+    expect(turnStart?.params.collaborationMode?.settings?.developer_instructions).toContain("Current device tag: pixel")
+  })
+
   test("generateStructured returns the final assistant JSON and stops the transient session", async () => {
     const process = new FakeCodexProcess((message, child) => {
       if (message.method === "initialize") {

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -55,7 +55,7 @@ interface CodexAppServerProcess {
   once(event: "error", listener: (error: Error) => void): this
 }
 
-type SpawnCodexAppServer = (cwd: string) => CodexAppServerProcess
+type SpawnCodexAppServer = (cwd: string, envOverrides?: Record<string, string>) => CodexAppServerProcess
 
 interface PendingRequest<TResult> {
   method: string
@@ -96,6 +96,7 @@ interface PendingTurn {
 interface SessionContext {
   chatId: string
   cwd: string
+  envSignature: string
   child: CodexAppServerProcess
   pendingRequests: Map<CodexRequestId, PendingRequest<unknown>>
   pendingTurn: PendingTurn | null
@@ -110,6 +111,7 @@ export interface StartCodexSessionArgs {
   model: string
   serviceTier?: ServiceTier
   sessionToken: string | null
+  envOverrides?: Record<string, string>
 }
 
 export interface StartCodexTurnArgs {
@@ -119,6 +121,7 @@ export interface StartCodexTurnArgs {
   serviceTier?: ServiceTier
   content: string
   planMode: boolean
+  developerInstructions?: string
   onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
   onApprovalRequest?: PendingTurn["onApprovalRequest"]
 }
@@ -638,17 +641,21 @@ export class CodexAppServerManager {
   private readonly spawnProcess: SpawnCodexAppServer
 
   constructor(args: { spawnProcess?: SpawnCodexAppServer } = {}) {
-    this.spawnProcess = args.spawnProcess ?? ((cwd) =>
+    this.spawnProcess = args.spawnProcess ?? ((cwd, envOverrides) =>
       spawn("codex", ["app-server"], {
         cwd,
         stdio: ["pipe", "pipe", "pipe"],
-        env: process.env,
+        env: {
+          ...process.env,
+          ...envOverrides,
+        },
       }) as unknown as CodexAppServerProcess)
   }
 
   async startSession(args: StartCodexSessionArgs) {
+    const envSignature = JSON.stringify(args.envOverrides ?? {})
     const existing = this.sessions.get(args.chatId)
-    if (existing && !existing.closed && existing.cwd === args.cwd) {
+    if (existing && !existing.closed && existing.cwd === args.cwd && existing.envSignature === envSignature) {
       return
     }
 
@@ -656,10 +663,11 @@ export class CodexAppServerManager {
       this.stopSession(args.chatId)
     }
 
-    const child = this.spawnProcess(args.cwd)
+    const child = this.spawnProcess(args.cwd, args.envOverrides)
     const context: SessionContext = {
       chatId: args.chatId,
       cwd: args.cwd,
+      envSignature,
       child,
       pendingRequests: new Map(),
       pendingTurn: null,
@@ -770,7 +778,7 @@ export class CodexAppServerManager {
           settings: {
             model: args.model,
             reasoning_effort: null,
-            developer_instructions: null,
+            developer_instructions: args.developerInstructions ?? null,
           },
         },
       } satisfies TurnStartParams)

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -8,6 +8,7 @@ class FakeWebSocket {
   readonly sent: unknown[] = []
   readonly data = {
     subscriptions: new Map(),
+    clientContext: undefined,
   }
 
   send(message: string) {
@@ -117,6 +118,77 @@ describe("ws-router", () => {
         v: PROTOCOL_VERSION,
         type: "ack",
         id: "terminal-input-1",
+      },
+    ])
+  })
+
+  test("stores client context and passes it to chat.send", async () => {
+    const calls: unknown[] = []
+    const router = createWsRouter({
+      store: { state: createEmptyState() } as never,
+      agent: {
+        getActiveStatuses: () => new Map(),
+        send: async (command: unknown, clientContext: unknown) => {
+          calls.push({ command, clientContext })
+          return { chatId: "chat-1" }
+        },
+      } as never,
+      terminals: {
+        getSnapshot: () => null,
+        onEvent: () => () => {},
+      } as never,
+      keybindings: {
+        getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT,
+        onChange: () => () => {},
+      } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "ctx-1",
+        command: {
+          type: "system.setClientContext",
+          context: {
+            currentUserDevice: "pixel",
+            currentUserDeviceLabel: "pixel",
+          },
+        },
+      })
+    )
+
+    await router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "chat-send-1",
+        command: {
+          type: "chat.send",
+          projectId: "project-1",
+          content: "hello",
+        },
+      })
+    )
+
+    expect(calls).toEqual([
+      {
+        command: {
+          type: "chat.send",
+          projectId: "project-1",
+          content: "hello",
+        },
+        clientContext: {
+          currentUserDevice: "pixel",
+          currentUserDeviceLabel: "pixel",
+        },
       },
     ])
   })

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun"
 import { PROTOCOL_VERSION } from "../shared/types"
-import type { ChatEvent, ClientContext, ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
+import type { ClientContext, ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
 import { isClientEnvelope } from "../shared/protocol"
 import type { AgentCoordinator } from "./agent"
 import type { DiscoveredProject } from "./discovery"

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun"
 import { PROTOCOL_VERSION } from "../shared/types"
-import type { ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
+import type { ChatEvent, ClientContext, ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
 import { isClientEnvelope } from "../shared/protocol"
 import type { AgentCoordinator } from "./agent"
 import type { DiscoveredProject } from "./discovery"
@@ -14,6 +14,7 @@ import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } fr
 
 export interface ClientState {
   subscriptions: Map<string, SubscriptionTopic>
+  clientContext?: ClientContext
 }
 
 interface CreateWsRouterArgs {
@@ -191,6 +192,11 @@ export function createWsRouter({
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           return
         }
+        case "system.setClientContext": {
+          ws.data.clientContext = command.context
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          return
+        }
         case "update.check": {
           const snapshot = updateManager
             ? await updateManager.checkForUpdates({ force: command.force })
@@ -276,7 +282,7 @@ export function createWsRouter({
           break
         }
         case "chat.send": {
-          const result = await agent.send(command)
+          const result = await agent.send(command, ws.data.clientContext)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
           break
         }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -10,6 +10,20 @@ import type {
 
 export type EditorPreset = "cursor" | "vscode" | "windsurf" | "custom"
 
+export type CurrentUserDevice =
+  | "pixel"
+  | "android"
+  | "macbook"
+  | "ios"
+  | "windows"
+  | "linux"
+  | "unknown"
+
+export interface ClientContext {
+  currentUserDevice: CurrentUserDevice
+  currentUserDeviceLabel?: string
+}
+
 export interface EditorOpenSettings {
   preset: EditorPreset
   commandTemplate: string
@@ -46,6 +60,7 @@ export type ClientCommand =
   | { type: "project.create"; localPath: string; title: string }
   | { type: "project.remove"; projectId: string }
   | { type: "system.ping" }
+  | { type: "system.setClientContext"; context: ClientContext }
   | { type: "update.check"; force?: boolean }
   | { type: "update.install" }
   | { type: "settings.readKeybindings" }


### PR DESCRIPTION
## Summary
- detect the current user device in the browser and send it to the server as client context
- inject CURRENT_USER_DEVICE and CURRENT_USER_DEVICE_LABEL into agent runtime environments
- pass matching runtime instructions into Claude and Codex turns so simple device questions are answered directly

## Notes
- this PR is intentionally scoped to device-context propagation only
- sidebar completion marker behavior is tracked separately in #31

## Verification
- rtk bash -lc '/root/.bun/bin/bun run check'