### PR TITLE
Add git clone support to Add Project modal

### DIFF
--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -427,9 +427,11 @@ async function isServerReady() {
 }
 
 export interface ProjectRequest {
-  mode: "new" | "existing"
+  mode: "new" | "existing" | "clone"
   localPath: string
+  fallbackPath?: string
   title: string
+  cloneUrl?: string
 }
 
 export type StartChatIntent =
@@ -1126,12 +1128,16 @@ export function useKannaState(activeChatId: string | null): KannaState {
       return { projectId: result.projectId, localPath: intent.localPath }
     }
 
-    const result = await socket.command<{ projectId: string }>(
-      intent.project.mode === "new"
-        ? { type: "project.create", localPath: intent.project.localPath, title: intent.project.title }
-        : { type: "project.open", localPath: intent.project.localPath }
-    )
-    return { projectId: result.projectId, localPath: intent.project.localPath }
+    let command: Parameters<typeof socket.command>[0]
+    if (intent.project.mode === "clone" && intent.project.cloneUrl) {
+      command = { type: "project.clone", cloneUrl: intent.project.cloneUrl, localPath: intent.project.localPath, fallbackPath: intent.project.fallbackPath, title: intent.project.title }
+    } else if (intent.project.mode === "new") {
+      command = { type: "project.create", localPath: intent.project.localPath, title: intent.project.title }
+    } else {
+      command = { type: "project.open", localPath: intent.project.localPath }
+    }
+    const result = await socket.command<{ projectId: string; localPath?: string }>(command)
+    return { projectId: result.projectId, localPath: result.localPath ?? intent.project.localPath }
   }, [socket])
 
   const startChatFromIntent = useCallback(async (intent: StartChatIntent) => {
@@ -1149,6 +1155,10 @@ export function useKannaState(activeChatId: string | null): KannaState {
       await createChatForProject(projectId)
     } catch (error) {
       setCommandError(error instanceof Error ? error.message : String(error))
+      // Re-throw for clone operations so the modal can show the error inline
+      if (intent.kind === "project_request" && intent.project.mode === "clone") {
+        throw error
+      }
     } finally {
       setStartingLocalPath(null)
     }

--- a/src/client/components/LocalDev.tsx
+++ b/src/client/components/LocalDev.tsx
@@ -31,7 +31,7 @@ interface LocalDevProps {
   newProjectOpen: boolean
   onNewProjectOpenChange: (open: boolean) => void
   onOpenProject: (localPath: string) => Promise<void>
-  onCreateProject: (project: { mode: "new" | "existing"; localPath: string; title: string }) => Promise<void>
+  onCreateProject: (project: { mode: "new" | "existing" | "clone"; localPath: string; fallbackPath?: string; title: string; cloneUrl?: string }) => Promise<void>
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -307,9 +307,7 @@ export function LocalDev({
       <NewProjectModal
         open={newProjectOpen}
         onOpenChange={onNewProjectOpenChange}
-        onConfirm={(project) => {
-          void onCreateProject(project)
-        }}
+        onConfirm={(project) => onCreateProject(project)}
       />
 
       <div className="py-4 text-center">

--- a/src/client/components/NewProjectModal.tsx
+++ b/src/client/components/NewProjectModal.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
+import { Check, GitBranch, Loader2 } from "lucide-react"
 import { DEFAULT_NEW_PROJECT_ROOT } from "../../shared/branding"
+import { parseGitRepoUrl, toCloneUrl } from "../../shared/git-url"
 import { Button } from "./ui/button"
 import {
   Dialog,
@@ -11,13 +13,24 @@ import {
 import { Input } from "./ui/input"
 import { SegmentedControl } from "./ui/segmented-control"
 
+export type ProjectMode = "new" | "existing" | "clone"
+
+export interface NewProjectResult {
+  mode: ProjectMode
+  localPath: string
+  fallbackPath?: string
+  title: string
+  cloneUrl?: string
+}
+
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onConfirm: (project: { mode: Tab; localPath: string; title: string }) => void
+  onConfirm: (project: NewProjectResult) => Promise<void>
 }
 
 type Tab = "new" | "existing"
+type CloneStatus = "idle" | "cloning" | "success" | "error"
 
 function toKebab(str: string): string {
   return str
@@ -32,79 +45,152 @@ export function NewProjectModal({ open, onOpenChange, onConfirm }: Props) {
   const [tab, setTab] = useState<Tab>("new")
   const [name, setName] = useState("")
   const [existingPath, setExistingPath] = useState("")
+  const [cloneStatus, setCloneStatus] = useState<CloneStatus>("idle")
+  const [cloneError, setCloneError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const existingInputRef = useRef<HTMLInputElement>(null)
+
+  const isBusy = cloneStatus === "cloning" || cloneStatus === "success"
 
   useEffect(() => {
     if (open) {
       setTab("new")
       setName("")
       setExistingPath("")
+      setCloneStatus("idle")
+      setCloneError(null)
       setTimeout(() => inputRef.current?.focus(), 0)
     }
   }, [open])
 
   useEffect(() => {
-    if (open) {
+    if (open && !isBusy) {
       setTimeout(() => {
         if (tab === "new") inputRef.current?.focus()
         else existingInputRef.current?.focus()
       }, 0)
     }
-  }, [tab, open])
+  }, [tab, open, isBusy])
+
+  // Detect git URLs in either input
+  const activeValue = tab === "new" ? name : existingPath
+  const parsedGitUrl = useMemo(() => parseGitRepoUrl(activeValue), [activeValue])
+  const isCloneMode = parsedGitUrl !== null
 
   const kebab = toKebab(name)
   const newPath = kebab ? `${DEFAULT_NEW_PROJECT_ROOT}/${kebab}` : ""
   const trimmedExisting = existingPath.trim()
 
-  const canSubmit = tab === "new" ? !!kebab : !!trimmedExisting
+  // For clone mode: derive path from the repo name, with owner-repo fallback
+  const clonePath = parsedGitUrl ? `${DEFAULT_NEW_PROJECT_ROOT}/${parsedGitUrl.repo}` : ""
+  const cloneFallbackPath = parsedGitUrl ? `${DEFAULT_NEW_PROJECT_ROOT}/${parsedGitUrl.owner}-${parsedGitUrl.repo}` : ""
 
-  const handleSubmit = () => {
+  const canSubmit = !isBusy && (isCloneMode
+    ? !!parsedGitUrl
+    : tab === "new"
+      ? !!kebab
+      : !!trimmedExisting)
+
+  const handleSubmit = useCallback(async () => {
     if (!canSubmit) return
-    if (tab === "new") {
+
+    if (isCloneMode && parsedGitUrl) {
+      // Keep modal open with progress for clones
+      setCloneStatus("cloning")
+      setCloneError(null)
+      try {
+        await onConfirm({
+          mode: "clone",
+          localPath: clonePath,
+          fallbackPath: cloneFallbackPath,
+          title: parsedGitUrl.repo,
+          cloneUrl: toCloneUrl(activeValue),
+        })
+        setCloneStatus("success")
+        // Brief success flash then close
+        setTimeout(() => onOpenChange(false), 600)
+      } catch (error) {
+        setCloneStatus("error")
+        setCloneError(error instanceof Error ? error.message : String(error))
+      }
+    } else if (tab === "new") {
       onConfirm({ mode: "new", localPath: newPath, title: name.trim() })
+      onOpenChange(false)
     } else {
       const folderName = trimmedExisting.split("/").pop() || trimmedExisting
       onConfirm({ mode: "existing", localPath: trimmedExisting, title: folderName })
+      onOpenChange(false)
     }
-    onOpenChange(false)
-  }
+  }, [canSubmit, isCloneMode, parsedGitUrl, clonePath, activeValue, tab, newPath, name, trimmedExisting, onConfirm, onOpenChange])
+
+  const cloneIndicator = parsedGitUrl && (
+    <div className="flex items-center gap-1.5 text-xs text-primary">
+      <GitBranch className="h-3.5 w-3.5 flex-shrink-0" />
+      <span>
+        Clone <span className="font-medium">{parsedGitUrl.owner}/{parsedGitUrl.repo}</span> into {clonePath}
+      </span>
+    </div>
+  )
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="sm">
+    <Dialog open={open} onOpenChange={isBusy ? undefined : onOpenChange}>
+      <DialogContent
+        size="sm"
+        onInteractOutside={isBusy ? (e) => e.preventDefault() : undefined}
+        onEscapeKeyDown={isBusy ? (e) => e.preventDefault() : undefined}
+      >
         <DialogBody className="space-y-4">
           <DialogTitle>Add Project</DialogTitle>
 
-          <SegmentedControl
-            value={tab}
-            onValueChange={setTab}
-            options={[
-              { value: "new" as Tab, label: "New Folder" },
-              { value: "existing" as Tab, label: "Existing Path" },
-            ]}
-            className="w-full mb-2"
-            optionClassName="flex-1 justify-center"
-          />
+          {!isBusy && (
+            <SegmentedControl
+              value={tab}
+              onValueChange={setTab}
+              options={[
+                { value: "new" as Tab, label: "New Folder" },
+                { value: "existing" as Tab, label: "Existing Path" },
+              ]}
+              className="w-full mb-2"
+              optionClassName="flex-1 justify-center"
+            />
+          )}
 
-          {tab === "new" ? (
+          {isBusy ? (
+            <div className="space-y-3 py-2">
+              <div className="flex items-center gap-2.5">
+                {cloneStatus === "cloning" ? (
+                  <Loader2 className="h-4 w-4 text-primary animate-spin flex-shrink-0" />
+                ) : (
+                  <Check className="h-4 w-4 text-green-500 flex-shrink-0" />
+                )}
+                <span className="text-sm text-foreground">
+                  {cloneStatus === "cloning"
+                    ? <>Cloning <span className="font-medium">{parsedGitUrl?.owner}/{parsedGitUrl?.repo}</span>&hellip;</>
+                    : <>Cloned <span className="font-medium">{parsedGitUrl?.owner}/{parsedGitUrl?.repo}</span></>}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground font-mono pl-6.5">
+                {clonePath}
+              </p>
+            </div>
+          ) : tab === "new" ? (
             <div className="space-y-2">
               <Input
                 ref={inputRef}
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => { setName(e.target.value); setCloneError(null) }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit()
+                  if (e.key === "Enter") void handleSubmit()
                   if (e.key === "Escape") onOpenChange(false)
                 }}
-                placeholder="Project name"
+                placeholder="Project name or GitHub/GitLab URL"
               />
-              {newPath && (
+              {isCloneMode ? cloneIndicator : newPath ? (
                 <p className="text-xs text-muted-foreground font-mono">
                   {newPath}
                 </p>
-              )}
+              ) : null}
             </div>
           ) : (
             <div className="space-y-2">
@@ -112,32 +198,42 @@ export function NewProjectModal({ open, onOpenChange, onConfirm }: Props) {
                 ref={existingInputRef}
                 type="text"
                 value={existingPath}
-                onChange={(e) => setExistingPath(e.target.value)}
+                onChange={(e) => { setExistingPath(e.target.value); setCloneError(null) }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit()
+                  if (e.key === "Enter") void handleSubmit()
                   if (e.key === "Escape") onOpenChange(false)
                 }}
-                placeholder="~/Projects/my-app"
+                placeholder="~/Projects/my-app or GitHub/GitLab URL"
               />
-              <p className="text-xs text-muted-foreground">
-                The folder will be created if it doesn't exist.
-              </p>
+              {isCloneMode ? cloneIndicator : (
+                <p className="text-xs text-muted-foreground">
+                  The folder will be created if it doesn't exist.
+                </p>
+              )}
+            </div>
+          )}
+
+          {cloneError && (
+            <div className="text-sm text-destructive border border-destructive/20 bg-destructive/5 rounded-lg px-3 py-2">
+              {cloneError}
             </div>
           )}
         </DialogBody>
-        <DialogFooter>
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-          >
-            Create
-          </Button>
-        </DialogFooter>
+        {!isBusy && (
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleSubmit()}
+              disabled={!canSubmit}
+            >
+              {isCloneMode ? "Clone" : "Create"}
+            </Button>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/server/paths.ts
+++ b/src/server/paths.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process"
 import { mkdir, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
@@ -24,6 +25,69 @@ export async function ensureProjectDirectory(localPath: string) {
   if (!info.isDirectory()) {
     throw new Error("Project path must be a directory")
   }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Pick a clone destination that doesn't already exist.
+ * Tries `localPath` first, then falls back to `fallbackPath` if provided.
+ * Returns the resolved absolute path that was chosen.
+ */
+export async function resolveClonePath(localPath: string, fallbackPath?: string): Promise<string> {
+  const primary = resolveLocalPath(localPath)
+  if (!(await pathExists(primary))) {
+    return primary
+  }
+  if (fallbackPath) {
+    const secondary = resolveLocalPath(fallbackPath)
+    if (!(await pathExists(secondary))) {
+      return secondary
+    }
+  }
+  throw new Error(`Destination path '${primary}' already exists`)
+}
+
+/**
+ * Clone a git repository into the given local path.
+ * The parent directory is created if it doesn't exist.
+ * Rejects if `git clone` exits with a non-zero code.
+ */
+export async function cloneRepository(cloneUrl: string, resolvedPath: string): Promise<void> {
+  const parentDir = path.dirname(resolvedPath)
+
+  await mkdir(parentDir, { recursive: true })
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("git", ["clone", cloneUrl, resolvedPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stderr = ""
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    child.on("error", (err) => {
+      reject(new Error(`Failed to start git clone: ${err.message}`))
+    })
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        const message = stderr.trim() || `git clone exited with code ${code}`
+        reject(new Error(message))
+      }
+    })
+  })
 }
 
 export function getProjectUploadDir(localPath: string) {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -8,7 +8,7 @@ import { DiffStore } from "./diff-store"
 import { EventStore } from "./event-store"
 import { openExternal } from "./external-open"
 import { KeybindingsManager } from "./keybindings"
-import { ensureProjectDirectory } from "./paths"
+import { cloneRepository, ensureProjectDirectory, resolveClonePath } from "./paths"
 import { TerminalManager } from "./terminal-manager"
 import type { UpdateManager } from "./update-manager"
 import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
@@ -761,6 +761,14 @@ export function createWsRouter({
           const project = await store.openProject(command.localPath, command.title)
           await refreshDiscovery()
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: { projectId: project.id } })
+          break
+        }
+        case "project.clone": {
+          const cloneDest = await resolveClonePath(command.localPath, command.fallbackPath)
+          await cloneRepository(command.cloneUrl, cloneDest)
+          const project = await store.openProject(cloneDest, command.title)
+          await refreshDiscovery()
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: { projectId: project.id, localPath: cloneDest } })
           break
         }
         case "project.remove": {

--- a/src/shared/git-url.ts
+++ b/src/shared/git-url.ts
@@ -1,0 +1,54 @@
+/**
+ * Utilities for detecting and parsing GitHub/GitLab clone URLs.
+ */
+
+const GIT_URL_PATTERNS = [
+  // HTTPS: https://github.com/owner/repo or https://github.com/owner/repo.git
+  /^https?:\/\/(github\.com|gitlab\.com)\/([^/]+)\/([^/.]+?)(?:\.git)?\/?$/,
+  // SSH: git@github.com:owner/repo.git
+  /^git@(github\.com|gitlab\.com):([^/]+)\/([^/.]+?)(?:\.git)?\/?$/,
+]
+
+export interface ParsedGitUrl {
+  host: string
+  owner: string
+  repo: string
+  url: string
+}
+
+/**
+ * Check if a string looks like a GitHub or GitLab repository URL.
+ */
+export function isGitRepoUrl(input: string): boolean {
+  const trimmed = input.trim()
+  return GIT_URL_PATTERNS.some((pattern) => pattern.test(trimmed))
+}
+
+/**
+ * Parse a GitHub/GitLab URL into its components.
+ * Returns null if the input isn't a valid git repo URL.
+ */
+export function parseGitRepoUrl(input: string): ParsedGitUrl | null {
+  const trimmed = input.trim()
+  for (const pattern of GIT_URL_PATTERNS) {
+    const match = trimmed.match(pattern)
+    if (match) {
+      return {
+        host: match[1]!,
+        owner: match[2]!,
+        repo: match[3]!,
+        url: trimmed,
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Normalize a git repo URL to HTTPS format for cloning.
+ */
+export function toCloneUrl(input: string): string {
+  const parsed = parseGitRepoUrl(input)
+  if (!parsed) return input.trim()
+  return `https://${parsed.host}/${parsed.owner}/${parsed.repo}.git`
+}

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -50,6 +50,7 @@ export type TerminalEvent =
 export type ClientCommand =
   | { type: "project.open"; localPath: string }
   | { type: "project.create"; localPath: string; title: string }
+  | { type: "project.clone"; cloneUrl: string; localPath: string; fallbackPath?: string; title: string }
   | { type: "project.remove"; projectId: string }
   | { type: "sidebar.reorderProjectGroups"; projectIds: string[] }
   | { type: "project.readDiffPatch"; projectId: string; path: string }


### PR DESCRIPTION
## Summary
- Detect GitHub/GitLab URLs (HTTPS and SSH) pasted into the Add Project modal and clone the repo instead of creating a blank project
- Show inline clone indicator with repo owner/name and destination path when a URL is detected
- Async modal UX: spinner during clone, green checkmark on success, inline error on failure with retry
- Graceful path collision handling: falls back to `owner-repo` directory name if `repo` already exists

## Test plan
- [ ] Paste a GitHub HTTPS URL (e.g. `https://github.com/anthropics/claude-code`) into New Folder tab — should show clone indicator and clone on submit
- [ ] Paste a GitLab SSH URL (e.g. `git@gitlab.com:owner/repo.git`) — should detect and show clone indicator
- [ ] Clone a repo where the directory name already exists — should fall back to `owner-repo` path
- [ ] Clone a nonexistent repo — should show inline error, modal stays open for retry
- [ ] Verify regular project creation (no URL) still works as before
- [ ] Verify Existing Path tab also detects URLs and triggers clone mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)