### PR TITLE
Trust X-Forwarded-Proto when serving behind HTTPS tunnels

### DIFF
--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -11,10 +11,15 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-async function startPasswordServer() {
+async function startPasswordServer(options: { trustProxy?: boolean; port?: number } = {}) {
   const projectDir = await mkdtemp(path.join(tmpdir(), "kanna-auth-test-"))
   tempDirs.push(projectDir)
-  const server = await startKannaServer({ port: 4320, strictPort: true, password: "secret" })
+  const server = await startKannaServer({
+    port: options.port ?? 4320,
+    strictPort: true,
+    password: "secret",
+    trustProxy: options.trustProxy ?? false,
+  })
   const project = await server.store.openProject(projectDir, "Project")
   return { server, projectDir, project }
 }
@@ -164,6 +169,92 @@ describe("password auth", () => {
       })
       expect(contentResponse.status).toBe(200)
       expect(await contentResponse.text()).toBe("hello from upload")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("ignores forwarded headers when trustProxy is off", async () => {
+    const { server } = await startPasswordServer({ port: 54321 })
+
+    try {
+      const response = await fetch(`http://localhost:${server.port}/`, {
+        redirect: "manual",
+        headers: {
+          Accept: "text/html",
+          "X-Forwarded-Host": "evil.test",
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(response.status).toBe(302)
+      expect(response.headers.get("location")).toBe(`http://localhost:${server.port}/auth/login?next=%2F`)
+
+      const loginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.test",
+          "X-Forwarded-Host": "evil.test",
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(loginResponse.status).toBe(403)
+
+      const goodLoginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `http://localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(goodLoginResponse.status).toBe(200)
+      const cookieHeader = goodLoginResponse.headers.get("set-cookie") ?? ""
+      expect(cookieHeader).not.toContain("Secure")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("honors forwarded headers when trustProxy is on", async () => {
+    const { server } = await startPasswordServer({ port: 54322, trustProxy: true })
+
+    try {
+      const redirect = await fetch(`http://localhost:${server.port}/`, {
+        redirect: "manual",
+        headers: {
+          Accept: "text/html",
+          "X-Forwarded-Host": `localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(redirect.status).toBe(302)
+      expect(redirect.headers.get("location")).toBe(`https://localhost:${server.port}/auth/login?next=%2F`)
+
+      const loginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `https://localhost:${server.port}`,
+          "X-Forwarded-Host": `localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(loginResponse.status).toBe(200)
+      expect(loginResponse.headers.get("set-cookie") ?? "").toContain("Secure")
+
+      const evilResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `http://localhost:${server.port}`,
+        },
+      })
+      expect(evilResponse.status).toBe(200)
     } finally {
       await server.stop()
     }

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -47,11 +47,29 @@ function sanitizeNextPath(nextPath: string | null | undefined) {
   return nextPath
 }
 
-function shouldUseSecureCookie(req: Request) {
+function forwardedProto(req: Request): string | null {
+  const xfp = req.headers.get("x-forwarded-proto")
+  if (xfp) return xfp.split(",")[0].trim().toLowerCase()
+  return null
+}
+
+function effectiveOrigin(req: Request, trustProxy: boolean): string {
+  const url = new URL(req.url)
+  if (!trustProxy) return url.origin
+  const proto = forwardedProto(req)
+  const scheme = proto ?? url.protocol.replace(":", "")
+  return `${scheme}://${url.host}`
+}
+
+function shouldUseSecureCookie(req: Request, trustProxy: boolean) {
+  if (trustProxy) {
+    const proto = forwardedProto(req)
+    if (proto) return proto === "https"
+  }
   return new URL(req.url).protocol === "https:"
 }
 
-function buildCookie(name: string, value: string, req: Request, extras: string[] = []) {
+function buildCookie(name: string, value: string, req: Request, trustProxy: boolean, extras: string[] = []) {
   const parts = [
     `${name}=${encodeURIComponent(value)}`,
     "Path=/",
@@ -59,7 +77,7 @@ function buildCookie(name: string, value: string, req: Request, extras: string[]
     "SameSite=Strict",
   ]
 
-  if (shouldUseSecureCookie(req)) {
+  if (shouldUseSecureCookie(req, trustProxy)) {
     parts.push("Secure")
   }
 
@@ -101,9 +119,22 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;")
 }
 
-export function createAuthManager(password: string): AuthManager {
+export interface AuthManagerOptions {
+  /**
+   * When true, the auth layer trusts X-Forwarded-Proto to decide whether the
+   * public origin is https. The hostname always comes from the Host header
+   * (never X-Forwarded-Host) because X-Forwarded-Host is passed through by
+   * some tunnels unmodified and would otherwise allow open redirects.
+   * Enable only when the server is reachable solely through a trusted reverse
+   * proxy such as cloudflared.
+   */
+  trustProxy?: boolean
+}
+
+export function createAuthManager(password: string, options: AuthManagerOptions = {}): AuthManager {
   const sessions = new Set<string>()
   const expectedPassword = Buffer.from(password)
+  const trustProxy = options.trustProxy ?? false
 
   function getSessionToken(req: Request) {
     return parseCookies(req.headers.get("cookie")).get(SESSION_COOKIE_NAME) ?? null
@@ -117,13 +148,15 @@ export function createAuthManager(password: string): AuthManager {
   function validateOrigin(req: Request) {
     const origin = req.headers.get("origin")
     if (!origin) return true
-    return origin === new URL(req.url).origin
+    if (origin === new URL(req.url).origin) return true
+    if (!trustProxy) return false
+    return origin === effectiveOrigin(req, trustProxy)
   }
 
   function createSessionCookie(req: Request) {
     const sessionToken = randomBytes(32).toString("base64url")
     sessions.add(sessionToken)
-    return buildCookie(SESSION_COOKIE_NAME, sessionToken, req)
+    return buildCookie(SESSION_COOKIE_NAME, sessionToken, req, trustProxy)
   }
 
   function clearSessionCookie(req: Request) {
@@ -131,7 +164,7 @@ export function createAuthManager(password: string): AuthManager {
     if (sessionToken) {
       sessions.delete(sessionToken)
     }
-    return buildCookie(SESSION_COOKIE_NAME, "", req, ["Max-Age=0"])
+    return buildCookie(SESSION_COOKIE_NAME, "", req, trustProxy, ["Max-Age=0"])
   }
 
   function verifyPassword(candidate: string) {
@@ -152,7 +185,7 @@ export function createAuthManager(password: string): AuthManager {
   function unauthorizedResponse(req: Request) {
     if (req.method === "GET" && requestWantsHtml(req)) {
       const url = new URL(req.url)
-      const loginUrl = new URL("/auth/login", req.url)
+      const loginUrl = new URL("/auth/login", effectiveOrigin(req, trustProxy))
       loginUrl.searchParams.set("next", sanitizeNextPath(`${url.pathname}${url.search}`))
       return Response.redirect(loginUrl, 302)
     }
@@ -163,7 +196,7 @@ export function createAuthManager(password: string): AuthManager {
   function renderLoginPage(req: Request) {
     if (isAuthenticated(req)) {
       const currentUrl = new URL(req.url)
-      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), req.url), 302)
+      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), effectiveOrigin(req, trustProxy)), 302)
     }
 
     const currentUrl = new URL(req.url)
@@ -264,7 +297,7 @@ export function createAuthManager(password: string): AuthManager {
         return Response.json({ error: "Invalid password" }, { status: 401 })
       }
 
-      const redirectUrl = new URL("/auth/login", req.url)
+      const redirectUrl = new URL("/auth/login", effectiveOrigin(req, trustProxy))
       redirectUrl.searchParams.set("error", "1")
       redirectUrl.searchParams.set("next", sanitizeNextPath(nextPath || fallbackNextPath))
       return Response.redirect(redirectUrl, 302)
@@ -272,7 +305,7 @@ export function createAuthManager(password: string): AuthManager {
 
     const response = wantsJson
       ? Response.json({ ok: true, nextPath: sanitizeNextPath(nextPath || fallbackNextPath) })
-      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), req.url), 302)
+      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), effectiveOrigin(req, trustProxy)), 302)
 
     response.headers.set("Set-Cookie", createSessionCookie(req))
     return response

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -49,6 +49,7 @@ export interface CliRuntimeDeps {
   startServer: (options: CliOptions & {
     update: CliUpdateOptions
     onMigrationProgress?: (message: string) => void
+    trustProxy?: boolean
   }) => Promise<{ port: number; stop: () => Promise<void> }>
   fetchLatestVersion: (packageName: string) => Promise<string>
   installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
@@ -268,6 +269,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   const { port, stop } = await deps.startServer({
     ...parsedArgs.options,
+    trustProxy: isShareEnabled(parsedArgs.options.share),
     onMigrationProgress: deps.log,
     update: {
       version: deps.version,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -60,6 +60,14 @@ export interface StartKannaServerOptions {
   host?: string
   password?: string | null
   strictPort?: boolean
+  /**
+   * When true, the auth layer trusts X-Forwarded-Proto / X-Forwarded-Host
+   * headers for CSRF origin checks, redirect URLs, and the Secure cookie flag.
+   * Only enable when the server is reachable solely through a trusted reverse
+   * proxy such as cloudflared — otherwise these headers are client-controlled
+   * and allow CSRF bypass / open redirects.
+   */
+  trustProxy?: boolean
   onMigrationProgress?: (message: string) => void
   update?: {
     version: string
@@ -72,7 +80,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const port = options.port ?? 3210
   const hostname = options.host ?? "127.0.0.1"
   const strictPort = options.strictPort ?? false
-  const auth = options.password ? createAuthManager(options.password) : null
+  const auth = options.password ? createAuthManager(options.password, { trustProxy: options.trustProxy ?? false }) : null
   const store = new EventStore()
   const diffStore = new DiffStore(store.dataDir)
   const machineDisplayName = getMachineDisplayName()


### PR DESCRIPTION
## Summary

Makes `--cloudflared` (and other HTTPS-terminating reverse proxies) work correctly with `--password` protection. Without this, logging in through `https://<tunnel-hostname>` returns **403 Forbidden** on `/auth/login` POST. The fix is gated behind an explicit `trustProxy` flag so direct-reach deployments (LAN, `--host`, `--remote`, local dev) cannot be attacked via forwarded-header spoofing.

## Problem

When Kanna runs behind an HTTPS-terminating proxy, the upstream connection is plain HTTP. `new URL(req.url)` reports `http://...`, which breaks three things:

1. **`/auth/login` POST → 403.** `validateOrigin` compares the browser's `Origin: https://host` header against `new URL(req.url).origin` (`http://host`). Mismatch ⇒ 403.
2. **Session cookie missing `Secure`.** `shouldUseSecureCookie` checks `req.url` protocol, so cookies set on an HTTPS-served login are not marked `Secure` and some browsers drop them.
3. **Redirects use `http://`.** `Response.redirect(new URL(..., req.url))` produces `Location: http://...`, forcing the edge to upgrade or causing mixed-content warnings.

Repro:

```bash
kanna --cloudflared <token> --password <pw>
# open https://<public-hostname>, try to log in → 403
```

## Fix

Read `X-Forwarded-Proto` to reconstruct the effective public origin, and use it for:

- origin validation (accepts either the direct `req.url` origin or the forwarded one)
- redirect `Location` URLs (login page, login error, post-login, unauthorized HTML)
- the `Secure` cookie flag

Gated behind an explicit `trustProxy` option on `createAuthManager` / `startKannaServer`. The CLI auto-enables it for `--cloudflared` and `--share` (server binds `127.0.0.1` in those modes, so the only ingress is the TLS-terminating tunnel). For all other modes it stays off and behavior is unchanged.

Hostname is always taken from the `Host` header reflected in `req.url`; `X-Forwarded-Host` is never trusted — some tunnels pass it through unmodified, which would preserve an open-redirect vector.

## Security rationale

Trusting forwarded headers unconditionally would allow:

1. **Host-header / forwarded-header injection → open redirect + CSRF bypass.** Any client that can reach the server directly could set `X-Forwarded-Host: evil.test` + `X-Forwarded-Proto: https` to divert post-login redirects to an attacker domain and bypass `validateOrigin`.
2. **Spoofed `X-Forwarded-Proto` forcing `Secure` on plain HTTP.** Direct-HTTP users would be locked out of their session.

The `trustProxy` gate plus the "never trust `X-Forwarded-Host`" rule closes both.

## Test plan

- [x] `curl https://<tunnel>/` returns `302 Location: https://<tunnel>/auth/login?next=%2F` (was `http://...`)
- [x] `curl -X POST -H "Origin: https://<tunnel>" https://<tunnel>/auth/login` with wrong password returns `302` to `?error=1` (was `403`)
- [x] Browser login flow end-to-end through `cloudflared --token` works with `--password`
- [x] New auth tests: evil forwarded headers ignored when `trustProxy` is off; legitimate forwarded proto flips `Secure` cookie + HTTPS redirect when on
- [ ] Localhost / `--remote` / `--host <lan-ip>` unchanged (no forwarded headers trusted ⇒ same behavior)
- [ ] Existing `src/server/auth.test.ts` still passes