### PR TITLE
Add diff viewer to right sidebar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@xterm/xterm": "^6.0.0",
         "cloudflared": "^0.7.1",
         "default-shell": "^2.2.0",
+        "diff": "^8.0.4",
         "file-type": "^22.0.0",
         "qrcode": "^1.5.4",
         "react-resizable-panels": "^4.7.3",
@@ -29,6 +30,7 @@
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "@types/bun": "latest",
+        "@types/diff": "^8.0.0",
         "@types/node": "^24.10.1",
         "@types/qrcode": "^1.5.6",
         "@types/react": "19.2.7",
@@ -372,6 +374,8 @@
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
+    "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -473,6 +477,8 @@
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@xterm/xterm": "^6.0.0",
     "cloudflared": "^0.7.1",
     "default-shell": "^2.2.0",
+    "diff": "^8.0.4",
     "file-type": "^22.0.0",
     "qrcode": "^1.5.4",
     "react-resizable-panels": "^4.7.3"
@@ -68,6 +69,7 @@
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/typography": "^0.5.19",
     "@types/bun": "latest",
+    "@types/diff": "^8.0.0",
     "@types/node": "^24.10.1",
     "@types/qrcode": "^1.5.6",
     "@types/react": "19.2.7",

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -664,6 +664,7 @@ export function ChatPage() {
               <RightSidebar
                 onClose={() => toggleRightSidebar(projectId)}
                 onRefresh={refetchDiff}
+                onSendAll={(message) => void state.handleSend(message)}
               />
             </div>
           </ResizablePanel>

--- a/src/client/app/ChatPage.tsx
+++ b/src/client/app/ChatPage.tsx
@@ -29,6 +29,7 @@ import { useTerminalToggleAnimation } from "./useTerminalToggleAnimation"
 import type { KannaState } from "./useKannaState"
 import { KannaTranscript } from "./KannaTranscript"
 import { useStickyChatFocus } from "./useStickyChatFocus"
+import { useGitDiff } from "../hooks/useDiffExtractor"
 
 const EMPTY_STATE_TEXT = "What are we building?"
 const EMPTY_STATE_TYPING_INTERVAL_MS = 19
@@ -136,6 +137,7 @@ export function ChatPage() {
   const shouldRenderTerminalLayout = Boolean(projectId && hasTerminals)
   const showRightSidebar = Boolean(projectId && rightSidebarLayout.isVisible)
   const shouldRenderRightSidebarLayout = Boolean(projectId)
+  const { refetch: refetchDiff } = useGitDiff(state.socket, projectId, showRightSidebar)
   const {
     isAnimating: isTerminalAnimating,
     mainPanelGroupRef,
@@ -661,6 +663,7 @@ export function ChatPage() {
             >
               <RightSidebar
                 onClose={() => toggleRightSidebar(projectId)}
+                onRefresh={refetchDiff}
               />
             </div>
           </ResizablePanel>

--- a/src/client/components/chat-ui/RightSidebar.test.ts
+++ b/src/client/components/chat-ui/RightSidebar.test.ts
@@ -3,10 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { RightSidebar } from "./RightSidebar"
 
 describe("RightSidebar", () => {
-  test("renders the placeholder copy", () => {
+  test("renders the empty-state copy when no diffs are loaded", () => {
     const markup = renderToStaticMarkup(RightSidebar({ onClose: () => {} }))
 
-    expect(markup).toContain("diffs coming soon")
+    expect(markup).toContain("No diffs to display")
   })
 
   test("renders the close affordance", () => {

--- a/src/client/components/chat-ui/RightSidebar.tsx
+++ b/src/client/components/chat-ui/RightSidebar.tsx
@@ -1,15 +1,27 @@
-import { X } from "lucide-react"
+import { RefreshCw, X } from "lucide-react"
+import { DiffView } from "../diff"
 
 interface RightSidebarProps {
   onClose: () => void
+  onRefresh?: () => void
 }
 
-export function RightSidebar({ onClose }: RightSidebarProps) {
+export function RightSidebar({ onClose, onRefresh }: RightSidebarProps) {
   return (
     <div className="h-full min-h-0 border-l border-border bg-background md:min-w-[300px]">
       <div className="flex h-full min-h-0 flex-col">
         <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
           <div className="min-w-0 flex-1 truncate text-xs text-muted-foreground">Diffs</div>
+          {onRefresh && (
+            <button
+              type="button"
+              aria-label="Refresh diff"
+              onClick={onRefresh}
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+          )}
           <button
             type="button"
             aria-label="Close right sidebar"
@@ -20,9 +32,7 @@ export function RightSidebar({ onClose }: RightSidebarProps) {
           </button>
         </div>
 
-        <div className="flex flex-1 items-center justify-center px-6 text-center">
-          <p className="text-sm text-muted-foreground">diffs coming soon</p>
-        </div>
+        <DiffView />
       </div>
     </div>
   )

--- a/src/client/components/chat-ui/RightSidebar.tsx
+++ b/src/client/components/chat-ui/RightSidebar.tsx
@@ -4,9 +4,10 @@ import { DiffView } from "../diff"
 interface RightSidebarProps {
   onClose: () => void
   onRefresh?: () => void
+  onSendAll?: (message: string) => void
 }
 
-export function RightSidebar({ onClose, onRefresh }: RightSidebarProps) {
+export function RightSidebar({ onClose, onRefresh, onSendAll }: RightSidebarProps) {
   return (
     <div className="h-full min-h-0 border-l border-border bg-background md:min-w-[300px]">
       <div className="flex h-full min-h-0 flex-col">
@@ -32,7 +33,7 @@ export function RightSidebar({ onClose, onRefresh }: RightSidebarProps) {
           </button>
         </div>
 
-        <DiffView />
+        <DiffView onSendAll={onSendAll} />
       </div>
     </div>
   )

--- a/src/client/components/diff/DiffChunk.tsx
+++ b/src/client/components/diff/DiffChunk.tsx
@@ -1,0 +1,191 @@
+import { Fragment, memo, useCallback, useMemo, useState } from "react"
+import type { DiffChunk as DiffChunkType, DiffLine, DiffSide, CommentThread, LineNumber, DiffSegment } from "./types"
+import { computeWordLevelDiff, shouldComputeWordDiff } from "./wordDiff"
+import { DiffLineRow } from "./DiffLineRow"
+import { DiffCommentForm } from "./DiffCommentForm"
+import { DiffCommentThread } from "./DiffCommentThread"
+
+interface DiffChunkProps {
+  chunk: DiffChunkType
+  filePath: string
+  threads: CommentThread[]
+  onAddComment: (line: LineNumber, body: string, codeContent: string | undefined, side: DiffSide) => void
+  onRemoveThread: (threadId: string) => void
+  onReplyToThread: (threadId: string, body: string) => void
+  onRemoveMessage: (threadId: string, messageId: string) => void
+  onCopyPrompt: (threadId: string) => string
+}
+
+export const DiffChunk = memo(function DiffChunk({
+  chunk,
+  filePath,
+  threads,
+  onAddComment,
+  onRemoveThread,
+  onReplyToThread,
+  onRemoveMessage,
+  onCopyPrompt,
+}: DiffChunkProps) {
+  const [hoveredLine, setHoveredLine] = useState<number | null>(null)
+  const [commentingLine, setCommentingLine] = useState<{
+    side: DiffSide
+    lineNumber: number
+  } | null>(null)
+
+  // ---- Word-level diff map (line index -> segments) ----
+  const wordDiffMap = useMemo(() => {
+    const map = new Map<number, DiffSegment[]>()
+    const lines = chunk.lines
+    let i = 0
+
+    while (i < lines.length) {
+      const line = lines[i]
+      if (line.type === "delete") {
+        // Collect consecutive deletes
+        let j = i + 1
+        while (j < lines.length && lines[j].type === "delete") j++
+        const deleteLines = lines.slice(i, j)
+        const deleteStartIdx = i
+
+        // Collect consecutive adds after deletes
+        const addLines: { line: DiffLine; index: number }[] = []
+        while (j < lines.length && lines[j].type === "add") {
+          addLines.push({ line: lines[j], index: j })
+          j++
+        }
+
+        // Pair and compute
+        const max = Math.max(deleteLines.length, addLines.length)
+        for (let k = 0; k < max; k++) {
+          const del = deleteLines[k]
+          const add = addLines[k]
+          if (del && add && shouldComputeWordDiff(del.content, add.line.content)) {
+            const result = computeWordLevelDiff(del.content, add.line.content)
+            map.set(deleteStartIdx + k, result.oldSegments)
+            map.set(add.index, result.newSegments)
+          }
+        }
+
+        i = j
+      } else {
+        i++
+      }
+    }
+
+    return map
+  }, [chunk.lines])
+
+  // ---- Threads for a specific line ----
+  const getThreadsForLine = useCallback(
+    (lineNumber: number, side: DiffSide) =>
+      threads.filter((t) => {
+        const lineMatch =
+          typeof t.line === "number" ? t.line === lineNumber : t.line[1] === lineNumber
+        return lineMatch && t.side === side
+      }),
+    [threads],
+  )
+
+  // ---- Comment handlers ----
+  const handleToggleComment = useCallback(
+    (line: DiffLine) => {
+      const lineNumber = line.newLineNumber ?? line.oldLineNumber
+      const side: DiffSide = line.type === "delete" ? "old" : "new"
+      if (!lineNumber) return
+
+      if (commentingLine?.side === side && commentingLine.lineNumber === lineNumber) {
+        setCommentingLine(null)
+      } else {
+        setCommentingLine({ side, lineNumber })
+      }
+    },
+    [commentingLine],
+  )
+
+  const handleSubmitComment = useCallback(
+    (body: string) => {
+      if (!commentingLine) return
+
+      // Find the code content for context
+      const { side, lineNumber } = commentingLine
+      const sourceLine = chunk.lines.find((l) =>
+        side === "old" ? l.oldLineNumber === lineNumber : l.newLineNumber === lineNumber,
+      )
+
+      onAddComment(lineNumber, body, sourceLine?.content, side)
+      setCommentingLine(null)
+    },
+    [commentingLine, chunk.lines, onAddComment],
+  )
+
+  return (
+    <div>
+      {/* Chunk header */}
+      <div className="sticky top-0 z-[1] border-y border-border bg-muted/80 px-3 py-0.5 font-mono text-[10px] leading-5 text-muted-foreground backdrop-blur-sm">
+        {chunk.header.replace(/^@@.*@@\s?/, "")}
+      </div>
+
+      <table className="w-full table-fixed border-collapse font-mono text-xs">
+        <tbody>
+          {chunk.lines.map((line, index) => {
+            const lineNumber = line.newLineNumber ?? line.oldLineNumber ?? 0
+            const lineSide: DiffSide = line.type === "delete" ? "old" : "new"
+            const lineThreads =
+              lineNumber > 0
+                ? getThreadsForLine(lineNumber, lineSide)
+                : []
+
+            const isCommentTarget =
+              commentingLine?.side === lineSide && commentingLine.lineNumber === lineNumber
+
+            return (
+              <Fragment key={index}>
+                <DiffLineRow
+                  line={line}
+                  index={index}
+                  isCommentTarget={isCommentTarget}
+                  hoveredIndex={hoveredLine}
+                  onMouseEnter={() => setHoveredLine(index)}
+                  onMouseLeave={() => setHoveredLine(null)}
+                  onCommentClick={() => handleToggleComment(line)}
+                  diffSegments={wordDiffMap.get(index)}
+                />
+
+                {/* Comment threads attached to this line */}
+                {lineThreads.map((thread) => (
+                  <tr key={thread.id}>
+                    <td colSpan={3} className="p-0">
+                      <div className="mx-2 my-1.5">
+                        <DiffCommentThread
+                          thread={thread}
+                          onRemoveThread={onRemoveThread}
+                          onReplyToThread={onReplyToThread}
+                          onRemoveMessage={onRemoveMessage}
+                          onCopyPrompt={onCopyPrompt}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+
+                {/* New comment form */}
+                {isCommentTarget && (
+                  <tr>
+                    <td colSpan={3} className="p-0">
+                      <div className="mx-2 my-1.5">
+                        <DiffCommentForm
+                          onSubmit={handleSubmitComment}
+                          onCancel={() => setCommentingLine(null)}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+})

--- a/src/client/components/diff/DiffCommentForm.tsx
+++ b/src/client/components/diff/DiffCommentForm.tsx
@@ -1,0 +1,95 @@
+import { useRef, useState, useEffect } from "react"
+import { Send, XIcon } from "lucide-react"
+import { cn } from "../../lib/utils"
+
+interface DiffCommentFormProps {
+  onSubmit: (body: string) => void
+  onCancel: () => void
+  initialValue?: string
+  placeholder?: string
+  submitLabel?: string
+  autoFocus?: boolean
+}
+
+export function DiffCommentForm({
+  onSubmit,
+  onCancel,
+  initialValue = "",
+  placeholder = "Add a comment...",
+  submitLabel = "Comment",
+  autoFocus = true,
+}: DiffCommentFormProps) {
+  const [value, setValue] = useState(initialValue)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (autoFocus) {
+      // Small delay so the row animation finishes before focus
+      const id = requestAnimationFrame(() => textareaRef.current?.focus())
+      return () => cancelAnimationFrame(id)
+    }
+  }, [autoFocus])
+
+  function handleSubmit() {
+    const trimmed = value.trim()
+    if (!trimmed) return
+    onSubmit(trimmed)
+    setValue("")
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSubmit()
+    }
+    if (e.key === "Escape") {
+      e.preventDefault()
+      onCancel()
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-lg border border-border bg-card p-2 shadow-sm">
+      <textarea
+        ref={textareaRef}
+        data-gramm="false"
+        data-gramm_editor="false"
+        data-enable-grammarly="false"
+        autoComplete="off"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={2}
+        className={cn(
+          "w-full resize-none rounded-md border-0 bg-transparent px-1.5 py-1 text-xs leading-relaxed text-foreground placeholder:text-muted-foreground/60 focus:outline-none",
+          "font-[inherit]",
+        )}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-muted-foreground/50">
+          {navigator.platform.includes("Mac") ? "\u2318" : "Ctrl"}+Enter to submit
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex h-6 items-center gap-1 rounded-md px-2 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <XIcon className="h-3 w-3" />
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!value.trim()}
+            className="flex h-6 items-center gap-1 rounded-md bg-logo px-2 text-[11px] font-medium text-white transition-colors hover:bg-logo/90 disabled:opacity-40"
+          >
+            <Send className="h-3 w-3" />
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/client/components/diff/DiffCommentThread.tsx
+++ b/src/client/components/diff/DiffCommentThread.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react"
+import { Check, Copy, MessageSquareReply, Trash2 } from "lucide-react"
+import type { CommentThread } from "./types"
+import { DiffCommentForm } from "./DiffCommentForm"
+import { cn } from "../../lib/utils"
+
+interface DiffCommentThreadProps {
+  thread: CommentThread
+  onRemoveThread: (threadId: string) => void
+  onReplyToThread: (threadId: string, body: string) => void
+  onRemoveMessage: (threadId: string, messageId: string) => void
+  onCopyPrompt: (threadId: string) => string
+}
+
+export function DiffCommentThread({
+  thread,
+  onRemoveThread,
+  onReplyToThread,
+  onRemoveMessage,
+  onCopyPrompt,
+}: DiffCommentThreadProps) {
+  const [isReplying, setIsReplying] = useState(false)
+  const [isCopied, setIsCopied] = useState(false)
+
+  const lineLabel =
+    typeof thread.line === "number" ? `L${thread.line}` : `L${thread.line[0]}-${thread.line[1]}`
+
+  async function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation()
+    try {
+      const prompt = onCopyPrompt(thread.id)
+      await navigator.clipboard.writeText(prompt)
+      setIsCopied(true)
+      setTimeout(() => setIsCopied(false), 2000)
+    } catch {
+      // clipboard not available
+    }
+  }
+
+  const rootMessage = thread.messages[0]
+  if (!rootMessage) return null
+
+  return (
+    <div className="rounded-lg border border-logo/20 bg-card shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+        <span className="truncate rounded bg-logo/10 px-1.5 py-0.5 font-mono text-[10px] text-logo">
+          {thread.filePath}:{lineLabel}
+        </span>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={handleCopy}
+            title="Copy comment as prompt"
+            className="flex h-6 items-center gap-1 rounded-md px-1.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Copy className="h-3 w-3" />
+            {isCopied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsReplying((prev) => !prev)}
+            title="Reply"
+            className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <MessageSquareReply className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="space-y-0 divide-y divide-border">
+        {thread.messages.map((message, idx) => (
+          <div
+            key={message.id}
+            className={cn("group/msg flex items-start gap-2 px-3 py-2", idx > 0 && "pl-6")}
+          >
+            <p className="min-w-0 flex-1 whitespace-pre-wrap text-xs leading-relaxed text-foreground">
+              {message.body}
+            </p>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                if (idx === 0) {
+                  onRemoveThread(thread.id)
+                } else {
+                  onRemoveMessage(thread.id, message.id)
+                }
+              }}
+              title={idx === 0 ? "Resolve thread" : "Delete reply"}
+              className={cn(
+                "flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-all group-hover/msg:opacity-100",
+                idx === 0
+                  ? "text-green-600 hover:bg-green-500/10 dark:text-green-400"
+                  : "text-red-500 hover:bg-red-500/10 dark:text-red-400",
+              )}
+            >
+              {idx === 0 ? <Check className="h-3 w-3" /> : <Trash2 className="h-3 w-3" />}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Reply form */}
+      {isReplying && (
+        <div className="border-t border-border p-2">
+          <DiffCommentForm
+            onSubmit={(body) => {
+              onReplyToThread(thread.id, body)
+              setIsReplying(false)
+            }}
+            onCancel={() => setIsReplying(false)}
+            placeholder="Write a reply..."
+            submitLabel="Reply"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/client/components/diff/DiffFileCard.tsx
+++ b/src/client/components/diff/DiffFileCard.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react"
+import { ChevronDown, ChevronRight, FilePlus, FileMinus, FileEdit, FileSymlink } from "lucide-react"
+import type { DiffFile, CommentThread, DiffSide, LineNumber } from "./types"
+import { DiffChunk } from "./DiffChunk"
+import { cn } from "../../lib/utils"
+
+interface DiffFileCardProps {
+  file: DiffFile
+  threads: CommentThread[]
+  defaultCollapsed?: boolean
+  onAddComment: (filePath: string, line: LineNumber, body: string, codeContent: string | undefined, side: DiffSide) => void
+  onRemoveThread: (threadId: string) => void
+  onReplyToThread: (threadId: string, body: string) => void
+  onRemoveMessage: (threadId: string, messageId: string) => void
+  onCopyPrompt: (threadId: string) => string
+}
+
+const statusConfig: Record<
+  DiffFile["status"],
+  { icon: typeof FileEdit; label: string; colorClass: string; bgClass: string }
+> = {
+  modified: {
+    icon: FileEdit,
+    label: "M",
+    colorClass: "text-yellow-600 dark:text-yellow-400",
+    bgClass: "bg-yellow-500/10",
+  },
+  added: {
+    icon: FilePlus,
+    label: "A",
+    colorClass: "text-green-600 dark:text-green-400",
+    bgClass: "bg-green-500/10",
+  },
+  deleted: {
+    icon: FileMinus,
+    label: "D",
+    colorClass: "text-red-600 dark:text-red-400",
+    bgClass: "bg-red-500/10",
+  },
+  renamed: {
+    icon: FileSymlink,
+    label: "R",
+    colorClass: "text-blue-600 dark:text-blue-400",
+    bgClass: "bg-blue-500/10",
+  },
+}
+
+export function DiffFileCard({
+  file,
+  threads,
+  defaultCollapsed = false,
+  onAddComment,
+  onRemoveThread,
+  onReplyToThread,
+  onRemoveMessage,
+  onCopyPrompt,
+}: DiffFileCardProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+  const cfg = statusConfig[file.status]
+  const StatusIcon = cfg.icon
+  const fileThreads = threads.filter((t) => t.filePath === file.path)
+  const threadCount = fileThreads.length
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      {/* File header */}
+      <button
+        type="button"
+        onClick={() => setCollapsed((prev) => !prev)}
+        className={cn(
+          "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-muted/50",
+          collapsed ? "border-b-0" : "border-b border-border",
+        )}
+      >
+        {collapsed ? (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+
+        <span className={cn("flex h-5 w-5 items-center justify-center rounded", cfg.bgClass)}>
+          <StatusIcon className={cn("h-3 w-3", cfg.colorClass)} />
+        </span>
+
+        <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+          {file.path}
+          {file.oldPath && (
+            <span className="ml-1 text-muted-foreground">
+              (from {file.oldPath})
+            </span>
+          )}
+        </span>
+
+        {/* Stats */}
+        <span className="flex shrink-0 items-center gap-1.5 text-[10px] tabular-nums">
+          {file.additions > 0 && (
+            <span className="text-green-600 dark:text-green-400">+{file.additions}</span>
+          )}
+          {file.deletions > 0 && (
+            <span className="text-red-600 dark:text-red-400">-{file.deletions}</span>
+          )}
+          {threadCount > 0 && (
+            <span className="ml-1 rounded-full bg-logo/15 px-1.5 py-0.5 text-[10px] font-medium text-logo">
+              {threadCount}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {/* Chunks */}
+      {!collapsed && (
+        <div className="overflow-x-auto bg-background">
+          {file.chunks.map((chunk, chunkIdx) => (
+            <DiffChunk
+              key={chunkIdx}
+              chunk={chunk}
+              filePath={file.path}
+              threads={fileThreads}
+              onAddComment={(line, body, codeContent, side) =>
+                onAddComment(file.path, line, body, codeContent, side)
+              }
+              onRemoveThread={onRemoveThread}
+              onReplyToThread={onReplyToThread}
+              onRemoveMessage={onRemoveMessage}
+              onCopyPrompt={onCopyPrompt}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/client/components/diff/DiffLineRow.tsx
+++ b/src/client/components/diff/DiffLineRow.tsx
@@ -1,0 +1,137 @@
+import { memo } from "react"
+import { MessageSquarePlus } from "lucide-react"
+import type { DiffLine, DiffSegment } from "./types"
+import { cn } from "../../lib/utils"
+
+interface DiffLineRowProps {
+  line: DiffLine
+  index: number
+  isCommentTarget: boolean
+  hoveredIndex: number | null
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+  onCommentClick: () => void
+  onClick?: () => void
+  diffSegments?: DiffSegment[]
+}
+
+const lineTypeClass: Record<DiffLine["type"], string> = {
+  add: "bg-green-500/8 dark:bg-green-500/10",
+  delete: "bg-red-500/8 dark:bg-red-500/10",
+  context: "",
+}
+
+const lineNumClass: Record<DiffLine["type"], string> = {
+  add: "text-green-700/50 dark:text-green-400/40",
+  delete: "text-red-700/50 dark:text-red-400/40",
+  context: "text-muted-foreground/50",
+}
+
+const prefixMap: Record<DiffLine["type"], string> = {
+  add: "+",
+  delete: "-",
+  context: " ",
+}
+
+const prefixClass: Record<DiffLine["type"], string> = {
+  add: "text-green-600 dark:text-green-400",
+  delete: "text-red-600 dark:text-red-400",
+  context: "text-muted-foreground/40",
+}
+
+function WordDiffHighlighter({ segments }: { segments: DiffSegment[] }) {
+  return (
+    <span>
+      {segments.map((seg, i) => {
+        if (seg.type === "unchanged") return <span key={i}>{seg.value}</span>
+        const highlight =
+          seg.type === "added"
+            ? "bg-green-400/25 dark:bg-green-400/20 rounded-[2px]"
+            : "bg-red-400/25 dark:bg-red-400/20 rounded-[2px]"
+        return (
+          <span key={i} className={highlight}>
+            {seg.value}
+          </span>
+        )
+      })}
+    </span>
+  )
+}
+
+export const DiffLineRow = memo(function DiffLineRow({
+  line,
+  index,
+  isCommentTarget,
+  hoveredIndex,
+  onMouseEnter,
+  onMouseLeave,
+  onCommentClick,
+  onClick,
+  diffSegments,
+}: DiffLineRowProps) {
+  const isHovered = hoveredIndex === index
+  const lineNumber = line.newLineNumber ?? line.oldLineNumber
+
+  return (
+    <tr
+      className={cn(
+        "group relative",
+        lineTypeClass[line.type],
+        isCommentTarget && "ring-1 ring-inset ring-logo/30",
+      )}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      {/* Old line number */}
+      <td
+        className={cn(
+          "w-[42px] min-w-[42px] select-none px-1.5 text-right align-top text-[11px] leading-5 tabular-nums",
+          lineNumClass[line.type],
+        )}
+      >
+        {line.oldLineNumber ?? ""}
+      </td>
+
+      {/* New line number + comment button */}
+      <td
+        className={cn(
+          "w-[42px] min-w-[42px] select-none px-1.5 text-right align-top text-[11px] leading-5 tabular-nums relative",
+          lineNumClass[line.type],
+        )}
+      >
+        <span>{line.newLineNumber ?? ""}</span>
+        {isHovered && lineNumber != null && (
+          <button
+            type="button"
+            aria-label="Add comment"
+            className="absolute -left-[3px] top-[1px] flex h-[18px] w-[18px] items-center justify-center rounded bg-logo text-white shadow-sm transition-transform hover:scale-110"
+            onClick={(e) => {
+              e.stopPropagation()
+              onCommentClick()
+            }}
+          >
+            <MessageSquarePlus className="h-3 w-3" />
+          </button>
+        )}
+      </td>
+
+      {/* Code content */}
+      <td className="w-full p-0 align-top">
+        <div className="flex min-h-[20px] items-start">
+          <span
+            className={cn(
+              "inline-block w-4 shrink-0 text-center text-[11px] leading-5 select-none",
+              prefixClass[line.type],
+            )}
+          >
+            {prefixMap[line.type]}
+          </span>
+          <span className="flex-1 whitespace-pre-wrap break-all px-1.5 font-mono text-xs leading-5 text-foreground select-text">
+            {diffSegments ? <WordDiffHighlighter segments={diffSegments} /> : line.content}
+          </span>
+        </div>
+      </td>
+    </tr>
+  )
+})

--- a/src/client/components/diff/DiffView.tsx
+++ b/src/client/components/diff/DiffView.tsx
@@ -1,14 +1,18 @@
 import { useCallback } from "react"
-import { ClipboardCopy, MessageSquare, Trash2 } from "lucide-react"
+import { ClipboardCopy, MessageSquare, Send, Trash2 } from "lucide-react"
 import { useDiffStore } from "../../stores/diffStore"
 import type { DiffSide, LineNumber } from "./types"
 import { DiffFileCard } from "./DiffFileCard"
+
+interface DiffViewProps {
+  onSendAll?: (message: string) => void
+}
 
 /**
  * Top-level diff viewer. Reads from the shared diffStore and renders all files
  * with inline commenting support.
  */
-export function DiffView() {
+export function DiffView({ onSendAll }: DiffViewProps) {
   const files = useDiffStore((s) => s.files)
   const threads = useDiffStore((s) => s.threads)
   const addThread = useDiffStore((s) => s.addThread)
@@ -37,6 +41,13 @@ export function DiffView() {
     }
   }, [generateAllThreadsPrompt])
 
+  const handleSendAll = useCallback(() => {
+    const prompt = generateAllThreadsPrompt()
+    if (prompt && onSendAll) {
+      onSendAll(`Address these comments:\n\n${prompt}`)
+    }
+  }, [generateAllThreadsPrompt, onSendAll])
+
   // ---- Empty state ----
   if (files.length === 0) {
     return (
@@ -59,6 +70,17 @@ export function DiffView() {
             {threads.length} comment{threads.length !== 1 ? "s" : ""}
           </span>
           <div className="flex items-center gap-1">
+            {onSendAll && (
+              <button
+                type="button"
+                onClick={handleSendAll}
+                title="Send all comments to chat"
+                className="flex h-6 items-center gap-1 rounded-md bg-logo px-2 text-[11px] font-medium text-white transition-colors hover:bg-logo/90"
+              >
+                <Send className="h-3 w-3" />
+                Send all
+              </button>
+            )}
             <button
               type="button"
               onClick={handleCopyAll}

--- a/src/client/components/diff/DiffView.tsx
+++ b/src/client/components/diff/DiffView.tsx
@@ -1,0 +1,105 @@
+import { useCallback } from "react"
+import { ClipboardCopy, MessageSquare, Trash2 } from "lucide-react"
+import { useDiffStore } from "../../stores/diffStore"
+import type { DiffSide, LineNumber } from "./types"
+import { DiffFileCard } from "./DiffFileCard"
+
+/**
+ * Top-level diff viewer. Reads from the shared diffStore and renders all files
+ * with inline commenting support.
+ */
+export function DiffView() {
+  const files = useDiffStore((s) => s.files)
+  const threads = useDiffStore((s) => s.threads)
+  const addThread = useDiffStore((s) => s.addThread)
+  const removeThread = useDiffStore((s) => s.removeThread)
+  const replyToThread = useDiffStore((s) => s.replyToThread)
+  const removeMessage = useDiffStore((s) => s.removeMessage)
+  const generateThreadPrompt = useDiffStore((s) => s.generateThreadPrompt)
+  const generateAllThreadsPrompt = useDiffStore((s) => s.generateAllThreadsPrompt)
+  // clear is available via useDiffStore.getState().clear() if needed
+
+  const handleAddComment = useCallback(
+    (filePath: string, line: LineNumber, body: string, codeContent: string | undefined, side: DiffSide) => {
+      addThread({ filePath, line, side, body, codeContent })
+    },
+    [addThread],
+  )
+
+  const handleCopyAll = useCallback(async () => {
+    const prompt = generateAllThreadsPrompt()
+    if (prompt) {
+      try {
+        await navigator.clipboard.writeText(prompt)
+      } catch {
+        // clipboard may not be available
+      }
+    }
+  }, [generateAllThreadsPrompt])
+
+  // ---- Empty state ----
+  if (files.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+        <p className="text-sm text-muted-foreground">No diffs to display</p>
+        <p className="text-xs text-muted-foreground/60">
+          Diffs from tool calls will appear here
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {/* Toolbar */}
+      {threads.length > 0 && (
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-1.5">
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <MessageSquare className="h-3.5 w-3.5" />
+            {threads.length} comment{threads.length !== 1 ? "s" : ""}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleCopyAll}
+              title="Copy all comments as prompt"
+              className="flex h-6 items-center gap-1 rounded-md px-2 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ClipboardCopy className="h-3 w-3" />
+              Copy all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (confirm("Clear all comments?")) {
+                  // Only clear threads, keep files
+                  useDiffStore.setState({ threads: [] })
+                }
+              }}
+              title="Clear all comments"
+              className="flex h-6 items-center gap-1 rounded-md px-2 text-[11px] text-red-500 transition-colors hover:bg-red-500/10 dark:text-red-400"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* File list */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+        {files.map((file) => (
+          <DiffFileCard
+            key={file.path}
+            file={file}
+            threads={threads}
+            onAddComment={handleAddComment}
+            onRemoveThread={removeThread}
+            onReplyToThread={replyToThread}
+            onRemoveMessage={removeMessage}
+            onCopyPrompt={generateThreadPrompt}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/client/components/diff/createDiffFromEdit.ts
+++ b/src/client/components/diff/createDiffFromEdit.ts
@@ -1,0 +1,60 @@
+import { createTwoFilesPatch } from "diff"
+import { parseUnifiedDiff } from "./parseDiff"
+import type { DiffFile } from "./types"
+
+/**
+ * Create a DiffFile from an edit operation (oldString → newString).
+ * Uses the `diff` library to generate a unified patch, then parses it with
+ * our standard unified-diff parser so the result is identical to what we'd
+ * get from `git diff`.
+ */
+export function createDiffFromEdit(
+  filePath: string,
+  oldString: string,
+  newString: string,
+): DiffFile | null {
+  if (oldString === newString) return null
+
+  const patch = createTwoFilesPatch(
+    `a/${filePath}`,
+    `b/${filePath}`,
+    oldString,
+    newString,
+    undefined,
+    undefined,
+    { context: 3 },
+  )
+
+  const files = parseUnifiedDiff(patch)
+  return files[0] ?? null
+}
+
+/**
+ * Create a DiffFile for a newly-written file (no old content).
+ */
+export function createDiffFromWrite(
+  filePath: string,
+  content: string,
+): DiffFile {
+  const lines = content.split("\n")
+  return {
+    path: filePath,
+    status: "added",
+    additions: lines.length,
+    deletions: 0,
+    chunks: [
+      {
+        header: `@@ -0,0 +1,${lines.length} @@`,
+        oldStart: 0,
+        oldLines: 0,
+        newStart: 1,
+        newLines: lines.length,
+        lines: lines.map((line, i) => ({
+          type: "add" as const,
+          content: line,
+          newLineNumber: i + 1,
+        })),
+      },
+    ],
+  }
+}

--- a/src/client/components/diff/index.ts
+++ b/src/client/components/diff/index.ts
@@ -1,0 +1,13 @@
+export { DiffView } from "./DiffView"
+export { parseUnifiedDiff } from "./parseDiff"
+export { createDiffFromEdit, createDiffFromWrite } from "./createDiffFromEdit"
+export type {
+  DiffFile,
+  DiffChunk,
+  DiffLine,
+  DiffSide,
+  LineNumber,
+  CommentThread,
+  CommentMessage,
+  DiffSegment,
+} from "./types"

--- a/src/client/components/diff/parseDiff.ts
+++ b/src/client/components/diff/parseDiff.ts
@@ -1,0 +1,178 @@
+import type { DiffFile, DiffChunk, DiffLine } from "./types"
+
+/**
+ * Parse a unified diff string (the output of `git diff`) into structured data.
+ *
+ * This is a client-side-only parser -- no git or filesystem access needed.
+ * Port of the core parsing logic from difit's GitDiffParser.
+ */
+export function parseUnifiedDiff(diffText: string): DiffFile[] {
+  if (!diffText.trim()) return []
+
+  const files: DiffFile[] = []
+  const fileBlocks = diffText.split(/^diff --git /m).slice(1)
+
+  for (const fileBlock of fileBlocks) {
+    const block = `diff --git ${fileBlock}`
+    const file = parseFileBlock(block)
+    if (file) files.push(file)
+  }
+
+  return files
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function stripGitPrefix(raw: string): string {
+  const trimmed = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw
+  const prefixes = ["a/", "b/"]
+  for (const p of prefixes) {
+    if (trimmed.startsWith(p)) return trimmed.slice(p.length)
+  }
+  return trimmed
+}
+
+function parseHeaderPaths(headerLine: string): { oldPath?: string; newPath?: string } | null {
+  if (!headerLine.startsWith("diff --git ")) return null
+
+  const raw = headerLine.slice("diff --git ".length)
+  const segments: string[] = []
+  let current = ""
+  let inQuotes = false
+
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i]
+    const prev = i > 0 ? raw[i - 1] : null
+    if (char === '"' && prev !== "\\") {
+      inQuotes = !inQuotes
+      current += char
+      continue
+    }
+    if (char === " " && !inQuotes) {
+      if (current) {
+        segments.push(current)
+        current = ""
+      }
+      continue
+    }
+    current += char
+  }
+  if (current) segments.push(current)
+
+  if (segments.length !== 2) return null
+  return {
+    oldPath: stripGitPrefix(segments[0]),
+    newPath: stripGitPrefix(segments[1]),
+  }
+}
+
+function extractPathFromLine(line: string | undefined, prefix: string): string | undefined {
+  if (!line?.startsWith(prefix)) return undefined
+  const raw = line.slice(prefix.length)
+  if (raw === "/dev/null") return undefined
+  return stripGitPrefix(raw)
+}
+
+function parseFileBlock(block: string): DiffFile | null {
+  const lines = block.split("\n")
+  const headerLine = lines[0]
+  const headerPaths = parseHeaderPaths(headerLine)
+
+  const minusLine = lines.find((l) => l.startsWith("--- "))
+  const plusLine = lines.find((l) => l.startsWith("+++ "))
+  const renameFromLine = lines.find((l) => l.startsWith("rename from "))
+  const renameToLine = lines.find((l) => l.startsWith("rename to "))
+
+  const plusPath = extractPathFromLine(plusLine, "+++ ")
+  const minusPath = extractPathFromLine(minusLine, "--- ")
+  const renameFromPath = renameFromLine ? renameFromLine.slice("rename from ".length) : undefined
+  const renameToPath = renameToLine ? renameToLine.slice("rename to ".length) : undefined
+
+  const newPath = renameToPath ?? plusPath ?? headerPaths?.newPath
+  const oldPath = renameFromPath ?? minusPath ?? headerPaths?.oldPath ?? newPath
+
+  if (!newPath) return null
+
+  let status: DiffFile["status"] = "modified"
+  const newFileMode = lines.find((l) => l.startsWith("new file mode"))
+  const deletedFileMode = lines.find((l) => l.startsWith("deleted file mode"))
+
+  if (newFileMode || minusLine?.includes("/dev/null")) {
+    status = "added"
+  } else if (deletedFileMode || plusLine?.includes("/dev/null")) {
+    status = "deleted"
+  } else if (oldPath !== newPath) {
+    status = "renamed"
+  }
+
+  const chunks = parseChunks(lines)
+  const { additions, deletions } = countLines(chunks)
+
+  return {
+    path: newPath,
+    oldPath: status === "renamed" && oldPath !== newPath ? oldPath : undefined,
+    status,
+    additions,
+    deletions,
+    chunks,
+  }
+}
+
+function parseChunks(lines: string[]): DiffChunk[] {
+  const chunks: DiffChunk[] = []
+  let current: DiffChunk | null = null
+  let oldNum = 0
+  let newNum = 0
+
+  for (const line of lines) {
+    if (line.startsWith("@@")) {
+      if (current) chunks.push(current)
+
+      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)/)
+      if (match) {
+        const oldStart = parseInt(match[1])
+        const oldLines = parseInt(match[2] || "1")
+        const newStart = parseInt(match[3])
+        const newLines = parseInt(match[4] || "1")
+        oldNum = oldStart
+        newNum = newStart
+
+        current = { header: line, oldStart, oldLines, newStart, newLines, lines: [] }
+      }
+    } else if (current && (line.startsWith("+") || line.startsWith("-") || line.startsWith(" "))) {
+      const type: DiffLine["type"] = line.startsWith("+")
+        ? "add"
+        : line.startsWith("-")
+          ? "delete"
+          : "context"
+
+      const diffLine: DiffLine = {
+        type,
+        content: line.slice(1),
+        oldLineNumber: type !== "add" ? oldNum : undefined,
+        newLineNumber: type !== "delete" ? newNum : undefined,
+      }
+
+      current.lines.push(diffLine)
+      if (type !== "add") oldNum++
+      if (type !== "delete") newNum++
+    }
+  }
+
+  if (current) chunks.push(current)
+  return chunks
+}
+
+function countLines(chunks: DiffChunk[]): { additions: number; deletions: number } {
+  let additions = 0
+  let deletions = 0
+  for (const chunk of chunks) {
+    for (const line of chunk.lines) {
+      if (line.type === "add") additions++
+      else if (line.type === "delete") deletions++
+    }
+  }
+  return { additions, deletions }
+}

--- a/src/client/components/diff/types.ts
+++ b/src/client/components/diff/types.ts
@@ -1,0 +1,55 @@
+// ---- Diff data model (inspired by difit, narrowed for our use-case) ----
+
+export interface DiffFile {
+  path: string
+  oldPath?: string
+  status: "modified" | "added" | "deleted" | "renamed"
+  additions: number
+  deletions: number
+  chunks: DiffChunk[]
+}
+
+export interface DiffChunk {
+  header: string
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  lines: DiffLine[]
+}
+
+export interface DiffLine {
+  type: "add" | "delete" | "context"
+  content: string
+  oldLineNumber?: number
+  newLineNumber?: number
+}
+
+// ---- Comment data model ----
+
+export type DiffSide = "old" | "new"
+export type LineNumber = number | [number, number]
+
+export interface CommentMessage {
+  id: string
+  body: string
+  createdAt: string
+}
+
+export interface CommentThread {
+  id: string
+  filePath: string
+  line: LineNumber
+  side: DiffSide
+  createdAt: string
+  updatedAt: string
+  codeContent?: string
+  messages: CommentMessage[]
+}
+
+// ---- Word-level diff ----
+
+export interface DiffSegment {
+  value: string
+  type: "unchanged" | "added" | "removed"
+}

--- a/src/client/components/diff/wordDiff.ts
+++ b/src/client/components/diff/wordDiff.ts
@@ -1,0 +1,50 @@
+import { diffWordsWithSpace, diffWords } from "diff"
+import type { DiffSegment } from "./types"
+
+export interface WordLevelDiffResult {
+  oldSegments: DiffSegment[]
+  newSegments: DiffSegment[]
+}
+
+/**
+ * Compute word-level diff between two strings.
+ * Returns segments for both old and new lines, marked as unchanged / added / removed.
+ */
+export function computeWordLevelDiff(oldContent: string, newContent: string): WordLevelDiffResult {
+  const changes = diffWordsWithSpace(oldContent, newContent)
+  const oldSegments: DiffSegment[] = []
+  const newSegments: DiffSegment[] = []
+
+  for (const change of changes) {
+    if (change.added) {
+      newSegments.push({ value: change.value, type: "added" })
+    } else if (change.removed) {
+      oldSegments.push({ value: change.value, type: "removed" })
+    } else {
+      oldSegments.push({ value: change.value, type: "unchanged" })
+      newSegments.push({ value: change.value, type: "unchanged" })
+    }
+  }
+
+  return { oldSegments, newSegments }
+}
+
+/**
+ * Check if two lines are similar enough to warrant word-level highlighting.
+ * Requires at least 20 % shared content.
+ */
+export function shouldComputeWordDiff(oldContent: string, newContent: string): boolean {
+  if (!oldContent.trim() || !newContent.trim()) return false
+  if (oldContent === newContent) return false
+
+  const changes = diffWords(oldContent, newContent)
+  let unchangedLen = 0
+  let totalLen = 0
+
+  for (const c of changes) {
+    totalLen += c.value.length
+    if (!c.added && !c.removed) unchangedLen += c.value.length
+  }
+
+  return unchangedLen / totalLen >= 0.2
+}

--- a/src/client/hooks/useDiffExtractor.ts
+++ b/src/client/hooks/useDiffExtractor.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useDiffStore } from "../stores/diffStore"
+import { parseUnifiedDiff } from "../components/diff/parseDiff"
+import type { KannaSocket } from "../app/socket"
+
+/**
+ * Fetches `git diff HEAD` from the server for the current project and
+ * populates the diffStore so the right-sidebar viewer stays up-to-date.
+ *
+ * Refetches whenever the caller bumps `refreshKey` (e.g. on sidebar open,
+ * after a tool call completes, etc.).
+ */
+export function useGitDiff(
+  socket: KannaSocket | null,
+  projectId: string | null,
+  isVisible: boolean,
+) {
+  const fetchInFlightRef = useRef(false)
+
+  const fetchDiff = useCallback(async () => {
+    if (!socket || !projectId || fetchInFlightRef.current) return
+    fetchInFlightRef.current = true
+
+    try {
+      const result = await socket.command<{ diff: string }>({
+        type: "git.diff",
+        projectId,
+      })
+
+      const files = parseUnifiedDiff(result.diff)
+      useDiffStore.getState().setFiles(files)
+    } catch (err) {
+      console.warn("[useGitDiff] failed to fetch diff:", err)
+      useDiffStore.getState().setFiles([])
+    } finally {
+      fetchInFlightRef.current = false
+    }
+  }, [socket, projectId])
+
+  // Fetch when the sidebar becomes visible
+  useEffect(() => {
+    if (isVisible) {
+      void fetchDiff()
+    }
+  }, [isVisible, fetchDiff])
+
+  // Also clear when projectId changes
+  useEffect(() => {
+    useDiffStore.getState().clear()
+  }, [projectId])
+
+  return { refetch: fetchDiff }
+}

--- a/src/client/stores/diffStore.ts
+++ b/src/client/stores/diffStore.ts
@@ -1,0 +1,159 @@
+import { create } from "zustand"
+import type { DiffFile, CommentThread, DiffSide, LineNumber } from "../components/diff/types"
+
+// ---------------------------------------------------------------------------
+// Comment formatting – produces a prompt string from threads
+// ---------------------------------------------------------------------------
+
+function lineLabel(line: LineNumber): string {
+  return typeof line === "number" ? `L${line}` : `L${line[0]}-L${line[1]}`
+}
+
+function formatThread(thread: CommentThread): string {
+  const header = `${thread.filePath}:${lineLabel(thread.line)}`
+  const bodies = thread.messages.map((m) => m.body)
+  return [header, ...bodies].join("\n")
+}
+
+export function formatAllThreadsPrompt(threads: CommentThread[]): string {
+  if (threads.length === 0) return ""
+  return threads.map(formatThread).join("\n=====\n")
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+let nextId = 1
+function createId(): string {
+  return `cmt_${Date.now()}_${nextId++}`
+}
+
+interface DiffState {
+  /** The files currently displayed in the diff sidebar. */
+  files: DiffFile[]
+
+  /** All comment threads across every file. */
+  threads: CommentThread[]
+
+  /** Replace the current diff set (e.g. when a new diff payload arrives). */
+  setFiles: (files: DiffFile[]) => void
+
+  /** Clear all files and threads. */
+  clear: () => void
+
+  // -- Comment CRUD --
+
+  addThread: (params: {
+    filePath: string
+    line: LineNumber
+    side: DiffSide
+    body: string
+    codeContent?: string
+  }) => CommentThread
+
+  replyToThread: (threadId: string, body: string) => void
+
+  removeThread: (threadId: string) => void
+
+  removeMessage: (threadId: string, messageId: string) => void
+
+  updateMessage: (threadId: string, messageId: string, newBody: string) => void
+
+  /** Get all threads for a given file. */
+  threadsForFile: (filePath: string) => CommentThread[]
+
+  /** Build a single prompt string from all threads (for pasting into chat). */
+  generateAllThreadsPrompt: () => string
+
+  /** Build a prompt for a single thread. */
+  generateThreadPrompt: (threadId: string) => string
+}
+
+export const useDiffStore = create<DiffState>()((set, get) => ({
+  files: [],
+  threads: [],
+
+  setFiles: (files) => set({ files }),
+
+  clear: () => set({ files: [], threads: [] }),
+
+  addThread: (params) => {
+    const now = new Date().toISOString()
+    const id = createId()
+    const thread: CommentThread = {
+      id,
+      filePath: params.filePath,
+      line: params.line,
+      side: params.side,
+      createdAt: now,
+      updatedAt: now,
+      codeContent: params.codeContent,
+      messages: [{ id, body: params.body, createdAt: now }],
+    }
+    set((state) => ({ threads: [...state.threads, thread] }))
+    return thread
+  },
+
+  replyToThread: (threadId, body) => {
+    const now = new Date().toISOString()
+    set((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === threadId
+          ? {
+              ...t,
+              updatedAt: now,
+              messages: [...t.messages, { id: createId(), body, createdAt: now }],
+            }
+          : t,
+      ),
+    }))
+  },
+
+  removeThread: (threadId) =>
+    set((state) => ({ threads: state.threads.filter((t) => t.id !== threadId) })),
+
+  removeMessage: (threadId, messageId) => {
+    const thread = get().threads.find((t) => t.id === threadId)
+    if (!thread) return
+    // Removing the root message removes the whole thread
+    if (thread.messages[0]?.id === messageId) {
+      get().removeThread(threadId)
+      return
+    }
+    const now = new Date().toISOString()
+    set((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === threadId
+          ? { ...t, updatedAt: now, messages: t.messages.filter((m) => m.id !== messageId) }
+          : t,
+      ),
+    }))
+  },
+
+  updateMessage: (threadId, messageId, newBody) => {
+    const now = new Date().toISOString()
+    set((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === threadId
+          ? {
+              ...t,
+              updatedAt: now,
+              messages: t.messages.map((m) =>
+                m.id === messageId ? { ...m, body: newBody, createdAt: now } : m,
+              ),
+            }
+          : t,
+      ),
+    }))
+  },
+
+  threadsForFile: (filePath) => get().threads.filter((t) => t.filePath === filePath),
+
+  generateAllThreadsPrompt: () => formatAllThreadsPrompt(get().threads),
+
+  generateThreadPrompt: (threadId) => {
+    const thread = get().threads.find((t) => t.id === threadId)
+    return thread ? formatThread(thread) : ""
+  },
+}))

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -314,6 +314,29 @@ export function createWsRouter({
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           break
         }
+        case "git.diff": {
+          const project = store.getProject(command.projectId)
+          if (!project) {
+            throw new Error("Project not found")
+          }
+          const { execSync } = await import("child_process")
+          let diff = ""
+          try {
+            diff = execSync("git diff HEAD --no-ext-diff --color=never", {
+              cwd: project.localPath,
+              encoding: "utf-8",
+              maxBuffer: 10 * 1024 * 1024,
+            })
+          } catch (err) {
+            // git diff exits 1 when there are differences in some configs,
+            // but stdout still contains the diff.
+            if (err && typeof err === "object" && "stdout" in err && typeof (err as { stdout: unknown }).stdout === "string") {
+              diff = (err as { stdout: string }).stdout
+            }
+          }
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: { diff } })
+          return
+        }
         case "terminal.create": {
           const project = store.getProject(command.projectId)
           if (!project) {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -82,6 +82,7 @@ export type ClientCommand =
   | { type: "terminal.input"; terminalId: string; data: string }
   | { type: "terminal.resize"; terminalId: string; cols: number; rows: number }
   | { type: "terminal.close"; terminalId: string }
+  | { type: "git.diff"; projectId: string }
 
 export type ClientEnvelope =
   | { v: 1; type: "subscribe"; id: string; topic: SubscriptionTopic }


### PR DESCRIPTION
## Summary
- Replaces the "diffs coming soon" placeholder with a full unified diff viewer powered by live `git diff HEAD` from the project repo
- Adds a `git.diff` WebSocket command that runs `git diff HEAD` on the server and returns raw unified diff text
- Builds a complete diff component system (parser, file cards, chunk renderer, line rows with word-level highlights) using Kanna's existing design tokens
- Includes an inline commenting system with threads, replies, and copy-as-prompt for sending review notes back to chat

<img width="5122" height="2832" alt="CleanShot 2026-04-03 at 11 57 40@2x" src="https://github.com/user-attachments/assets/2ba26f45-bbc3-4e9f-bea8-5fd67457fafa" />

## New files
| File | Purpose |
|------|---------|
| `src/client/components/diff/types.ts` | DiffFile, DiffChunk, DiffLine, CommentThread types |
| `src/client/components/diff/parseDiff.ts` | Client-side unified diff parser |
| `src/client/components/diff/wordDiff.ts` | Word-level diff via `diff` npm package |
| `src/client/components/diff/DiffLineRow.tsx` | Line row with gutters, prefix, word highlights, comment button |
| `src/client/components/diff/DiffChunk.tsx` | Chunk renderer with word-diff map and inline comments |
| `src/client/components/diff/DiffCommentForm.tsx` | Comment textarea (Cmd+Enter submit) |
| `src/client/components/diff/DiffCommentThread.tsx` | Thread card with replies, resolve, copy prompt |
| `src/client/components/diff/DiffFileCard.tsx` | Collapsible file header with status icon and +/- stats |
| `src/client/components/diff/DiffView.tsx` | Top-level viewer reading from Zustand store |
| `src/client/components/diff/createDiffFromEdit.ts` | Utility to create DiffFile from old/new strings |
| `src/client/hooks/useDiffExtractor.ts` | `useGitDiff` hook — fetches diff on sidebar open |
| `src/client/stores/diffStore.ts` | Zustand store for files + comment threads |

## Modified files
- `src/shared/protocol.ts` — added `git.diff` command type
- `src/server/ws-router.ts` — added `git.diff` handler (execSync in project cwd)
- `src/client/app/ChatPage.tsx` — wired `useGitDiff` hook, passes `onRefresh` to sidebar
- `src/client/components/chat-ui/RightSidebar.tsx` — renders `DiffView`, added refresh button
- `src/client/components/chat-ui/RightSidebar.test.ts` — updated assertion for new empty state

## Test plan
- [ ] Open a project with uncommitted changes, toggle the right sidebar — diffs should appear
- [ ] Click the refresh button — diff should re-fetch
- [ ] Hover over a line and click the comment button — form appears inline
- [ ] Submit a comment (Cmd+Enter) — thread renders below the line
- [ ] Reply to a thread, resolve a thread, copy prompt
- [ ] Switch projects — diff clears and re-fetches for the new repo
- [ ] Open sidebar on a clean repo — "No diffs to display" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)