### PR TITLE
Add button to sidebar chat items for manual rename

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -34,6 +34,9 @@ function KannaLayout() {
   const handleOpenAddProjectModal = useCallback(() => {
     state.openAddProjectModal()
   }, [state])
+  const handleSidebarRenameChat = useCallback((chat: Parameters<typeof state.handleRenameChat>[0]) => {
+    void state.handleRenameChat(chat)
+  }, [state.handleRenameChat])
   const handleSidebarDeleteChat = useCallback((chat: Parameters<typeof state.handleDeleteChat>[0]) => {
     void state.handleDeleteChat(chat)
   }, [state.handleDeleteChat])
@@ -65,6 +68,7 @@ function KannaLayout() {
       onCreateChat={handleSidebarCreateChat}
       currentProjectId={state.activeProjectId}
       keybindings={state.keybindings}
+      onRenameChat={handleSidebarRenameChat}
       onDeleteChat={handleSidebarDeleteChat}
       onOpenAddProjectModal={handleOpenAddProjectModal}
       onCopyPath={handleSidebarCopyPath}
@@ -80,6 +84,7 @@ function KannaLayout() {
     handleSidebarCopyPath,
     handleSidebarCreateChat,
     handleSidebarDeleteChat,
+    handleSidebarRenameChat,
     handleSidebarOpenExternalPath,
     handleSidebarRemoveProject,
     showMobileOpenButton,

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -34,6 +34,7 @@ interface KannaSidebarProps {
   onCreateChat: (projectId: string) => void
   currentProjectId: string | null
   keybindings: KeybindingsSnapshot | null
+  onRenameChat: (chat: SidebarChatRow) => void
   onDeleteChat: (chat: SidebarChatRow) => void
   onOpenAddProjectModal: () => void
   onCopyPath: (localPath: string) => void
@@ -59,6 +60,7 @@ function KannaSidebarImpl({
   onCreateChat,
   currentProjectId,
   keybindings,
+  onRenameChat,
   onDeleteChat,
   onOpenAddProjectModal,
   onCopyPath,
@@ -185,10 +187,11 @@ function KannaSidebarImpl({
           navigate(`/chat/${chatId}`)
           onClose()
         }}
+        onRenameChat={() => onRenameChat(chat)}
         onDeleteChat={() => onDeleteChat(chat)}
       />
     )
-  }, [activeChatId, navigate, nowMs, onClose, onDeleteChat, resolvedKeybindings, showNumberJumpHints, visibleIndexByChatId])
+  }, [activeChatId, navigate, nowMs, onClose, onRenameChat, onDeleteChat, resolvedKeybindings, showNumberJumpHints, visibleIndexByChatId])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -330,6 +330,7 @@ export interface KannaState {
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleCancel: () => Promise<void>
   handleStopDraining: () => Promise<void>
+  handleRenameChat: (chat: SidebarChatRow) => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleCopyPath: (localPath: string) => Promise<void>
@@ -928,6 +929,22 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }, [activeChatId, socket])
 
