### PR TITLE
Fix infinite restart loop when running via bunx

### DIFF
--- a/src/server/cli-supervisor.ts
+++ b/src/server/cli-supervisor.ts
@@ -6,6 +6,7 @@ import {
   CLI_CHILD_COMMAND_ENV_VAR,
   CLI_CHILD_MODE,
   CLI_CHILD_MODE_ENV_VAR,
+  CLI_STARTUP_UPDATE_RESTART_EXIT_CODE,
   CLI_SUPPRESS_OPEN_ONCE_ENV_VAR,
   isUiUpdateRestart,
   parseChildArgsEnv,
@@ -26,7 +27,9 @@ function getChildProcessSpec() {
 function spawnChild(argv: string[]) {
   const childProcess = getChildProcessSpec()
   const suppressOpenThisChild = suppressOpenOnNextChild
+  const skipUpdateThisChild = skipUpdateOnNextChild
   suppressOpenOnNextChild = false
+  skipUpdateOnNextChild = false
   return new Promise<ChildExit>((resolve, reject) => {
     const child = spawn(childProcess.command, [...childProcess.args, ...argv], {
       stdio: "inherit",
@@ -34,6 +37,7 @@ function spawnChild(argv: string[]) {
         ...process.env,
         [CLI_CHILD_MODE_ENV_VAR]: CLI_CHILD_MODE,
         ...(suppressOpenThisChild ? { [CLI_SUPPRESS_OPEN_ONCE_ENV_VAR]: "1" } : {}),
+        ...(skipUpdateThisChild ? { KANNA_DISABLE_SELF_UPDATE: "1" } : {}),
       },
     })
 
@@ -68,10 +72,27 @@ function spawnChild(argv: string[]) {
 
 const argv = process.argv.slice(2)
 let suppressOpenOnNextChild = false
+let skipUpdateOnNextChild = false
+let lastStartupUpdateRestart = false
 
 while (true) {
   const result = await spawnChild(argv)
   if (shouldRestartCliProcess(result.code, result.signal)) {
+    const isStartupUpdate = result.signal === null && result.code === CLI_STARTUP_UPDATE_RESTART_EXIT_CODE
+
+    // Guard against infinite restart loops: if two consecutive startup-update
+    // restarts happen it means the installed update did not change the binary
+    // that actually runs (e.g. when launched via `bunx`, which maintains its
+    // own package cache). Skip the self-update on the next spawn so the child
+    // proceeds normally instead of trying to update again.
+    if (isStartupUpdate && lastStartupUpdateRestart) {
+      console.log(`${LOG_PREFIX} update installed but the running binary did not change, continuing with current version`)
+      skipUpdateOnNextChild = true
+      lastStartupUpdateRestart = false
+    } else {
+      lastStartupUpdateRestart = isStartupUpdate
+    }
+
     suppressOpenOnNextChild = isUiUpdateRestart(result.code, result.signal)
     console.log(`${LOG_PREFIX} supervisor restarting ${CLI_COMMAND} in the same terminal session`)
     continue


### PR DESCRIPTION
## Summary

- Fixes an infinite restart loop that occurs when running `bunx kanna-code` after the package is already cached
- The supervisor now detects two consecutive startup-update restarts (exit code 75) and sets `KANNA_DISABLE_SELF_UPDATE=1` on the next child spawn to break the cycle

## Problem

When kanna is launched via `bunx`, the auto-update logic enters an infinite loop:

1. `maybeSelfUpdate` fetches the latest version from npm
2. Compares it to `deps.version` (read from the bunx-cached `package.json`)
3. Since bunx caches a copy, the versions mismatch on subsequent runs — bunx always serves its cached copy
4. Installs the latest version globally via `bun install -g`
5. Exits with code 75 (startup update restart)
6. Supervisor restarts the child — but it's still the bunx-cached binary
7. The child reads the same old version from its `package.json`, thinks it needs to update again
8. Repeat forever

This manifests as rapid-fire output:
```
[kanna] checking for updates
[kanna] installing kanna-code@0.26.5
Saved lockfile
[kanna] restarting into updated version
[kanna] supervisor restarting kanna in the same terminal session
[kanna] checking for updates
[kanna] installing kanna-code@0.26.5
...
```

## Fix

The supervisor (`cli-supervisor.ts`) now tracks whether the previous child exit was also a startup-update restart. If two consecutive startup-update restarts occur, it means the installed update did not change the binary that actually runs (the bunx cache is immutable). The supervisor then:

1. Logs a message explaining the situation
2. Sets `KANNA_DISABLE_SELF_UPDATE=1` for the next child spawn (this env var was already respected by `maybeSelfUpdate`)
3. Allows the child to proceed normally with the current version

This is a minimal, safe change — it only affects the edge case of consecutive code-75 exits, and uses the existing `KANNA_DISABLE_SELF_UPDATE` mechanism.

## Test plan

- [x] Existing tests pass (`bun test` — 27 tests, 0 failures)
- [ ] Run `bunx kanna-code` twice — second run should no longer loop
- [ ] Run `bun install -g kanna-code && kanna` — normal update flow still works
- [ ] UI-triggered updates (exit code 76) are unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)