### PR TITLE
Add queued messages: send while agent is running

### DIFF
--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -5,6 +5,7 @@ import { ChatInput, type ChatInputHandle } from "../components/chat-ui/ChatInput
 import { ChatNavbar } from "../components/chat-ui/ChatNavbar"
 import { RightSidebar } from "../components/chat-ui/RightSidebar"
 import { TerminalWorkspace } from "../components/chat-ui/TerminalWorkspace"
+import { DrainingIndicator } from "../components/messages/DrainingIndicator"
 import { ProcessingMessage } from "../components/messages/ProcessingMessage"
 import { Card, CardContent } from "../components/ui/card"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable"
@@ -325,6 +326,9 @@ export function ChatPage() {
                   onExitPlanModeConfirm={state.handleExitPlanMode}
                 />
                 {state.isProcessing ? <ProcessingMessage status={state.runtime?.status} /> : null}
+                {!state.isProcessing && state.isDraining ? (
+                  <DrainingIndicator onStop={() => void state.handleStopDraining()} />
+                ) : null}
                 {state.commandError ? (
                   <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-xl px-4 py-3">
                     {state.commandError}

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -7,6 +7,7 @@ import { RightSidebar } from "../components/chat-ui/RightSidebar"
 import { TerminalWorkspace } from "../components/chat-ui/TerminalWorkspace"
 import { DrainingIndicator } from "../components/messages/DrainingIndicator"
 import { ProcessingMessage } from "../components/messages/ProcessingMessage"
+import { QueuedMessageIndicator } from "../components/messages/QueuedMessageIndicator"
 import { Card, CardContent } from "../components/ui/card"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable"
 import { ScrollArea } from "../components/ui/scroll-area"
@@ -328,6 +329,9 @@ export function ChatPage() {
                 {state.isProcessing ? <ProcessingMessage status={state.runtime?.status} /> : null}
                 {!state.isProcessing && state.isDraining ? (
                   <DrainingIndicator onStop={() => void state.handleStopDraining()} />
+                ) : null}
+                {state.hasQueuedMessage ? (
+                  <QueuedMessageIndicator onCancel={() => void state.handleCancelQueued()} />
                 ) : null}
                 {state.commandError ? (
                   <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-xl px-4 py-3">

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -150,6 +150,7 @@ export interface KannaState {
   availableProviders: ProviderCatalogEntry[]
   isProcessing: boolean
   canCancel: boolean
+  isDraining: boolean
   transcriptPaddingBottom: number
   showScrollButton: boolean
   navbarLocalPath?: string
@@ -168,6 +169,7 @@ export interface KannaState {
   handleInstallUpdate: () => Promise<void>
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
+  handleStopDraining: () => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
@@ -389,6 +391,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const availableProviders = activeChatSnapshot?.availableProviders ?? PROVIDERS
   const isProcessing = isProcessingStatus(runtime?.status)
   const canCancel = canCancelStatus(runtime?.status)
+  const isDraining = runtime?.isDraining ?? false
   const transcriptPaddingBottom = FIXED_TRANSCRIPT_PADDING_BOTTOM
   const showScrollButton = !isAtBottom && messages.length > 0
   const fallbackLocalProjectPath = localProjects?.projects[0]?.localPath ?? null
@@ -604,6 +607,15 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }
 
+  async function handleStopDraining() {
+    if (!activeChatId) return
+    try {
+      await socket.command({ type: "chat.stopDraining", chatId: activeChatId })
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }
+
   async function handleDeleteChat(chat: SidebarChatRow) {
     const confirmed = await dialog.confirm({
       title: "Delete Chat",
@@ -781,6 +793,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     availableProviders,
     isProcessing,
     canCancel,
+    isDraining,
     transcriptPaddingBottom,
     showScrollButton,
     navbarLocalPath,
@@ -799,6 +812,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleInstallUpdate,
     handleSend,
     handleCancel,
+    handleStopDraining,
     handleDeleteChat,
     handleRemoveProject,
     handleOpenExternal,

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -151,6 +151,7 @@ export interface KannaState {
   isProcessing: boolean
   canCancel: boolean
   isDraining: boolean
+  hasQueuedMessage: boolean
   transcriptPaddingBottom: number
   showScrollButton: boolean
   navbarLocalPath?: string
@@ -170,6 +171,7 @@ export interface KannaState {
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
   handleStopDraining: () => Promise<void>
+  handleCancelQueued: () => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
@@ -392,6 +394,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const isProcessing = isProcessingStatus(runtime?.status)
   const canCancel = canCancelStatus(runtime?.status)
   const isDraining = runtime?.isDraining ?? false
+  const hasQueuedMessage = runtime?.hasQueuedMessage ?? false
   const transcriptPaddingBottom = FIXED_TRANSCRIPT_PADDING_BOTTOM
   const showScrollButton = !isAtBottom && messages.length > 0
   const fallbackLocalProjectPath = localProjects?.projects[0]?.localPath ?? null
@@ -616,6 +619,15 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }
 
+  async function handleCancelQueued() {
+    if (!activeChatId) return
+    try {
+      await socket.command({ type: "chat.cancelQueued", chatId: activeChatId })
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }
+
   async function handleDeleteChat(chat: SidebarChatRow) {
     const confirmed = await dialog.confirm({
       title: "Delete Chat",
@@ -794,6 +806,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     isProcessing,
     canCancel,
     isDraining,
+    hasQueuedMessage,
     transcriptPaddingBottom,
     showScrollButton,
     navbarLocalPath,
@@ -813,6 +826,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleSend,
     handleCancel,
     handleStopDraining,
+    handleCancelQueued,
     handleDeleteChat,
     handleRemoveProject,
     handleOpenExternal,

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -576,7 +576,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     }
 
     const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0
-    if (event.key === "Enter" && !event.shiftKey && !canCancel && !isTouchDevice) {
+    if (event.key === "Enter" && !event.shiftKey && !isTouchDevice) {
       event.preventDefault()
       void handleSubmit()
     }
@@ -695,17 +695,19 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
               type="button"
               onPointerDown={(event) => {
                 event.preventDefault()
-                if (canCancel) {
-                  onCancel?.()
-                } else if (!disabled && canSubmit && !hasPendingUploads) {
+                if (canSubmit && !hasPendingUploads) {
                   void handleSubmit()
+                } else if (canCancel) {
+                  onCancel?.()
                 }
               }}
-              disabled={!canCancel && (disabled || !canSubmit || hasPendingUploads)}
+              disabled={canSubmit ? hasPendingUploads : !canCancel}
               size="icon"
               className="flex-shrink-0 bg-slate-600 text-white dark:bg-white dark:text-slate-900 rounded-full cursor-pointer h-10 w-10 md:h-11 md:w-11 mb-1 -mr-0.5 md:mr-0 md:mb-1.5 touch-manipulation disabled:bg-white/60 disabled:text-slate-700"
             >
-              {canCancel ? (
+              {canSubmit ? (
+                <ArrowUp className="h-5 w-5 md:h-6 md:w-6" />
+              ) : canCancel ? (
                 <div className="w-3 h-3 md:w-4 md:h-4 rounded-xs bg-current" />
               ) : (
                 <ArrowUp className="h-5 w-5 md:h-6 md:w-6" />

--- a/src/client/components/messages/DrainingIndicator.tsx
+++ b/src/client/components/messages/DrainingIndicator.tsx
@@ -1,0 +1,33 @@
+import { Loader2, X } from "lucide-react"
+import { MetaRow, MetaContent } from "./shared"
+import { AnimatedShinyText } from "../ui/animated-shiny-text"
+
+interface DrainingIndicatorProps {
+  onStop: () => void
+}
+
+export function DrainingIndicator({ onStop }: DrainingIndicatorProps) {
+  return (
+    <MetaRow className="ml-[1px]">
+      <MetaContent>
+        <div className="group/draining relative flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 group-hover/draining:opacity-0 transition-opacity">
+            <Loader2 className="size-4.5 animate-spin text-muted-icon" />
+            <AnimatedShinyText className="ml-[1px] text-sm" shimmerWidth={44}>
+              Running...
+            </AnimatedShinyText>
+          </div>
+          <button
+            onClick={onStop}
+            className="absolute inset-0 flex items-center gap-1.5 opacity-0 group-hover/draining:opacity-100 transition-opacity cursor-pointer"
+          >
+            <X className="size-4.5 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">
+              Stop
+            </span>
+          </button>
+        </div>
+      </MetaContent>
+    </MetaRow>
+  )
+}

--- a/src/client/components/messages/QueuedMessageIndicator.tsx
+++ b/src/client/components/messages/QueuedMessageIndicator.tsx
@@ -1,0 +1,32 @@
+import { Clock, X } from "lucide-react"
+import { MetaRow, MetaContent } from "./shared"
+
+interface QueuedMessageIndicatorProps {
+  onCancel: () => void
+}
+
+export function QueuedMessageIndicator({ onCancel }: QueuedMessageIndicatorProps) {
+  return (
+    <MetaRow className="ml-[1px]">
+      <MetaContent>
+        <div className="group/queued relative flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 group-hover/queued:opacity-0 transition-opacity">
+            <Clock className="size-4.5 text-muted-icon" />
+            <span className="ml-[1px] text-sm text-muted-foreground">
+              Message queued
+            </span>
+          </div>
+          <button
+            onClick={onCancel}
+            className="absolute inset-0 flex items-center gap-1.5 opacity-0 group-hover/queued:opacity-100 transition-opacity cursor-pointer"
+          >
+            <X className="size-4.5 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">
+              Cancel
+            </span>
+          </button>
+        </div>
+      </MetaContent>
+    </MetaRow>
+  )
+}

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -619,6 +619,373 @@ describe("AgentCoordinator codex integration", () => {
     expect(store.messages.some((entry) => entry.kind === "interrupted")).toBe(true)
   })
 
+  test("UI unblocks immediately when result arrives even if stream stays open", async () => {
+    let resolveStream!: () => void
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          // Produce the result event
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 120_000,
+              result: "done",
+            }),
+          }
+          // Stream stays open (simulates background tasks still running)
+          await new Promise<void>((resolve) => {
+            resolveStream = resolve
+          })
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {
+            resolveStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "run something with a background task",
+    })
+
+    // Wait for the result message to be persisted
+    await waitFor(() => store.messages.some((entry) => entry.kind === "result"))
+
+    // The active turn should be removed even though the stream is still open.
+    // This is the key assertion: the UI should show idle (not "Running...")
+    // so the user can send new messages without hitting stop.
+    expect(coordinator.getActiveStatuses().has("chat-1")).toBe(false)
+    expect(store.turnFinishedCount).toBe(1)
+
+    // The stream is still open, so it should be draining
+    expect(coordinator.getDrainingChatIds().has("chat-1")).toBe(true)
+
+    // Clean up the hanging stream
+    resolveStream()
+
+    // After the stream closes, draining should stop
+    await waitFor(() => !coordinator.getDrainingChatIds().has("chat-1"))
+  })
+
+  test("stopDraining closes the stream and removes from draining set", async () => {
+    let resolveStream!: () => void
+    let streamClosed = false
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "done",
+            }),
+          }
+          await new Promise<void>((resolve) => {
+            resolveStream = resolve
+          })
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {
+            streamClosed = true
+            resolveStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "work",
+    })
+
+    await waitFor(() => coordinator.getDrainingChatIds().has("chat-1"))
+
+    await coordinator.stopDraining("chat-1")
+
+    expect(coordinator.getDrainingChatIds().has("chat-1")).toBe(false)
+    expect(streamClosed).toBe(true)
+  })
+
+  test("cancel immediately removes active turn so UI shows idle", async () => {
+    let resolveInterrupt!: () => void
+    const interruptCalled = new Promise<void>((resolve) => {
+      resolveInterrupt = resolve
+    })
+    // interrupt() that hangs until we resolve it — simulating a slow SDK
+    let interruptDone = false
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          // Stream that never ends (simulates the SDK hanging)
+          await new Promise(() => {})
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {
+            resolveInterrupt()
+            // Hang to simulate a slow interrupt
+            await new Promise<void>((resolve) => {
+              setTimeout(() => {
+                interruptDone = true
+                resolve()
+              }, 100)
+            })
+          },
+          close: () => {},
+        }
+      },
+    }
+
+    const stateChanges: number[] = []
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {
+        stateChanges.push(Date.now())
+      },
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "do something",
+    })
+
+    // Wait for the turn to be running
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Cancel — this should immediately remove from active turns
+    const cancelPromise = coordinator.cancel("chat-1")
+
+    // The turn should be removed from activeTurns immediately,
+    // BEFORE interrupt() resolves
+    await interruptCalled
+    expect(coordinator.getActiveStatuses().has("chat-1")).toBe(false)
+    expect(interruptDone).toBe(false) // interrupt is still in progress
+
+    await cancelPromise
+
+    // Verify only one "interrupted" message was appended
+    const interruptedMessages = store.messages.filter((entry) => entry.kind === "interrupted")
+    expect(interruptedMessages).toHaveLength(1)
+  })
+
+  test("concurrent cancel calls only produce a single interrupted message", async () => {
+    let resolveStream!: () => void
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          await new Promise<void>((resolve) => {
+            resolveStream = resolve
+          })
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {
+            resolveStream()
+          },
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "work",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Fire multiple cancel calls concurrently (simulating repeated stop button clicks)
+    await Promise.all([
+      coordinator.cancel("chat-1"),
+      coordinator.cancel("chat-1"),
+      coordinator.cancel("chat-1"),
+    ])
+
+    // Only one "interrupted" message should exist
+    const interruptedMessages = store.messages.filter((entry) => entry.kind === "interrupted")
+    expect(interruptedMessages).toHaveLength(1)
+  })
+
+  test("runTurn stops processing events after cancel", async () => {
+    let resolveStream!: () => void
+    let yieldExtraEvent!: () => void
+    let extraEventYielded = false
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          // Wait for cancel, then yield another event that should be ignored
+          await new Promise<void>((resolve) => {
+            resolveStream = resolve
+          })
+          // This event arrives after cancel — should not be processed
+          extraEventYielded = true
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "assistant_text",
+              text: "this should be ignored after cancel",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {
+            resolveStream()
+          },
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "work",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    const messageCountBefore = store.messages.filter((entry) => entry.kind === "assistant_text").length
+    await coordinator.cancel("chat-1")
+
+    // Give the stream time to yield the extra event
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const postCancelTextMessages = store.messages.filter((entry) => entry.kind === "assistant_text")
+    expect(postCancelTextMessages.length).toBe(messageCountBefore)
+  })
+
   test("cancelling a waiting codex exit-plan prompt discards it without starting a follow-up turn", async () => {
     let releaseInterrupt!: () => void
     const interrupted = new Promise<void>((resolve) => {

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1080,6 +1080,364 @@ describe("AgentCoordinator codex integration", () => {
     expect(discardedResult.content).toEqual({ discarded: true })
     expect(startTurnCalls).toEqual(["plan this"])
   })
+
+  test("queues a message when a turn is active and auto-starts on completion", async () => {
+    let resolveFirstStream!: () => void
+    const startTurnCalls: string[] = []
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: { content: string }): Promise<HarnessTurn> {
+        startTurnCalls.push(args.content)
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          if (startTurnCalls.length === 1) {
+            // First turn: wait for us to resolve before producing result
+            await new Promise<void>((resolve) => {
+              resolveFirstStream = resolve
+            })
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {
+            resolveFirstStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    // Start the first turn
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "first message",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Queue a second message while the first is running
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "queued message",
+    })
+
+    // The queued message should be tracked
+    expect(coordinator.getQueuedChatIds().has("chat-1")).toBe(true)
+    // User prompt should appear in transcript immediately
+    const userPrompts = store.messages.filter((e) => e.kind === "user_prompt")
+    expect(userPrompts).toHaveLength(2) // first + queued
+
+    // Resolve the first stream to complete the first turn
+    resolveFirstStream()
+
+    // The queued message should auto-start as a second turn
+    await waitFor(() => store.turnFinishedCount === 2)
+    expect(startTurnCalls).toEqual(["first message", "queued message"])
+    expect(coordinator.getQueuedChatIds().has("chat-1")).toBe(false)
+  })
+
+  test("latest queued message replaces previous", async () => {
+    let resolveFirstStream!: () => void
+    const startTurnCalls: string[] = []
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: { content: string }): Promise<HarnessTurn> {
+        startTurnCalls.push(args.content)
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          if (startTurnCalls.length === 1) {
+            await new Promise<void>((resolve) => {
+              resolveFirstStream = resolve
+            })
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {
+            resolveFirstStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "first message",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Queue two messages — only the latest should run
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "message A",
+    })
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "message B",
+    })
+
+    // Both user prompts appear in transcript
+    const userPrompts = store.messages.filter((e) => e.kind === "user_prompt")
+    expect(userPrompts).toHaveLength(3) // first + A + B
+
+    resolveFirstStream()
+
+    // Only message B should actually start as a turn
+    await waitFor(() => store.turnFinishedCount === 2)
+    expect(startTurnCalls).toEqual(["first message", "message B"])
+  })
+
+  test("cancel preserves queued message and it fires after cancellation", async () => {
+    const startTurnCalls: string[] = []
+    let resolveStream!: () => void
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: { content: string }): Promise<HarnessTurn> {
+        startTurnCalls.push(args.content)
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          if (startTurnCalls.length === 1) {
+            // First turn hangs until cancelled
+            await new Promise<void>((resolve) => {
+              resolveStream = resolve
+            })
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {
+            resolveStream?.()
+          },
+          close: () => {
+            resolveStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "first message",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Queue a message while running
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "queued message",
+    })
+
+    expect(coordinator.getQueuedChatIds().has("chat-1")).toBe(true)
+
+    // Cancel the active turn
+    await coordinator.cancel("chat-1")
+
+    // The queued message should fire as a new turn
+    await waitFor(() => store.turnFinishedCount >= 1)
+    await waitFor(() => startTurnCalls.length === 2)
+    expect(startTurnCalls).toEqual(["first message", "queued message"])
+  })
+
+  test("cancelQueued removes queued message so it does not fire", async () => {
+    let resolveFirstStream!: () => void
+    const startTurnCalls: string[] = []
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: { content: string }): Promise<HarnessTurn> {
+        startTurnCalls.push(args.content)
+
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          if (startTurnCalls.length === 1) {
+            await new Promise<void>((resolve) => {
+              resolveFirstStream = resolve
+            })
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {
+            resolveFirstStream?.()
+          },
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "first message",
+    })
+
+    await waitFor(() => coordinator.getActiveStatuses().get("chat-1") === "running")
+
+    // Queue then cancel the queued message
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "queued message",
+    })
+    expect(coordinator.getQueuedChatIds().has("chat-1")).toBe(true)
+
+    coordinator.cancelQueued("chat-1")
+    expect(coordinator.getQueuedChatIds().has("chat-1")).toBe(false)
+
+    // Complete the first turn
+    resolveFirstStream()
+
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    // Give it time to potentially start a queued turn (it shouldn't)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(startTurnCalls).toEqual(["first message"])
+  })
 })
 
 function createFakeStore() {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -373,6 +373,14 @@ export class AgentCoordinator {
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<string | null>
   readonly activeTurns = new Map<string, ActiveTurn>()
   readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
+  readonly queuedMessages = new Map<
+    string,
+    {
+      command: Extract<ClientCommand, { type: "chat.send" }>
+      provider: AgentProvider
+      settings: { model: string; effort?: string; serviceTier?: "fast"; planMode: boolean }
+    }
+  >()
 
   constructor(args: AgentCoordinatorArgs) {
     this.store = args.store
@@ -404,6 +412,16 @@ export class AgentCoordinator {
     if (!draining) return
     draining.turn.close()
     this.drainingStreams.delete(chatId)
+    this.onStateChange()
+  }
+
+  getQueuedChatIds(): Set<string> {
+    return new Set(this.queuedMessages.keys())
+  }
+
+  cancelQueued(chatId: string) {
+    if (!this.queuedMessages.has(chatId)) return
+    this.queuedMessages.delete(chatId)
     this.onStateChange()
   }
 
@@ -575,6 +593,22 @@ export class AgentCoordinator {
     const chat = this.store.requireChat(chatId)
     const provider = this.resolveProvider(command, chat.provider)
     const settings = this.getProviderSettings(provider, command)
+
+    // If a turn is already running, queue the message instead of throwing.
+    // The user prompt is appended to the transcript immediately so it appears
+    // in the UI right away. When the active turn finishes, runTurn()'s finally
+    // block will auto-start a new turn with the queued message.
+    if (this.activeTurns.has(chatId)) {
+      await this.store.appendMessage(
+        chatId,
+        timestamped({ kind: "user_prompt", content: command.content, attachments: command.attachments ?? [] }, Date.now())
+      )
+      // Latest message wins — replaces any previously queued message.
+      this.queuedMessages.set(chatId, { command, provider, settings })
+      this.onStateChange()
+      return { chatId }
+    }
+
     await this.startTurnForChat({
       chatId,
       provider,
@@ -701,6 +735,42 @@ export class AgentCoordinator {
           )
           await this.store.recordTurnFailed(active.chatId, message)
           this.onStateChange()
+        }
+      } else {
+        // Check for a queued user message. If the user sent a message while
+        // this turn was running, auto-start a new turn with their message.
+        // This fires even after cancellation — the user explicitly sent the
+        // message, so it should still be processed.
+        const queued = this.queuedMessages.get(active.chatId)
+        if (queued) {
+          this.queuedMessages.delete(active.chatId)
+          try {
+            await this.startTurnForChat({
+              chatId: active.chatId,
+              provider: queued.provider,
+              content: queued.command.content,
+              attachments: queued.command.attachments ?? [],
+              model: queued.settings.model,
+              effort: queued.settings.effort,
+              serviceTier: queued.settings.serviceTier,
+              planMode: queued.settings.planMode,
+              appendUserPrompt: false, // Already appended when queued
+            })
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            await this.store.appendMessage(
+              active.chatId,
+              timestamped({
+                kind: "result",
+                subtype: "error",
+                isError: true,
+                durationMs: 0,
+                result: message,
+              })
+            )
+            await this.store.recordTurnFailed(active.chatId, message)
+            this.onStateChange()
+          }
         }
       }
     }

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -372,6 +372,7 @@ export class AgentCoordinator {
   private readonly codexManager: CodexAppServerManager
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<string | null>
   readonly activeTurns = new Map<string, ActiveTurn>()
+  readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
 
   constructor(args: AgentCoordinatorArgs) {
     this.store = args.store
@@ -392,6 +393,18 @@ export class AgentCoordinator {
     const pending = this.activeTurns.get(chatId)?.pendingTool
     if (!pending) return null
     return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
+  }
+
+  getDrainingChatIds(): Set<string> {
+    return new Set(this.drainingStreams.keys())
+  }
+
+  async stopDraining(chatId: string) {
+    const draining = this.drainingStreams.get(chatId)
+    if (!draining) return
+    draining.turn.close()
+    this.drainingStreams.delete(chatId)
+    this.onStateChange()
   }
 
   private resolveProvider(command: Extract<ClientCommand, { type: "chat.send" }>, currentProvider: AgentProvider | null) {
@@ -432,6 +445,13 @@ export class AgentCoordinator {
     planMode: boolean
     appendUserPrompt: boolean
   }) {
+    // Close any lingering draining stream before starting a new turn.
+    const draining = this.drainingStreams.get(args.chatId)
+    if (draining) {
+      draining.turn.close()
+      this.drainingStreams.delete(args.chatId)
+    }
+
     const chat = this.store.requireChat(args.chatId)
     if (this.activeTurns.has(args.chatId)) {
       throw new Error("Chat is already running")
@@ -588,6 +608,10 @@ export class AgentCoordinator {
   private async runTurn(active: ActiveTurn) {
     try {
       for await (const event of active.turn.stream) {
+        // Once cancelled, stop processing further stream events.
+        // cancel() already removed us from activeTurns and notified the UI.
+        if (active.cancelRequested) break
+
         if (event.type === "session_token" && event.sessionToken) {
           await this.store.setSessionToken(active.chatId, event.sessionToken)
           this.onStateChange()
@@ -608,6 +632,14 @@ export class AgentCoordinator {
           } else if (!active.cancelRequested) {
             await this.store.recordTurnFinished(active.chatId)
           }
+          // Remove from activeTurns as soon as the result arrives so the UI
+          // transitions to idle immediately. The stream may still be open
+          // (e.g. background tasks), but the user should be able to send
+          // new messages without having to hit stop first.
+          this.activeTurns.delete(active.chatId)
+          // Track the still-open stream so the UI can show a draining
+          // indicator and the user can stop background tasks.
+          this.drainingStreams.set(active.chatId, { turn: active.turn })
         }
 
         this.onStateChange()
@@ -632,7 +664,14 @@ export class AgentCoordinator {
         await this.store.recordTurnCancelled(active.chatId)
       }
       active.turn.close()
-      this.activeTurns.delete(active.chatId)
+      // Only remove if we're still the active turn for this chat.
+      // We may have already been removed by result handling or cancel(),
+      // and a new turn may have started for the same chatId.
+      if (this.activeTurns.get(active.chatId) === active) {
+        this.activeTurns.delete(active.chatId)
+      }
+      // Stream has fully ended — no longer draining.
+      this.drainingStreams.delete(active.chatId)
       this.onStateChange()
 
       if (active.postToolFollowUp && !active.cancelRequested) {
@@ -668,9 +707,18 @@ export class AgentCoordinator {
   }
 
   async cancel(chatId: string) {
+    // Also clean up any draining stream for this chat.
+    const draining = this.drainingStreams.get(chatId)
+    if (draining) {
+      draining.turn.close()
+      this.drainingStreams.delete(chatId)
+    }
+
     const active = this.activeTurns.get(chatId)
     if (!active) return
 
+    // Guard against concurrent cancel() calls — only the first one does work.
+    if (active.cancelRequested) return
     active.cancelRequested = true
 
     const pendingTool = active.pendingTool
@@ -696,14 +744,23 @@ export class AgentCoordinator {
     active.cancelRecorded = true
     active.hasFinalResult = true
 
-    try {
-      await active.turn.interrupt()
-    } catch {
-      active.turn.close()
-    }
-
+    // Remove from activeTurns immediately so the UI reflects the cancellation
+    // right away, rather than waiting for interrupt() which may hang.
     this.activeTurns.delete(chatId)
     this.onStateChange()
+
+    // Now attempt to interrupt/close the underlying stream in the background.
+    // This is best-effort — the turn is already removed from active state above,
+    // and runTurn()'s finally block will also call close().
+    try {
+      await Promise.race([
+        active.turn.interrupt(),
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+      ])
+    } catch {
+      // interrupt() failed — force close
+    }
+    active.turn.close()
   }
 
   async respondTool(command: Extract<ClientCommand, { type: "chat.respondTool" }>) {

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -51,7 +51,7 @@ describe("read models", () => {
       lastTurnOutcome: null,
     })
 
-    const chat = deriveChatSnapshot(state, new Map(), new Set(), "chat-1", () => [])
+    const chat = deriveChatSnapshot(state, new Map(), new Set(), new Set(), "chat-1", () => [])
     expect(chat?.runtime.provider).toBe("claude")
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -51,7 +51,7 @@ describe("read models", () => {
       lastTurnOutcome: null,
     })
 
-    const chat = deriveChatSnapshot(state, new Map(), "chat-1", () => [])
+    const chat = deriveChatSnapshot(state, new Map(), new Set(), "chat-1", () => [])
     expect(chat?.runtime.provider).toBe("claude")
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -97,6 +97,7 @@ export function deriveLocalProjectsSnapshot(
 export function deriveChatSnapshot(
   state: StoreState,
   activeStatuses: Map<string, KannaStatus>,
+  drainingChatIds: Set<string>,
   chatId: string,
   getMessages: (chatId: string) => ChatSnapshot["messages"]
 ): ChatSnapshot | null {
@@ -111,6 +112,7 @@ export function deriveChatSnapshot(
     localPath: project.localPath,
     title: chat.title,
     status: deriveStatus(chat, activeStatuses.get(chat.id)),
+    isDraining: drainingChatIds.has(chat.id),
     provider: chat.provider,
     planMode: chat.planMode,
     sessionToken: chat.sessionToken,

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -98,6 +98,7 @@ export function deriveChatSnapshot(
   state: StoreState,
   activeStatuses: Map<string, KannaStatus>,
   drainingChatIds: Set<string>,
+  queuedChatIds: Set<string>,
   chatId: string,
   getMessages: (chatId: string) => ChatSnapshot["messages"]
 ): ChatSnapshot | null {
@@ -113,6 +114,7 @@ export function deriveChatSnapshot(
     title: chat.title,
     status: deriveStatus(chat, activeStatuses.get(chat.id)),
     isDraining: drainingChatIds.has(chat.id),
+    hasQueuedMessage: queuedChatIds.has(chat.id),
     provider: chat.provider,
     planMode: chat.planMode,
     sessionToken: chat.sessionToken,

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -41,7 +41,7 @@ describe("ws-router", () => {
   test("acks system.ping without broadcasting snapshots", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -80,7 +80,7 @@ describe("ws-router", () => {
   test("acks terminal.input without rebroadcasting terminal snapshots", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -124,7 +124,7 @@ describe("ws-router", () => {
   test("subscribes and unsubscribes chat topics", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -192,7 +192,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -293,7 +293,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -41,7 +41,7 @@ describe("ws-router", () => {
   test("acks system.ping without broadcasting snapshots", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getQueuedChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -80,7 +80,7 @@ describe("ws-router", () => {
   test("acks terminal.input without rebroadcasting terminal snapshots", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getQueuedChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -124,7 +124,7 @@ describe("ws-router", () => {
   test("subscribes and unsubscribes chat topics", () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getQueuedChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -192,7 +192,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getQueuedChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -293,7 +293,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getQueuedChatIds: () => new Set() } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -121,7 +121,7 @@ export function createWsRouter({
       id,
       snapshot: {
         type: "chat",
-        data: deriveChatSnapshot(store.state, agent.getActiveStatuses(), topic.chatId, (chatId) => store.getMessages(chatId)),
+        data: deriveChatSnapshot(store.state, agent.getActiveStatuses(), agent.getDrainingChatIds(), topic.chatId, (chatId) => store.getMessages(chatId)),
       },
     }
   }
@@ -282,6 +282,11 @@ export function createWsRouter({
         }
         case "chat.cancel": {
           await agent.cancel(command.chatId)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          break
+        }
+        case "chat.stopDraining": {
+          await agent.stopDraining(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
         }

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -121,7 +121,7 @@ export function createWsRouter({
       id,
       snapshot: {
         type: "chat",
-        data: deriveChatSnapshot(store.state, agent.getActiveStatuses(), agent.getDrainingChatIds(), topic.chatId, (chatId) => store.getMessages(chatId)),
+        data: deriveChatSnapshot(store.state, agent.getActiveStatuses(), agent.getDrainingChatIds(), agent.getQueuedChatIds(), topic.chatId, (chatId) => store.getMessages(chatId)),
       },
     }
   }
@@ -271,6 +271,7 @@ export function createWsRouter({
         }
         case "chat.delete": {
           await agent.cancel(command.chatId)
+          agent.cancelQueued(command.chatId)
           await store.deleteChat(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
@@ -287,6 +288,11 @@ export function createWsRouter({
         }
         case "chat.stopDraining": {
           await agent.stopDraining(command.chatId)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          break
+        }
+        case "chat.cancelQueued": {
+          agent.cancelQueued(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
         }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -76,6 +76,7 @@ export type ClientCommand =
     }
   | { type: "chat.cancel"; chatId: string }
   | { type: "chat.stopDraining"; chatId: string }
+  | { type: "chat.cancelQueued"; chatId: string }
   | { type: "chat.respondTool"; chatId: string; toolUseId: string; result: unknown }
   | { type: "terminal.create"; projectId: string; terminalId: string; cols: number; rows: number; scrollback: number }
   | { type: "terminal.input"; terminalId: string; data: string }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -75,6 +75,7 @@ export type ClientCommand =
       planMode?: boolean
     }
   | { type: "chat.cancel"; chatId: string }
+  | { type: "chat.stopDraining"; chatId: string }
   | { type: "chat.respondTool"; chatId: string; toolUseId: string; result: unknown }
   | { type: "terminal.create"; projectId: string; terminalId: string; cols: number; rows: number; scrollback: number }
   | { type: "terminal.input"; terminalId: string; data: string }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -592,6 +592,7 @@ export interface ChatRuntime {
   title: string
   status: KannaStatus
   isDraining: boolean
+  hasQueuedMessage: boolean
   provider: AgentProvider | null
   planMode: boolean
   sessionToken: string | null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -591,6 +591,7 @@ export interface ChatRuntime {
   localPath: string
   title: string
   status: KannaStatus
+  isDraining: boolean
   provider: AgentProvider | null
   planMode: boolean
   sessionToken: string | null


### PR DESCRIPTION
## Summary

Builds on #37 (cancel race fixes + draining indicator). Allows users to send messages while the agent is actively processing — the message is queued server-side, appears immediately in the transcript, and auto-starts as a new turn once the current turn finishes.

- **Server-side queue**: `queuedMessages` map in `AgentCoordinator`. `send()` queues instead of throwing "Chat is already running". `runTurn()` finally block auto-starts queued turns after completion. Queued messages survive cancellation.
- **Chat input UX**: Submit button shows send arrow when text is present (even during processing), stop square when empty. Enter always submits. Users can send and stop from the same input.
- **QueuedMessageIndicator**: "Message queued" with hover-to-cancel crossfade, same pattern as `DrainingIndicator`.
- **Protocol**: `chat.cancelQueued` command. Chat deletion also clears queued messages.

> **Note**: This PR includes commits from #37 and should be merged after it.

## Changes

| Layer | File | What changed |
|-------|------|-------------|
| Server | `agent.ts` | `queuedMessages` map, queue-on-busy in `send()`, auto-start in `runTurn()` finally, `cancelQueued()`, `getQueuedChatIds()` |
| Protocol | `protocol.ts` | `chat.cancelQueued` command |
| Types | `types.ts` | `hasQueuedMessage` on `ChatRuntime` |
| Read models | `read-models.ts` | `queuedChatIds` param in `deriveChatSnapshot` |
| Router | `ws-router.ts` | Handle `chat.cancelQueued`, pass queue state, clear queue on delete |
| Client state | `useKannaState.ts` | `hasQueuedMessage`, `handleCancelQueued` |
| Chat input | `ChatInput.tsx` | Button shows send vs stop based on text presence; Enter always submits |
| UI (new) | `QueuedMessageIndicator.tsx` | "Message queued" indicator with hover-to-cancel |
| Chat page | `ChatPage.tsx` | Render `QueuedMessageIndicator` |
| Tests | `agent.test.ts` | 4 new tests: queue+auto-start, latest-replaces, cancel-preserves-queue, cancelQueued |
| Tests | `read-models.test.ts`, `ws-router.test.ts` | Updated for new parameters/mocks |

## Test plan

- [x] `bun test src/server/agent.test.ts` — 21 tests pass (4 new)
- [x] `bun test src/server/read-models.test.ts` — passes
- [x] `bun test src/server/ws-router.test.ts` — passes
- [x] `bun test src/client/app/useKannaState.test.ts` — 15 tests pass
- [x] Full suite: 281 pass, 5 pre-existing failures (cli-runtime, terminal-manager)
- [ ] Manual: start a long-running agent task → type and send a message → verify it queues, shows in transcript, and auto-fires when turn completes
- [ ] Manual: hover "Message queued" indicator → verify cancel button appears
- [ ] Manual: cancel queued message → verify it doesn't fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)