### PR TITLE
Reduce duplication and simplify architecture

### DIFF
--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -312,15 +312,6 @@ export function ChangelogSection({
 
 
               <div className="flex flex-row items-center justify-end min-w-0 flex-1 gap-2 ">
-                {/* <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                  
-                  <span className="rounded-full bg-muted px-2.5 py-1 font-mono text-foreground/80">
-                    {release.tag_name}
-                  </span>
-                </div> */}
-
-             
-            
                   <a
                   href={release.html_url}
                   target="_blank"
@@ -435,7 +426,7 @@ export function SettingsPage() {
   const { theme, setTheme } = useTheme()
   const [changelogStatus, setChangelogStatus] = useState<ChangelogStatus>("idle")
   const [signingOut, setSigningOut] = useState(false)
-  const [authEnabled, setAuthEnabled] = useState(false)
+  const authEnabled = state.authEnabled
   const [releases, setReleases] = useState<GithubRelease[]>([])
   const [changelogError, setChangelogError] = useState<string | null>(null)
   const selectedPage = resolveSettingsSectionId(sectionId) ?? "general"
@@ -510,34 +501,6 @@ export function SettingsPage() {
     if (resolveSettingsSectionId(sectionId)) return
     navigate("/settings/general", { replace: true })
   }, [navigate, sectionId])
-
-  useEffect(() => {
-    let cancelled = false
-
-    void fetch("/auth/status", {
-      method: "GET",
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-      },
-    })
-      .then(async (response) => {
-        if (!response.ok) return { enabled: false }
-        return await response.json() as { enabled?: boolean }
-      })
-      .then((payload) => {
-        if (cancelled) return
-        setAuthEnabled(payload.enabled === true)
-      })
-      .catch(() => {
-        if (cancelled) return
-        setAuthEnabled(false)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   useEffect(() => {
     if (selectedPage !== "changelog" || isConnecting) return

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -52,39 +52,10 @@ function sameHistory(left: ChatSnapshot["history"] | null | undefined, right: Ch
     && left.recentLimit === right.recentLimit
 }
 
-function sameQueuedMessage(left: QueuedChatMessage, right: QueuedChatMessage) {
-  return left.id === right.id
-    && left.content === right.content
-    && left.createdAt === right.createdAt
-    && left.provider === right.provider
-    && left.model === right.model
-    && left.planMode === right.planMode
-    && JSON.stringify(left.modelOptions) === JSON.stringify(right.modelOptions)
-    && sameAttachmentArray(left.attachments, right.attachments)
-}
-
-function sameAttachmentArray(left: ChatAttachment[], right: ChatAttachment[]) {
-  if (left === right) return true
-  if (left.length !== right.length) return false
-  return left.every((attachment, index) => {
-    const other = right[index]
-    return Boolean(other)
-      && attachment.id === other.id
-      && attachment.kind === other.kind
-      && attachment.displayName === other.displayName
-      && attachment.absolutePath === other.absolutePath
-      && attachment.relativePath === other.relativePath
-      && attachment.contentUrl === other.contentUrl
-      && attachment.mimeType === other.mimeType
-      && attachment.size === other.size
-  })
-}
-
 function sameQueuedMessages(left: ChatSnapshot["queuedMessages"] | null | undefined, right: ChatSnapshot["queuedMessages"] | null | undefined) {
   if (left === right) return true
-  if (!left || !right) return false
-  if (left.length !== right.length) return false
-  return left.every((message, index) => sameQueuedMessage(message, right[index]!))
+  if (!left || !right || left.length !== right.length) return false
+  return left.every((msg, i) => JSON.stringify(msg) === JSON.stringify(right[i]))
 }
 
 function sameDiffs(left: ChatDiffSnapshot | null | undefined, right: ChatDiffSnapshot | null | undefined) {
@@ -513,6 +484,7 @@ export interface KannaState {
   handleCreateProject: (project: ProjectRequest) => Promise<void>
   handleCheckForUpdates: (options?: { force?: boolean }) => Promise<void>
   handleInstallUpdate: () => Promise<void>
+  authEnabled: boolean
   handleSignOut: () => Promise<void>
   handleSend: (content: string, options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean }) => Promise<void>
   handleSteerQueuedMessage: (queuedMessageId: string) => Promise<void>
@@ -544,6 +516,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const socket = useKannaSocket()
   const dialog = useAppDialog()
 
+  const [authEnabled, setAuthEnabled] = useState(false)
   const [sidebarData, setSidebarData] = useState<SidebarData>({ projectGroups: [] })
   const [localProjects, setLocalProjects] = useState<LocalProjectsSnapshot | null>(null)
   const [updateSnapshot, setUpdateSnapshot] = useState<UpdateSnapshot | null>(null)
@@ -582,6 +555,15 @@ export function useKannaState(activeChatId: string | null): KannaState {
   const editorLabel = getEditorPresetLabel(useTerminalPreferencesStore((store) => store.editorPreset))
 
   useEffect(() => socket.onStatus(setConnectionStatus), [socket])
+
+  useEffect(() => {
+    let cancelled = false
+    void fetch("/auth/status", { method: "GET", cache: "no-store", headers: { Accept: "application/json" } })
+      .then(async (r) => r.ok ? await r.json() as { enabled?: boolean } : { enabled: false })
+      .then((p) => { if (!cancelled) setAuthEnabled(p.enabled === true) })
+      .catch(() => { if (!cancelled) setAuthEnabled(false) })
+    return () => { cancelled = true }
+  }, [])
 
   useEffect(() => {
     return socket.subscribe<SidebarData>({ type: "sidebar" }, (snapshot) => {
@@ -1308,33 +1290,28 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }, [activeChatId, fallbackLocalProjectPath, isProcessing, navigate, optimisticUserPrompts, selectedProjectId, serverTranscriptEntries, sidebarData.projectGroups, socket])
 
-  const handleSteerQueuedMessage = useCallback(async (queuedMessageId: string) => {
+  const sendQueueCommand = useCallback(async (
+    type: "message.steer" | "message.dequeue",
+    queuedMessageId: string,
+  ) => {
     if (!activeChatId) return
     try {
-      await socket.command({
-        type: "message.steer",
-        chatId: activeChatId,
-        queuedMessageId,
-      })
+      await socket.command({ type, chatId: activeChatId, queuedMessageId })
       setCommandError(null)
     } catch (error) {
       setCommandError(error instanceof Error ? error.message : String(error))
     }
   }, [activeChatId, socket])
 
-  const handleRemoveQueuedMessage = useCallback(async (queuedMessageId: string) => {
-    if (!activeChatId) return
-    try {
-      await socket.command({
-        type: "message.dequeue",
-        chatId: activeChatId,
-        queuedMessageId,
-      })
-      setCommandError(null)
-    } catch (error) {
-      setCommandError(error instanceof Error ? error.message : String(error))
-    }
-  }, [activeChatId, socket])
+  const handleSteerQueuedMessage = useCallback(
+    (queuedMessageId: string) => sendQueueCommand("message.steer", queuedMessageId),
+    [sendQueueCommand],
+  )
+
+  const handleRemoveQueuedMessage = useCallback(
+    (queuedMessageId: string) => sendQueueCommand("message.dequeue", queuedMessageId),
+    [sendQueueCommand],
+  )
 
   const handleCancel = useCallback(async () => {
     if (!activeChatId) return
@@ -1558,6 +1535,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     isDraining,
     navbarLocalPath,
     editorLabel,
+    authEnabled,
     hasSelectedProject,
     addProjectModalOpen,
     openSidebar,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -127,6 +127,13 @@ function logClaudeSteer(stage: string, details?: Record<string, unknown>) {
   }))
 }
 
+class SteerLogger {
+  constructor(private chatId: string, private sessionId: string) {}
+  log(stage: string, extra?: Record<string, unknown>) {
+    logClaudeSteer(stage, { chatId: this.chatId, sessionId: this.sessionId, ...extra })
+  }
+}
+
 const STEERED_MESSAGE_PREFIX = `<system-message>
 The user would like to inform you of something while you continue to work. Acknowledge receipt immediately with a text response, then continue with the task at hand, incorporating the user's feedback if needed.
 </system-message>`
@@ -1018,9 +1025,7 @@ export class AgentCoordinator {
       session.nextPromptSeq = promptSeq
       session.pendingPromptSeqs.push(promptSeq)
       active.claudePromptSeq = promptSeq
-      logClaudeSteer("claude_prompt_sent", {
-        chatId: args.chatId,
-        sessionId: session.id,
+      new SteerLogger(args.chatId, session.id).log("claude_prompt_sent", {
         promptSeq,
         activeStatus: active.status,
         contentPreview: args.content.slice(0, 160),
@@ -1207,6 +1212,7 @@ export class AgentCoordinator {
   }
 
   private async runClaudeSession(session: ClaudeSessionState) {
+    const steerLog = new SteerLogger(session.chatId, session.id)
     try {
       for await (const event of session.session.stream) {
         if (event.type === "session_token" && event.sessionToken) {
@@ -1221,9 +1227,7 @@ export class AgentCoordinator {
         const active = this.activeTurns.get(session.chatId)
         if (event.entry.kind === "system_init" && active) {
           active.status = "running"
-          logClaudeSteer("claude_event_system_init", {
-            chatId: session.chatId,
-            sessionId: session.id,
+          steerLog.log("claude_event_system_init", {
             activePromptSeq: active.claudePromptSeq ?? null,
             pendingPromptSeqs: [...session.pendingPromptSeqs],
           })
@@ -1233,9 +1237,7 @@ export class AgentCoordinator {
           ? (session.pendingPromptSeqs.shift() ?? null)
           : null
 
-        logClaudeSteer("claude_event", {
-          chatId: session.chatId,
-          sessionId: session.id,
+        steerLog.log("claude_event", {
           entryKind: event.entry.kind,
           activePromptSeq: active?.claudePromptSeq ?? null,
           completedPromptSeq: completedClaudePromptSeq,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,5 +1,5 @@
 import { randomBytes, timingSafeEqual } from "node:crypto"
-import { APP_NAME } from "../shared/branding"
+
 
 const SESSION_COOKIE_NAME = "kanna_session"
 
@@ -18,7 +18,6 @@ export interface AuthManager {
   handleLogin(req: Request, nextPath: string): Promise<Response>
   handleLogout(req: Request): Response
   handleStatus(req: Request): Response
-  renderLoginPage(req: Request): Response
   unauthorizedResponse(req: Request): Response
 }
 
@@ -68,37 +67,11 @@ function buildCookie(name: string, value: string, req: Request, extras: string[]
 }
 
 async function readLoginForm(req: Request) {
-  const contentType = req.headers.get("content-type") ?? ""
-
-  if (contentType.includes("application/json")) {
-    const payload = await req.json() as { password?: unknown; next?: unknown }
-    return {
-      password: typeof payload.password === "string" ? payload.password : "",
-      nextPath: sanitizeNextPath(typeof payload.next === "string" ? payload.next : "/"),
-      wantsJson: true,
-    }
-  }
-
-  const formData = await req.formData()
+  const payload = await req.json() as { password?: unknown; next?: unknown }
   return {
-    password: String(formData.get("password") ?? ""),
-    nextPath: sanitizeNextPath(String(formData.get("next") ?? "/")),
-    wantsJson: false,
+    password: typeof payload.password === "string" ? payload.password : "",
+    nextPath: sanitizeNextPath(typeof payload.next === "string" ? payload.next : "/"),
   }
-}
-
-function requestWantsHtml(req: Request) {
-  const accept = req.headers.get("accept") ?? ""
-  return accept.includes("text/html")
-}
-
-function escapeHtml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("\"", "&quot;")
-    .replaceAll("'", "&#39;")
 }
 
 export function createAuthManager(password: string): AuthManager {
@@ -149,108 +122,8 @@ export function createAuthManager(password: string): AuthManager {
     } satisfies AuthStatusPayload)
   }
 
-  function unauthorizedResponse(req: Request) {
-    if (req.method === "GET" && requestWantsHtml(req)) {
-      const url = new URL(req.url)
-      const loginUrl = new URL("/auth/login", req.url)
-      loginUrl.searchParams.set("next", sanitizeNextPath(`${url.pathname}${url.search}`))
-      return Response.redirect(loginUrl, 302)
-    }
-
+  function unauthorizedResponse(_req: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  function renderLoginPage(req: Request) {
-    if (isAuthenticated(req)) {
-      const currentUrl = new URL(req.url)
-      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), req.url), 302)
-    }
-
-    const currentUrl = new URL(req.url)
-    const nextPath = sanitizeNextPath(currentUrl.searchParams.get("next"))
-    const showError = currentUrl.searchParams.get("error") === "1"
-    const html = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>${escapeHtml(APP_NAME)} Login</title>
-    <style>
-      :root { color-scheme: dark; }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: ui-sans-serif, system-ui, sans-serif;
-        background:
-          radial-gradient(circle at top, rgba(255,255,255,0.10), transparent 28%),
-          linear-gradient(160deg, #16181d 0%, #0b0d10 55%, #050608 100%);
-        color: #f4f7fb;
-        display: grid;
-        place-items: center;
-        padding: 24px;
-      }
-      .card {
-        width: min(420px, 100%);
-        border: 1px solid rgba(255,255,255,0.12);
-        background: rgba(12, 15, 20, 0.88);
-        backdrop-filter: blur(10px);
-        border-radius: 24px;
-        padding: 28px;
-        box-shadow: 0 24px 70px rgba(0,0,0,0.35);
-      }
-      h1 { margin: 0 0 8px; font-size: 28px; }
-      p { margin: 0 0 20px; color: #a6b0bd; line-height: 1.5; }
-      label { display: block; font-size: 13px; margin-bottom: 8px; color: #d7dce4; }
-      input {
-        width: 100%;
-        border-radius: 14px;
-        border: 1px solid rgba(255,255,255,0.16);
-        background: rgba(255,255,255,0.04);
-        color: inherit;
-        padding: 14px 16px;
-        font-size: 15px;
-        margin-bottom: 16px;
-      }
-      button {
-        width: 100%;
-        border: 0;
-        border-radius: 14px;
-        padding: 14px 16px;
-        background: linear-gradient(135deg, #f4ede0 0%, #d9c4a1 100%);
-        color: #16181d;
-        font-size: 15px;
-        font-weight: 700;
-        cursor: pointer;
-      }
-      .error {
-        margin-bottom: 16px;
-        border-radius: 14px;
-        background: rgba(255, 106, 106, 0.12);
-        border: 1px solid rgba(255, 106, 106, 0.24);
-        color: #ffb8b8;
-        padding: 12px 14px;
-        font-size: 14px;
-      }
-    </style>
-  </head>
-  <body>
-    <form class="card" method="post" action="/auth/login">
-      <h1>${escapeHtml(APP_NAME)}</h1>
-      <p>This server is password protected. Enter the launch password to continue.</p>
-      ${showError ? '<div class="error">Incorrect password. Try again.</div>' : ""}
-      <input type="hidden" name="next" value="${escapeHtml(nextPath)}" />
-      <label for="password">Password</label>
-      <input id="password" name="password" type="password" autocomplete="current-password" autofocus required />
-      <button type="submit">Unlock</button>
-    </form>
-  </body>
-</html>`
-    return new Response(html, {
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-      },
-    })
   }
 
   async function handleLogin(req: Request, fallbackNextPath: string) {
@@ -258,21 +131,12 @@ export function createAuthManager(password: string): AuthManager {
       return Response.json({ error: "Forbidden" }, { status: 403 })
     }
 
-    const { password: candidate, nextPath, wantsJson } = await readLoginForm(req)
+    const { password: candidate, nextPath } = await readLoginForm(req)
     if (!verifyPassword(candidate)) {
-      if (wantsJson) {
-        return Response.json({ error: "Invalid password" }, { status: 401 })
-      }
-
-      const redirectUrl = new URL("/auth/login", req.url)
-      redirectUrl.searchParams.set("error", "1")
-      redirectUrl.searchParams.set("next", sanitizeNextPath(nextPath || fallbackNextPath))
-      return Response.redirect(redirectUrl, 302)
+      return Response.json({ error: "Invalid password" }, { status: 401 })
     }
 
-    const response = wantsJson
-      ? Response.json({ ok: true, nextPath: sanitizeNextPath(nextPath || fallbackNextPath) })
-      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), req.url), 302)
+    const response = Response.json({ ok: true, nextPath: sanitizeNextPath(nextPath || fallbackNextPath) })
 
     response.headers.set("Set-Cookie", createSessionCookie(req))
     return response
@@ -298,7 +162,6 @@ export function createAuthManager(password: string): AuthManager {
     handleLogin,
     handleLogout,
     handleStatus,
-    renderLoginPage,
     unauthorizedResponse,
   }
 }

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -4,6 +4,7 @@ import { hasCommand, spawnDetached } from "./process-utils"
 import { APP_NAME, CLI_COMMAND, getDataDirDisplay, LOG_PREFIX, PACKAGE_NAME } from "../shared/branding"
 import type { ShareMode } from "../shared/share"
 import { isShareEnabled, isTokenShareMode } from "../shared/share"
+import { parseNetworkFlags } from "../shared/network-flags"
 import type { UpdateInstallErrorCode } from "../shared/types"
 import { PROD_SERVER_PORT } from "../shared/ports"
 import { CLI_SUPPRESS_OPEN_ONCE_ENV_VAR } from "./restart"
@@ -95,12 +96,8 @@ Options:
 
 export function parseArgs(argv: string[]): ParsedArgs {
   let port = PROD_SERVER_PORT
-  let host = "127.0.0.1"
   let openBrowser = true
-  let share: ShareMode = false
   let password: string | null = null
-  let sawHost = false
-  let sawRemote = false
   let strictPort = false
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -121,34 +118,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     if (arg === "--host") {
       const next = argv[index + 1]
       if (!next || next.startsWith("-")) throw new Error("Missing value for --host")
-      if (isShareEnabled(share)) {
-        throw new Error(typeof share === "string" ? "--share cannot be used with --host" : "--cloudflared cannot be used with --host")
-      }
-      host = next
-      sawHost = true
       index += 1
       continue
     }
-    if (arg === "--remote") {
-      if (isShareEnabled(share)) {
-        throw new Error(typeof share === "string" ? "--share cannot be used with --remote" : "--cloudflared cannot be used with --remote")
-      }
-      host = "0.0.0.0"
-      sawRemote = true
-      continue
-    }
-    if (arg === "--share") {
-      if (sawHost) throw new Error("--share cannot be used with --host")
-      if (sawRemote) throw new Error("--share cannot be used with --remote")
-      share = "quick"
-      continue
-    }
     if (arg === "--cloudflared") {
-      if (sawHost) throw new Error("--cloudflared cannot be used with --host")
-      if (sawRemote) throw new Error("--cloudflared cannot be used with --remote")
-      const next = argv[index + 1]
-      if (!next || next.startsWith("-")) throw new Error("Missing value for --cloudflared")
-      share = { kind: "token", token: next }
       index += 1
       continue
     }
@@ -167,16 +140,19 @@ export function parseArgs(argv: string[]): ParsedArgs {
       strictPort = true
       continue
     }
+    if (arg === "--share" || arg === "--remote") continue
     if (!arg.startsWith("-")) throw new Error(`Unexpected positional argument: ${arg}`)
   }
+
+  const network = parseNetworkFlags(argv)
 
   return {
     kind: "run",
     options: {
       port,
-      host,
+      host: network.host,
       openBrowser,
-      share,
+      share: network.share,
       password,
       strictPort,
     },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -162,7 +162,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
           if (auth) {
             if (url.pathname === "/auth/login") {
               if (req.method === "GET") {
-                return auth.renderLoginPage(req)
+                return Response.redirect(new URL("/", req.url), 302)
               }
               if (req.method === "POST") {
                 return auth.handleLogin(req, "/")

--- a/src/server/share.ts
+++ b/src/server/share.ts
@@ -63,48 +63,13 @@ function createNamedTunnel(token: string, localUrl: string) {
   return tunnel
 }
 
-async function awaitQuickTunnelUrl(tunnel: ShareTunnelProcess) {
-  return await new Promise<string>((resolve, reject) => {
-    let settled = false
-
-    const cleanup = () => {
-      tunnel.off("url", handleUrl)
-      tunnel.off("error", handleError)
-      tunnel.off("exit", handleExit)
-    }
-
-    const settle = (callback: () => void) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      callback()
-    }
-
-    const handleUrl = (url: string) => {
-      settle(() => resolve(normalizePublicUrl(url)))
-    }
-
-    const handleError = (error: Error) => {
-      settle(() => reject(error))
-    }
-
-    const handleExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      settle(() => reject(new Error(`Cloudflare tunnel exited before a public URL was ready (code: ${String(code)}, signal: ${String(signal)})`)))
-    }
-
-    tunnel.once("url", handleUrl)
-    tunnel.once("error", handleError)
-    tunnel.once("exit", handleExit)
-  })
-}
-
-async function awaitNamedTunnelReady(tunnel: ShareTunnelProcess) {
+async function awaitTunnelReady(tunnel: ShareTunnelProcess, options?: { resolveOnConnected?: boolean }) {
   return await new Promise<string | null>((resolve, reject) => {
     let settled = false
 
     const cleanup = () => {
       tunnel.off("url", handleUrl)
-      tunnel.off("connected", handleConnected)
+      if (options?.resolveOnConnected) tunnel.off("connected", handleConnected)
       tunnel.off("error", handleError)
       tunnel.off("exit", handleExit)
     }
@@ -133,7 +98,7 @@ async function awaitNamedTunnelReady(tunnel: ShareTunnelProcess) {
     }
 
     tunnel.once("url", handleUrl)
-    tunnel.once("connected", handleConnected)
+    if (options?.resolveOnConnected) tunnel.once("connected", handleConnected)
     tunnel.once("error", handleError)
     tunnel.once("exit", handleExit)
   })
@@ -148,9 +113,7 @@ export async function startShareTunnel(
   const tunnel = isTokenShareMode(shareMode)
     ? (deps.createNamedTunnel ?? createNamedTunnel)(shareMode.token, localUrl)
     : (deps.createQuickTunnel ?? ((url) => Tunnel.quick(url)))(localUrl)
-  const publicUrl = isTokenShareMode(shareMode)
-    ? await awaitNamedTunnelReady(tunnel)
-    : await awaitQuickTunnelUrl(tunnel)
+  const publicUrl = await awaitTunnelReady(tunnel, isTokenShareMode(shareMode) ? { resolveOnConnected: true } : undefined)
 
   return {
     publicUrl,

--- a/src/shared/dev-ports.ts
+++ b/src/shared/dev-ports.ts
@@ -1,5 +1,6 @@
 import type { ShareMode } from "./share"
 import { isShareEnabled } from "./share"
+import { parseNetworkFlags } from "./network-flags"
 
 export const DEFAULT_DEV_CLIENT_PORT = 5174
 
@@ -79,58 +80,26 @@ export function stripShareArg(args: string[]) {
 export function parseDevArgs(args: string[], localHostname: string): DevArgResolution {
   const { clientPort, serverPort } = resolveDevPorts(args)
   const serverArgs = stripShareArg(stripPortArg(args))
-  let share: ShareMode = false
-  let sawHost = false
-  let sawRemote = false
+  const network = parseNetworkFlags(args)
+  const hosts = new Set<string>(["localhost", "127.0.0.1", "0.0.0.0", localHostname])
   let backendTargetHost = "127.0.0.1"
   let allowAllHosts = false
-  const hosts = new Set<string>(["localhost", "127.0.0.1", "0.0.0.0", localHostname])
 
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index]
-    if (arg === "--share") {
-      if (sawHost) throw new Error("--share cannot be used with --host")
-      if (sawRemote) throw new Error("--share cannot be used with --remote")
-      share = "quick"
-      continue
-    }
-    if (arg === "--cloudflared") {
-      if (sawHost) throw new Error("--cloudflared cannot be used with --host")
-      if (sawRemote) throw new Error("--cloudflared cannot be used with --remote")
-      const next = args[index + 1]
-      if (!next || next.startsWith("-")) throw new Error("Missing value for --cloudflared")
-      share = { kind: "token", token: next }
-      index += 1
-      continue
-    }
-    if (arg === "--remote") {
-      if (isShareEnabled(share)) {
-        throw new Error(typeof share === "string" ? "--share cannot be used with --remote" : "--cloudflared cannot be used with --remote")
-      }
-      sawRemote = true
-      backendTargetHost = "127.0.0.1"
-      allowAllHosts = true
-      continue
-    }
-    if (arg !== "--host") continue
-
-    const next = args[index + 1]
-    if (!next || next.startsWith("-")) continue
-    if (isShareEnabled(share)) {
-      throw new Error(typeof share === "string" ? "--share cannot be used with --host" : "--cloudflared cannot be used with --host")
-    }
-    sawHost = true
-    hosts.add(next)
-    backendTargetHost = next === "0.0.0.0" ? "127.0.0.1" : next
-    index += 1
+  // Resolve dev-specific host behavior (allowed hosts list, backend target)
+  if (network.sawRemote) {
+    allowAllHosts = true
+  }
+  if (network.sawHost) {
+    hosts.add(network.host)
+    backendTargetHost = network.host === "0.0.0.0" ? "127.0.0.1" : network.host
   }
 
   return {
     clientPort,
     serverPort,
-    share,
+    share: network.share,
     backendTargetHost,
-    allowedHosts: isShareEnabled(share) || allowAllHosts ? true : [...hosts],
+    allowedHosts: isShareEnabled(network.share) || allowAllHosts ? true : [...hosts],
     serverArgs,
   }
 }

--- a/src/shared/network-flags.ts
+++ b/src/shared/network-flags.ts
@@ -1,0 +1,56 @@
+import type { ShareMode } from "./share"
+import { isShareEnabled } from "./share"
+
+export interface NetworkFlags {
+  share: ShareMode
+  host: string
+  sawHost: boolean
+  sawRemote: boolean
+}
+
+export function parseNetworkFlags(argv: string[]): NetworkFlags {
+  let share: ShareMode = false
+  let host = "127.0.0.1"
+  let sawHost = false
+  let sawRemote = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--share") {
+      if (sawHost) throw new Error("--share cannot be used with --host")
+      if (sawRemote) throw new Error("--share cannot be used with --remote")
+      share = "quick"
+      continue
+    }
+    if (arg === "--cloudflared") {
+      if (sawHost) throw new Error("--cloudflared cannot be used with --host")
+      if (sawRemote) throw new Error("--cloudflared cannot be used with --remote")
+      const next = argv[index + 1]
+      if (!next || next.startsWith("-")) throw new Error("Missing value for --cloudflared")
+      share = { kind: "token", token: next }
+      index += 1
+      continue
+    }
+    if (arg === "--host") {
+      const next = argv[index + 1]
+      if (!next || next.startsWith("-")) continue
+      if (isShareEnabled(share)) {
+        throw new Error(typeof share === "string" ? "--share cannot be used with --host" : "--cloudflared cannot be used with --host")
+      }
+      host = next
+      sawHost = true
+      index += 1
+      continue
+    }
+    if (arg === "--remote") {
+      if (isShareEnabled(share)) {
+        throw new Error(typeof share === "string" ? "--share cannot be used with --remote" : "--cloudflared cannot be used with --remote")
+      }
+      host = "0.0.0.0"
+      sawRemote = true
+      continue
+    }
+  }
+
+  return { share, host, sawHost, sawRemote }
+}


### PR DESCRIPTION
## Summary

- **Extract `parseNetworkFlags`** — Deduplicate `--share`/`--cloudflared`/`--host`/`--remote` flag parsing that was copy-pasted between `cli-runtime.ts` and `dev-ports.ts` into a single shared module
- **Unify tunnel await functions** — Replace `awaitQuickTunnelUrl` and `awaitNamedTunnelReady` with a single `awaitTunnelReady` function using a `resolveOnConnected` option
- **Thread `authEnabled` through `KannaState`** — Remove duplicate `fetch("/auth/status")` from `SettingsPage` by hoisting auth status into the shared state context
- **Extract `sendQueueCommand` helper** — Deduplicate identical try/catch/setCommandError pattern in steer and dequeue handlers
- **Simplify structural comparators** — Replace ~35-line manual field-by-field `sameQueuedMessage`/`sameAttachmentArray` with `JSON.stringify` equality
- **Add `SteerLogger` class** — Reduce repeated `chatId`/`sessionId` threading across `logClaudeSteer` call sites
- **Remove server-rendered login page** — Delete ~90-line HTML template and helpers (`renderLoginPage`, `escapeHtml`, `requestWantsHtml`) since the React SPA handles login via JSON API
- **Remove dead code** — Delete commented-out JSX tag badge block from SettingsPage

**Net result: 127 insertions, 357 deletions (~230 net lines removed)**

## Test plan

- [ ] Verify `kanna` starts and serves the UI on default port
- [ ] Verify `--share`, `--cloudflared`, `--host`, `--remote` flags work in both prod and dev mode
- [ ] Verify password auth login/logout flow works via JSON API
- [ ] Verify steer and dequeue message actions work in chat
- [ ] Verify Settings page reflects auth status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)