### PR TITLE
Add voice dictation via OpenAI Whisper API

### DIFF
--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   Info,
   Loader2,
   Menu,
+  Mic,
   Monitor,
   Moon,
   MessageSquareQuote,
@@ -49,6 +50,11 @@ import {
 } from "../stores/terminalPreferencesStore"
 import { useChatPreferencesStore } from "../stores/chatPreferencesStore"
 import { CHAT_SOUND_OPTIONS, useChatSoundPreferencesStore, type ChatSoundId, type ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import {
+  useVoiceDictationStore,
+  VOICE_DICTATION_LANGUAGES,
+  type VoiceDictationLanguage,
+} from "../stores/voiceDictationStore"
 import type { KannaState } from "./useKannaState"
 
 const sidebarItems = [
@@ -69,6 +75,12 @@ const sidebarItems = [
     label: "Keybindings",
     icon: Command,
     subtitle: "Edit global app shortcuts stored in the active keybindings file.",
+  },
+  {
+    id: "voice",
+    label: "Voice Dictation",
+    icon: Mic,
+    subtitle: "Configure voice-to-text transcription using OpenAI Whisper.",
   },
   // always last
   {
@@ -416,6 +428,13 @@ export function SettingsPage() {
   const setProviderDefaultModel = useChatPreferencesStore((store) => store.setProviderDefaultModel)
   const setProviderDefaultModelOptions = useChatPreferencesStore((store) => store.setProviderDefaultModelOptions)
   const setProviderDefaultPlanMode = useChatPreferencesStore((store) => store.setProviderDefaultPlanMode)
+  const voiceDictationEnabled = useVoiceDictationStore((store) => store.voiceDictationEnabled)
+  const openaiApiKey = useVoiceDictationStore((store) => store.openaiApiKey)
+  const voiceDictationLanguage = useVoiceDictationStore((store) => store.voiceDictationLanguage)
+  const setVoiceDictationEnabled = useVoiceDictationStore((store) => store.setVoiceDictationEnabled)
+  const setOpenaiApiKey = useVoiceDictationStore((store) => store.setOpenaiApiKey)
+  const setVoiceDictationLanguage = useVoiceDictationStore((store) => store.setVoiceDictationLanguage)
+  const [apiKeyDraft, setApiKeyDraft] = useState(openaiApiKey)
   const resolvedKeybindings = useMemo(() => getResolvedKeybindings(keybindings), [keybindings])
   const keybindingsFilePathDisplay = resolvedKeybindings.filePathDisplay || getKeybindingsFilePathDisplay()
   const [scrollbackDraft, setScrollbackDraft] = useState(String(scrollbackLines))
@@ -522,6 +541,10 @@ export function SettingsPage() {
 
   function commitEditorCommand() {
     setEditorCommandTemplate(editorCommandDraft)
+  }
+
+  function commitApiKey() {
+    setOpenaiApiKey(apiKeyDraft)
   }
 
   function handleChatSoundPreferenceChange(nextValue: ChatSoundPreference) {
@@ -1056,6 +1079,63 @@ export function SettingsPage() {
                         </SettingsRow>
                       )
                     })}
+                  </div>
+                ) : selectedPage === "voice" ? (
+                  <div className="border-b border-border">
+                    <SettingsRow
+                      title="Enable Voice Dictation"
+                      description="Show a microphone button on the chat input when the field is empty. Requires an OpenAI API key."
+                      bordered={false}
+                    >
+                      <SegmentedControl
+                        value={voiceDictationEnabled ? "on" : "off"}
+                        onValueChange={(v) => setVoiceDictationEnabled(v === "on")}
+                        options={[
+                          { value: "off", label: "Off" },
+                          { value: "on", label: "On" },
+                        ]}
+                        size="sm"
+                      />
+                    </SettingsRow>
+
+                    <SettingsRow
+                      title="OpenAI API Key"
+                      description="Your OpenAI API key for Whisper transcription. Stored locally in your browser."
+                    >
+                      <Input
+                        type="password"
+                        autoComplete="off"
+                        placeholder="sk-..."
+                        value={apiKeyDraft}
+                        onChange={(e) => setApiKeyDraft(e.target.value)}
+                        onBlur={commitApiKey}
+                        onKeyDown={(e) => handleTextInputKeyDown(e, commitApiKey)}
+                        className="min-w-[280px] font-mono"
+                      />
+                    </SettingsRow>
+
+                    <SettingsRow
+                      title="Language"
+                      description="The spoken language for transcription. Auto lets Whisper detect it automatically."
+                    >
+                      <Select
+                        value={voiceDictationLanguage}
+                        onValueChange={(v) => setVoiceDictationLanguage(v as VoiceDictationLanguage)}
+                      >
+                        <SelectTrigger className="min-w-[180px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {VOICE_DICTATION_LANGUAGES.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </SettingsRow>
                   </div>
                 ) : (
                   <ChangelogSection

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { ArrowUp, Paperclip } from "lucide-react"
+import { ArrowUp, Loader2, Mic, Paperclip } from "lucide-react"
 import {
   type AgentProvider,
   type ChatAttachment,
@@ -16,6 +16,7 @@ import { Textarea } from "../ui/textarea"
 import { ScrollArea } from "../ui/scroll-area"
 import { cn } from "../../lib/utils"
 import { useIsStandalone } from "../../hooks/useIsStandalone"
+import { useVoiceRecorder } from "../../hooks/useVoiceRecorder"
 import { useChatInputStore } from "../../stores/chatInputStore"
 import { NEW_CHAT_COMPOSER_ID, type ComposerState, useChatPreferencesStore } from "../../stores/chatPreferencesStore"
 import { CHAT_INPUT_ATTRIBUTE, focusNextChatInput } from "../../app/chatFocusPolicy"
@@ -220,6 +221,36 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const uploadedAttachments = attachments.filter((attachment) => attachment.status === "uploaded")
   const hasPendingUploads = attachments.some((attachment) => attachment.status === "uploading")
   const canSubmit = value.trim().length > 0 || uploadedAttachments.length > 0
+
+  // Voice dictation
+  const [voiceError, setVoiceError] = useState<string | null>(null)
+  const voiceRecorder = useVoiceRecorder({
+    onTranscription: useCallback((text: string) => {
+      setValue((current) => {
+        const separator = current.length > 0 && !current.endsWith(" ") ? " " : ""
+        const next = current + separator + text
+        if (chatId) setDraft(chatId, next)
+        return next
+      })
+      // Trigger auto-resize after transcription appends text
+      requestAnimationFrame(() => {
+        if (textareaRef.current) {
+          textareaRef.current.style.height = "auto"
+          textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
+        }
+        textareaRef.current?.focus()
+      })
+    }, [chatId, setDraft]),
+    onError: useCallback((message: string) => {
+      setVoiceError(message)
+      const timer = setTimeout(() => setVoiceError(null), 5000)
+      return () => clearTimeout(timer)
+    }, []),
+  })
+  const showMicButton = voiceRecorder.isAvailable && !canSubmit && !canCancel
+  const isRecording = voiceRecorder.status === "recording"
+  const isTranscribing = voiceRecorder.status === "transcribing"
+
   const orderedAttachments = [...attachments].sort((left, right) => {
     if (left.kind === right.kind) return 0
     return left.kind === "image" ? -1 : 1
@@ -667,16 +698,32 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 event.preventDefault()
                 if (canCancel) {
                   onCancel?.()
+                } else if (isRecording) {
+                  voiceRecorder.stopRecording()
+                } else if (showMicButton && !isTranscribing) {
+                  setVoiceError(null)
+                  voiceRecorder.startRecording()
                 } else if (!disabled && canSubmit && !hasPendingUploads) {
                   void handleSubmit()
                 }
               }}
-              disabled={!canCancel && (disabled || !canSubmit || hasPendingUploads)}
+              disabled={!canCancel && !isRecording && !showMicButton && !isTranscribing && (disabled || !canSubmit || hasPendingUploads)}
               size="icon"
-              className="flex-shrink-0 bg-slate-600 text-white dark:bg-white dark:text-slate-900 rounded-full cursor-pointer h-10 w-10 md:h-11 md:w-11 mb-1 -mr-0.5 md:mr-0 md:mb-1.5 touch-manipulation disabled:bg-white/60 disabled:text-slate-700"
+              className={cn(
+                "flex-shrink-0 rounded-full cursor-pointer h-10 w-10 md:h-11 md:w-11 mb-1 -mr-0.5 md:mr-0 md:mb-1.5 touch-manipulation",
+                isRecording
+                  ? "bg-red-500 text-white shadow-none"
+                  : "bg-slate-600 text-white dark:bg-white dark:text-slate-900 disabled:bg-white/60 disabled:text-slate-700"
+              )}
             >
               {canCancel ? (
                 <div className="w-3 h-3 md:w-4 md:h-4 rounded-xs bg-current" />
+              ) : isRecording ? (
+                <div className="w-3 h-3 md:w-4 md:h-4 rounded-full bg-current animate-pulse" />
+              ) : isTranscribing ? (
+                <Loader2 className="h-5 w-5 md:h-6 md:w-6 animate-spin" />
+              ) : showMicButton ? (
+                <Mic className="h-5 w-5 md:h-6 md:w-6" />
               ) : (
                 <ArrowUp className="h-5 w-5 md:h-6 md:w-6" />
               )}
@@ -687,6 +734,11 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
         {uploadError ? (
           <div className="max-w-[840px] mx-auto mt-2 px-1 text-sm text-destructive">
             {uploadError}
+          </div>
+        ) : null}
+        {voiceError ? (
+          <div className="max-w-[840px] mx-auto mt-2 px-1 text-sm text-destructive">
+            {voiceError}
           </div>
         ) : null}
       </div>

--- a/src/client/hooks/useVoiceRecorder.ts
+++ b/src/client/hooks/useVoiceRecorder.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useVoiceDictationStore } from "../stores/voiceDictationStore"
+
+export type VoiceRecorderStatus = "idle" | "recording" | "transcribing"
+
+interface UseVoiceRecorderOptions {
+  onTranscription: (text: string) => void
+  onError: (message: string) => void
+}
+
+interface UseVoiceRecorderResult {
+  status: VoiceRecorderStatus
+  isAvailable: boolean
+  startRecording: () => void
+  stopRecording: () => void
+}
+
+function getSupportedMimeType(): string {
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+    "audio/ogg;codecs=opus",
+  ]
+  for (const mime of candidates) {
+    if (typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported(mime)) {
+      return mime
+    }
+  }
+  return ""
+}
+
+function getFileExtension(mimeType: string): string {
+  if (mimeType.startsWith("audio/webm")) return ".webm"
+  if (mimeType.startsWith("audio/mp4")) return ".mp4"
+  if (mimeType.startsWith("audio/ogg")) return ".ogg"
+  return ".webm"
+}
+
+export function useVoiceRecorder({
+  onTranscription,
+  onError,
+}: UseVoiceRecorderOptions): UseVoiceRecorderResult {
+  const [status, setStatus] = useState<VoiceRecorderStatus>("idle")
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const streamRef = useRef<MediaStream | null>(null)
+  const mimeTypeRef = useRef<string>("")
+
+  // Stable refs for callbacks to avoid stale closures
+  const onTranscriptionRef = useRef(onTranscription)
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    onTranscriptionRef.current = onTranscription
+    onErrorRef.current = onError
+  }, [onTranscription, onError])
+
+  const voiceDictationEnabled = useVoiceDictationStore((s) => s.voiceDictationEnabled)
+  const openaiApiKey = useVoiceDictationStore((s) => s.openaiApiKey)
+
+  const isAvailable =
+    voiceDictationEnabled &&
+    openaiApiKey.length > 0 &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function" &&
+    typeof MediaRecorder !== "undefined"
+
+  const releaseStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current = null
+    }
+  }, [])
+
+  const transcribe = useCallback(async (audioBlob: Blob) => {
+    setStatus("transcribing")
+
+    const { openaiApiKey: apiKey, voiceDictationLanguage: language } =
+      useVoiceDictationStore.getState()
+
+    const extension = getFileExtension(mimeTypeRef.current)
+    const formData = new FormData()
+    formData.append("audio", audioBlob, `recording${extension}`)
+    if (language !== "auto") {
+      formData.append("language", language)
+    }
+
+    try {
+      const response = await fetch("/api/transcribe", {
+        method: "POST",
+        headers: {
+          "X-OpenAI-Api-Key": apiKey,
+        },
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({ error: "Transcription failed" }))
+        const message =
+          typeof body === "object" && body !== null && "error" in body
+            ? String((body as { error: string }).error)
+            : "Transcription failed"
+        onErrorRef.current(message)
+        return
+      }
+
+      const result = (await response.json()) as { text: string }
+      if (result.text && result.text.trim().length > 0) {
+        onTranscriptionRef.current(result.text.trim())
+      }
+    } catch {
+      onErrorRef.current("Failed to reach transcription server")
+    } finally {
+      setStatus("idle")
+    }
+  }, [])
+
+  const startRecording = useCallback(async () => {
+    if (status !== "idle") return
+
+    chunksRef.current = []
+    setStatus("recording")
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      streamRef.current = stream
+
+      const mimeType = getSupportedMimeType()
+      mimeTypeRef.current = mimeType
+
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream)
+
+      mediaRecorderRef.current = recorder
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data)
+        }
+      }
+
+      recorder.onstop = () => {
+        releaseStream()
+        const chunks = chunksRef.current
+        if (chunks.length === 0) {
+          setStatus("idle")
+          return
+        }
+        const audioBlob = new Blob(chunks, {
+          type: mimeTypeRef.current || "audio/webm",
+        })
+        chunksRef.current = []
+        void transcribe(audioBlob)
+      }
+
+      recorder.start()
+    } catch (err) {
+      releaseStream()
+      setStatus("idle")
+
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        onErrorRef.current("Microphone access denied. Check your browser permissions.")
+      } else if (err instanceof DOMException && err.name === "NotFoundError") {
+        onErrorRef.current("No microphone found. Please connect a microphone.")
+      } else {
+        onErrorRef.current("Failed to start recording.")
+      }
+    }
+  }, [status, releaseStream, transcribe])
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.stop()
+    } else {
+      releaseStream()
+      if (status === "recording") {
+        setStatus("idle")
+      }
+    }
+  }, [releaseStream, status])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current?.state === "recording") {
+        mediaRecorderRef.current.stop()
+      }
+      releaseStream()
+    }
+  }, [releaseStream])
+
+  return {
+    status,
+    isAvailable,
+    startRecording: useCallback(() => void startRecording(), [startRecording]),
+    stopRecording,
+  }
+}