+  const handleRenameChat = useCallback(async (chat: SidebarChatRow) => {
+    const newTitle = await dialog.prompt({
+      title: "Rename Chat",
+      description: "Enter a new name for this chat.",
+      initialValue: chat.title,
+      placeholder: "Chat name",
+      confirmLabel: "Rename",
+    })
+    if (!newTitle) return
+    try {
+      await socket.command({ type: "chat.rename", chatId: chat.chatId, title: newTitle })
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }, [dialog, socket])
+
   const handleDeleteChat = useCallback(async (chat: SidebarChatRow) => {
     const confirmed = await dialog.confirm({
       title: "Delete Chat",
@@ -1152,6 +1169,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleSend,
     handleCancel,
     handleStopDraining,
+    handleRenameChat,
     handleDeleteChat,
     handleRemoveProject,
     handleCopyPath,

--- a/src/client/components/chat-ui/sidebar/ChatRow.test.tsx
+++ b/src/client/components/chat-ui/sidebar/ChatRow.test.tsx
@@ -23,6 +23,7 @@ describe("ChatRow", () => {
         activeChatId={null}
         nowMs={60_000}
         onSelectChat={() => undefined}
+        onRenameChat={() => undefined}
         onDeleteChat={() => undefined}
       />
     )
@@ -39,6 +40,7 @@ describe("ChatRow", () => {
         shortcutHint="1"
         showShortcutHint
         onSelectChat={() => undefined}
+        onRenameChat={() => undefined}
         onDeleteChat={() => undefined}
       />
     )

--- a/src/client/components/chat-ui/sidebar/ChatRow.tsx
+++ b/src/client/components/chat-ui/sidebar/ChatRow.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react"
-import { Archive, Loader2 } from "lucide-react"
+import { Archive, Loader2, Pencil } from "lucide-react"
 import type { SidebarChatRow } from "../../../../shared/types"
 import { AnimatedShinyText } from "../../ui/animated-shiny-text"
 import { Button } from "../../ui/button"
@@ -16,6 +16,7 @@ interface Props {
   shortcutHint?: string | null
   showShortcutHint?: boolean
   onSelectChat: (chatId: string) => void
+  onRenameChat: (chatId: string) => void
   onDeleteChat: (chatId: string) => void
 }
 
@@ -26,6 +27,7 @@ function ChatRowImpl({
   shortcutHint = null,
   showShortcutHint = false,
   onSelectChat,
+  onRenameChat,
   onDeleteChat,
 }: Props) {
   const ageLabel = formatSidebarAgeLabel(chat.lastMessageAt, nowMs)
@@ -72,7 +74,7 @@ function ChatRowImpl({
           chat.title
         )}
       </span>
-      <div className="relative h-7 w-7 mr-[2px] shrink-0">
+      <div className="relative h-7 w-14 mr-[2px] shrink-0">
         {trailingLabel ? (
           showShortcutKeycap ? (
             <span className="hidden md:flex absolute inset-0 items-center justify-end pr-0.5 text-[11px] text-foreground transition-opacity group-hover:opacity-0">
@@ -86,23 +88,39 @@ function ChatRowImpl({
             </span>
           )
         ) : null}
-        <Button
-          variant="ghost"
-          size="icon"
+        <div
           className={cn(
-            "absolute inset-0 h-7 w-7 opacity-100 cursor-pointer rounded-sm hover:!bg-transparent !border-0",
+            "absolute inset-0 flex items-center justify-end gap-0.5",
             trailingLabel
               ? "md:opacity-0 md:group-hover:opacity-100"
               : "opacity-100 md:opacity-0 md:group-hover:opacity-100"
           )}
-          onClick={(event) => {
-            event.stopPropagation()
-            onDeleteChat(chat.chatId)
-          }}
-          title="Delete chat"
         >
-          <Archive className="size-3.5" />
-        </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 cursor-pointer rounded-sm hover:!bg-transparent !border-0"
+            onClick={(event) => {
+              event.stopPropagation()
+              onRenameChat(chat.chatId)
+            }}
+            title="Rename chat"
+          >
+            <Pencil className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 cursor-pointer rounded-sm hover:!bg-transparent !border-0"
+            onClick={(event) => {
+              event.stopPropagation()
+              onDeleteChat(chat.chatId)
+            }}
+            title="Delete chat"
+          >
+            <Archive className="size-3.5" />
+          </Button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds a pencil (rename) icon button next to the existing archive button on each chat row in the sidebar
- Clicking it opens a prompt dialog pre-filled with the current title, allowing users to manually rename chats
- Wires up the existing `chat.rename` backend support (protocol command, event store, WebSocket handler) — no backend changes needed

<img width="994" height="811" alt="Screenshot 2026-04-09 at 17 10 04" src="https://github.com/user-attachments/assets/a31acb81-699c-4a92-9d6f-5ff44f6e7a7f" />
<img width="994" height="811" alt="Screenshot 2026-04-09 at 17 10 11" src="https://github.com/user-attachments/assets/081447d9-de09-4fac-9c76-c7a1abdb4fff" />

## Test plan
- [ ] Hover a chat in the sidebar — pencil and archive icons appear side by side
- [ ] Click pencil — "Rename Chat" dialog opens with current title pre-filled and selected
- [ ] Enter a new name and confirm — title updates instantly in the sidebar
- [ ] Cancel or press Escape — no change occurs
- [ ] Archive button still works as before
- [ ] Mobile: both icons visible without hover