--- a/src/client/stores/voiceDictationStore.ts
+++ b/src/client/stores/voiceDictationStore.ts
@@ -1,0 +1,113 @@
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+export type VoiceDictationLanguage = "auto" | string
+
+export const DEFAULT_VOICE_DICTATION_ENABLED = false
+export const DEFAULT_OPENAI_API_KEY = ""
+export const DEFAULT_VOICE_DICTATION_LANGUAGE: VoiceDictationLanguage = "auto"
+
+export const VOICE_DICTATION_LANGUAGES: Array<{ value: string; label: string }> = [
+  { value: "auto", label: "Auto (detect)" },
+  { value: "af", label: "Afrikaans" },
+  { value: "ar", label: "Arabic" },
+  { value: "hy", label: "Armenian" },
+  { value: "az", label: "Azerbaijani" },
+  { value: "be", label: "Belarusian" },
+  { value: "bs", label: "Bosnian" },
+  { value: "bg", label: "Bulgarian" },
+  { value: "ca", label: "Catalan" },
+  { value: "zh", label: "Chinese" },
+  { value: "hr", label: "Croatian" },
+  { value: "cs", label: "Czech" },
+  { value: "da", label: "Danish" },
+  { value: "nl", label: "Dutch" },
+  { value: "en", label: "English" },
+  { value: "et", label: "Estonian" },
+  { value: "fi", label: "Finnish" },
+  { value: "fr", label: "French" },
+  { value: "gl", label: "Galician" },
+  { value: "de", label: "German" },
+  { value: "el", label: "Greek" },
+  { value: "he", label: "Hebrew" },
+  { value: "hi", label: "Hindi" },
+  { value: "hu", label: "Hungarian" },
+  { value: "is", label: "Icelandic" },
+  { value: "id", label: "Indonesian" },
+  { value: "it", label: "Italian" },
+  { value: "ja", label: "Japanese" },
+  { value: "kn", label: "Kannada" },
+  { value: "kk", label: "Kazakh" },
+  { value: "ko", label: "Korean" },
+  { value: "lv", label: "Latvian" },
+  { value: "lt", label: "Lithuanian" },
+  { value: "mk", label: "Macedonian" },
+  { value: "ms", label: "Malay" },
+  { value: "mr", label: "Marathi" },
+  { value: "mi", label: "Maori" },
+  { value: "ne", label: "Nepali" },
+  { value: "no", label: "Norwegian" },
+  { value: "fa", label: "Persian" },
+  { value: "pl", label: "Polish" },
+  { value: "pt", label: "Portuguese" },
+  { value: "ro", label: "Romanian" },
+  { value: "ru", label: "Russian" },
+  { value: "sr", label: "Serbian" },
+  { value: "sk", label: "Slovak" },
+  { value: "sl", label: "Slovenian" },
+  { value: "es", label: "Spanish" },
+  { value: "sw", label: "Swahili" },
+  { value: "sv", label: "Swedish" },
+  { value: "tl", label: "Tagalog" },
+  { value: "ta", label: "Tamil" },
+  { value: "th", label: "Thai" },
+  { value: "tr", label: "Turkish" },
+  { value: "uk", label: "Ukrainian" },
+  { value: "ur", label: "Urdu" },
+  { value: "vi", label: "Vietnamese" },
+  { value: "cy", label: "Welsh" },
+]
+
+const VALID_LANGUAGE_CODES = new Set(VOICE_DICTATION_LANGUAGES.map((l) => l.value))
+
+export function normalizeVoiceDictationLanguage(value?: string): VoiceDictationLanguage {
+  if (typeof value === "string" && VALID_LANGUAGE_CODES.has(value)) {
+    return value
+  }
+  return DEFAULT_VOICE_DICTATION_LANGUAGE
+}
+
+export interface VoiceDictationState {
+  voiceDictationEnabled: boolean
+  openaiApiKey: string
+  voiceDictationLanguage: VoiceDictationLanguage
+  setVoiceDictationEnabled: (value: boolean) => void
+  setOpenaiApiKey: (value: string) => void
+  setVoiceDictationLanguage: (value: VoiceDictationLanguage) => void
+}
+
+export const useVoiceDictationStore = create<VoiceDictationState>()(
+  persist(
+    (set) => ({
+      voiceDictationEnabled: DEFAULT_VOICE_DICTATION_ENABLED,
+      openaiApiKey: DEFAULT_OPENAI_API_KEY,
+      voiceDictationLanguage: DEFAULT_VOICE_DICTATION_LANGUAGE,
+      setVoiceDictationEnabled: (value) => set({ voiceDictationEnabled: Boolean(value) }),
+      setOpenaiApiKey: (value) => set({ openaiApiKey: typeof value === "string" ? value : "" }),
+      setVoiceDictationLanguage: (value) =>
+        set({ voiceDictationLanguage: normalizeVoiceDictationLanguage(value) }),
+    }),
+    {
+      name: "voice-dictation-preferences",
+      version: 1,
+      migrate: (persistedState) => {
+        const state = persistedState as Partial<VoiceDictationState> | undefined
+        return {
+          voiceDictationEnabled: Boolean(state?.voiceDictationEnabled),
+          openaiApiKey: typeof state?.openaiApiKey === "string" ? state.openaiApiKey : DEFAULT_OPENAI_API_KEY,
+          voiceDictationLanguage: normalizeVoiceDictationLanguage(state?.voiceDictationLanguage),
+        }
+      },
+    }
+  )
+)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -165,6 +165,11 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             return projectFileContentResponse
           }
 
+          const transcribeResponse = await handleTranscribe(req, url)
+          if (transcribeResponse) {
+            return transcribeResponse
+          }
+
           return serveStatic(distDir, url.pathname)
         },
         websocket: {
@@ -379,6 +384,73 @@ async function handleProjectUploadDelete(req: Request, url: URL, store: EventSto
   })
 
   return Response.json({ ok: deleted })
+}
+
+const MAX_AUDIO_SIZE_BYTES = 25 * 1024 * 1024 // OpenAI Whisper limit
+
+async function handleTranscribe(req: Request, url: URL) {
+  if (req.method !== "POST") return null
+
+  if (url.pathname !== "/api/transcribe") return null
+
+  const apiKey = req.headers.get("X-OpenAI-Api-Key")
+  if (!apiKey) {
+    return Response.json({ error: "Missing OpenAI API key" }, { status: 401 })
+  }
+
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return Response.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  const audioFile = formData.get("audio")
+  if (!(audioFile instanceof File)) {
+    return Response.json({ error: "No audio file provided" }, { status: 400 })
+  }
+
+  if (audioFile.size > MAX_AUDIO_SIZE_BYTES) {
+    return Response.json({ error: "Audio file exceeds 25 MB limit" }, { status: 413 })
+  }
+
+  const language = formData.get("language")
+
+  // Build FormData for OpenAI Whisper API
+  const whisperForm = new FormData()
+  whisperForm.append("file", audioFile, audioFile.name || "audio.webm")
+  whisperForm.append("model", "whisper-1")
+  if (typeof language === "string" && language.length > 0 && language !== "auto") {
+    whisperForm.append("language", language)
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: whisperForm,
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}))
+      const errorMessage =
+        typeof errorBody === "object" &&
+        errorBody !== null &&
+        "error" in errorBody &&
+        typeof (errorBody as { error: { message?: string } }).error?.message === "string"
+          ? (errorBody as { error: { message: string } }).error.message
+          : "Transcription failed"
+      return Response.json({ error: errorMessage }, { status: response.status })
+    }
+
+    const result = (await response.json()) as { text: string }
+    return Response.json({ text: result.text })
+  } catch (error) {
+    console.error("[transcribe] Whisper API request failed:", error)
+    return Response.json({ error: "Failed to reach OpenAI API" }, { status: 502 })
+  }
 }
 
 async function serveStatic(distDir: string, pathname: string) {


### PR DESCRIPTION
# Add voice dictation via OpenAI Whisper API

## Summary

Adds voice-to-text dictation to the chat input using OpenAI's Whisper API. When enabled, the send button seamlessly morphs into a microphone button whenever the text field is empty (WhatsApp/Telegram-style UX). Users can dictate instead of typing, and the transcribed text is appended to the textarea for review before sending.

<img width="1406" height="929" alt="Screenshot 2026-04-09 at 19 09 43" src="https://github.com/user-attachments/assets/3bb9756e-67eb-4f6d-94e9-dec6787ffb5b" />
<img width="1406" height="929" alt="Screenshot 2026-04-09 at 19 09 49" src="https://github.com/user-attachments/assets/e5906695-7032-40f5-82ae-0bc0b856b482" />
<img width="1406" height="929" alt="Screenshot 2026-04-09 at 19 10 02" src="https://github.com/user-attachments/assets/7273f22f-39be-49df-b7c6-3ac55f45d171" />
<img width="1406" height="929" alt="Screenshot 2026-04-09 at 19 10 21" src="https://github.com/user-attachments/assets/ffa43088-9447-48f4-9b88-dbb4033cb8f8" />

## What changed

### New files
- **`src/client/stores/voiceDictationStore.ts`** — Zustand persisted store for voice settings (enabled toggle, OpenAI API key, language preference with 57 Whisper-supported languages + auto-detect)
- **`src/client/hooks/useVoiceRecorder.ts`** — Custom hook encapsulating the full recording lifecycle via browser MediaRecorder API, with a clean state machine (`idle → recording → transcribing → idle`) and graceful error handling for mic permissions, missing hardware, and API failures

### Modified files
- **`src/client/components/chat-ui/ChatInput.tsx`** — Send button now transitions between five visual states based on priority:
  1. **Cancel** (■ square) — agent is running, unchanged
  2. **Recording** (● pulsing red dot) — stop recording
  3. **Transcribing** (↻ spinner) — waiting for Whisper response
  4. **Mic** (🎤) — field is empty, ready to record
  5. **Send** (↑ arrow) — field has content, send message

- **`src/client/app/SettingsPage.tsx`** — New "Voice Dictation" settings section with:
  - Enable/disable toggle
  - OpenAI API key input (password-masked, commit-on-blur)
  - Language dropdown (Auto + 57 languages)

- **`src/server/server.ts`** — New `POST /api/transcribe` proxy endpoint that forwards audio to OpenAI's Whisper API, avoiding CORS issues. API key is passed per-request via header (not stored server-side). Includes file size validation (25 MB limit) and error forwarding.

## Design decisions

- **Button replacement over adding a second button** — The send button is already disabled/dead space when the field is empty. Morphing it into a mic button keeps the UI clean and follows established patterns (WhatsApp, Telegram, iMessage).
- **Server-side proxy** — Browser-to-OpenAI direct calls would hit CORS. The `/api/transcribe` endpoint is a thin passthrough.
- **API key in localStorage** — Consistent with how all other preferences are stored in this app. The key is transmitted per-request to the server proxy, never persisted server-side.
- **Audio format** — Uses `audio/webm;codecs=opus` (Chrome/Firefox) with automatic fallback to `audio/mp4` (Safari). Both are natively supported by Whisper.
- **Append, don't replace** — Transcribed text is appended to existing textarea content with smart spacing, so users can mix typing and dictation freely.

## How to test

1. Go to **Settings → Voice Dictation** → toggle **On**
2. Enter an OpenAI API key (`sk-...`)
3. Optionally select a language (or leave on Auto)
4. Navigate to any chat — the send button should show a 🎤 mic icon when the field is empty
5. Type some text — verify the button morphs back to ↑ send
6. Clear the field, click mic → grant microphone permission → speak → click the red dot to stop
7. Verify the spinner appears during transcription, then text appears in the textarea
8. Click send — verify the message sends normally
9. Test error cases: invalid API key, deny mic permission, empty recording

## Compatibility

- Chrome, Firefox, Edge (webm/opus)
- Safari (mp4 fallback)
- Gracefully hidden when browser lacks MediaRecorder support