### PR TITLE
feat(auto-continue): auto-continue on Claude/Codex rate limit with scheduled reset

### DIFF
--- a/.c3/README.md
+++ b/.c3/README.md
@@ -1,0 +1,64 @@
+---
+id: c3-0
+title: Kanna
+goal: Provide a beautiful browser UI for Claude Code and Codex CLIs, with project-first navigation, multi-provider agent coordination, and event-sourced local persistence.
+summary: Bun+React web app that drives Claude Agent SDK and Codex App Server over WebSocket, persisting all state as append-only JSONL and rendering live transcripts with hydrated tool calls.
+c3-version: 4
+---
+
+# ${PROJECT}
+## Goal
+
+${GOAL}
+
+<!--
+WHY DOCUMENT:
+- Enforce consistency (current and future work)
+- Enforce quality (current and future work)
+- Support auditing (verifiable, cross-referenceable)
+- Be maintainable (worth the upkeep cost)
+
+ANTI-GOALS:
+- Over-documenting -> stale quickly, maintenance burden
+- Text walls -> hard to review, hard to maintain
+- Isolated content -> can't verify from multiple angles
+
+PRINCIPLES:
+- Diagrams over text. Always.
+- Fewer meaningful sections > many shallow sections
+- Add sections that elaborate the Goal - remove those that don't
+- Cross-content integrity: same fact from different angles aids auditing
+
+GUARDRAILS:
+- Must have: Goal + Abstract Constraints + Containers table
+- Prefer: 3-5 focused sections
+- This is the entry point - navigable, not exhaustive
+
+REF HYGIENE (context level = system-wide concerns):
+- Cite refs that govern cross-container behavior
+  (system-wide error strategy, auth patterns, inter-container data flow)
+- Container-specific patterns belong in container docs
+- If a ref only applies within one container, cite it there instead
+
+Common sections (create whatever serves your Goal):
+- Overview (diagram), Actors, Abstract Constraints, Containers, External Systems, Linkages
+
+Delete this comment block after drafting.
+-->
+## Abstract Constraints
+
+| Constraint | Rationale | Affected Containers |
+|------------|-----------|---------------------|
+| Event sourcing for all state mutations | Replayable history, crash-safe, debuggable audit trail | c3-2 |
+| CQRS: write path (events) decoupled from read path (derived models) | UI subscribes to fast snapshots without touching the log | c3-1, c3-2 |
+| Reactive WebSocket broadcasting of snapshots on every state change | Multiple tabs and agents stay consistent in real time | c3-1, c3-2 |
+| Local-first: all user data under ~/.kanna/data, default bind is localhost | Zero server infra, user owns their data, safe by default | c3-2 |
+| Provider-agnostic agent coordination (Claude Agent SDK + Codex App Server) | Per-turn provider/model/effort picks without forking transcript model | c3-1, c3-2 |
+| Strong TypeScript typing — no any/untyped shapes at boundaries | Shared types guarantee client+server agree on protocol + events | c3-1, c3-2, c3-3 |
+## Containers
+
+| ID | Name | Boundary | Status | Responsibilities | Goal Contribution |
+|------|------|------|------|------|------|
+| c3-1 | Client | app | implemented | Render transcript, accept chat input, manage sidebar + settings, subscribe to WebSocket pushes | Provides the browser UX that makes Claude/Codex usable through a beautiful chat view |
+| c3-2 | Server | service | implemented | Host HTTP+WS on localhost, drive agents, persist events, derive read models | Single-binary local backend that coordinates providers and owns all state |
+| c3-3 | Shared | library | implemented | Define protocol, types, tool normalization, ports, branding shared by client and server | Guarantees client + server agree on wire format and domain types |

--- a/.c3/_index/structural.md
+++ b/.c3/_index/structural.md
@@ -1,7 +1,10 @@
 # C3 Structural Index
-<!-- hash: sha256:19399c2ae7a3d447c2fe501ae0acb7cd27cad75fdd6d54bf58642780b6da97a0 -->
+<!-- hash: sha256:651c48aee01eb39da48679d02f5280daccec070ea3eb1b6d338bb14ed8936ef8 -->
 
 ## adr-00000000-c3-adoption — C3 Architecture Documentation Adoption (adr)
+blocks: Goal ✓
+
+## adr-20260420-import-button-mobile-visible — import-button-mobile-visible (adr)
 blocks: Goal ✓
 
 ## c3-0 — Kanna (context)

--- a/.c3/_index/structural.md
+++ b/.c3/_index/structural.md
@@ -1,0 +1,474 @@
+# C3 Structural Index
+<!-- hash: sha256:19399c2ae7a3d447c2fe501ae0acb7cd27cad75fdd6d54bf58642780b6da97a0 -->
+
+## adr-00000000-c3-adoption — C3 Architecture Documentation Adoption (adr)
+blocks: Goal ✓
+
+## c3-0 — Kanna (context)
+reverse deps: adr-00000000-c3-adoption, c3-1, c3-2, c3-3
+blocks: Abstract Constraints ✓, Containers ✓, Goal ✓
+
+## c3-1 — Client (container)
+context: c3-0
+reverse deps: c3-101, c3-102, c3-103, c3-110, c3-111, c3-112, c3-113, c3-114, c3-115, c3-116, c3-117, c3-118
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ✓, Goal ✓, Responsibilities ✓
+
+## c3-101 — socket-client (component)
+container: c3-1 | context: c3-0
+refs: ref-ws-subscription, ref-strong-typing
+files: src/client/app/socket.ts, src/client/app/socket.test.ts
+constraints from: c3-0, c3-1, ref-ws-subscription, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-102 — state-stores (component)
+container: c3-1 | context: c3-0
+refs: ref-zustand-store, ref-strong-typing, ref-colocated-bun-test
+files: src/client/stores/**/*.ts
+constraints from: c3-0, c3-1, ref-zustand-store, ref-strong-typing, ref-colocated-bun-test
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-103 — ui-primitives (component)
+container: c3-1 | context: c3-0
+refs: ref-strong-typing
+files: src/client/components/ui/**/*.tsx
+constraints from: c3-0, c3-1, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-110 — app-shell (component)
+container: c3-1 | context: c3-0
+refs: ref-ws-subscription, ref-cqrs-read-models
+files: src/main.tsx, src/client/app/App.tsx, src/client/app/App.test.tsx, src/client/app/useKannaState.ts, src/client/app/useKannaState.test.ts, src/client/app/derived.ts, src/client/app/chatFocusPolicy.ts, src/client/app/chatFocusPolicy.test.ts, src/client/app/chatNotifications.ts, src/client/app/PageHeader.tsx, src/client/components/LocalDev.tsx, src/client/hooks/**/*.ts, src/client/hooks/**/*.tsx, src/client/lib/**/*.ts
+constraints from: c3-0, c3-1, ref-ws-subscription, ref-cqrs-read-models
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-111 — sidebar (component)
+container: c3-1 | context: c3-0
+refs: ref-cqrs-read-models, ref-zustand-store
+files: src/client/app/KannaSidebar.tsx, src/client/app/sidebarNumberJump.ts, src/client/app/sidebarNumberJump.test.ts
+constraints from: c3-0, c3-1, ref-cqrs-read-models, ref-zustand-store
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-112 — chat-page (component)
+container: c3-1 | context: c3-0
+refs: ref-ws-subscription, ref-cqrs-read-models
+files: src/client/app/ChatPage/**/*.ts, src/client/app/ChatPage/**/*.tsx, src/client/app/ChatPage.test.ts, src/client/app/useStickyChatFocus.ts, src/client/app/useRightSidebarToggleAnimation.ts, src/client/app/useTerminalToggleAnimation.ts
+constraints from: c3-0, c3-1, ref-ws-subscription, ref-cqrs-read-models
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-113 — transcript (component)
+container: c3-1 | context: c3-0
+refs: ref-tool-hydration, ref-provider-adapter
+files: src/client/app/KannaTranscript.tsx, src/client/app/KannaTranscript.test.tsx
+constraints from: c3-0, c3-1, ref-tool-hydration, ref-provider-adapter
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-114 — messages-renderer (component)
+container: c3-1 | context: c3-0
+refs: ref-tool-hydration, ref-strong-typing
+files: src/client/components/messages/**/*.tsx, src/client/components/messages/**/*.ts
+constraints from: c3-0, c3-1, ref-tool-hydration, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-115 — chat-ui-chrome (component)
+container: c3-1 | context: c3-0
+refs: ref-provider-adapter, ref-zustand-store
+files: src/client/components/chat-ui/**/*.tsx, src/client/components/chat-ui/**/*.ts
+constraints from: c3-0, c3-1, ref-provider-adapter, ref-zustand-store
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-116 — settings-page (component)
+container: c3-1 | context: c3-0
+refs: ref-zustand-store, ref-local-first-data
+files: src/client/app/SettingsPage.tsx, src/client/app/SettingsPage.test.tsx
+constraints from: c3-0, c3-1, ref-zustand-store, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-117 — local-projects-page (component)
+container: c3-1 | context: c3-0
+refs: ref-ws-subscription, ref-local-first-data
+files: src/client/app/LocalProjectsPage.tsx, src/client/components/NewProjectModal.tsx
+constraints from: c3-0, c3-1, ref-ws-subscription, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-118 — terminal-workspace (component)
+container: c3-1 | context: c3-0
+refs: ref-zustand-store, ref-ws-subscription
+files: src/client/app/ChatPage/TerminalWorkspaceShell.tsx, src/client/app/terminalToggleAnimation.ts, src/client/app/terminalToggleAnimation.test.ts, src/client/app/terminalLayoutResize.ts, src/client/app/terminalLayoutResize.test.ts
+constraints from: c3-0, c3-1, ref-zustand-store, ref-ws-subscription
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-2 — Server (container)
+context: c3-0
+reverse deps: c3-201, c3-202, c3-203, c3-204, c3-205, c3-206, c3-207, c3-208, c3-209, c3-210, c3-211, c3-212, c3-213, c3-214, c3-215, c3-216, c3-217, c3-218, c3-219, c3-220, c3-221, c3-222
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ✓, Goal ✓, Responsibilities ✓
+
+## c3-201 — cli-entry (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/cli.ts, src/server/cli-runtime.ts, src/server/cli-runtime.test.ts, src/server/cli-supervisor.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-202 — http-ws-server (component)
+container: c3-2 | context: c3-0
+refs: ref-ws-subscription, ref-local-first-data
+files: src/server/server.ts
+constraints from: c3-0, c3-2, ref-ws-subscription, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-203 — auth (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/auth.ts, src/server/auth.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-204 — paths-config (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/paths.ts, src/server/machine-name.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-205 — events-schema (component)
+container: c3-2 | context: c3-0
+refs: ref-event-sourcing, ref-strong-typing
+files: src/server/events.ts, src/server/harness-types.ts
+constraints from: c3-0, c3-2, ref-event-sourcing, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-206 — event-store (component)
+container: c3-2 | context: c3-0
+refs: ref-event-sourcing, ref-local-first-data, ref-colocated-bun-test
+files: src/server/event-store.ts, src/server/event-store.test.ts
+constraints from: c3-0, c3-2, ref-event-sourcing, ref-local-first-data, ref-colocated-bun-test
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-207 — read-models (component)
+container: c3-2 | context: c3-0
+refs: ref-cqrs-read-models, ref-strong-typing
+files: src/server/read-models.ts, src/server/read-models.test.ts
+constraints from: c3-0, c3-2, ref-cqrs-read-models, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-208 — ws-router (component)
+container: c3-2 | context: c3-0
+refs: ref-ws-subscription, ref-cqrs-read-models, ref-colocated-bun-test
+files: src/server/ws-router.ts, src/server/ws-router.test.ts
+constraints from: c3-0, c3-2, ref-ws-subscription, ref-cqrs-read-models, ref-colocated-bun-test
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-209 — process-utils (component)
+container: c3-2 | context: c3-0
+refs: ref-strong-typing
+files: src/server/process-utils.ts, src/server/process-utils.test.ts
+constraints from: c3-0, c3-2, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-210 — agent-coordinator (component)
+container: c3-2 | context: c3-0
+refs: ref-provider-adapter, ref-event-sourcing, ref-tool-hydration, ref-colocated-bun-test
+files: src/server/agent.ts, src/server/agent.test.ts
+constraints from: c3-0, c3-2, ref-provider-adapter, ref-event-sourcing, ref-tool-hydration, ref-colocated-bun-test
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-211 — codex-app-server (component)
+container: c3-2 | context: c3-0
+refs: ref-provider-adapter, ref-strong-typing
+files: src/server/codex-app-server.ts, src/server/codex-app-server.test.ts, src/server/codex-app-server-protocol.ts
+constraints from: c3-0, c3-2, ref-provider-adapter, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-212 — provider-catalog (component)
+container: c3-2 | context: c3-0
+refs: ref-provider-adapter
+files: src/server/provider-catalog.ts, src/server/provider-catalog.test.ts
+constraints from: c3-0, c3-2, ref-provider-adapter
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-213 — quick-response (component)
+container: c3-2 | context: c3-0
+refs: ref-provider-adapter
+files: src/server/quick-response.ts, src/server/quick-response.test.ts, src/server/generate-title.ts, src/server/title-generation.live.test.ts, src/server/generate-commit-message.ts, src/server/generate-commit-message.test.ts, src/server/llm-provider.ts, src/server/llm-provider.test.ts
+constraints from: c3-0, c3-2, ref-provider-adapter
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-214 — discovery (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/discovery.ts, src/server/discovery.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-215 — diff-store (component)
+container: c3-2 | context: c3-0
+refs: ref-tool-hydration
+files: src/server/diff-store.ts, src/server/diff-store.test.ts
+constraints from: c3-0, c3-2, ref-tool-hydration
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-216 — terminal-manager (component)
+container: c3-2 | context: c3-0
+refs: ref-ws-subscription
+files: src/server/terminal-manager.ts, src/server/terminal-manager.test.ts
+constraints from: c3-0, c3-2, ref-ws-subscription
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-217 — uploads (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/uploads.ts, src/server/uploads.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-218 — share (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/share.ts, src/server/share.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-219 — update-manager (component)
+container: c3-2 | context: c3-0
+refs: ref-cqrs-read-models
+files: src/server/update-manager.ts, src/server/update-manager.test.ts
+constraints from: c3-0, c3-2, ref-cqrs-read-models
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-220 — restart (component)
+container: c3-2 | context: c3-0
+refs: ref-ws-subscription
+files: src/server/restart.ts, src/server/restart.test.ts
+constraints from: c3-0, c3-2, ref-ws-subscription
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-221 — external-open (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/external-open.ts, src/server/external-open.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-222 — keybindings (component)
+container: c3-2 | context: c3-0
+refs: ref-local-first-data
+files: src/server/keybindings.ts, src/server/keybindings.test.ts
+constraints from: c3-0, c3-2, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-3 — Shared (container)
+context: c3-0
+reverse deps: c3-301, c3-302, c3-303, c3-304, c3-305, c3-306
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ✓, Goal ✓, Responsibilities ✓
+
+## c3-301 — types (component)
+container: c3-3 | context: c3-0
+refs: ref-strong-typing
+files: src/shared/types.ts
+constraints from: c3-0, c3-3, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-302 — protocol (component)
+container: c3-3 | context: c3-0
+refs: ref-ws-subscription, ref-strong-typing
+files: src/shared/protocol.ts
+constraints from: c3-0, c3-3, ref-ws-subscription, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-303 — tools (component)
+container: c3-3 | context: c3-0
+refs: ref-tool-hydration, ref-strong-typing, ref-colocated-bun-test
+files: src/shared/tools.ts, src/shared/tools.test.ts
+constraints from: c3-0, c3-3, ref-tool-hydration, ref-strong-typing, ref-colocated-bun-test
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-304 — ports (component)
+container: c3-3 | context: c3-0
+refs: ref-strong-typing
+files: src/shared/ports.ts, src/shared/dev-ports.ts, src/shared/dev-ports.test.ts
+constraints from: c3-0, c3-3, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-305 — branding (component)
+container: c3-3 | context: c3-0
+refs: ref-local-first-data
+files: src/shared/branding.ts, src/shared/branding.test.ts
+constraints from: c3-0, c3-3, ref-local-first-data
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## c3-306 — share-shared (component)
+container: c3-3 | context: c3-0
+refs: ref-strong-typing
+files: src/shared/share.ts
+constraints from: c3-0, c3-3, ref-strong-typing
+blocks: Container Connection ✓, Dependencies ✓, Goal ✓, Related Refs ✓
+
+## ref-colocated-bun-test — Colocated Bun Test (ref)
+reverse deps: c3-102, c3-206, c3-208, c3-210, c3-303
+files: **/*.test.ts, **/*.test.tsx, **/*.live.test.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-cqrs-read-models — CQRS Read Models (ref)
+reverse deps: c3-110, c3-111, c3-112, c3-207, c3-208, c3-219
+files: src/server/read-models.ts, src/server/read-models.test.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-event-sourcing — Event Sourcing (ref)
+reverse deps: c3-205, c3-206, c3-210
+files: src/server/events.ts, src/server/event-store.ts, src/server/event-store.test.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-local-first-data — Local-First Data (ref)
+reverse deps: c3-116, c3-117, c3-201, c3-202, c3-203, c3-204, c3-206, c3-214, c3-217, c3-218, c3-221, c3-222, c3-305
+files: src/server/paths.ts, src/shared/branding.ts, src/server/cli.ts, src/server/auth.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-provider-adapter — Provider Adapter (ref)
+reverse deps: c3-113, c3-115, c3-210, c3-211, c3-212, c3-213
+files: src/server/agent.ts, src/server/provider-catalog.ts, src/server/codex-app-server.ts, src/server/codex-app-server-protocol.ts, src/server/quick-response.ts, src/server/llm-provider.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-strong-typing — Strong Typing Policy (ref)
+reverse deps: c3-101, c3-102, c3-103, c3-114, c3-205, c3-207, c3-209, c3-211, c3-301, c3-302, c3-303, c3-304, c3-306
+files: src/shared/**/*.ts, tsconfig.json
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-tool-hydration — Tool Call Hydration (ref)
+reverse deps: c3-113, c3-114, c3-210, c3-215, c3-303
+files: src/shared/tools.ts, src/shared/tools.test.ts, src/client/components/messages/**/*.tsx, src/server/agent.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-ws-subscription — WebSocket Subscription (ref)
+reverse deps: c3-101, c3-110, c3-112, c3-117, c3-118, c3-202, c3-208, c3-216, c3-220, c3-302
+files: src/shared/protocol.ts, src/server/ws-router.ts, src/client/app/socket.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-zustand-store — Zustand Store Pattern (ref)
+reverse deps: c3-102, c3-111, c3-115, c3-116, c3-118
+files: src/client/stores/**/*.ts
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## File Map
+**/*.live.test.ts → ref-colocated-bun-test
+**/*.test.ts → ref-colocated-bun-test
+**/*.test.tsx → ref-colocated-bun-test
+src/client/app/App.test.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/App.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/ChatPage.test.ts → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/ChatPage/**/*.ts → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/ChatPage/**/*.tsx → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/ChatPage/TerminalWorkspaceShell.tsx → c3-118 | refs: ref-ws-subscription, ref-zustand-store
+src/client/app/KannaSidebar.tsx → c3-111 | refs: ref-cqrs-read-models, ref-zustand-store
+src/client/app/KannaTranscript.test.tsx → c3-113 | refs: ref-provider-adapter, ref-tool-hydration
+src/client/app/KannaTranscript.tsx → c3-113 | refs: ref-provider-adapter, ref-tool-hydration
+src/client/app/LocalProjectsPage.tsx → c3-117 | refs: ref-local-first-data, ref-ws-subscription
+src/client/app/PageHeader.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/SettingsPage.test.tsx → c3-116 | refs: ref-local-first-data, ref-zustand-store
+src/client/app/SettingsPage.tsx → c3-116 | refs: ref-local-first-data, ref-zustand-store
+src/client/app/chatFocusPolicy.test.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/chatFocusPolicy.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/chatNotifications.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/derived.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/sidebarNumberJump.test.ts → c3-111 | refs: ref-cqrs-read-models, ref-zustand-store
+src/client/app/sidebarNumberJump.ts → c3-111 | refs: ref-cqrs-read-models, ref-zustand-store
+src/client/app/socket.test.ts → c3-101 | refs: ref-strong-typing, ref-ws-subscription
+src/client/app/socket.ts → c3-101, ref-ws-subscription | refs: ref-strong-typing, ref-ws-subscription
+src/client/app/terminalLayoutResize.test.ts → c3-118 | refs: ref-ws-subscription, ref-zustand-store
+src/client/app/terminalLayoutResize.ts → c3-118 | refs: ref-ws-subscription, ref-zustand-store
+src/client/app/terminalToggleAnimation.test.ts → c3-118 | refs: ref-ws-subscription, ref-zustand-store
+src/client/app/terminalToggleAnimation.ts → c3-118 | refs: ref-ws-subscription, ref-zustand-store
+src/client/app/useKannaState.test.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/useKannaState.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/useRightSidebarToggleAnimation.ts → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/useStickyChatFocus.ts → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/app/useTerminalToggleAnimation.ts → c3-112 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/components/LocalDev.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/components/NewProjectModal.tsx → c3-117 | refs: ref-local-first-data, ref-ws-subscription
+src/client/components/chat-ui/**/*.ts → c3-115 | refs: ref-provider-adapter, ref-zustand-store
+src/client/components/chat-ui/**/*.tsx → c3-115 | refs: ref-provider-adapter, ref-zustand-store
+src/client/components/messages/**/*.ts → c3-114 | refs: ref-strong-typing, ref-tool-hydration
+src/client/components/messages/**/*.tsx → c3-114, ref-tool-hydration | refs: ref-strong-typing, ref-tool-hydration
+src/client/components/ui/**/*.tsx → c3-103 | refs: ref-strong-typing
+src/client/hooks/**/*.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/hooks/**/*.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/lib/**/*.ts → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/client/stores/**/*.ts → c3-102, ref-zustand-store | refs: ref-colocated-bun-test, ref-strong-typing, ref-zustand-store
+src/main.tsx → c3-110 | refs: ref-cqrs-read-models, ref-ws-subscription
+src/server/agent.test.ts → c3-210 | refs: ref-colocated-bun-test, ref-event-sourcing, ref-provider-adapter, ref-tool-hydration
+src/server/agent.ts → c3-210, ref-provider-adapter, ref-tool-hydration | refs: ref-colocated-bun-test, ref-event-sourcing, ref-provider-adapter, ref-tool-hydration
+src/server/auth.test.ts → c3-203 | refs: ref-local-first-data
+src/server/auth.ts → c3-203, ref-local-first-data | refs: ref-local-first-data
+src/server/cli-runtime.test.ts → c3-201 | refs: ref-local-first-data
+src/server/cli-runtime.ts → c3-201 | refs: ref-local-first-data
+src/server/cli-supervisor.ts → c3-201 | refs: ref-local-first-data
+src/server/cli.ts → c3-201, ref-local-first-data | refs: ref-local-first-data
+src/server/codex-app-server-protocol.ts → c3-211, ref-provider-adapter | refs: ref-provider-adapter, ref-strong-typing
+src/server/codex-app-server.test.ts → c3-211 | refs: ref-provider-adapter, ref-strong-typing
+src/server/codex-app-server.ts → c3-211, ref-provider-adapter | refs: ref-provider-adapter, ref-strong-typing
+src/server/diff-store.test.ts → c3-215 | refs: ref-tool-hydration
+src/server/diff-store.ts → c3-215 | refs: ref-tool-hydration
+src/server/discovery.test.ts → c3-214 | refs: ref-local-first-data
+src/server/discovery.ts → c3-214 | refs: ref-local-first-data
+src/server/event-store.test.ts → c3-206, ref-event-sourcing | refs: ref-colocated-bun-test, ref-event-sourcing, ref-local-first-data
+src/server/event-store.ts → c3-206, ref-event-sourcing | refs: ref-colocated-bun-test, ref-event-sourcing, ref-local-first-data
+src/server/events.ts → c3-205, ref-event-sourcing | refs: ref-event-sourcing, ref-strong-typing
+src/server/external-open.test.ts → c3-221 | refs: ref-local-first-data
+src/server/external-open.ts → c3-221 | refs: ref-local-first-data
+src/server/generate-commit-message.test.ts → c3-213 | refs: ref-provider-adapter
+src/server/generate-commit-message.ts → c3-213 | refs: ref-provider-adapter
+src/server/generate-title.ts → c3-213 | refs: ref-provider-adapter
+src/server/harness-types.ts → c3-205 | refs: ref-event-sourcing, ref-strong-typing
+src/server/keybindings.test.ts → c3-222 | refs: ref-local-first-data
+src/server/keybindings.ts → c3-222 | refs: ref-local-first-data
+src/server/llm-provider.test.ts → c3-213 | refs: ref-provider-adapter
+src/server/llm-provider.ts → c3-213, ref-provider-adapter | refs: ref-provider-adapter
+src/server/machine-name.ts → c3-204 | refs: ref-local-first-data
+src/server/paths.ts → c3-204, ref-local-first-data | refs: ref-local-first-data
+src/server/process-utils.test.ts → c3-209 | refs: ref-strong-typing
+src/server/process-utils.ts → c3-209 | refs: ref-strong-typing
+src/server/provider-catalog.test.ts → c3-212 | refs: ref-provider-adapter
+src/server/provider-catalog.ts → c3-212, ref-provider-adapter | refs: ref-provider-adapter
+src/server/quick-response.test.ts → c3-213 | refs: ref-provider-adapter
+src/server/quick-response.ts → c3-213, ref-provider-adapter | refs: ref-provider-adapter
+src/server/read-models.test.ts → c3-207, ref-cqrs-read-models | refs: ref-cqrs-read-models, ref-strong-typing
+src/server/read-models.ts → c3-207, ref-cqrs-read-models | refs: ref-cqrs-read-models, ref-strong-typing
+src/server/restart.test.ts → c3-220 | refs: ref-ws-subscription
+src/server/restart.ts → c3-220 | refs: ref-ws-subscription
+src/server/server.ts → c3-202 | refs: ref-local-first-data, ref-ws-subscription
+src/server/share.test.ts → c3-218 | refs: ref-local-first-data
+src/server/share.ts → c3-218 | refs: ref-local-first-data
+src/server/terminal-manager.test.ts → c3-216 | refs: ref-ws-subscription
+src/server/terminal-manager.ts → c3-216 | refs: ref-ws-subscription
+src/server/title-generation.live.test.ts → c3-213 | refs: ref-provider-adapter
+src/server/update-manager.test.ts → c3-219 | refs: ref-cqrs-read-models
+src/server/update-manager.ts → c3-219 | refs: ref-cqrs-read-models
+src/server/uploads.test.ts → c3-217 | refs: ref-local-first-data
+src/server/uploads.ts → c3-217 | refs: ref-local-first-data
+src/server/ws-router.test.ts → c3-208 | refs: ref-colocated-bun-test, ref-cqrs-read-models, ref-ws-subscription
+src/server/ws-router.ts → c3-208, ref-ws-subscription | refs: ref-colocated-bun-test, ref-cqrs-read-models, ref-ws-subscription
+src/shared/**/*.ts → ref-strong-typing
+src/shared/branding.test.ts → c3-305 | refs: ref-local-first-data
+src/shared/branding.ts → c3-305, ref-local-first-data | refs: ref-local-first-data
+src/shared/dev-ports.test.ts → c3-304 | refs: ref-strong-typing
+src/shared/dev-ports.ts → c3-304 | refs: ref-strong-typing
+src/shared/ports.ts → c3-304 | refs: ref-strong-typing
+src/shared/protocol.ts → c3-302, ref-ws-subscription | refs: ref-strong-typing, ref-ws-subscription
+src/shared/share.ts → c3-306 | refs: ref-strong-typing
+src/shared/tools.test.ts → c3-303, ref-tool-hydration | refs: ref-colocated-bun-test, ref-strong-typing, ref-tool-hydration
+src/shared/tools.ts → c3-303, ref-tool-hydration | refs: ref-colocated-bun-test, ref-strong-typing, ref-tool-hydration
+src/shared/types.ts → c3-301 | refs: ref-strong-typing
+tsconfig.json → ref-strong-typing
+
+## Ref Map
+ref-colocated-bun-test cited by: c3-102, c3-206, c3-208, c3-210, c3-303
+ref-cqrs-read-models cited by: c3-110, c3-111, c3-112, c3-207, c3-208, c3-219
+ref-event-sourcing cited by: c3-205, c3-206, c3-210
+ref-local-first-data cited by: c3-116, c3-117, c3-201, c3-202, c3-203, c3-204, c3-206, c3-214, c3-217, c3-218, c3-221, c3-222, c3-305
+ref-provider-adapter cited by: c3-113, c3-115, c3-210, c3-211, c3-212, c3-213
+ref-strong-typing cited by: c3-101, c3-102, c3-103, c3-114, c3-205, c3-207, c3-209, c3-211, c3-301, c3-302, c3-303, c3-304, c3-306
+ref-tool-hydration cited by: c3-113, c3-114, c3-210, c3-215, c3-303
+ref-ws-subscription cited by: c3-101, c3-110, c3-112, c3-117, c3-118, c3-202, c3-208, c3-216, c3-220, c3-302
+ref-zustand-store cited by: c3-102, c3-111, c3-115, c3-116, c3-118

--- a/.c3/adr/adr-00000000-c3-adoption.md
+++ b/.c3/adr/adr-00000000-c3-adoption.md
@@ -1,0 +1,253 @@
+---
+id: adr-00000000-c3-adoption
+title: C3 Architecture Documentation Adoption
+type: adr
+status: implemented
+date: "20260420"
+affects:
+    - c3-0
+c3-version: 4
+---
+
+# C3 Architecture Documentation Adoption
+## Goal
+
+Adopt C3 methodology for kanna.
+
+<!--
+EXIT CRITERIA (all must be true to mark implemented):
+- All containers documented with Goal Contribution
+- All components documented with Container Connection
+- Refs extracted for repeated patterns
+- Integrity checks pass
+- Audit passes
+-->
+## Workflow
+
+```mermaid
+flowchart TD
+    GOAL([Goal]) --> S0
+
+    subgraph S0["Stage 0: Inventory"]
+        S0_DISCOVER[Discover codebase] --> S0_ASK{Gaps?}
+        S0_ASK -->|Yes| S0_SOCRATIC[Socratic] --> S0_DISCOVER
+        S0_ASK -->|No| S0_LIST[List items + diagram]
+    end
+
+    S0_LIST --> G0{Inventory complete?}
+    G0 -->|No| S0_DISCOVER
+    G0 -->|Yes| S1
+
+    subgraph S1["Stage 1: Details"]
+        S1_CONTAINER[Per container] --> S1_INT[Internal comp]
+        S1_CONTAINER --> S1_LINK[Linkage comp]
+        S1_INT --> S1_REF[Extract refs]
+        S1_LINK --> S1_REF
+        S1_REF --> S1_ASK{Questions?}
+        S1_ASK -->|Yes| S1_SOCRATIC[Socratic] --> S1_CONTAINER
+        S1_ASK -->|No| S1_NEXT{More?}
+        S1_NEXT -->|Yes| S1_CONTAINER
+    end
+
+    S1_NEXT -->|No| G1{Fix inventory?}
+    G1 -->|Yes| S0_DISCOVER
+    G1 -->|No| S2
+
+    subgraph S2["Stage 2: Finalize"]
+        S2_CHECK[Integrity checks]
+    end
+
+    S2_CHECK --> G2{Issues?}
+    G2 -->|Inventory| S0_DISCOVER
+    G2 -->|Detail| S1_CONTAINER
+    G2 -->|None| DONE([Implemented])
+```
+
+---
+## Stage 0: Inventory
+
+### Context Discovery
+
+| Arg | Value |
+|-----|-------|
+| PROJECT | Kanna |
+| GOAL | Beautiful browser UI for Claude Code + Codex CLIs with project-first navigation, multi-provider agent coordination, and event-sourced local persistence |
+| SUMMARY | Bun+React app driving Claude Agent SDK and Codex App Server over WebSocket, persisting state as append-only JSONL, rendering hydrated tool calls in real time |
+
+### Abstract Constraints
+
+| Constraint | Rationale | Affected Containers |
+|------------|-----------|---------------------|
+| Event sourcing for all state mutations | Replayable history, crash-safe, debuggable audit trail | c3-2 |
+| CQRS: write (events) decoupled from read (derived models) | UI subscribes to fast snapshots without touching the log | c3-1, c3-2 |
+| Reactive WebSocket broadcasting on every state change | Multiple tabs and agents stay consistent in real time | c3-1, c3-2 |
+| Local-first: data under ~/.kanna/data, default bind localhost | Zero server infra, user owns data, safe by default | c3-2 |
+| Provider-agnostic agent coordination (Claude + Codex) | Per-turn provider/model/effort picks without forking transcript model | c3-1, c3-2 |
+| Strong TypeScript typing — no any at boundaries | Client + server agree on protocol + events | c3-1, c3-2, c3-3 |
+
+### Container Discovery
+
+| N | CONTAINER_NAME | BOUNDARY | GOAL | SUMMARY |
+|---|----------------|----------|------|---------|
+| 1 | client | app | Render chat, accept input, subscribe to WS pushes | React + Zustand SPA under src/client |
+| 2 | server | service | Drive agents, persist events, broadcast snapshots | Bun HTTP+WS runtime under src/server |
+| 3 | shared | library | Publish wire protocol + domain types used by both sides | Code under src/shared imported by client and server |
+
+### Component Discovery (Brief)
+
+| N | NN | COMPONENT_NAME | CATEGORY | GOAL | SUMMARY |
+|---|----|--------------  |----------|------|---------|
+| 1 | 01 | socket-client | foundation | Connect WS, route messages, emit commands | src/client/app/socket.ts |
+| 1 | 02 | state-stores | foundation | Zustand stores for chat/terminal/sidebar/prefs | src/client/stores/* |
+| 1 | 03 | ui-primitives | foundation | Radix + shadcn primitives (button, dialog, popover...) | src/client/components/ui/* |
+| 1 | 10 | app-shell | feature | Router, top-level page hookup, central state hook | src/client/app/App.tsx + useKannaState.ts |
+| 1 | 11 | sidebar | feature | Project-first sidebar with drag ordering, jump shortcuts | src/client/app/KannaSidebar.tsx |
+| 1 | 12 | chat-page | feature | Chat route shell: transcript viewport + input dock + terminal | src/client/app/ChatPage/* |
+| 1 | 13 | transcript | feature | Render hydrated transcript entries | src/client/app/KannaTranscript.tsx |
+| 1 | 14 | messages-renderer | feature | Render each transcript entry type (tool calls, text, diffs) | src/client/components/messages/* |
+| 1 | 15 | chat-ui-chrome | feature | Input, composer controls, provider/model pickers | src/client/components/chat-ui/* |
+| 1 | 16 | settings-page | feature | Settings dialogs and preferences | src/client/app/SettingsPage.tsx |
+| 1 | 17 | local-projects-page | feature | List/open locally discovered projects | src/client/app/LocalProjectsPage.tsx |
+| 1 | 18 | terminal-workspace | feature | Embedded xterm panel + layout animation | src/client/app/ChatPage/TerminalWorkspaceShell.tsx |
+| 2 | 01 | cli-entry | foundation | CLI parsing, supervisor, runtime, browser launcher | src/server/cli*.ts |
+| 2 | 02 | http-ws-server | foundation | HTTP + WebSocket server, static serving, auth hookup | src/server/server.ts |
+| 2 | 03 | auth | foundation | Password gate + session cookie for API/WS | src/server/auth.ts |
+| 2 | 04 | paths-config | foundation | Data paths, machine name, branding helpers | src/server/paths.ts + machine-name.ts |
+| 2 | 05 | events-schema | foundation | Event type definitions for JSONL logs | src/server/events.ts |
+| 2 | 06 | event-store | foundation | Append-only JSONL with replay + snapshot compaction | src/server/event-store.ts |
+| 2 | 07 | read-models | foundation | Derive sidebar/chat/project views from event state | src/server/read-models.ts |
+| 2 | 08 | ws-router | foundation | Subscribe/command routing over WebSocket | src/server/ws-router.ts |
+| 2 | 09 | process-utils | foundation | Process spawning + lifecycle helpers | src/server/process-utils.ts |
+| 2 | 10 | agent-coordinator | feature | Multi-provider turn management | src/server/agent.ts |
+| 2 | 11 | codex-app-server | feature | JSON-RPC client for Codex App Server | src/server/codex-app-server*.ts |
+| 2 | 12 | provider-catalog | feature | Provider/model/effort normalization | src/server/provider-catalog.ts |
+| 2 | 13 | quick-response | feature | Structured Haiku queries with Codex fallback (titles, commits) | quick-response.ts + generate-title.ts + generate-commit-message.ts + llm-provider.ts |
+| 2 | 14 | discovery | feature | Auto-discover Claude + Codex local projects | src/server/discovery.ts |
+| 2 | 15 | diff-store | feature | Per-chat diff state for hydrated file-change UI | src/server/diff-store.ts |
+| 2 | 16 | terminal-manager | feature | PTY sessions for embedded terminal | src/server/terminal-manager.ts |
+| 2 | 17 | uploads | feature | File uploads + attachment handling | src/server/uploads.ts |
+| 2 | 18 | share | feature | Cloudflare quick-tunnel + named tunnel + QR | src/server/share.ts |
+| 2 | 19 | update-manager | feature | Self-update notifications | src/server/update-manager.ts |
+| 2 | 20 | restart | feature | In-place restart flow | src/server/restart.ts |
+| 2 | 21 | external-open | feature | Open URLs/files in external apps | src/server/external-open.ts |
+| 2 | 22 | keybindings | feature | User keybinding persistence | src/server/keybindings.ts |
+| 3 | 01 | types | foundation | Core domain types, provider catalog, transcript entry types | src/shared/types.ts |
+| 3 | 02 | protocol | foundation | WebSocket wire protocol shapes | src/shared/protocol.ts |
+| 3 | 03 | tools | foundation | Tool call normalization + hydration | src/shared/tools.ts |
+| 3 | 04 | ports | foundation | Port allocation + dev-port helpers | src/shared/ports.ts + dev-ports.ts |
+| 3 | 05 | branding | foundation | App name + data dir paths | src/shared/branding.ts |
+| 3 | 06 | share-shared | foundation | Share feature types shared with client | src/shared/share.ts |
+
+### Ref Discovery
+
+| SLUG | TITLE | GOAL | Scope | Applies To |
+|------|-------|------|-------|------------|
+| ref-event-sourcing | Event Sourcing | All mutations go through append-only JSONL; readers replay | cross-container | c3-2 event-store, events-schema, read-models |
+| ref-cqrs-read-models | CQRS Read Models | Derive view models from event state; broadcast diffs | cross-container | c3-1 state-stores, c3-2 read-models + ws-router |
+| ref-ws-subscription | WebSocket Subscription | Single WS with typed subscribe/command envelope | cross-container | c3-1 socket-client, c3-2 ws-router, c3-3 protocol |
+| ref-provider-adapter | Provider Adapter | Normalize Claude Agent SDK and Codex into one transcript model | cross-container | c3-2 agent-coordinator, provider-catalog, codex-app-server, quick-response |
+| ref-zustand-store | Zustand Store Pattern | Per-concern store, persist via localStorage as needed | client | c3-1 state-stores |
+| ref-colocated-bun-test | Colocated Bun Test | *.test.ts next to impl, runs under `bun test` | cross-container | all |
+| ref-strong-typing | Strong Typing Policy | No any/unknown at boundaries; prefer shared types | cross-container | all |
+| ref-local-first-data | Local-First Data | All persistence under ~/.kanna/data; localhost-default binding | server | c3-2 event-store, paths-config |
+| ref-tool-hydration | Tool Call Hydration | Normalize provider tool calls into unified transcript entries | cross-container | c3-3 tools, c3-1 messages-renderer, c3-2 agent-coordinator |
+
+### Overview Diagram
+
+```mermaid
+graph LR
+  User((User)) --> Browser
+  Browser[Browser<br/>React + Zustand<br/>c3-1] <-->|WebSocket| Server
+  Server[Bun Server<br/>HTTP + WS<br/>c3-2]
+  Server --> ClaudeSDK[Claude Agent SDK]
+  Server --> CodexRPC[Codex App Server]
+  Server --> FS[(~/.kanna/data/<br/>JSONL + snapshot)]
+  Server --> ProjFS[(Project Dirs)]
+  Browser -.-> Shared[src/shared/<br/>c3-3]
+  Server -.-> Shared
+```
+
+### Gate 0
+
+- [x] Context args filled
+- [x] Abstract Constraints identified
+- [x] All containers identified with args (including BOUNDARY)
+- [x] All components identified (brief) with args and category
+- [x] Cross-cutting refs identified
+- [x] Overview diagram generated
+## Stage 1: Details
+
+<!--
+Fill in each container with its components.
+- Internal: components that are self-contained
+- Linkage: components that handle connections to other containers
+- Extract refs when patterns repeat
+- If new item found -> back to Stage 0
+-->
+
+### Container: c3-1
+
+**Created:** [ ] `.c3/c3-1-{slug}/README.md`
+
+| Type | Component ID | Name | Category | Doc Created |
+|------|--------------|------|----------|-------------|
+| Internal | | | | [ ] |
+| Linkage | | | | [ ] |
+
+### Container: c3-N
+
+_(repeat per container from Stage 0)_
+
+### Refs Created
+
+| Ref ID | Pattern | Doc Created |
+|--------|---------|-------------|
+| | | [ ] |
+
+### Gate 1
+
+- [ ] All container README.md created
+- [ ] All component docs created
+- [ ] All refs documented
+- [ ] No new items discovered (else -> Gate 0)
+
+---
+## Stage 2: Finalize
+
+<!--
+Integrity checks - verify everything connects.
+If issues found -> back to appropriate stage.
+-->
+
+### Integrity Checks
+
+| Check | Status |
+|-------|--------|
+| Context <-> Container (all containers listed in c3-0) | [ ] |
+| Container <-> Component (all components listed in container README) | [ ] |
+| Component <-> Component (linkages documented) | [ ] |
+| * <-> Refs (refs cited correctly, Cited By updated) | [ ] |
+
+### Gate 2
+
+- [ ] All integrity checks pass
+- [ ] Run audit
+
+---
+## Conflict Resolution
+
+If later stage reveals earlier errors:
+
+| Conflict | Found In | Affects | Resolution |
+|----------|----------|---------|------------|
+| | | | |
+
+---
+## Exit
+
+When Gate 2 complete -> change frontmatter status to `implemented`
+## Audit Record
+
+| Phase | Date | Notes |
+|-------|------|-------|
+| Adopted | 20260420 | Initial C3 structure created |

--- a/.c3/adr/adr-20260420-import-button-mobile-visible.md
+++ b/.c3/adr/adr-20260420-import-button-mobile-visible.md
@@ -1,0 +1,16 @@
+---
+id: adr-20260420-import-button-mobile-visible
+title: import-button-mobile-visible
+type: adr
+status: implemented
+date: "2026-04-20T00:00:00Z"
+---
+
+# import-button-mobile-visible
+## Goal
+
+--value
+## Work Breakdown
+
+## Risks
+

--- a/.c3/adr/adr-20260421-pm2-update-reloader.md
+++ b/.c3/adr/adr-20260421-pm2-update-reloader.md
@@ -1,0 +1,50 @@
+---
+id: adr-20260421-pm2-update-reloader
+title: pm2-update-reloader
+type: adr
+status: implemented
+date: "2026-04-21T00:00:00Z"
+---
+
+# pm2-update-reloader
+## Goal
+
+Replace macOS launchd supervision with pm2 for the dev deploy path, and wire the in-app Update button to trigger a pm2-reload pipeline (git pull → build → `pm2 reload`). Abstract the update mechanism so the existing npm/self-update path and the new git/pm2 path coexist and can be swapped without touching `UpdateManager` or server wiring.
+
+## Decision
+
+Introduced two interfaces in `src/server/update-strategy.ts`:
+
+- `UpdateChecker.check()` — returns `{ latestVersion, updateAvailable }`
+- `UpdateReloader.reload()` — performs install / reload, throws `UpdateInstallError` on failure
+
+Shipped two implementations of each, wired by a factory `createUpdateStrategy` keyed on `KANNA_RELOADER`:
+
+| Mode | Checker | Reloader | Default? |
+|------|---------|----------|----------|
+| `supervisor` (or unset) | `NpmChecker` (npm registry) | `SupervisorExitReloader` (install → restart_pending → process exit 76 → parent respawn) | yes |
+| `pm2` | `GitChecker` (git fetch → HEAD vs origin/branch) | `Pm2Reloader` (git pull → cond. bun install → bun run build → `pm2.reload`) | opt-in |
+
+`UpdateManager` depends only on the interfaces; no knowledge of npm/git/pm2.
+
+## Env Vars
+
+- `KANNA_RELOADER` — `supervisor` (default) or `pm2`
+- `KANNA_REPO_DIR` — required when `KANNA_RELOADER=pm2`; absolute path to the git worktree pm2 runs from
+- `KANNA_PM2_PROCESS_NAME` — optional; defaults to `kanna`; must match the `name:` field in the pm2 ecosystem config
+
+## Ops
+
+- `scripts/pm2.config.cjs.tmpl` — templated pm2 ecosystem file (envsubst renders `${REPO_DIR}` + `${PM2_NAME}` into `scripts/pm2.config.cjs`, which is gitignored)
+- `scripts/deploy.sh` — now installs pm2 if missing, renders the config, and runs `pm2 reload` (or `pm2 start` on first run). Drops `launchctl kickstart`.
+
+## Work Breakdown
+
+Done across 11 tasks (see `docs/plans/2026-04-21-pm2-update-reloader.md`): interfaces + npm/supervisor impl → factory → UpdateManager refactor → server wiring → pm2 dep → GitChecker → Pm2Reloader → pm2 ecosystem template → deploy.sh rewrite → manual verification.
+
+## Risks
+
+- `detectLockfileChange` returns `true` on any git error (fresh clone, no `HEAD@{1}`) — conservatively over-installs rather than skipping a needed `bun install`.
+- pm2 self-reload race: pm2 signals the current process immediately; `cli.ts` may exit with 0 instead of 76 if pm2's SIGTERM wins over the `restart_pending` listener. Harmless because `autorestart: true` restarts regardless of exit code.
+- `branch: "main"` is hardcoded in the factory's `GitChecker` wiring; dev-only scope, low risk.
+- pm2 is a `devDependency`, lazy-imported only in pm2 mode — end users on the supervisor path never pull it.

--- a/.c3/c3-1-client/README.md
+++ b/.c3/c3-1-client/README.md
@@ -1,0 +1,55 @@
+---
+id: c3-1
+title: Client
+type: container
+parent: c3-0
+goal: 'Render the chat experience: hydrate transcripts, accept input, drive sidebar/settings, and stay synchronized with server state via WebSocket subscriptions.'
+boundary: app
+c3-version: 4
+---
+
+# client
+## Goal
+
+Render the chat experience: hydrate transcripts, accept input, drive sidebar/settings, and stay synchronized with server state via WebSocket subscriptions.
+## Responsibilities
+
+- Own the browser-side state surface (Zustand stores, React context, URL routing).
+- Subscribe to server snapshots over WebSocket and diff them into the local view model.
+- Render hydrated transcripts including provider-agnostic tool calls, plan-mode prompts, and diffs.
+- Accept user input: chat composer, provider/model switches, settings, drag-to-reorder projects, terminal keystrokes.
+- Degrade gracefully when the socket drops or auth is required.
+## Complexity Assessment
+
+**Level:** <!-- [trivial|simple|moderate|complex|critical] -->
+**Why:** <!-- signals observed from code analysis -->
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-101 | socket-client | foundation | implemented | Single WS transport + typed envelope dispatch |
+| c3-102 | state-stores | foundation | implemented | UI-local state via per-concern Zustand stores |
+| c3-103 | ui-primitives | foundation | implemented | Radix + shadcn primitives used by every feature |
+| c3-110 | app-shell | feature | implemented | Router, central state hook, socket wiring |
+| c3-111 | sidebar | feature | implemented | Project-first nav with drag-order + status dots |
+| c3-112 | chat-page | feature | implemented | Chat route shell composing transcript + input + terminal |
+| c3-113 | transcript | feature | implemented | Virtualized hydrated transcript list |
+| c3-114 | messages-renderer | feature | implemented | Per-kind renderers for transcript entries |
+| c3-115 | chat-ui-chrome | feature | implemented | Composer + provider/model/effort pickers |
+| c3-116 | settings-page | feature | implemented | Preferences, keybindings, data location |
+| c3-117 | local-projects-page | feature | implemented | List + open locally discovered projects |
+| c3-118 | terminal-workspace | feature | implemented | Embedded xterm panel with layout persistence |
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-1-client/c3-101-socket-client.md
+++ b/.c3/c3-1-client/c3-101-socket-client.md
@@ -1,0 +1,52 @@
+---
+id: c3-101
+title: socket-client
+type: component
+category: foundation
+parent: c3-1
+goal: Maintain the single WebSocket to the backend, decode typed envelopes, and dispatch commands + subscription push messages.
+uses:
+    - ref-ws-subscription
+    - ref-strong-typing
+c3-version: 4
+---
+
+# socket-client
+## Goal
+
+Maintain the single WebSocket to the backend, decode typed envelopes, and dispatch commands + subscription push messages.
+## Container Connection
+
+Provides the transport every other client component depends on. Without it the client has no way to reach the server, subscribe to snapshots, or send commands.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Wire protocol envelopes | c3-302 |
+| IN (uses) | Ports + dev-ports config | c3-304 |
+| OUT (provides) | Socket client + subscribe/command API | c3-110 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Single WS + typed envelope exactly matches this component's shape |
+| ref-strong-typing | Decoded envelopes are typed, not parsed as any |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-102-state-stores.md
+++ b/.c3/c3-1-client/c3-102-state-stores.md
@@ -1,0 +1,57 @@
+---
+id: c3-102
+title: state-stores
+type: component
+category: foundation
+parent: c3-1
+goal: Hold UI-local state (chat input, terminal layout, sidebar, preferences) in small Zustand stores, persisting only what must survive reload.
+uses:
+    - ref-zustand-store
+    - ref-strong-typing
+    - ref-colocated-bun-test
+c3-version: 4
+---
+
+# state-stores
+## Goal
+
+Hold UI-local state (chat input, terminal layout, sidebar, preferences) in small Zustand stores, persisting only what must survive reload.
+## Container Connection
+
+Gives features a place to keep UI state without pushing it into React context or the server. Without it, the client would need a global store or ad-hoc hooks.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Typed hooks per concern | c3-110 |
+| OUT (provides) | Chat input + preferences stores | c3-115 |
+| OUT (provides) | Sidebar state | c3-111 |
+| OUT (provides) | Chat page layout state | c3-112 |
+| OUT (provides) | Settings preferences | c3-116 |
+| OUT (provides) | Terminal layout + preferences | c3-118 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|------|------|
+| ref-zustand-store | Codifies the per-concern store pattern |
+| ref-strong-typing | Each store exports typed selectors |
+| ref-colocated-bun-test |  |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-103-ui-primitives.md
+++ b/.c3/c3-1-client/c3-103-ui-primitives.md
@@ -1,0 +1,53 @@
+---
+id: c3-103
+title: ui-primitives
+type: component
+category: foundation
+parent: c3-1
+goal: 'Ship the low-level, brand-aligned UI primitives (Radix + shadcn derivatives: button, dialog, popover, scroll-area, tooltip, select, kbd, ...).'
+uses:
+    - ref-strong-typing
+c3-version: 4
+---
+
+# ui-primitives
+## Goal
+
+Ship the low-level, brand-aligned UI primitives (Radix + shadcn derivatives: button, dialog, popover, scroll-area, tooltip, select, kbd, ...).
+## Container Connection
+
+Feature components compose these primitives to keep interaction quality consistent across chat, sidebar, settings, and terminal.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Primitives | c3-111 |
+| OUT (provides) | Primitives | c3-112 |
+| OUT (provides) | Primitives | c3-115 |
+| OUT (provides) | Primitives | c3-116 |
+| OUT (provides) | Primitives | c3-117 |
+| OUT (provides) | Primitives | c3-118 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-strong-typing | Primitives forward typed props to Radix without loosening types |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-110-app-shell.md
+++ b/.c3/c3-1-client/c3-110-app-shell.md
@@ -1,0 +1,55 @@
+---
+id: c3-110
+title: app-shell
+type: component
+category: feature
+parent: c3-1
+goal: 'Own the top-level React shell: routing, Kanna state hook (useKannaState), socket wiring, global keybindings, and layout chrome.'
+uses:
+    - ref-ws-subscription
+    - ref-cqrs-read-models
+c3-version: 4
+---
+
+# app-shell
+## Goal
+
+Own the top-level React shell: routing, Kanna state hook (useKannaState), socket wiring, global keybindings, and layout chrome.
+## Container Connection
+
+Entry point for every client feature — without it, pages have no router, no shared state, and no socket.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Socket transport | c3-101 |
+| IN (uses) | Stores for preferences + layout | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+| OUT (provides) | Router-mounted chat page | c3-112 |
+| OUT (provides) | Router-mounted settings | c3-116 |
+| OUT (provides) | Router-mounted projects page | c3-117 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Shell opens the socket and threads snapshots through useKannaState |
+| ref-cqrs-read-models | Shell consumes derived snapshots, never the raw event log |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-111-sidebar.md
+++ b/.c3/c3-1-client/c3-111-sidebar.md
@@ -1,0 +1,52 @@
+---
+id: c3-111
+title: sidebar
+type: component
+category: feature
+parent: c3-1
+goal: 'Render the project-first sidebar: grouped chats, live status dots, drag-to-reorder project groups, number-key jumps.'
+uses:
+    - ref-cqrs-read-models
+    - ref-zustand-store
+c3-version: 4
+---
+
+# sidebar
+## Goal
+
+Render the project-first sidebar: grouped chats, live status dots, drag-to-reorder project groups, number-key jumps.
+## Container Connection
+
+Main navigation surface; the user never leaves this panel. Without it, there is no way to open chats or reorder projects.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Sidebar state store | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Sidebar view snapshots | c3-207 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-cqrs-read-models | Sidebar consumes the sidebarView projection, not raw events |
+| ref-zustand-store | Drag ordering persisted via zustand persist middleware |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-112-chat-page.md
+++ b/.c3/c3-1-client/c3-112-chat-page.md
@@ -1,0 +1,54 @@
+---
+id: c3-112
+title: chat-page
+type: component
+category: feature
+parent: c3-1
+goal: 'Compose the chat route: transcript viewport, input dock, terminal workspace, focus policy, and sidebar actions.'
+uses:
+    - ref-ws-subscription
+    - ref-cqrs-read-models
+c3-version: 4
+---
+
+# chat-page
+## Goal
+
+Compose the chat route: transcript viewport, input dock, terminal workspace, focus policy, and sidebar actions.
+## Container Connection
+
+The primary workspace of the app. Without it the user has nowhere to read or write agent turns.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Transcript renderer | c3-113 |
+| IN (uses) | Chat UI chrome (input) | c3-115 |
+| IN (uses) | Terminal workspace | c3-118 |
+| IN (uses) | Stores | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Subscribes to chat view for its sessionId |
+| ref-cqrs-read-models | Renders the chatView projection |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-113-transcript.md
+++ b/.c3/c3-1-client/c3-113-transcript.md
@@ -1,0 +1,52 @@
+---
+id: c3-113
+title: transcript
+type: component
+category: feature
+parent: c3-1
+goal: Render a hydrated list of transcript entries (text, tool calls, plan dialogs, diffs) with virtualized scrolling and sticky focus.
+uses:
+    - ref-tool-hydration
+    - ref-provider-adapter
+c3-version: 4
+---
+
+# transcript
+## Goal
+
+Render a hydrated list of transcript entries (text, tool calls, plan dialogs, diffs) with virtualized scrolling and sticky focus.
+## Container Connection
+
+Visual heart of the chat experience — transforms server-pushed transcript entries into readable, interactive UI.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Message renderers | c3-114 |
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Shared tool normalization | c3-303 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-tool-hydration | Dispatches renderers via hydrated tool kinds |
+| ref-provider-adapter | Same render path for Claude + Codex entries |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-114-messages-renderer.md
+++ b/.c3/c3-1-client/c3-114-messages-renderer.md
@@ -1,0 +1,52 @@
+---
+id: c3-114
+title: messages-renderer
+type: component
+category: feature
+parent: c3-1
+goal: Render each transcript entry kind (text, tool call, write_file, delete_file, plan, diff, ...) consistently, with collapse/expand and status.
+uses:
+    - ref-tool-hydration
+    - ref-strong-typing
+c3-version: 4
+---
+
+# messages-renderer
+## Goal
+
+Render each transcript entry kind (text, tool call, write_file, delete_file, plan, diff, ...) consistently, with collapse/expand and status.
+## Container Connection
+
+Encapsulates per-kind UI so transcript stays dumb; adding a new tool only touches this component plus shared hydration.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Shared tools | c3-303 |
+| OUT (provides) | Renderer map | c3-113 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-tool-hydration | Dispatches by kind only; never branches on provider |
+| ref-strong-typing | Exhaustive switch on transcript entry union |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-115-chat-ui-chrome.md
+++ b/.c3/c3-1-client/c3-115-chat-ui-chrome.md
@@ -1,0 +1,52 @@
+---
+id: c3-115
+title: chat-ui-chrome
+type: component
+category: feature
+parent: c3-1
+goal: 'Provide the composer and chat chrome: input dock, provider/model/effort pickers, attachment controls, queued message alignment.'
+uses:
+    - ref-provider-adapter
+    - ref-zustand-store
+c3-version: 4
+---
+
+# chat-ui-chrome
+## Goal
+
+Provide the composer and chat chrome: input dock, provider/model/effort pickers, attachment controls, queued message alignment.
+## Container Connection
+
+The user's input surface — without it there is nothing to send to the agent.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Chat input store + preferences | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Provider catalog types | c3-301 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-provider-adapter | Pickers use the normalized catalog instead of per-provider forms |
+| ref-zustand-store | Pending input persisted between route changes |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-116-settings-page.md
+++ b/.c3/c3-1-client/c3-116-settings-page.md
@@ -1,0 +1,52 @@
+---
+id: c3-116
+title: settings-page
+type: component
+category: feature
+parent: c3-1
+goal: 'Expose user settings: provider keys, theme, keybindings, chat preferences, notifications, data location.'
+uses:
+    - ref-zustand-store
+    - ref-local-first-data
+c3-version: 4
+---
+
+# settings-page
+## Goal
+
+Expose user settings: provider keys, theme, keybindings, chat preferences, notifications, data location.
+## Container Connection
+
+One place to configure how the client and the local server behave; without it users cannot customize the tool.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Preference stores | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Server keybinding projection | c3-222 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-zustand-store | Preferences live in stores with persistence |
+| ref-local-first-data | Settings surface the paths.ts data dir |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-117-local-projects-page.md
+++ b/.c3/c3-1-client/c3-117-local-projects-page.md
@@ -1,0 +1,51 @@
+---
+id: c3-117
+title: local-projects-page
+type: component
+category: feature
+parent: c3-1
+goal: List projects auto-discovered from local Claude and Codex history so users can open them into Kanna.
+uses:
+    - ref-ws-subscription
+    - ref-local-first-data
+c3-version: 4
+---
+
+# local-projects-page
+## Goal
+
+List projects auto-discovered from local Claude and Codex history so users can open them into Kanna.
+## Container Connection
+
+Onboarding on-ramp: makes the app immediately useful by surfacing existing work without manual configuration.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Server discovery feed | c3-214 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Subscribes to discovery projection |
+| ref-local-first-data | Only local history is read; no cloud lookup |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-client/c3-118-terminal-workspace.md
+++ b/.c3/c3-1-client/c3-118-terminal-workspace.md
@@ -1,0 +1,52 @@
+---
+id: c3-118
+title: terminal-workspace
+type: component
+category: feature
+parent: c3-1
+goal: Host the embedded xterm terminal panel with layout animation + resize + preference persistence.
+uses:
+    - ref-zustand-store
+    - ref-ws-subscription
+c3-version: 4
+---
+
+# terminal-workspace
+## Goal
+
+Host the embedded xterm terminal panel with layout animation + resize + preference persistence.
+## Container Connection
+
+Keeps shell work next to agent work without leaving the chat page.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Terminal layout + preference stores | c3-102 |
+| IN (uses) | Primitives | c3-103 |
+| IN (uses) | Server terminal manager | c3-216 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-zustand-store | Terminal layout persisted per user |
+| ref-ws-subscription | Terminal I/O streamed via WS |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/README.md
+++ b/.c3/c3-2-server/README.md
@@ -1,0 +1,65 @@
+---
+id: c3-2
+title: Server
+type: container
+parent: c3-0
+goal: 'Run the local Bun backend: serve HTTP+WebSocket, coordinate Claude + Codex agent turns, persist events, and broadcast derived read models.'
+boundary: service
+c3-version: 4
+---
+
+# server
+## Goal
+
+Run the local Bun backend: serve HTTP+WebSocket on localhost, coordinate Claude + Codex agent turns, persist events, and broadcast derived read models.
+## Responsibilities
+
+- Own the authoritative event log and derived read models; every state mutation lands as a JSONL event first.
+- Accept WebSocket subscriptions and commands; push fresh snapshots on every change.
+- Drive multi-provider agent turns (Claude Agent SDK, Codex App Server) through a single coordinator.
+- Discover local projects, manage terminals and uploads, operate share tunnels.
+- Gate network access (auth), supervise its own CLI lifecycle, and refuse to leave localhost unless explicitly asked.
+## Complexity Assessment
+
+**Level:** <!-- [trivial|simple|moderate|complex|critical] -->
+**Why:** <!-- signals observed from code analysis -->
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-201 | cli-entry | foundation | implemented | CLI parsing, supervisor, browser launcher |
+| c3-202 | http-ws-server | foundation | implemented | HTTP + WS + static serving |
+| c3-203 | auth | foundation | implemented | Password + session cookie gating |
+| c3-204 | paths-config | foundation | implemented | Central data-path resolution |
+| c3-205 | events-schema | foundation | implemented | Typed event unions for the log |
+| c3-206 | event-store | foundation | implemented | Append-only JSONL + replay + snapshot compaction |
+| c3-207 | read-models | foundation | implemented | Derived views from event state |
+| c3-208 | ws-router | foundation | implemented | WS subscribe/command multiplexer |
+| c3-209 | process-utils | foundation | implemented | Shared process lifecycle helpers |
+| c3-210 | agent-coordinator | feature | implemented | Multi-provider turn orchestration |
+| c3-211 | codex-app-server | feature | implemented | Codex App Server JSON-RPC adapter |
+| c3-212 | provider-catalog | feature | implemented | Provider/model/effort normalization |
+| c3-213 | quick-response | feature | implemented | Structured Haiku queries with Codex fallback |
+| c3-214 | discovery | feature | implemented | Auto-discover local Claude + Codex projects |
+| c3-215 | diff-store | feature | implemented | Per-chat diff state for file-change UI |
+| c3-216 | terminal-manager | feature | implemented | PTY sessions for embedded terminal |
+| c3-217 | uploads | feature | implemented | File upload handling |
+| c3-218 | share | feature | implemented | Cloudflare quick + named tunnels + QR |
+| c3-219 | update-manager | feature | implemented | npm version checking |
+| c3-220 | restart | feature | implemented | In-place server relaunch |
+| c3-221 | external-open | feature | implemented | Open URLs/files in external apps |
+| c3-222 | keybindings | feature | implemented | Persist user keybindings |
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-2-server/c3-201-cli-entry.md
+++ b/.c3/c3-2-server/c3-201-cli-entry.md
@@ -1,0 +1,52 @@
+---
+id: c3-201
+title: cli-entry
+type: component
+category: foundation
+parent: c3-2
+goal: Parse CLI flags, supervise the Bun server process, pick dev/prod runtime mode, and open the browser.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# cli-entry
+## Goal
+
+Parse CLI flags, supervise the Bun server process, pick dev/prod runtime mode, and open the browser.
+## Container Connection
+
+Boot path for the entire server. Without it the rest of c3-2 never runs.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Paths | c3-204 |
+| IN (uses) | Ports | c3-304 |
+| IN (uses) | Process utilities | c3-209 |
+| OUT (provides) | Runtime entry | c3-202 |
+| OUT (provides) | Share tunnel hookup | c3-218 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Defaults to localhost; --remote/--host/--share are explicit opt-ins |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-202-http-ws-server.md
+++ b/.c3/c3-2-server/c3-202-http-ws-server.md
@@ -1,0 +1,52 @@
+---
+id: c3-202
+title: http-ws-server
+type: component
+category: foundation
+parent: c3-2
+goal: Serve HTTP (static + API) and upgrade to WebSocket; attach auth gating; expose /health.
+uses:
+    - ref-ws-subscription
+    - ref-local-first-data
+c3-version: 4
+---
+
+# http-ws-server
+## Goal
+
+Serve HTTP (static + API) and upgrade to WebSocket; attach auth gating; expose /health.
+## Container Connection
+
+The network surface of the server. Without it, no client can reach read models or agent turns.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Auth gate | c3-203 |
+| IN (uses) | WS router | c3-208 |
+| OUT (provides) | HTTP + WS endpoints | c3-101 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Upgrades one WS per client, handed to ws-router |
+| ref-local-first-data | Default bind is 127.0.0.1 |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-203-auth.md
+++ b/.c3/c3-2-server/c3-203-auth.md
@@ -1,0 +1,48 @@
+---
+id: c3-203
+title: auth
+type: component
+category: foundation
+parent: c3-2
+goal: Gate HTTP + WS + API routes behind a launch-password session cookie when --password is set.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# auth
+## Goal
+
+Gate HTTP + WS + API routes behind a launch-password session cookie when --password is set.
+## Container Connection
+
+Keeps shared/tunnelled servers safe. Without it, --share would expose data without protection.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Middleware + session cookie | c3-202 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | When opting into wider surfaces, password becomes mandatory |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-204-paths-config.md
+++ b/.c3/c3-2-server/c3-204-paths-config.md
@@ -1,0 +1,51 @@
+---
+id: c3-204
+title: paths-config
+type: component
+category: foundation
+parent: c3-2
+goal: Resolve all filesystem paths (data dir, JSONL logs, snapshots) and machine identity helpers.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# paths-config
+## Goal
+
+Resolve all filesystem paths (data dir, JSONL logs, snapshots) and machine identity helpers.
+## Container Connection
+
+Single source of truth for where the server writes — prevents scattered path literals.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Path helpers | c3-206 |
+| OUT (provides) | Path helpers | c3-215 |
+| OUT (provides) | Path helpers | c3-217 |
+| OUT (provides) | Path helpers | c3-222 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Centralizes the ~/.kanna/data layout |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-205-events-schema.md
+++ b/.c3/c3-2-server/c3-205-events-schema.md
@@ -1,0 +1,52 @@
+---
+id: c3-205
+title: events-schema
+type: component
+category: foundation
+parent: c3-2
+goal: Define the event type definitions (project/chat/message/turn) appended to JSONL logs.
+uses:
+    - ref-event-sourcing
+    - ref-strong-typing
+c3-version: 4
+---
+
+# events-schema
+## Goal
+
+Define the event type definitions (project/chat/message/turn) appended to JSONL logs.
+## Container Connection
+
+The contract between writers (agent-coordinator, uploads, diff-store, etc.) and read-models. Without it events drift.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Typed event unions | c3-206 |
+| OUT (provides) | Typed event unions | c3-207 |
+| OUT (provides) | Typed event unions | c3-210 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-event-sourcing | Defines the event vocabulary appended to the log |
+| ref-strong-typing | Discriminated unions per event kind |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-206-event-store.md
+++ b/.c3/c3-2-server/c3-206-event-store.md
@@ -1,0 +1,55 @@
+---
+id: c3-206
+title: event-store
+type: component
+category: foundation
+parent: c3-2
+goal: Append events to JSONL, replay on boot, compact to snapshot.json when the log exceeds 2 MB.
+uses:
+    - ref-event-sourcing
+    - ref-local-first-data
+    - ref-colocated-bun-test
+c3-version: 4
+---
+
+# event-store
+## Goal
+
+Append events to JSONL, replay on boot, compact to snapshot.json when the log exceeds 2 MB.
+## Container Connection
+
+Authoritative state of the system. Without it, read-models and subscribers have no source of truth.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Events schema | c3-205 |
+| IN (uses) | Paths | c3-204 |
+| OUT (provides) | Append + replay API | c3-207 |
+| OUT (provides) | Append + replay API | c3-210 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|------|------|
+| ref-event-sourcing | Canonical implementation |
+| ref-local-first-data | All files under ~/.kanna/data |
+| ref-colocated-bun-test |  |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-207-read-models.md
+++ b/.c3/c3-2-server/c3-207-read-models.md
@@ -1,0 +1,52 @@
+---
+id: c3-207
+title: read-models
+type: component
+category: foundation
+parent: c3-2
+goal: Project events into derived views (sidebar, chat, projects, discovery) that ws-router broadcasts.
+uses:
+    - ref-cqrs-read-models
+    - ref-strong-typing
+c3-version: 4
+---
+
+# read-models
+## Goal
+
+Project events into derived views (sidebar, chat, projects, discovery) that ws-router broadcasts.
+## Container Connection
+
+Turns raw events into UI-shaped snapshots so clients never replay the log.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event stream | c3-206 |
+| IN (uses) | Events schema | c3-205 |
+| OUT (provides) | Projections | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-cqrs-read-models | Canonical implementation |
+| ref-strong-typing | Typed view models per UI surface |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-208-ws-router.md
+++ b/.c3/c3-2-server/c3-208-ws-router.md
@@ -1,0 +1,55 @@
+---
+id: c3-208
+title: ws-router
+type: component
+category: foundation
+parent: c3-2
+goal: 'Multiplex WS traffic: route subscribe/unsubscribe/command envelopes, push projections on every state change.'
+uses:
+    - ref-ws-subscription
+    - ref-cqrs-read-models
+    - ref-colocated-bun-test
+c3-version: 4
+---
+
+# ws-router
+## Goal
+
+Multiplex WS traffic: route subscribe/unsubscribe/command envelopes, push projections on every state change.
+## Container Connection
+
+The wire between read-models and every connected client.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Read models | c3-207 |
+| IN (uses) | Agent coordinator for commands | c3-210 |
+| IN (uses) | Protocol types | c3-302 |
+| OUT (provides) | Subscribe/command dispatch | c3-202 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|------|------|
+| ref-ws-subscription | Defines the router envelope and dispatch rules |
+| ref-cqrs-read-models | Only projections cross the wire |
+| ref-colocated-bun-test |  |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-209-process-utils.md
+++ b/.c3/c3-2-server/c3-209-process-utils.md
@@ -1,0 +1,53 @@
+---
+id: c3-209
+title: process-utils
+type: component
+category: foundation
+parent: c3-2
+goal: Helpers for spawning, signaling, and tearing down child processes (agents, terminals, tunnels).
+uses:
+    - ref-strong-typing
+c3-version: 4
+---
+
+# process-utils
+## Goal
+
+Helpers for spawning, signaling, and tearing down child processes (agents, terminals, tunnels).
+## Container Connection
+
+Keeps process lifecycle logic in one place so features don't reinvent it.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Process helpers | c3-201 |
+| OUT (provides) | Process helpers | c3-210 |
+| OUT (provides) | Process helpers | c3-211 |
+| OUT (provides) | Process helpers | c3-216 |
+| OUT (provides) | Process helpers | c3-218 |
+| OUT (provides) | Process helpers | c3-220 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-strong-typing | Typed handles for child processes |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-210-agent-coordinator.md
+++ b/.c3/c3-2-server/c3-210-agent-coordinator.md
@@ -1,0 +1,59 @@
+---
+id: c3-210
+title: agent-coordinator
+type: component
+category: feature
+parent: c3-2
+goal: 'Drive turn lifecycle across providers: start/cancel/resume Claude + Codex sessions, emit normalized transcript events.'
+uses:
+    - ref-provider-adapter
+    - ref-event-sourcing
+    - ref-tool-hydration
+    - ref-colocated-bun-test
+c3-version: 4
+---
+
+# agent-coordinator
+## Goal
+
+Drive turn lifecycle across providers: start/cancel/resume Claude + Codex sessions, emit normalized transcript events.
+## Container Connection
+
+The brain of the server — without it no agent turn executes.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Codex adapter | c3-211 |
+| IN (uses) | Provider catalog | c3-212 |
+| IN (uses) | Event store | c3-206 |
+| IN (uses) | Tool hydration | c3-303 |
+| IN (uses) | Process utils | c3-209 |
+| OUT (provides) | Turn commands | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|------|------|
+| ref-provider-adapter | Owns the provider-agnostic turn orchestration |
+| ref-event-sourcing | Writes turn events to the log first |
+| ref-tool-hydration | Normalizes tool calls before persistence |
+| ref-colocated-bun-test |  |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-211-codex-app-server.md
+++ b/.c3/c3-2-server/c3-211-codex-app-server.md
@@ -1,0 +1,52 @@
+---
+id: c3-211
+title: codex-app-server
+type: component
+category: feature
+parent: c3-2
+goal: 'Drive the Codex App Server over JSON-RPC: boot, run turns, translate Codex events into coordinator-friendly shapes.'
+uses:
+    - ref-provider-adapter
+    - ref-strong-typing
+c3-version: 4
+---
+
+# codex-app-server
+## Goal
+
+Drive the Codex App Server over JSON-RPC: boot, run turns, translate Codex events into coordinator-friendly shapes.
+## Container Connection
+
+Provides the Codex half of multi-provider support; without it users only have Claude.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Process utils | c3-209 |
+| OUT (provides) | Codex turn API | c3-210 |
+| OUT (provides) | Codex turn API | c3-213 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-provider-adapter | Adapter that stays behind the coordinator |
+| ref-strong-typing | Typed JSON-RPC protocol module |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-212-provider-catalog.md
+++ b/.c3/c3-2-server/c3-212-provider-catalog.md
@@ -1,0 +1,50 @@
+---
+id: c3-212
+title: provider-catalog
+type: component
+category: feature
+parent: c3-2
+goal: Normalize providers, models, reasoning effort levels, and Codex fast-mode flags into a single catalog.
+uses:
+    - ref-provider-adapter
+c3-version: 4
+---
+
+# provider-catalog
+## Goal
+
+Normalize providers, models, reasoning effort levels, and Codex fast-mode flags into a single catalog.
+## Container Connection
+
+Lets the coordinator, UI, and quick-response all agree on what providers/models exist.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Catalog | c3-210 |
+| OUT (provides) | Catalog | c3-213 |
+| OUT (provides) | Catalog types (re-exported) | c3-301 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-provider-adapter | Catalog is the shared vocabulary of the adapter |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-213-quick-response.md
+++ b/.c3/c3-2-server/c3-213-quick-response.md
@@ -1,0 +1,51 @@
+---
+id: c3-213
+title: quick-response
+type: component
+category: feature
+parent: c3-2
+goal: Execute lightweight structured queries (titles, commit messages) via Claude Haiku with Codex fallback.
+uses:
+    - ref-provider-adapter
+c3-version: 4
+---
+
+# quick-response
+## Goal
+
+Execute lightweight structured queries (titles, commit messages) via Claude Haiku with Codex fallback.
+## Container Connection
+
+Small background jobs that must stay fast and cheap; keeps the main coordinator focused on interactive turns.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Codex fallback | c3-211 |
+| IN (uses) | Provider catalog | c3-212 |
+| OUT (provides) | Title + commit generators | c3-208 |
+| OUT (provides) | Title + commit generators | c3-210 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-provider-adapter | Fallback path still honors catalog contracts |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-214-discovery.md
+++ b/.c3/c3-2-server/c3-214-discovery.md
@@ -1,0 +1,50 @@
+---
+id: c3-214
+title: discovery
+type: component
+category: feature
+parent: c3-2
+goal: Scan Claude Code and Codex local history directories to surface candidate projects for the local-projects page.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# discovery
+## Goal
+
+Scan Claude Code and Codex local history directories to surface candidate projects for the local-projects page.
+## Container Connection
+
+Zero-config on-ramp; without it users would start empty.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Paths | c3-204 |
+| OUT (provides) | Discovered projects | c3-207 |
+| OUT (provides) | Discovered projects | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Only reads user-local files, never hits network |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-215-diff-store.md
+++ b/.c3/c3-2-server/c3-215-diff-store.md
@@ -1,0 +1,52 @@
+---
+id: c3-215
+title: diff-store
+type: component
+category: feature
+parent: c3-2
+goal: Maintain per-chat diff state for hydrated write_file/delete_file tool rendering and commit scaffolding.
+uses:
+    - ref-tool-hydration
+c3-version: 4
+---
+
+# diff-store
+## Goal
+
+Maintain per-chat diff state for hydrated write_file/delete_file tool rendering and commit scaffolding.
+## Container Connection
+
+Lets the UI render full file diffs + commit flows without replaying tool events.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Paths | c3-204 |
+| IN (uses) | Tool hydration | c3-303 |
+| OUT (provides) | Diff snapshots | c3-207 |
+| OUT (provides) | Diff snapshots | c3-210 |
+| OUT (provides) | Diff snapshots | c3-213 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-tool-hydration | Diffs plug into the same tool entry pipeline |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-216-terminal-manager.md
+++ b/.c3/c3-2-server/c3-216-terminal-manager.md
@@ -1,0 +1,49 @@
+---
+id: c3-216
+title: terminal-manager
+type: component
+category: feature
+parent: c3-2
+goal: Spawn and manage PTY sessions for the embedded xterm terminal; stream I/O over WS.
+uses:
+    - ref-ws-subscription
+c3-version: 4
+---
+
+# terminal-manager
+## Goal
+
+Spawn and manage PTY sessions for the embedded xterm terminal; stream I/O over WS.
+## Container Connection
+
+Backs the terminal workspace component; without it there is no shell in the UI.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Process utils | c3-209 |
+| OUT (provides) | PTY sessions | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Terminal bytes flow over the same socket |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-217-uploads.md
+++ b/.c3/c3-2-server/c3-217-uploads.md
@@ -1,0 +1,50 @@
+---
+id: c3-217
+title: uploads
+type: component
+category: feature
+parent: c3-2
+goal: Accept file uploads (drag-drop attachments), store under data dir, emit events referencing the stored assets.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# uploads
+## Goal
+
+Accept file uploads (drag-drop attachments), store under data dir, emit events referencing the stored assets.
+## Container Connection
+
+Enables attachment-aware chats without leaving the local disk.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Paths | c3-204 |
+| IN (uses) | Event store | c3-206 |
+| OUT (provides) | Upload endpoint | c3-202 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Uploads land under ~/.kanna/data |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-218-share.md
+++ b/.c3/c3-2-server/c3-218-share.md
@@ -1,0 +1,50 @@
+---
+id: c3-218
+title: share
+type: component
+category: feature
+parent: c3-2
+goal: Create public trycloudflare URLs or named Cloudflare tunnels + terminal QR output.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# share
+## Goal
+
+Create public trycloudflare URLs or named Cloudflare tunnels + terminal QR output.
+## Container Connection
+
+Makes remote-sharing possible without inventing networking infra.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Process utils | c3-209 |
+| IN (uses) | Shared share types | c3-306 |
+| OUT (provides) | Tunnel URLs + QR | c3-201 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Only runs when the user opts in with --share |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-219-update-manager.md
+++ b/.c3/c3-2-server/c3-219-update-manager.md
@@ -4,34 +4,50 @@ title: update-manager
 type: component
 category: feature
 parent: c3-2
-goal: Check npm for newer kanna-code versions and expose update state to the UI.
+goal: Detect newer kanna-code versions, expose update state to the UI, and reload the app via a swappable strategy (npm/supervisor default, git/pm2 opt-in).
 uses:
     - ref-cqrs-read-models
+    - ref-strong-typing
 c3-version: 4
 ---
 
 # update-manager
 ## Goal
 
-Check npm for newer kanna-code versions and expose update state to the UI.
+Detect newer kanna-code versions, expose update state to the UI, and reload the app via a swappable strategy (npm/supervisor default, git/pm2 opt-in).
 ## Container Connection
 
-Keeps users aware of new versions without an external updater.
+Keeps users aware of new versions without an external updater, and lets operators swap the reload mechanism (supervisor-exit vs pm2-reload) without changing client or server wiring.
 ## Dependencies
 
 | Direction | What | From/To |
 |-----------|------|---------|
+| IN (uses) | `UpdateChecker` / `UpdateReloader` interfaces (in `update-strategy.ts`) | self |
 | OUT (provides) | Update status projection | c3-207 |
+| OUT (provides) | `restart_pending` signal consumed by CLI restart path | c3-201, c3-220 |
 ## Code References
 
-<!-- List concrete code files that implement this component -->
 | File | Purpose |
 |------|---------|
+| `src/server/update-manager.ts` | State machine; depends on `UpdateChecker` + `UpdateReloader` interfaces. Surfaces structured errors via `UpdateInstallError`. |
+| `src/server/update-strategy.ts` | Interfaces + `NpmChecker` / `GitChecker` / `SupervisorExitReloader` / `Pm2Reloader` + `createUpdateStrategy` factory (keyed on `KANNA_RELOADER`). |
+| `src/server/update-manager.test.ts` | Unit tests for the manager against fake checker/reloader. |
+| `src/server/update-strategy.test.ts` | Unit tests for all checkers, reloaders, and factory branches. |
+
+## Strategy Matrix
+
+| `KANNA_RELOADER` | Checker | Reloader | Extra env |
+|------------------|---------|----------|-----------|
+| unset / `supervisor` | `NpmChecker` | `SupervisorExitReloader` (install + exit 76) | — |
+| `pm2` | `GitChecker` | `Pm2Reloader` (git pull → build → pm2 reload) | `KANNA_REPO_DIR` (required), `KANNA_PM2_PROCESS_NAME` (optional, default `kanna`) |
+
 ## Related Refs
 
 | Ref | How It Serves Goal |
 |-----|-------------------|
 | ref-cqrs-read-models | Exposes update state as a projection |
+| ref-strong-typing | All side effects flow through typed DI interfaces — no `any`, no globals |
+
 ## Layer Constraints
 
 This component operates within these boundaries:
@@ -40,9 +56,11 @@ This component operates within these boundaries:
 - Focus on single responsibility within its domain
 - Cite refs for patterns instead of re-implementing
 - Hand off cross-component concerns to container
+- Keep `UpdateManager` free of strategy-specific knowledge (all branching lives in `createUpdateStrategy`)
 
 **MUST NOT:**
 - Import directly from other containers (use container linkages)
 - Define system-wide configuration (context responsibility)
 - Orchestrate multiple peer components (container responsibility)
 - Redefine patterns that exist in refs
+- Hardcode npm/git/pm2 behavior in `update-manager.ts` — extend via a new `UpdateChecker`/`UpdateReloader` pair

--- a/.c3/c3-2-server/c3-219-update-manager.md
+++ b/.c3/c3-2-server/c3-219-update-manager.md
@@ -1,0 +1,48 @@
+---
+id: c3-219
+title: update-manager
+type: component
+category: feature
+parent: c3-2
+goal: Check npm for newer kanna-code versions and expose update state to the UI.
+uses:
+    - ref-cqrs-read-models
+c3-version: 4
+---
+
+# update-manager
+## Goal
+
+Check npm for newer kanna-code versions and expose update state to the UI.
+## Container Connection
+
+Keeps users aware of new versions without an external updater.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Update status projection | c3-207 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-cqrs-read-models | Exposes update state as a projection |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-220-restart.md
+++ b/.c3/c3-2-server/c3-220-restart.md
@@ -1,0 +1,49 @@
+---
+id: c3-220
+title: restart
+type: component
+category: feature
+parent: c3-2
+goal: Implement in-place server restart (self-relaunch) after version updates or CLI flag changes.
+uses:
+    - ref-ws-subscription
+c3-version: 4
+---
+
+# restart
+## Goal
+
+Implement in-place server restart (self-relaunch) after version updates or CLI flag changes.
+## Container Connection
+
+Lets users upgrade without manually killing the process.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Process utils | c3-209 |
+| OUT (provides) | Restart command | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Clients observe restart state over WS |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-221-external-open.md
+++ b/.c3/c3-2-server/c3-221-external-open.md
@@ -1,0 +1,48 @@
+---
+id: c3-221
+title: external-open
+type: component
+category: feature
+parent: c3-2
+goal: Open URLs, files, and VS Code / editor links in the user's external apps.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# external-open
+## Goal
+
+Open URLs, files, and VS Code / editor links in the user's external apps.
+## Container Connection
+
+Small quality-of-life bridge between the UI and the host OS.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Open command | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Dispatches to local host only, never remote |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-server/c3-222-keybindings.md
+++ b/.c3/c3-2-server/c3-222-keybindings.md
@@ -1,0 +1,50 @@
+---
+id: c3-222
+title: keybindings
+type: component
+category: feature
+parent: c3-2
+goal: Persist per-user keybindings to ~/.kanna/data and sync them with the client.
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# keybindings
+## Goal
+
+Persist per-user keybindings to ~/.kanna/data and sync them with the client.
+## Container Connection
+
+Makes shortcut preferences survive restarts and multiple tabs.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Paths | c3-204 |
+| OUT (provides) | Keybinding projection | c3-207 |
+| OUT (provides) | Keybinding projection | c3-116 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Persisted under ~/.kanna/data |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/README.md
+++ b/.c3/c3-3-shared/README.md
@@ -1,0 +1,48 @@
+---
+id: c3-3
+title: Shared
+type: container
+parent: c3-0
+goal: Publish the wire protocol, core domain types, tool-call normalization, port/branding config that both client and server import.
+boundary: library
+c3-version: 4
+---
+
+# shared
+## Goal
+
+Publish the wire protocol, core domain types, tool-call normalization, port and branding config that both client and server import — a thin seam that keeps the two containers honest.
+## Responsibilities
+
+- Define domain types (projects, chats, turns, transcript entries, provider catalog).
+- Define the WebSocket protocol envelope shared by client + server.
+- Normalize tool-call shapes so Claude and Codex render through one pipeline.
+- Publish port helpers and branding constants.
+## Complexity Assessment
+
+**Level:** <!-- [trivial|simple|moderate|complex|critical] -->
+**Why:** <!-- signals observed from code analysis -->
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-301 | types | foundation | implemented | Core domain types shared by client + server |
+| c3-302 | protocol | foundation | implemented | WS envelope definitions |
+| c3-303 | tools | foundation | implemented | Tool-call hydration pipeline |
+| c3-304 | ports | foundation | implemented | Port constants + dev-port helpers |
+| c3-305 | branding | foundation | implemented | Product name + data dir constants |
+| c3-306 | share-shared | foundation | implemented | Share DTOs shared with client |
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-3-shared/c3-301-types.md
+++ b/.c3/c3-3-shared/c3-301-types.md
@@ -1,0 +1,49 @@
+---
+id: c3-301
+title: types
+type: component
+category: foundation
+parent: c3-3
+goal: Declare core domain types (projects, chats, turns, transcript entries, provider catalog shape) shared by client and server.
+uses:
+    - ref-strong-typing
+c3-version: 4
+---
+
+# types
+## Goal
+
+Declare core domain types (projects, chats, turns, transcript entries, provider catalog shape) shared by client and server.
+## Container Connection
+
+Anchor for shared typing; everything that crosses the wire uses these types.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Core types | c3-1 |
+| OUT (provides) | Core types | c3-2 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-strong-typing | Home of the shared type surface |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/c3-302-protocol.md
+++ b/.c3/c3-3-shared/c3-302-protocol.md
@@ -1,0 +1,51 @@
+---
+id: c3-302
+title: protocol
+type: component
+category: foundation
+parent: c3-3
+goal: Define WebSocket wire envelopes (WsInbound, WsOutbound, subscribe/command kinds, correlation IDs).
+uses:
+    - ref-ws-subscription
+    - ref-strong-typing
+c3-version: 4
+---
+
+# protocol
+## Goal
+
+Define WebSocket wire envelopes (WsInbound, WsOutbound, subscribe/command kinds, correlation IDs).
+## Container Connection
+
+The wire contract both sides of the socket respect.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Protocol envelopes | c3-101 |
+| OUT (provides) | Protocol envelopes | c3-208 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-ws-subscription | Protocol is the shared vocabulary of the subscription pattern |
+| ref-strong-typing | Envelopes are discriminated unions |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/c3-303-tools.md
+++ b/.c3/c3-3-shared/c3-303-tools.md
@@ -1,0 +1,55 @@
+---
+id: c3-303
+title: tools
+type: component
+category: foundation
+parent: c3-3
+goal: Normalize tool-call inputs from Claude + Codex into unified transcript tool entries (read, edit, write_file, delete_file, bash, plan, diff...).
+uses:
+    - ref-tool-hydration
+    - ref-strong-typing
+    - ref-colocated-bun-test
+c3-version: 4
+---
+
+# tools
+## Goal
+
+Normalize tool-call inputs from Claude + Codex into unified transcript tool entries (read, edit, write_file, delete_file, bash, plan, diff...).
+## Container Connection
+
+Lets both renderer and coordinator share a single hydration path.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Hydration functions | c3-113 |
+| OUT (provides) | Hydration functions | c3-114 |
+| OUT (provides) | Hydration functions | c3-210 |
+| OUT (provides) | Hydration functions | c3-215 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|------|------|
+| ref-tool-hydration | This module IS the hydration pipeline |
+| ref-strong-typing | Output is a discriminated tool-entry union |
+| ref-colocated-bun-test |  |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/c3-304-ports.md
+++ b/.c3/c3-3-shared/c3-304-ports.md
@@ -1,0 +1,50 @@
+---
+id: c3-304
+title: ports
+type: component
+category: foundation
+parent: c3-3
+goal: Centralize default ports and dev-mode port offsets (Vite client + Bun backend).
+uses:
+    - ref-strong-typing
+c3-version: 4
+---
+
+# ports
+## Goal
+
+Centralize default ports and dev-mode port offsets (Vite client + Bun backend).
+## Container Connection
+
+Keeps port defaults in sync between CLI, client build, and dev scripts.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Port constants | c3-201 |
+| OUT (provides) | Port constants | c3-202 |
+| OUT (provides) | Port constants | c3-101 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-strong-typing | Typed port constants |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/c3-305-branding.md
+++ b/.c3/c3-3-shared/c3-305-branding.md
@@ -1,0 +1,49 @@
+---
+id: c3-305
+title: branding
+type: component
+category: foundation
+parent: c3-3
+goal: Publish the product name + data dir constants ("kanna", ~/.kanna/data/...).
+uses:
+    - ref-local-first-data
+c3-version: 4
+---
+
+# branding
+## Goal
+
+Publish the product name + data dir constants (kanna, ~/.kanna/data/...).
+## Container Connection
+
+Keeps strings like app name + data dir in exactly one place.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Branding constants | c3-204 |
+| OUT (provides) | Branding constants | c3-110 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-local-first-data | Anchors the data path layout |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-shared/c3-306-share-shared.md
+++ b/.c3/c3-3-shared/c3-306-share-shared.md
@@ -1,0 +1,49 @@
+---
+id: c3-306
+title: share-shared
+type: component
+category: foundation
+parent: c3-3
+goal: Expose share/tunnel types used on both client and server (QR payload, public URL shape).
+uses:
+    - ref-strong-typing
+c3-version: 4
+---
+
+# share-shared
+## Goal
+
+Expose share/tunnel types used on both client and server (QR payload, public URL shape).
+## Container Connection
+
+Unifies the share feature across client + server without duplicating shapes.
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| OUT (provides) | Share DTOs | c3-218 |
+| OUT (provides) | Share DTOs | c3-110 |
+## Code References
+
+<!-- List concrete code files that implement this component -->
+| File | Purpose |
+|------|---------|
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-strong-typing | Shared DTOs |
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/code-map.yaml
+++ b/.c3/code-map.yaml
@@ -129,6 +129,8 @@ c3-218:
 c3-219:
   - src/server/update-manager.ts
   - src/server/update-manager.test.ts
+  - src/server/update-strategy.ts
+  - src/server/update-strategy.test.ts
 c3-220:
   - src/server/restart.ts
   - src/server/restart.test.ts

--- a/.c3/code-map.yaml
+++ b/.c3/code-map.yaml
@@ -1,0 +1,228 @@
+# C3 code-map: maps component and ref IDs to source file glob patterns.
+# Edit patterns, then verify with: c3x coverage
+
+# ---- Components ----
+
+# Client foundation
+c3-101:
+  - src/client/app/socket.ts
+  - src/client/app/socket.test.ts
+c3-102:
+  - src/client/stores/**/*.ts
+c3-103:
+  - src/client/components/ui/**/*.tsx
+
+# Client features
+c3-110:
+  - src/main.tsx
+  - src/client/app/App.tsx
+  - src/client/app/App.test.tsx
+  - src/client/app/useKannaState.ts
+  - src/client/app/useKannaState.test.ts
+  - src/client/app/derived.ts
+  - src/client/app/chatFocusPolicy.ts
+  - src/client/app/chatFocusPolicy.test.ts
+  - src/client/app/chatNotifications.ts
+  - src/client/app/PageHeader.tsx
+  - src/client/components/LocalDev.tsx
+  - src/client/hooks/**/*.ts
+  - src/client/hooks/**/*.tsx
+  - src/client/lib/**/*.ts
+c3-111:
+  - src/client/app/KannaSidebar.tsx
+  - src/client/app/sidebarNumberJump.ts
+  - src/client/app/sidebarNumberJump.test.ts
+c3-112:
+  - src/client/app/ChatPage/**/*.ts
+  - src/client/app/ChatPage/**/*.tsx
+  - src/client/app/ChatPage.test.ts
+  - src/client/app/useStickyChatFocus.ts
+  - src/client/app/useRightSidebarToggleAnimation.ts
+  - src/client/app/useTerminalToggleAnimation.ts
+c3-113:
+  - src/client/app/KannaTranscript.tsx
+  - src/client/app/KannaTranscript.test.tsx
+c3-114:
+  - src/client/components/messages/**/*.tsx
+  - src/client/components/messages/**/*.ts
+c3-115:
+  - src/client/components/chat-ui/**/*.tsx
+  - src/client/components/chat-ui/**/*.ts
+c3-116:
+  - src/client/app/SettingsPage.tsx
+  - src/client/app/SettingsPage.test.tsx
+c3-117:
+  - src/client/app/LocalProjectsPage.tsx
+  - src/client/components/NewProjectModal.tsx
+c3-118:
+  - src/client/app/ChatPage/TerminalWorkspaceShell.tsx
+  - src/client/app/terminalToggleAnimation.ts
+  - src/client/app/terminalToggleAnimation.test.ts
+  - src/client/app/terminalLayoutResize.ts
+  - src/client/app/terminalLayoutResize.test.ts
+
+# Server foundation
+c3-201:
+  - src/server/cli.ts
+  - src/server/cli-runtime.ts
+  - src/server/cli-runtime.test.ts
+  - src/server/cli-supervisor.ts
+c3-202:
+  - src/server/server.ts
+c3-203:
+  - src/server/auth.ts
+  - src/server/auth.test.ts
+c3-204:
+  - src/server/paths.ts
+  - src/server/machine-name.ts
+c3-205:
+  - src/server/events.ts
+  - src/server/harness-types.ts
+c3-206:
+  - src/server/event-store.ts
+  - src/server/event-store.test.ts
+c3-207:
+  - src/server/read-models.ts
+  - src/server/read-models.test.ts
+c3-208:
+  - src/server/ws-router.ts
+  - src/server/ws-router.test.ts
+c3-209:
+  - src/server/process-utils.ts
+  - src/server/process-utils.test.ts
+
+# Server features
+c3-210:
+  - src/server/agent.ts
+  - src/server/agent.test.ts
+c3-211:
+  - src/server/codex-app-server.ts
+  - src/server/codex-app-server.test.ts
+  - src/server/codex-app-server-protocol.ts
+c3-212:
+  - src/server/provider-catalog.ts
+  - src/server/provider-catalog.test.ts
+c3-213:
+  - src/server/quick-response.ts
+  - src/server/quick-response.test.ts
+  - src/server/generate-title.ts
+  - src/server/title-generation.live.test.ts
+  - src/server/generate-commit-message.ts
+  - src/server/generate-commit-message.test.ts
+  - src/server/llm-provider.ts
+  - src/server/llm-provider.test.ts
+c3-214:
+  - src/server/discovery.ts
+  - src/server/discovery.test.ts
+c3-215:
+  - src/server/diff-store.ts
+  - src/server/diff-store.test.ts
+c3-216:
+  - src/server/terminal-manager.ts
+  - src/server/terminal-manager.test.ts
+c3-217:
+  - src/server/uploads.ts
+  - src/server/uploads.test.ts
+c3-218:
+  - src/server/share.ts
+  - src/server/share.test.ts
+c3-219:
+  - src/server/update-manager.ts
+  - src/server/update-manager.test.ts
+c3-220:
+  - src/server/restart.ts
+  - src/server/restart.test.ts
+c3-221:
+  - src/server/external-open.ts
+  - src/server/external-open.test.ts
+c3-222:
+  - src/server/keybindings.ts
+  - src/server/keybindings.test.ts
+
+# Shared
+c3-301:
+  - src/shared/types.ts
+c3-302:
+  - src/shared/protocol.ts
+c3-303:
+  - src/shared/tools.ts
+  - src/shared/tools.test.ts
+c3-304:
+  - src/shared/ports.ts
+  - src/shared/dev-ports.ts
+  - src/shared/dev-ports.test.ts
+c3-305:
+  - src/shared/branding.ts
+  - src/shared/branding.test.ts
+c3-306:
+  - src/shared/share.ts
+
+# ---- Refs ----
+
+ref-event-sourcing:
+  - src/server/events.ts
+  - src/server/event-store.ts
+  - src/server/event-store.test.ts
+ref-cqrs-read-models:
+  - src/server/read-models.ts
+  - src/server/read-models.test.ts
+ref-ws-subscription:
+  - src/shared/protocol.ts
+  - src/server/ws-router.ts
+  - src/client/app/socket.ts
+ref-provider-adapter:
+  - src/server/agent.ts
+  - src/server/provider-catalog.ts
+  - src/server/codex-app-server.ts
+  - src/server/codex-app-server-protocol.ts
+  - src/server/quick-response.ts
+  - src/server/llm-provider.ts
+ref-zustand-store:
+  - src/client/stores/**/*.ts
+ref-colocated-bun-test:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.live.test.ts"
+ref-strong-typing:
+  - src/shared/**/*.ts
+  - tsconfig.json
+ref-local-first-data:
+  - src/server/paths.ts
+  - src/shared/branding.ts
+  - src/server/cli.ts
+  - src/server/auth.ts
+ref-tool-hydration:
+  - src/shared/tools.ts
+  - src/shared/tools.test.ts
+  - src/client/components/messages/**/*.tsx
+  - src/server/agent.ts
+
+# ---- Exclusions (not counted in coverage) ----
+_exclude:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.live.test.ts"
+  - dist/**
+  - scripts/**
+  - bin/**
+  - public/**
+  - docs/**
+  - assets/**
+  - "*.config.js"
+  - "*.config.ts"
+  - "vite.config.ts"
+  - "tailwind.config.js"
+  - "postcss.config.js"
+  - "tsconfig.json"
+  - "package.json"
+  - "bun.lock"
+  - "skills-lock.json"
+  - "index.html"
+  - ".c3/**"
+  - ".claude/**"
+  - ".github/**"
+  - ".agents/**"
+  - "README.md"
+  - "LICENSE"
+  - ".gitignore"
+  - "src/index.css"

--- a/.c3/config.yaml
+++ b/.c3/config.yaml
@@ -1,0 +1,1 @@
+# C3 configuration

--- a/.c3/refs/ref-colocated-bun-test.md
+++ b/.c3/refs/ref-colocated-bun-test.md
@@ -1,0 +1,52 @@
+---
+id: ref-colocated-bun-test
+title: Colocated Bun Test
+goal: Tests sit next to the file under test, named *.test.ts(x), and run under bun test — no separate test directory, no framework churn.
+c3-version: 4
+---
+
+# colocated-bun-test
+## Goal
+
+Tests sit next to the file under test, named *.test.ts(x), and run under bun test — no separate test directory, no framework churn.
+## Choice
+
+bun test as the single test runner. Test file naming: <module>.test.ts or <module>.test.tsx. Live integration tests end in .live.test.ts and are gated by env.
+## Why
+
+Keeps tests visible and close to behavior. Bun's fast startup eliminates the cost of running narrow test subsets while iterating.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Test lives next to impl | src/server/auth.ts + auth.test.ts |
+| Live APIs gated by .live.test.ts | title-generation.live.test.ts |
+| Use bun test <glob> to scope runs | bun test src/server/agent.test.ts |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-cqrs-read-models.md
+++ b/.c3/refs/ref-cqrs-read-models.md
@@ -1,0 +1,52 @@
+---
+id: ref-cqrs-read-models
+title: CQRS Read Models
+goal: Separate write path (event log) from read path (derived views) so subscribers consume fast snapshots without replaying the log.
+c3-version: 4
+---
+
+# cqrs-read-models
+## Goal
+
+Separate write path (event log) from read path (derived views) so subscribers consume fast snapshots without replaying the log.
+## Choice
+
+read-models.ts projects events into sidebar / chat / project views; ws-router broadcasts those views to subscribers on every state change.
+## Why
+
+Keeps UI render paths off the log; allows per-view memoization; lets derived shapes evolve without touching event schema.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| One read model per UI concern | sidebarView, chatView, projectsView |
+| Pure projections — no I/O from derivation | read-models.ts functions are deterministic |
+| Broadcast diffs on change, not on request | ws-router pushes on event append |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-event-sourcing.md
+++ b/.c3/refs/ref-event-sourcing.md
@@ -1,0 +1,52 @@
+---
+id: ref-event-sourcing
+title: Event Sourcing
+goal: Every state mutation is first captured as an immutable event appended to a JSONL log; system state is derived by replay + periodic snapshot compaction.
+c3-version: 4
+---
+
+# event-sourcing
+## Goal
+
+Every state mutation is first captured as an immutable event appended to a JSONL log; system state is derived by replay + periodic snapshot compaction.
+## Choice
+
+Append-only JSONL event logs (projects, chats, messages, turns) plus a compacted snapshot.json — no database. Implemented by src/server/event-store.ts and src/server/events.ts.
+## Why
+
+Zero-infra (no DB), crash-safe, human-inspectable, replayable for bug triage. Snapshots keep cold-start fast; replay tail handles recent events. Natural fit for a local-first single-user tool.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Mutations always emit an event first, derivations follow | agent-coordinator appends turn events; read-models react |
+| Events are append-only; never rewrite history | use new events for corrections, never edit log |
+| Compact when log exceeds 2 MB | snapshot.json generated on startup |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-local-first-data.md
+++ b/.c3/refs/ref-local-first-data.md
@@ -1,0 +1,52 @@
+---
+id: ref-local-first-data
+title: Local-First Data
+goal: All persistent state sits under ~/.kanna/data; the server binds to 127.0.0.1 by default and only exposes wider surfaces (LAN, tunnel) when the user opts in.
+c3-version: 4
+---
+
+# local-first-data
+## Goal
+
+All persistent state sits under ~/.kanna/data; the server binds to 127.0.0.1 by default and only exposes wider surfaces (LAN, tunnel) when the user opts in.
+## Choice
+
+paths.ts centralizes data paths; cli.ts defaults to localhost; --host / --remote / --share are explicit opt-ins; --password gates all surfaces when set.
+## Why
+
+Zero cloud lock-in, zero hosting cost, user owns data on their disk, safe default for a developer tool.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| All file paths flow through paths.ts | projects.jsonl, snapshot.json |
+| Bind only what user asked for | default 127.0.0.1, --remote for 0.0.0.0 |
+| Authenticated surfaces == all surfaces when --password set | API, /health, /ws |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-provider-adapter.md
+++ b/.c3/refs/ref-provider-adapter.md
@@ -1,0 +1,52 @@
+---
+id: ref-provider-adapter
+title: Provider Adapter
+goal: Normalize Claude Agent SDK and Codex App Server into one transcript + tool-call model so the UI never branches on provider.
+c3-version: 4
+---
+
+# provider-adapter
+## Goal
+
+Normalize Claude Agent SDK and Codex App Server into one transcript + tool-call model so the UI never branches on provider.
+## Choice
+
+agent-coordinator owns turn lifecycle. provider-catalog normalizes model/effort/fast-mode per provider. codex-app-server adapts Codex JSON-RPC. quick-response falls back Claude Haiku → Codex when needed.
+## Why
+
+Users switch providers mid-chat; transcript must stay unified. Isolating adapters keeps the rest of the server provider-agnostic.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Transcript types live in shared/types.ts, not per provider | TranscriptEntry is one union |
+| Tool calls route through shared/tools.ts hydration | unified icon/label regardless of provider |
+| Provider-specific quirks stay inside its adapter file | codex-app-server-protocol.ts |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-strong-typing.md
+++ b/.c3/refs/ref-strong-typing.md
@@ -1,0 +1,52 @@
+---
+id: ref-strong-typing
+title: Strong Typing Policy
+goal: No any / untyped shapes at boundaries — everything that crosses client↔server, provider↔coordinator, or log↔read-model is a named type in src/shared or the owning module.
+c3-version: 4
+---
+
+# strong-typing
+## Goal
+
+No any / untyped shapes at boundaries — everything that crosses client↔server, provider↔coordinator, or log↔read-model is a named type in src/shared or the owning module.
+## Choice
+
+TypeScript strict mode; shared types in src/shared/types.ts; protocol envelopes in src/shared/protocol.ts; events in src/server/events.ts.
+## Why
+
+Refactors stay safe, tool hydration logic can exhaustively switch on kinds, and client/server drift is caught at build time (bun run check).
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Discriminated unions over flags | TranscriptEntry kinds |
+| Shared types win over local duplicates | import from shared/types.ts |
+| bun run check must stay green | tsc --noEmit + vite build |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-tool-hydration.md
+++ b/.c3/refs/ref-tool-hydration.md
@@ -1,0 +1,52 @@
+---
+id: ref-tool-hydration
+title: Tool Call Hydration
+goal: Provider tool calls (Read, Edit, Bash, plan, diff, ...) are normalized into unified transcript entries by src/shared/tools.ts before rendering.
+c3-version: 4
+---
+
+# tool-hydration
+## Goal
+
+Provider tool calls (Read, Edit, Bash, plan, diff, ...) are normalized into unified transcript entries by src/shared/tools.ts before rendering.
+## Choice
+
+One hydration function per tool kind in shared/tools.ts; messages-renderer selects renderer by kind; agent-coordinator emits normalized entries before persisting.
+## Why
+
+Renderers stay simple and exhaustive; adding a tool is one shared normalization + one UI renderer; provider-agnostic by construction.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Hydration never throws — unknown tools map to generic entry | fallback branch in tools.ts |
+| No provider branching in renderers | messages-renderer dispatches on kind only |
+| Icons/labels live with hydration, not renderer | keeps hydration self-contained |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-ws-subscription.md
+++ b/.c3/refs/ref-ws-subscription.md
@@ -1,0 +1,52 @@
+---
+id: ref-ws-subscription
+title: WebSocket Subscription
+goal: A single typed WebSocket handles both subscriptions (push) and commands (pull), with a shared envelope defined in src/shared/protocol.ts.
+c3-version: 4
+---
+
+# ws-subscription
+## Goal
+
+A single typed WebSocket handles both subscriptions (push) and commands (pull), with a shared envelope defined in src/shared/protocol.ts.
+## Choice
+
+One WS per client. Server-side ws-router multiplexes subscribe/unsubscribe/command. Client-side socket.ts maintains the connection and dispatches typed envelopes.
+## Why
+
+Keeps the wire count flat, reuses the auth cookie, pairs naturally with the reactive read-model broadcast. Avoids REST polling, still supports one-shot commands.
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| All message shapes live in src/shared/protocol.ts | WsInbound / WsOutbound unions |
+| Commands return correlation IDs | request/response still works over the same socket |
+| Subscriptions receive full snapshots, not diffs | simpler reconciliation |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.c3/refs/ref-zustand-store.md
+++ b/.c3/refs/ref-zustand-store.md
@@ -1,0 +1,52 @@
+---
+id: ref-zustand-store
+title: Zustand Store Pattern
+goal: Client UI state lives in small Zustand stores scoped by concern (chat input, preferences, sidebar, terminal), persisted selectively via localStorage.
+c3-version: 4
+---
+
+# zustand-store
+## Goal
+
+Client UI state lives in small Zustand stores scoped by concern (chat input, preferences, sidebar, terminal), persisted selectively via localStorage.
+## Choice
+
+One store per concern under src/client/stores/. Prefer selectors + shallow equality. Persist via zustand/middleware when state must survive reloads.
+## Why
+
+Lightweight, no Provider tree, easy to test. Aligns with server-pushed snapshots (stores only hold UI-local state, server state comes via socket).
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| One concern per store file | chatInputStore, rightSidebarStore |
+| Colocate a *.test.ts | chatInputStore.test.ts |
+| Never store server-derived truth | server snapshots live in useKannaState hook, not a store |
+## Not This
+
+<!-- Alternatives we rejected and why -->
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ... | ... |
+## Scope
+
+<!-- Where does this choice apply? Be explicit about exclusions. -->
+
+**Applies to:**
+- <!-- containers/components where this ref governs behavior -->
+
+**Does NOT apply to:**
+- <!-- explicit exclusions -->
+## Override
+
+<!-- How to deviate from this choice when justified -->
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+## Cited By
+
+<!-- Updated when components cite this ref -->
+- c3-{N}{NN} ({component name})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          scope: "@cuongtranba"
 
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Thumbs.db
 # vite
 vite.config.ts.timestamp-*
 /.kanna
+
+# git worktrees
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ vite.config.ts.timestamp-*
 
 # git worktrees
 .worktrees/
+
+# pm2 rendered config (generated from scripts/pm2.config.cjs.tmpl)
+scripts/pm2.config.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vite.config.ts.timestamp-*
 
 # pm2 rendered config (generated from scripts/pm2.config.cjs.tmpl)
 scripts/pm2.config.cjs
+
+# pm2 local secrets (cloudflared token, password) — sourced by deploy.sh
+scripts/pm2.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Architecture
+
+This project uses C3 docs in `.c3/`.
+For architecture questions, changes, audits, file context -> `/c3`.
+Operations: query, audit, change, ref, sweep.
+File lookup: `c3x lookup <file-or-glob>` maps files/directories to components + refs.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ That's it. Kanna opens in your browser at [`localhost:3210`](http://localhost:32
 - **Project-first sidebar** — chats grouped under projects, with live status indicators (idle, running, waiting, failed)
 - **Drag-and-drop project ordering** — reorder project groups in the sidebar with persistent ordering
 - **Local project discovery** — auto-discovers projects from both Claude and Codex local history
+- **Bulk import Claude Code sessions** — one-click import of existing `~/.claude/projects/` sessions with full transcript and seamless resume via the Claude Agent SDK
 - **Rich transcript rendering** — hydrated tool calls, collapsible tool groups, plan mode dialogs, and interactive prompts with full result display
 - **Quick responses** — lightweight structured queries (e.g. title generation) via Haiku with automatic Codex fallback
 - **Plan mode** — review and approve agent plans before execution

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/kanna-code"><img src="https://img.shields.io/npm/v/kanna-code.svg?style=flat&colorA=18181b&colorB=f472b6" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/@cuongtranba/kanna"><img src="https://img.shields.io/npm/v/@cuongtranba/kanna.svg?style=flat&colorA=18181b&colorB=f472b6" alt="npm version" /></a>
 </p>
 
 <br />
@@ -27,7 +27,7 @@
 ## Quickstart
 
 ```bash
-bun install -g kanna-code
+bun install -g @cuongtranba/kanna
 ```
 
 If Bun isn't installed, install it first:
@@ -92,7 +92,7 @@ Embedded terminal support uses Bun's native PTY APIs and currently works on macO
 Install Kanna globally:
 
 ```bash
-bun install -g kanna-code
+bun install -g @cuongtranba/kanna
 ```
 
 If Bun isn't installed, install it first:
@@ -104,7 +104,7 @@ curl -fsSL https://bun.sh/install | bash
 Or clone and build from source:
 
 ```bash
-git clone https://github.com/jakemor/kanna.git
+git clone https://github.com/cuongtranba/kanna.git
 cd kanna
 bun install
 bun run build
@@ -270,10 +270,10 @@ Run Kanna as a background service on macOS under [pm2](https://pm2.keymetrics.io
 cd ~/path/to/kanna
 bun install
 bun run build
-bun link           # registers kanna-code → repo
+bun link           # registers @cuongtranba/kanna → repo
 ```
 
-After this, `~/.bun/install/global/node_modules/kanna-code` is a symlink to your repo.
+After this, `~/.bun/install/global/node_modules/@cuongtranba/kanna` is a symlink to your repo.
 
 ### 2. (Migrating from launchd) Unload the old agent
 
@@ -316,18 +316,18 @@ The update mechanism is abstracted behind `UpdateChecker` + `UpdateReloader` int
 
 | `KANNA_RELOADER` | Check | Reload | Notes |
 |---|---|---|---|
-| unset / `supervisor` | npm registry for `kanna-code` | `bun install -g kanna-code@latest`, exit 76, supervisor respawns | Default. End-user path for `bunx kanna`. |
+| unset / `supervisor` | npm registry for `@cuongtranba/kanna` | `bun install -g @cuongtranba/kanna@latest`, exit 76, supervisor respawns | Default. End-user path for `bunx kanna`. |
 | `pm2` | `git fetch` + `HEAD` vs `origin/main` | `git pull --ff-only` → cond. `bun install` → `bun run build` → `pm2 reload` | Dev/self-host path. Requires `KANNA_REPO_DIR`. |
 
 To add another reload mechanism (e.g., docker, systemd), implement the two interfaces and branch inside `createUpdateStrategy`; no changes to `UpdateManager`, `server.ts`, or any client code are needed.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=jakemor%2Fkanna&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=cuongtranba%2Fkanna&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=jakemor/kanna&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=jakemor/kanna&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=jakemor/kanna&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=cuongtranba/kanna&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=cuongtranba/kanna&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=cuongtranba/kanna&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,72 @@ All state is stored locally at `~/.kanna/data/`:
 
 Event logs are append-only JSONL. On startup, Kanna replays the log tail after the last snapshot, then compacts if the logs exceed 2 MB.
 
+## Self-hosting on macOS (launchd + Cloudflare tunnel)
+
+Run Kanna as a background service on macOS, exposed through a named Cloudflare tunnel. Reload after code changes with one command.
+
+### 1. Link the repo as the global install
+
+`bun link` makes the global `kanna` binary resolve to your checkout, so rebuilds go live without reinstalling:
+
+```bash
+cd ~/path/to/kanna
+bun install
+bun run build
+bun link           # registers kanna-code → repo
+```
+
+After this, `~/.bun/install/global/node_modules/kanna-code` is a symlink to your repo.
+
+### 2. Create a launchd agent
+
+Save to `~/Library/LaunchAgents/io.silentium.kanna.plist`, replacing `<TOKEN>` and `<PASSWORD>`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>io.silentium.kanna</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOU/.bun/bin/kanna</string>
+    <string>--cloudflared</string><string><TOKEN></string>
+    <string>--password</string><string><PASSWORD></string>
+    <string>--no-open</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>/tmp/kanna.log</string>
+  <key>StandardErrorPath</key><string>/tmp/kanna.err</string>
+</dict>
+</plist>
+```
+
+Load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/io.silentium.kanna.plist
+launchctl list | grep kanna          # should show a nonzero PID
+```
+
+### 3. Deploy script
+
+`scripts/deploy.sh` installs deps if needed, rebuilds the client, and restarts the launchd job:
+
+```bash
+./scripts/deploy.sh
+```
+
+Typical update flow after pulling new code:
+
+```bash
+git pull
+./scripts/deploy.sh
+```
+
+The tunnel reconnects in a few seconds and keeps the same public hostname configured on your Cloudflare tunnel.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=jakemor%2Fkanna&type=date&legend=top-left">

--- a/README.md
+++ b/README.md
@@ -258,13 +258,13 @@ All state is stored locally at `~/.kanna/data/`:
 
 Event logs are append-only JSONL. On startup, Kanna replays the log tail after the last snapshot, then compacts if the logs exceed 2 MB.
 
-## Self-hosting on macOS (launchd + Cloudflare tunnel)
+## Self-hosting on macOS (pm2 + Cloudflare tunnel)
 
-Run Kanna as a background service on macOS, exposed through a named Cloudflare tunnel. Reload after code changes with one command.
+Run Kanna as a background service on macOS under [pm2](https://pm2.keymetrics.io/), exposed through a named Cloudflare tunnel. The in-app **Update** button then pulls the latest commit, rebuilds, and hot-reloads the pm2 process — no terminal round-trip needed.
 
 ### 1. Link the repo as the global install
 
-`bun link` makes the global `kanna` binary resolve to your checkout, so rebuilds go live without reinstalling:
+`bun link` makes the global `kanna` binary resolve to your checkout:
 
 ```bash
 cd ~/path/to/kanna
@@ -275,54 +275,51 @@ bun link           # registers kanna-code → repo
 
 After this, `~/.bun/install/global/node_modules/kanna-code` is a symlink to your repo.
 
-### 2. Create a launchd agent
+### 2. (Migrating from launchd) Unload the old agent
 
-Save to `~/Library/LaunchAgents/io.silentium.kanna.plist`, replacing `<TOKEN>` and `<PASSWORD>`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>io.silentium.kanna</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/Users/YOU/.bun/bin/kanna</string>
-    <string>--cloudflared</string><string><TOKEN></string>
-    <string>--password</string><string><PASSWORD></string>
-    <string>--no-open</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/kanna.log</string>
-  <key>StandardErrorPath</key><string>/tmp/kanna.err</string>
-</dict>
-</plist>
-```
-
-Load it:
+If you previously ran Kanna under launchd, unload it once so pm2 can take over:
 
 ```bash
-launchctl load ~/Library/LaunchAgents/io.silentium.kanna.plist
-launchctl list | grep kanna          # should show a nonzero PID
+launchctl bootout gui/$(id -u)/io.silentium.kanna || true
 ```
 
-### 3. Deploy script
+### 3. First deploy
 
-`scripts/deploy.sh` installs deps if needed, rebuilds the client, and restarts the launchd job:
+`scripts/deploy.sh` installs pm2 if missing, renders `scripts/pm2.config.cjs` from the template (via `envsubst` from `brew install gettext`), and starts the pm2 process:
 
 ```bash
 ./scripts/deploy.sh
+pm2 list               # kanna should be "online"
+pm2 logs kanna --lines 50
 ```
 
-Typical update flow after pulling new code:
+`pm2 save` persists the running process list. To resurrect after a reboot, run `pm2 startup` once (pm2 prints the exact command) and then `pm2 save` again.
+
+The pm2 config sets `KANNA_RELOADER=pm2` and `KANNA_REPO_DIR=<repo>` so the in-app Update button triggers the pm2 reload pipeline (see next section). Override the pm2 process name with `KANNA_PM2_PROCESS_NAME` before running `./scripts/deploy.sh` if you need to run multiple instances.
+
+### 4. Redeploy / update
+
+Two ways to ship a new build:
+
+**a. From the UI (fastest).** Click **Update** in the running app. The server runs `git pull --ff-only` → conditional `bun install` → `bun run build` → `pm2.reload` internally, and the UI reconnects to the fresh build. If any step fails, the UI shows a red banner with the stderr tail and the old build keeps serving.
+
+**b. From the terminal.** Useful for non-Kanna deploys (e.g., pm2 config edits) or when the UI is unreachable:
 
 ```bash
 git pull
 ./scripts/deploy.sh
 ```
 
-The tunnel reconnects in a few seconds and keeps the same public hostname configured on your Cloudflare tunnel.
+### 5. Update strategies
+
+The update mechanism is abstracted behind `UpdateChecker` + `UpdateReloader` interfaces in `src/server/update-strategy.ts`, selected at startup by `KANNA_RELOADER`:
+
+| `KANNA_RELOADER` | Check | Reload | Notes |
+|---|---|---|---|
+| unset / `supervisor` | npm registry for `kanna-code` | `bun install -g kanna-code@latest`, exit 76, supervisor respawns | Default. End-user path for `bunx kanna`. |
+| `pm2` | `git fetch` + `HEAD` vs `origin/main` | `git pull --ff-only` → cond. `bun install` → `bun run build` → `pm2 reload` | Dev/self-host path. Requires `KANNA_REPO_DIR`. |
+
+To add another reload mechanism (e.g., docker, systemd), implement the two interfaces and branch inside `createUpdateStrategy`; no changes to `UpdateManager`, `server.ts`, or any client code are needed.
 
 ## Star History
 

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
+        "pm2": "6.0.14",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "react-markdown": "^10.1.0",
@@ -214,6 +215,16 @@
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
+    "@pm2/agent": ["@pm2/agent@2.1.1", "", { "dependencies": { "async": "~3.2.0", "chalk": "~3.0.0", "dayjs": "~1.8.24", "debug": "~4.3.1", "eventemitter2": "~5.0.1", "fast-json-patch": "^3.1.0", "fclone": "~1.0.11", "pm2-axon": "~4.0.1", "pm2-axon-rpc": "~0.7.0", "proxy-agent": "~6.4.0", "semver": "~7.5.0", "ws": "~7.5.10" } }, "sha512-0V9ckHWd/HSC8BgAbZSoq8KXUG81X97nSkAxmhKDhmF8vanyaoc1YXwc2KVkbWz82Rg4gjd2n9qiT3i7bdvGrQ=="],
+
+    "@pm2/blessed": ["@pm2/blessed@0.1.81", "", { "bin": { "blessed": "bin/tput.js" } }, "sha512-ZcNHqQjMuNRcQ7Z1zJbFIQZO/BDKV3KbiTckWdfbUaYhj7uNmUwb+FbdDWSCkvxNr9dBJQwvV17o6QBkAvgO0g=="],
+
+    "@pm2/io": ["@pm2/io@6.1.0", "", { "dependencies": { "async": "~2.6.1", "debug": "~4.3.1", "eventemitter2": "^6.3.1", "require-in-the-middle": "^5.0.0", "semver": "~7.5.4", "shimmer": "^1.2.0", "signal-exit": "^3.0.3", "tslib": "1.9.3" } }, "sha512-IxHuYURa3+FQ6BKePlgChZkqABUKFYH6Bwbw7V/pWU1pP6iR1sCI26l7P9ThUEB385ruZn/tZS3CXDUF5IA1NQ=="],
+
+    "@pm2/js-api": ["@pm2/js-api@0.8.0", "", { "dependencies": { "async": "^2.6.3", "debug": "~4.3.1", "eventemitter2": "^6.3.1", "extrareqp2": "^1.0.0", "ws": "^7.0.0" } }, "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA=="],
+
+    "@pm2/pm2-version-check": ["@pm2/pm2-version-check@1.0.4", "", { "dependencies": { "debug": "^4.3.1" } }, "sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -384,6 +395,8 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -428,7 +441,27 @@
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "amp": ["amp@0.3.1", "", {}, "sha512-OwIuC4yZaRogHKiuU5WlMR5Xk/jAcpPtawWL05Gj8Lvm2F6mwoJt4O/bHI+DHwG79vWd+8OFYM4/BzYqyRd3qw=="],
+
+    "amp-message": ["amp-message@0.1.2", "", { "dependencies": { "amp": "0.3.1" } }, "sha512-JqutcFwoU1+jhv7ArgW38bqrE+LQdcRv4NxNw0mp0JHQyB6tXesWRjtYKlDgHRY2o3JE5UTaBGUK8kSWUdxWUg=="],
+
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "ansis": ["ansis@4.0.0-node10", "", {}, "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
@@ -436,13 +469,25 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
+    "basic-ftp": ["basic-ftp@5.3.0", "", {}, "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "bodec": ["bodec@0.1.0", "", {}, "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -452,27 +497,49 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "charm": ["charm@0.1.2", "", {}, "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "cli-tableau": ["cli-tableau@2.0.1", "", { "dependencies": { "chalk": "3.0.0" } }, "sha512-he+WTicka9cl0Fg/y+YyxcN6/bfQ/1O3QmgxRXDhABKqLzvoOSM4fMzp39uMyLBulAFuywD2N7UaoQE7WaADxQ=="],
 
     "cloudflared": ["cloudflared@0.7.1", "", { "bin": { "cloudflared": "lib/cloudflared.js" } }, "sha512-jJn1Gu9Tf4qnIu8tfiHZ25Hs8rNcRYSVf8zAd97wvYdOCzftm1CTs1S/RPhijjGi8gUT1p9yzfDi9zYlU/0RwA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@2.15.1", "", {}, "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "croner": ["croner@4.1.97", "", {}, "sha512-/f6gpQuxDaqXu+1kwQYSckUglPaOrHdbIlBAu0YuW8/Cdb45XwXYNUBXg3r/9Mo6n540Kn/smKcZWko5x99KrQ=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "culvert": ["culvert@0.1.2", "", {}, "sha512-yi1x3EAWKjQTreYWeSd98431AV+IEE0qoDyOoaHJ7KJ21gv6HtBXHVLX74opVSGqcR8/AbjJBHAHpcOy2bj5Gg=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "dayjs": ["dayjs@1.11.15", "", {}, "sha512-MC+DfnSWiM9APs7fpiurHGCoeIx0Gdl6QZBy+5lu8MbYKN5FZEXqOgrundfibdfhGZ15o9hzmZ2xJjZnbvgKXQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "default-shell": ["default-shell@2.2.0", "", {}, "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -488,29 +555,67 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
+    "enquirer": ["enquirer@2.3.6", "", { "dependencies": { "ansi-colors": "^4.1.1" } }, "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter2": ["eventemitter2@5.0.1", "", {}, "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extrareqp2": ["extrareqp2@1.0.0", "", { "dependencies": { "follow-redirects": "^1.14.0" } }, "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA=="],
+
+    "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
+
+    "fclone": ["fclone@1.0.11", "", {}, "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-type": ["file-type@22.0.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw=="],
 
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "git-node-fs": ["git-node-fs@1.0.0", "", {}, "sha512-bLQypt14llVXBg0S0u8q8HmU7g9p3ysH+NvVlae5vILuUvs759665HvmR5+wb04KjHyjFcDRxdYb4kyNnluMUQ=="],
+
+    "git-sha1": ["git-sha1@0.1.2", "", {}, "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
@@ -522,25 +627,51 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "js-git": ["js-git@0.7.8", "", { "dependencies": { "bodec": "^0.1.0", "culvert": "^0.1.2", "git-sha1": "^0.1.2", "pako": "^0.2.5" } }, "sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -567,6 +698,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -666,11 +799,23 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "needle": ["needle@2.4.0", "", { "dependencies": { "debug": "^3.2.6", "iconv-lite": "^0.4.4", "sax": "^1.2.4" }, "bin": { "needle": "./bin/needle" } }, "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
@@ -678,11 +823,33 @@
 
     "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
 
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pidusage": ["pidusage@3.0.2", "", { "dependencies": { "safe-buffer": "^5.2.1" } }, "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w=="],
+
+    "pm2": ["pm2@6.0.14", "", { "dependencies": { "@pm2/agent": "~2.1.1", "@pm2/blessed": "0.1.81", "@pm2/io": "~6.1.0", "@pm2/js-api": "~0.8.0", "@pm2/pm2-version-check": "^1.0.4", "ansis": "4.0.0-node10", "async": "3.2.6", "chokidar": "3.6.0", "cli-tableau": "2.0.1", "commander": "2.15.1", "croner": "4.1.97", "dayjs": "1.11.15", "debug": "4.4.3", "enquirer": "2.3.6", "eventemitter2": "5.0.1", "fclone": "1.0.11", "js-yaml": "4.1.1", "mkdirp": "1.0.4", "needle": "2.4.0", "pidusage": "3.0.2", "pm2-axon": "~4.0.1", "pm2-axon-rpc": "~0.7.1", "pm2-deploy": "~1.0.2", "pm2-multimeter": "^0.1.2", "promptly": "2.2.0", "semver": "7.7.2", "source-map-support": "0.5.21", "sprintf-js": "1.1.2", "vizion": "~2.2.1" }, "optionalDependencies": { "pm2-sysmonit": "^1.2.8" }, "bin": { "pm2": "bin/pm2", "pm2-dev": "bin/pm2-dev", "pm2-docker": "bin/pm2-docker", "pm2-runtime": "bin/pm2-runtime" } }, "sha512-wX1FiFkzuT2H/UUEA8QNXDAA9MMHDsK/3UHj6Dkd5U7kxyigKDA5gyDw78ycTQZAuGCLWyUX5FiXEuVQWafukA=="],
+
+    "pm2-axon": ["pm2-axon@4.0.1", "", { "dependencies": { "amp": "~0.3.1", "amp-message": "~0.1.1", "debug": "^4.3.1", "escape-string-regexp": "^4.0.0" } }, "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg=="],
+
+    "pm2-axon-rpc": ["pm2-axon-rpc@0.7.1", "", { "dependencies": { "debug": "^4.3.1" } }, "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw=="],
+
+    "pm2-deploy": ["pm2-deploy@1.0.2", "", { "dependencies": { "run-series": "^1.1.8", "tv4": "^1.3.0" } }, "sha512-YJx6RXKrVrWaphEYf++EdOOx9EH18vM8RSZN/P1Y+NokTKqYAca/ejXwVLyiEpNju4HPZEk3Y2uZouwMqUlcgg=="],
+
+    "pm2-multimeter": ["pm2-multimeter@0.1.2", "", { "dependencies": { "charm": "~0.1.1" } }, "sha512-S+wT6XfyKfd7SJIBqRgOctGxaBzUOmVQzTAS+cg04TsEUObJVreha7lvCfX8zzGVr871XwCSnHUU7DQQ5xEsfA=="],
+
+    "pm2-sysmonit": ["pm2-sysmonit@1.2.8", "", { "dependencies": { "async": "^3.2.0", "debug": "^4.3.1", "pidusage": "^2.0.21", "systeminformation": "^5.7", "tx2": "~1.0.4" } }, "sha512-ACOhlONEXdCTVwKieBIQLSi2tQZ8eKinhcr9JpZSUAL8Qy0ajIgRtsLxG/lwPOW3JEKqPyw/UaHmTWhUzpP4kA=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -690,7 +857,13 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "promptly": ["promptly@2.2.0", "", { "dependencies": { "read": "^1.0.4" } }, "sha512-aC9j+BZsRSSzEsXBNBwDnAxujdx19HycZoKgRgzWnS8eOHg1asuf9heuLprfbe739zY3IdUQx+Egv6Jn135WHA=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "proxy-agent": ["proxy-agent@6.4.0", "", { "dependencies": { "agent-base": "^7.0.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.3", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.0.1", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.2" } }, "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "react": ["react@19.2.1", "", {}, "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw=="],
 
@@ -712,6 +885,10 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
+    "read": ["read@1.0.7", "", { "dependencies": { "mute-stream": "~0.0.4" } }, "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
@@ -726,19 +903,47 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-in-the-middle": ["require-in-the-middle@5.2.0", "", { "dependencies": { "debug": "^4.1.1", "module-details-from-path": "^1.0.3", "resolve": "^1.22.1" } }, "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "run-series": ["run-series@1.1.9", "", {}, "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
+    "shimmer": ["shimmer@1.2.1", "", {}, "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sprintf-js": ["sprintf-js@1.1.2", "", {}, "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -748,6 +953,12 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "systeminformation": ["systeminformation@5.31.5", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ=="],
+
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
@@ -756,6 +967,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
@@ -763,6 +976,10 @@
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tv4": ["tv4@1.3.0", "", {}, "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw=="],
+
+    "tx2": ["tx2@1.0.5", "", { "dependencies": { "json-stringify-safe": "^5.0.1" } }, "sha512-sJ24w0y03Md/bxzK4FU8J8JveYYUbSs2FViLJ2D/8bytSiyPRbuE3DyL/9UKYXTZlV3yXq0L8GLlhobTnekCVg=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
@@ -800,6 +1017,10 @@
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
+    "vizion": ["vizion@2.2.1", "", { "dependencies": { "async": "^2.6.3", "git-node-fs": "^1.0.0", "ini": "^1.3.5", "js-git": "^0.7.8" } }, "sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww=="],
+
+    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -807,6 +1028,32 @@
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@pm2/agent/dayjs": ["dayjs@1.8.36", "", {}, "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw=="],
+
+    "@pm2/agent/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "@pm2/agent/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
+
+    "@pm2/io/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
+    "@pm2/io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "@pm2/io/eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
+
+    "@pm2/io/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
+
+    "@pm2/io/tslib": ["tslib@1.9.3", "", {}, "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="],
+
+    "@pm2/js-api/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
+    "@pm2/js-api/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "@pm2/js-api/eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -820,6 +1067,28 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "needle/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "pm2-sysmonit/pidusage": ["pidusage@2.0.21", "", { "dependencies": { "safe-buffer": "^5.2.1" } }, "sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "vizion/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
+    "@pm2/agent/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "@pm2/io/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "@pm2/agent/semver/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "@pm2/io/semver/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
   }
 }

--- a/docs/plans/2026-04-20-import-claude-code-sessions-design.md
+++ b/docs/plans/2026-04-20-import-claude-code-sessions-design.md
@@ -1,0 +1,135 @@
+# Import Claude Code Sessions — Design
+
+**Date:** 2026-04-20
+**Status:** Approved, ready for implementation
+
+## Goal
+
+Bulk-import existing Claude Code CLI sessions from `~/.claude/projects/` into Kanna as native chats, preserving full transcript history and enabling seamless resume through the Claude Agent SDK.
+
+## Scope
+
+**In:**
+- Sidebar "Import" button beside existing "Add Project" button
+- One-shot scan of all `~/.claude/projects/*/*.jsonl` session files
+- Full transcript preload into Kanna chat (not stub/lazy)
+- Auto-create Kanna project if session's cwd is not yet tracked
+- Deduplication by `claudeSessionId`
+- Resume via session ID on next user turn (no forking)
+
+**Out (YAGNI):**
+- Running-process detection (`ps` scan)
+- Live session tailing
+- Separate sidebar section for un-imported CLI sessions
+- Codex session import
+- Bulk undo/delete for imported chats (existing per-chat delete suffices)
+
+## UI
+
+**Entry point:** new Import icon-button in sidebar header, sibling of Add Project.
+
+**Flow:**
+1. Click → confirmation modal: "Scan `~/.claude/projects/` and import sessions into Kanna?"
+2. Progress toast: "Scanning X sessions..." → streams count updates via WS
+3. Final toast: "Imported Y new, skipped Z existing, failed W"
+4. Sidebar refreshes with new projects and chats appearing under their groups
+
+## Architecture
+
+### New server module
+
+`src/server/import-claude-sessions.ts` — orchestrates scan, parse, dedup, write.
+
+### Scan phase
+
+- Walk `~/.claude/projects/*/` directories
+- List `*.jsonl` files per subdir (exclude snapshots/compacted files)
+- Decode folder name → cwd path via existing `resolveEncodedClaudePath` (discovery.ts:22)
+- Skip if cwd no longer exists on disk
+
+### Parse phase (per session file)
+
+- Read JSONL line-by-line, JSON.parse each
+- Extract `sessionId` from first record
+- Skip if `sessionId` already present in Kanna `chats.jsonl` (dedup)
+- Map each record → Kanna message event:
+  - user prompt → `message_appended { role: "user", ... }`
+  - assistant text → `message_appended { role: "assistant", ... }`
+  - tool_use / tool_result → normalized via `src/shared/tools.ts`
+- Emit `turn_finished` at assistant-response boundaries
+- Skip empty sessions (0 messages)
+- On malformed line: log + skip line, continue file (don't abort)
+
+### Write phase
+
+- Append `chat_created` event to `chats.jsonl`:
+  - `provider: "claude"`
+  - `claudeSessionId: <sessionId>`
+  - `status: "idle"`
+  - `projectId: <resolved or newly-created>`
+- Append all `message_appended` + `turn_finished` events to `messages.jsonl` / `turns.jsonl`
+- Trigger async title generation (existing Haiku pipeline) for untitled chats
+
+### Auto-create project
+
+If session cwd doesn't map to any existing Kanna project, emit `project_opened` event using same flow as Add Project modal.
+
+### Transport
+
+New WS command: `importClaudeSessions`
+Response shape: `{ imported: number, skipped: number, failed: number, newProjects: number }`
+Progress events streamed: `{ type: "importProgress", scanned, imported }`
+
+## Resume behavior
+
+- Kanna chat stores `claudeSessionId`
+- Next user turn: `AgentCoordinator` passes `resume: <sessionId>` option to Claude Agent SDK
+- SDK continues same session → appends to original `~/.claude/projects/*.jsonl`
+- No fork, no duplicate session ID
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Malformed JSONL line | Log + skip line, continue file |
+| Empty session (0 messages) | Skip, no chat created |
+| Session file still being written (CLI active) | Import current snapshot; resume continues normally |
+| Project dir deleted on disk | Skip session, count as failed |
+| Re-import of existing session | Dedup by `claudeSessionId`, skip |
+| Very large session (>10k messages) | Stream events; single progress update per 100 entries |
+
+## Testing
+
+### Unit
+
+`src/server/import-claude-sessions.test.ts`:
+- Fixture valid session → produces correct chat + message events
+- Fixture malformed JSONL → skips bad lines, imports rest
+- Fixture empty session → skipped
+- Fixture with tool_use/tool_result → normalized via shared/tools
+- Dedup: re-import produces 0 new
+- Missing project dir → failed count
+- Auto-create project when cwd new
+
+### Integration
+
+Full pipeline: WS `importClaudeSessions` → event store → read models → sidebar snapshot.
+
+## Files to touch
+
+**New:**
+- `src/server/import-claude-sessions.ts`
+- `src/server/import-claude-sessions.test.ts`
+- `src/client/components/ImportSessionsButton.tsx` (or inline in sidebar header)
+
+**Modified:**
+- `src/server/ws-router.ts` — add `importClaudeSessions` command handler
+- `src/shared/protocol.ts` — add command + progress event types
+- `src/server/events.ts` — reuse existing events; no new types needed
+- `src/client/app/KannaSidebar.tsx` — render Import button next to Add Project
+- `src/client/app/useKannaState.ts` — wire WS command + toast feedback
+- `src/server/agent.ts` — verify `resume: claudeSessionId` is passed (likely already supported)
+
+## Open questions
+
+None blocking. Implementation can proceed.

--- a/docs/plans/2026-04-20-import-claude-code-sessions.md
+++ b/docs/plans/2026-04-20-import-claude-code-sessions.md
@@ -1,0 +1,1198 @@
+# Import Claude Code Sessions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an "Import" button to the Kanna sidebar that scans `~/.claude/projects/*/*.jsonl` and bulk-creates Kanna chats from each session with full transcript preloaded, deduped by Claude session ID.
+
+**Architecture:** New server module `claude-session-importer.ts` parses Claude Code session JSONL files, maps records to Kanna `TranscriptEntry` values, and emits events through the existing `EventStore` (`openProject` → `createChat` → `renameChat` → `setChatProvider` → `appendMessage` × N → `setSessionToken`). Dedup uses the `sessionToken` field already present on `ChatRecord` (agent.ts:620 passes it as `resume` to the Claude Agent SDK, so imported chats resume seamlessly). New WS command `sessions.importClaude` handles the request; client adds an icon button next to the existing Add Project button in the sidebar header.
+
+**Tech Stack:** TypeScript, Bun, React 19, Zustand, Vite, WebSocket (custom envelope protocol). Existing test framework: `bun test`.
+
+**Reference design:** `docs/plans/2026-04-20-import-claude-code-sessions-design.md`
+
+---
+
+## Preflight
+
+**Run before starting:** ensure clean `main`, install deps.
+
+```bash
+git status                  # expect clean
+bun install
+bun run check               # typecheck + build baseline passes
+bun test                    # baseline green
+```
+
+Create a worktree (recommended):
+
+```bash
+git worktree add ../kanna-import-sessions -b feat/import-claude-sessions
+cd ../kanna-import-sessions
+```
+
+All paths below are relative to repo root.
+
+---
+
+## Task 1: Define Claude session record type
+
+**Files:**
+- Create: `src/server/claude-session-types.ts`
+
+**Purpose:** Narrow, self-contained TypeScript types for Claude Code JSONL records. Keep parsing strict — only fields we use.
+
+**Step 1: Create the types file.**
+
+```ts
+// src/server/claude-session-types.ts
+
+export interface ClaudeSessionRecordBase {
+  type: string
+  uuid?: string
+  parentUuid?: string | null
+  sessionId?: string
+  timestamp?: string
+  cwd?: string
+  version?: string
+}
+
+export interface ClaudeSessionUserRecord extends ClaudeSessionRecordBase {
+  type: "user"
+  message: {
+    role: "user"
+    content: string | Array<
+      | { type: "text"; text: string }
+      | { type: "tool_result"; tool_use_id: string; content?: unknown; is_error?: boolean }
+    >
+  }
+}
+
+export interface ClaudeSessionAssistantRecord extends ClaudeSessionRecordBase {
+  type: "assistant"
+  message: {
+    role: "assistant"
+    id?: string
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+    >
+  }
+}
+
+export interface ClaudeSessionSummaryRecord extends ClaudeSessionRecordBase {
+  type: "summary"
+  summary?: string
+}
+
+export interface ClaudeSessionSystemRecord extends ClaudeSessionRecordBase {
+  type: "system"
+  content?: string
+}
+
+export type ClaudeSessionRecord =
+  | ClaudeSessionUserRecord
+  | ClaudeSessionAssistantRecord
+  | ClaudeSessionSummaryRecord
+  | ClaudeSessionSystemRecord
+  | ClaudeSessionRecordBase
+
+export interface ParsedClaudeSession {
+  sessionId: string
+  filePath: string
+  cwd: string
+  firstTimestamp: number
+  lastTimestamp: number
+  records: ClaudeSessionRecord[]
+}
+```
+
+**Step 2: Typecheck.**
+
+```bash
+bun run tsc --noEmit
+```
+
+Expected: no errors.
+
+**Step 3: Commit.**
+
+```bash
+git add src/server/claude-session-types.ts
+git commit -m "feat(import): add Claude Code session record types"
+```
+
+---
+
+## Task 2: JSONL parser — happy path test first
+
+**Files:**
+- Create: `src/server/claude-session-parser.ts`
+- Create: `src/server/claude-session-parser.test.ts`
+- Create: `src/server/__fixtures__/claude-session-valid.jsonl`
+
+**Step 1: Write the happy-path fixture.**
+
+`src/server/__fixtures__/claude-session-valid.jsonl`:
+
+```jsonl
+{"type":"user","uuid":"u1","sessionId":"sess-abc","cwd":"/tmp/kanna-test-proj","timestamp":"2026-04-20T10:00:00.000Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:01.000Z","message":{"role":"assistant","id":"msg-1","content":[{"type":"text","text":"hi back"}]}}
+{"type":"user","uuid":"u2","parentUuid":"a1","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:02.000Z","message":{"role":"user","content":"run ls"}}
+{"type":"assistant","uuid":"a2","parentUuid":"u2","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:03.000Z","message":{"role":"assistant","id":"msg-2","content":[{"type":"tool_use","id":"tu-1","name":"Bash","input":{"command":"ls","description":"list files"}}]}}
+{"type":"user","uuid":"u3","parentUuid":"a2","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:04.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-1","content":"file1\nfile2"}]}}
+{"type":"assistant","uuid":"a3","parentUuid":"u3","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:05.000Z","message":{"role":"assistant","id":"msg-3","content":[{"type":"text","text":"done"}]}}
+```
+
+**Step 2: Write failing test.**
+
+`src/server/claude-session-parser.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseClaudeSessionFile } from "./claude-session-parser"
+
+const FIXTURE_DIR = path.join(__dirname, "__fixtures__")
+
+describe("parseClaudeSessionFile", () => {
+  test("parses valid session with user, assistant, tool_use, tool_result", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-valid.jsonl"))
+    expect(parsed).not.toBeNull()
+    if (!parsed) return
+    expect(parsed.sessionId).toBe("sess-abc")
+    expect(parsed.cwd).toBe("/tmp/kanna-test-proj")
+    expect(parsed.records.length).toBe(6)
+    expect(parsed.firstTimestamp).toBeGreaterThan(0)
+    expect(parsed.lastTimestamp).toBeGreaterThanOrEqual(parsed.firstTimestamp)
+  })
+})
+```
+
+Run: `bun test src/server/claude-session-parser.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement minimal parser.**
+
+`src/server/claude-session-parser.ts`:
+
+```ts
+import { readFileSync, statSync } from "node:fs"
+import type { ClaudeSessionRecord, ParsedClaudeSession } from "./claude-session-types"
+
+function tryParse(line: string): ClaudeSessionRecord | null {
+  try {
+    const parsed = JSON.parse(line)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+    if (typeof (parsed as ClaudeSessionRecord).type !== "string") return null
+    return parsed as ClaudeSessionRecord
+  } catch {
+    return null
+  }
+}
+
+export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | null {
+  let raw: string
+  try {
+    raw = readFileSync(filePath, "utf8")
+  } catch {
+    return null
+  }
+
+  const records: ClaudeSessionRecord[] = []
+  let sessionId: string | null = null
+  let cwd: string | null = null
+  let first = Number.POSITIVE_INFINITY
+  let last = 0
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const record = tryParse(trimmed)
+    if (!record) continue
+
+    if (!sessionId && typeof record.sessionId === "string") sessionId = record.sessionId
+    if (!cwd && typeof record.cwd === "string") cwd = record.cwd
+
+    const ts = typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN
+    if (!Number.isNaN(ts)) {
+      if (ts < first) first = ts
+      if (ts > last) last = ts
+    }
+
+    records.push(record)
+  }
+
+  if (!sessionId) return null
+  if (records.length === 0) return null
+
+  const mtime = statSync(filePath).mtimeMs
+  return {
+    sessionId,
+    filePath,
+    cwd: cwd ?? "",
+    firstTimestamp: Number.isFinite(first) ? first : mtime,
+    lastTimestamp: last > 0 ? last : mtime,
+    records,
+  }
+}
+```
+
+**Step 4: Run test — expect PASS.**
+
+```bash
+bun test src/server/claude-session-parser.test.ts
+```
+
+**Step 5: Commit.**
+
+```bash
+git add src/server/claude-session-parser.ts src/server/claude-session-parser.test.ts src/server/__fixtures__/claude-session-valid.jsonl
+git commit -m "feat(import): parse Claude Code session JSONL files"
+```
+
+---
+
+## Task 3: Parser edge cases — malformed / empty
+
+**Files:**
+- Create: `src/server/__fixtures__/claude-session-malformed.jsonl`
+- Create: `src/server/__fixtures__/claude-session-empty.jsonl`
+- Modify: `src/server/claude-session-parser.test.ts`
+
+**Step 1: Add fixtures.**
+
+`claude-session-malformed.jsonl`:
+
+```jsonl
+{"type":"user","uuid":"u1","sessionId":"sess-bad","cwd":"/tmp/x","timestamp":"2026-04-20T10:00:00.000Z","message":{"role":"user","content":"ok"}}
+not valid json at all
+{"type":"assistant","uuid":"a1","sessionId":"sess-bad","timestamp":"2026-04-20T10:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"still works"}]}}
+```
+
+`claude-session-empty.jsonl`: create an empty file.
+
+```bash
+: > src/server/__fixtures__/claude-session-empty.jsonl
+```
+
+**Step 2: Add tests.**
+
+Append to `claude-session-parser.test.ts`:
+
+```ts
+  test("skips malformed lines, keeps valid ones", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-malformed.jsonl"))
+    expect(parsed).not.toBeNull()
+    if (!parsed) return
+    expect(parsed.records.length).toBe(2)
+    expect(parsed.sessionId).toBe("sess-bad")
+  })
+
+  test("returns null for empty file", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-empty.jsonl"))
+    expect(parsed).toBeNull()
+  })
+
+  test("returns null for missing file", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "does-not-exist.jsonl"))
+    expect(parsed).toBeNull()
+  })
+```
+
+**Step 3: Run — expect PASS without code changes (parser already handles these).**
+
+```bash
+bun test src/server/claude-session-parser.test.ts
+```
+
+**Step 4: Commit.**
+
+```bash
+git add src/server/claude-session-parser.test.ts src/server/__fixtures__/claude-session-malformed.jsonl src/server/__fixtures__/claude-session-empty.jsonl
+git commit -m "test(import): cover malformed and empty Claude session files"
+```
+
+---
+
+## Task 4: Map Claude records → Kanna TranscriptEntry
+
+**Files:**
+- Create: `src/server/claude-session-mapper.ts`
+- Create: `src/server/claude-session-mapper.test.ts`
+
+**Step 1: Write failing test.**
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { mapClaudeRecordsToEntries } from "./claude-session-mapper"
+import type { ClaudeSessionRecord } from "./claude-session-types"
+
+describe("mapClaudeRecordsToEntries", () => {
+  const baseTs = "2026-04-20T10:00:00.000Z"
+
+  test("user message → user_prompt entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      { type: "user", uuid: "u1", timestamp: baseTs, message: { role: "user", content: "hello" } },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("user_prompt")
+    if (entries[0].kind === "user_prompt") {
+      expect(entries[0].content).toBe("hello")
+    }
+  })
+
+  test("assistant text → assistant_text entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        timestamp: baseTs,
+        message: { role: "assistant", id: "m1", content: [{ type: "text", text: "hi" }] },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("assistant_text")
+    if (entries[0].kind === "assistant_text") {
+      expect(entries[0].text).toBe("hi")
+    }
+  })
+
+  test("assistant tool_use → tool_call entry with normalized Bash tool", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "assistant",
+        uuid: "a2",
+        timestamp: baseTs,
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu-1", name: "Bash", input: { command: "ls" } }],
+        },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("tool_call")
+    if (entries[0].kind === "tool_call") {
+      expect(entries[0].tool.toolKind).toBe("bash")
+      expect(entries[0].tool.toolId).toBe("tu-1")
+    }
+  })
+
+  test("user tool_result → tool_result entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "user",
+        uuid: "u1",
+        timestamp: baseTs,
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu-1", content: "file1\nfile2" }],
+        },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("tool_result")
+    if (entries[0].kind === "tool_result") {
+      expect(entries[0].toolId).toBe("tu-1")
+      expect(entries[0].content).toBe("file1\nfile2")
+    }
+  })
+
+  test("skips summary and system records", () => {
+    const records: ClaudeSessionRecord[] = [
+      { type: "summary", summary: "x" },
+      { type: "system", content: "y" },
+      { type: "user", uuid: "u1", timestamp: baseTs, message: { role: "user", content: "hi" } },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+  })
+})
+```
+
+Run: `bun test src/server/claude-session-mapper.test.ts` — expect FAIL.
+
+**Step 2: Implement mapper.**
+
+`src/server/claude-session-mapper.ts`:
+
+```ts
+import { normalizeToolCall } from "../shared/tools"
+import type {
+  AssistantTextEntry,
+  ToolCallEntry,
+  ToolResultEntry,
+  TranscriptEntry,
+  UserPromptEntry,
+} from "../shared/types"
+import type {
+  ClaudeSessionAssistantRecord,
+  ClaudeSessionRecord,
+  ClaudeSessionUserRecord,
+} from "./claude-session-types"
+
+function toMillis(value: string | undefined): number {
+  if (!value) return Date.now()
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : Date.now()
+}
+
+function makeId(uuid: string | undefined, suffix: string): string {
+  if (uuid) return `${uuid}-${suffix}`
+  return `${crypto.randomUUID()}-${suffix}`
+}
+
+function mapUserRecord(record: ClaudeSessionUserRecord): TranscriptEntry[] {
+  const createdAt = toMillis(record.timestamp)
+  const content = record.message.content
+
+  if (typeof content === "string") {
+    const entry: UserPromptEntry = {
+      _id: makeId(record.uuid, "user"),
+      kind: "user_prompt",
+      createdAt,
+      content,
+    }
+    return [entry]
+  }
+
+  const entries: TranscriptEntry[] = []
+  for (let i = 0; i < content.length; i += 1) {
+    const block = content[i]
+    if (block.type === "tool_result") {
+      const resultEntry: ToolResultEntry = {
+        _id: makeId(record.uuid, `tool_result-${i}`),
+        kind: "tool_result",
+        createdAt,
+        toolId: block.tool_use_id,
+        content: typeof block.content === "string" ? block.content : block.content ?? null,
+        isError: block.is_error === true,
+      }
+      entries.push(resultEntry)
+    }
+  }
+  return entries
+}
+
+function mapAssistantRecord(record: ClaudeSessionAssistantRecord): TranscriptEntry[] {
+  const createdAt = toMillis(record.timestamp)
+  const messageId = record.message.id
+
+  const entries: TranscriptEntry[] = []
+  for (let i = 0; i < record.message.content.length; i += 1) {
+    const block = record.message.content[i]
+    if (block.type === "text") {
+      const entry: AssistantTextEntry = {
+        _id: makeId(record.uuid, `text-${i}`),
+        messageId,
+        kind: "assistant_text",
+        createdAt,
+        text: block.text,
+      }
+      entries.push(entry)
+      continue
+    }
+    if (block.type === "tool_use") {
+      const tool = normalizeToolCall({
+        toolName: block.name,
+        toolId: block.id,
+        input: block.input ?? {},
+      })
+      const entry: ToolCallEntry = {
+        _id: makeId(record.uuid, `tool_call-${i}`),
+        messageId,
+        kind: "tool_call",
+        createdAt,
+        tool,
+      }
+      entries.push(entry)
+    }
+  }
+  return entries
+}
+
+export function mapClaudeRecordsToEntries(records: ClaudeSessionRecord[]): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = []
+  for (const record of records) {
+    if (record.type === "user") {
+      entries.push(...mapUserRecord(record as ClaudeSessionUserRecord))
+    } else if (record.type === "assistant") {
+      entries.push(...mapAssistantRecord(record as ClaudeSessionAssistantRecord))
+    }
+    // summary/system/other: skipped
+  }
+  return entries
+}
+```
+
+**Step 3: Run test — expect PASS.**
+
+```bash
+bun test src/server/claude-session-mapper.test.ts
+```
+
+**Step 4: Commit.**
+
+```bash
+git add src/server/claude-session-mapper.ts src/server/claude-session-mapper.test.ts
+git commit -m "feat(import): map Claude session records to Kanna transcript entries"
+```
+
+---
+
+## Task 5: Scanner — walk ~/.claude/projects/
+
+**Files:**
+- Create: `src/server/claude-session-scanner.ts`
+- Create: `src/server/claude-session-scanner.test.ts`
+
+**Step 1: Failing test using a temp dir.**
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { scanClaudeSessions } from "./claude-session-scanner"
+
+function makeTempClaudeHome(): { home: string; cleanup: () => void } {
+  const home = mkdtempSync(path.join(tmpdir(), "kanna-claude-home-"))
+  return { home, cleanup: () => rmSync(home, { recursive: true, force: true }) }
+}
+
+describe("scanClaudeSessions", () => {
+  test("returns empty list when ~/.claude/projects missing", () => {
+    const { home, cleanup } = makeTempClaudeHome()
+    try {
+      expect(scanClaudeSessions(home)).toEqual([])
+    } finally {
+      cleanup()
+    }
+  })
+
+  test("discovers session files inside project folders", () => {
+    const { home, cleanup } = makeTempClaudeHome()
+    try {
+      const realProj = mkdtempSync(path.join(tmpdir(), "kanna-proj-"))
+      const folderName = realProj.replace(/\//g, "-")
+      const projDir = path.join(home, ".claude", "projects", folderName)
+      mkdirSync(projDir, { recursive: true })
+      const sessionPath = path.join(projDir, "sess-abc.jsonl")
+      const line = JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId: "sess-abc",
+        cwd: realProj,
+        timestamp: "2026-04-20T10:00:00.000Z",
+        message: { role: "user", content: "hi" },
+      })
+      writeFileSync(sessionPath, `${line}\n`, "utf8")
+
+      const sessions = scanClaudeSessions(home)
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].sessionId).toBe("sess-abc")
+      expect(sessions[0].filePath).toBe(sessionPath)
+      rmSync(realProj, { recursive: true, force: true })
+    } finally {
+      cleanup()
+    }
+  })
+})
+```
+
+Run: expect FAIL.
+
+**Step 2: Implement scanner.**
+
+`src/server/claude-session-scanner.ts`:
+
+```ts
+import { existsSync, readdirSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+import type { ParsedClaudeSession } from "./claude-session-types"
+import { parseClaudeSessionFile } from "./claude-session-parser"
+
+export function scanClaudeSessions(homeDir: string = homedir()): ParsedClaudeSession[] {
+  const projectsDir = path.join(homeDir, ".claude", "projects")
+  if (!existsSync(projectsDir)) return []
+
+  const sessions: ParsedClaudeSession[] = []
+  for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const projDir = path.join(projectsDir, entry.name)
+
+    for (const file of readdirSync(projDir, { withFileTypes: true })) {
+      if (!file.isFile() || !file.name.endsWith(".jsonl")) continue
+      const parsed = parseClaudeSessionFile(path.join(projDir, file.name))
+      if (parsed) sessions.push(parsed)
+    }
+  }
+
+  return sessions
+}
+```
+
+**Step 3: Run — PASS.**
+
+```bash
+bun test src/server/claude-session-scanner.test.ts
+```
+
+**Step 4: Commit.**
+
+```bash
+git add src/server/claude-session-scanner.ts src/server/claude-session-scanner.test.ts
+git commit -m "feat(import): scan ~/.claude/projects for session files"
+```
+
+---
+
+## Task 6: Importer orchestrator — dedup + event emission
+
+**Files:**
+- Create: `src/server/claude-session-importer.ts`
+- Create: `src/server/claude-session-importer.test.ts`
+
+This module glues scan → parse → map → store. Dedup on `chat.sessionToken === sessionId`. Skip sessions whose `cwd` doesn't exist on disk.
+
+**Step 1: Failing test using real `EventStore` with temp data dir.**
+
+```ts
+import { describe, expect, test, beforeEach } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EventStore } from "./event-store"
+import { importClaudeSessions } from "./claude-session-importer"
+
+function fresh() {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kanna-data-"))
+  const homeDir = mkdtempSync(path.join(tmpdir(), "kanna-home-"))
+  const realProj = mkdtempSync(path.join(tmpdir(), "kanna-proj-"))
+  return { dataDir, homeDir, realProj, cleanup: () => {
+    rmSync(dataDir, { recursive: true, force: true })
+    rmSync(homeDir, { recursive: true, force: true })
+    rmSync(realProj, { recursive: true, force: true })
+  } }
+}
+
+function seedSession(homeDir: string, realProj: string, sessionId: string) {
+  const folderName = realProj.replace(/\//g, "-")
+  const projDir = path.join(homeDir, ".claude", "projects", folderName)
+  mkdirSync(projDir, { recursive: true })
+  const line1 = JSON.stringify({
+    type: "user", uuid: "u1", sessionId, cwd: realProj,
+    timestamp: "2026-04-20T10:00:00.000Z",
+    message: { role: "user", content: "hi" },
+  })
+  const line2 = JSON.stringify({
+    type: "assistant", uuid: "a1", sessionId, cwd: realProj,
+    timestamp: "2026-04-20T10:00:01.000Z",
+    message: { role: "assistant", id: "m1", content: [{ type: "text", text: "hello" }] },
+  })
+  writeFileSync(path.join(projDir, `${sessionId}.jsonl`), `${line1}\n${line2}\n`, "utf8")
+}
+
+describe("importClaudeSessions", () => {
+  test("imports a session, creating project + chat + messages", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-aaa")
+      const store = new EventStore({ dataDir: ctx.dataDir })
+      await store.initialize()
+
+      const result = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(result.failed).toBe(0)
+
+      const chats = [...store.state.chatsById.values()].filter((c) => !c.deletedAt)
+      expect(chats.length).toBe(1)
+      expect(chats[0].sessionToken).toBe("sess-aaa")
+      expect(chats[0].provider).toBe("claude")
+      expect(store.getMessages(chats[0].id).length).toBe(2)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+
+  test("re-import is a no-op (dedup by sessionToken)", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-bbb")
+      const store = new EventStore({ dataDir: ctx.dataDir })
+      await store.initialize()
+
+      await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      const second = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+
+      expect(second.imported).toBe(0)
+      expect(second.skipped).toBe(1)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+
+  test("skips session whose cwd no longer exists", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-ccc")
+      rmSync(ctx.realProj, { recursive: true, force: true })
+      const store = new EventStore({ dataDir: ctx.dataDir })
+      await store.initialize()
+
+      const result = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(result.imported).toBe(0)
+      expect(result.failed).toBe(1)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+})
+```
+
+Check `EventStore` constructor shape in `src/server/event-store.ts` (look for `constructor(...)` near line 120-180) — if it takes a different shape, adjust the test. If `initialize()` isn't the entry, use whatever the existing code calls on startup (see `src/server/server.ts`).
+
+Run: expect FAIL — module missing.
+
+**Step 2: Implement importer.**
+
+`src/server/claude-session-importer.ts`:
+
+```ts
+import { existsSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import type { EventStore } from "./event-store"
+import { mapClaudeRecordsToEntries } from "./claude-session-mapper"
+import { scanClaudeSessions } from "./claude-session-scanner"
+import type { ParsedClaudeSession } from "./claude-session-types"
+
+export interface ImportClaudeSessionsResult {
+  imported: number
+  skipped: number
+  failed: number
+  newProjects: number
+}
+
+export interface ImportClaudeSessionsArgs {
+  store: EventStore
+  homeDir?: string
+  onProgress?: (update: { scanned: number; imported: number }) => void
+}
+
+function cwdExists(cwd: string): boolean {
+  if (!cwd) return false
+  try {
+    return statSync(cwd).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function deriveTitle(session: ParsedClaudeSession): string {
+  for (const record of session.records) {
+    if (record.type !== "user") continue
+    const content = (record as { message?: { content?: unknown } }).message?.content
+    if (typeof content === "string") {
+      const trimmed = content.trim()
+      if (trimmed) return trimmed.slice(0, 60)
+    }
+  }
+  return "Imported session"
+}
+
+export async function importClaudeSessions(args: ImportClaudeSessionsArgs): Promise<ImportClaudeSessionsResult> {
+  const { store, homeDir = homedir(), onProgress } = args
+  const sessions = scanClaudeSessions(homeDir)
+
+  let imported = 0
+  let skipped = 0
+  let failed = 0
+  let newProjects = 0
+
+  const existingSessionTokens = new Set<string>()
+  for (const chat of store.state.chatsById.values()) {
+    if (chat.deletedAt) continue
+    if (chat.sessionToken) existingSessionTokens.add(chat.sessionToken)
+  }
+
+  let scanned = 0
+  for (const session of sessions) {
+    scanned += 1
+    if (onProgress) onProgress({ scanned, imported })
+
+    if (existingSessionTokens.has(session.sessionId)) {
+      skipped += 1
+      continue
+    }
+    if (!cwdExists(session.cwd)) {
+      failed += 1
+      continue
+    }
+
+    const entries = mapClaudeRecordsToEntries(session.records)
+    if (entries.length === 0) {
+      skipped += 1
+      continue
+    }
+
+    try {
+      const projectBefore = store.state.projectIdsByPath.get(session.cwd)
+      const project = await store.openProject(session.cwd)
+      if (!projectBefore) newProjects += 1
+
+      const chat = await store.createChat(project.id)
+      await store.setChatProvider(chat.id, "claude")
+      await store.renameChat(chat.id, deriveTitle(session))
+
+      for (const entry of entries) {
+        await store.appendMessage(chat.id, entry)
+      }
+
+      await store.setSessionToken(chat.id, session.sessionId)
+      existingSessionTokens.add(session.sessionId)
+      imported += 1
+      if (onProgress) onProgress({ scanned, imported })
+    } catch (error) {
+      console.error("[kanna/import] failed to import session", session.filePath, error)
+      failed += 1
+    }
+  }
+
+  return { imported, skipped, failed, newProjects }
+}
+```
+
+**Step 3: Run — PASS.**
+
+```bash
+bun test src/server/claude-session-importer.test.ts
+```
+
+If `EventStore` constructor signature differs, read `src/server/event-store.ts` around the constructor definition (search for `class EventStore`, then `constructor(`). Adjust the test setup to match (e.g. `new EventStore(dataDir)` vs `new EventStore({ dataDir })`).
+
+**Step 4: Commit.**
+
+```bash
+git add src/server/claude-session-importer.ts src/server/claude-session-importer.test.ts
+git commit -m "feat(import): orchestrate import with dedup and event emission"
+```
+
+---
+
+## Task 7: Add WS protocol command
+
+**Files:**
+- Modify: `src/shared/protocol.ts`
+
+**Step 1: Add the command and progress event to the union.**
+
+In `ClientCommand` union, add:
+
+```ts
+  | { type: "sessions.importClaude" }
+```
+
+Keep the rest untouched. Place the new variant near `project.create` for locality.
+
+**Step 2: Typecheck.**
+
+```bash
+bun run tsc --noEmit
+```
+
+Expected: no errors. If there are exhaustive switch statements over `ClientCommand` (search `ws-router.ts` for `switch (command.type)`), TypeScript will flag missing case — we handle that in Task 8, so a failure here is only acceptable in `ws-router.ts`.
+
+**Step 3: Commit.**
+
+```bash
+git add src/shared/protocol.ts
+git commit -m "feat(import): add sessions.importClaude WS command"
+```
+
+---
+
+## Task 8: Wire WS handler
+
+**Files:**
+- Modify: `src/server/ws-router.ts`
+
+**Step 1: Add import.**
+
+Near the top of `ws-router.ts`, add:
+
+```ts
+import { importClaudeSessions } from "./claude-session-importer"
+```
+
+**Step 2: Add the command case.**
+
+Find the big `switch (command.type)` (look for `case "chat.create"` around line 802). Add a new case near `project.create`:
+
+```ts
+        case "sessions.importClaude": {
+          const result = await importClaudeSessions({ store })
+          if (result.newProjects > 0) {
+            await refreshDiscovery()
+          }
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
+          await broadcastSidebarToAll()
+          break
+        }
+```
+
+If the existing file has a helper named `broadcastSidebarToAll` or similar, use it. Otherwise look for how `chat.create` or `project.create` broadcasts sidebar updates (`broadcastChatAndSidebar` or `broadcastSidebar`) and mirror it. Grep first:
+
+```bash
+grep -n "broadcastSidebar\|broadcastChatAndSidebar\|refreshDiscovery" src/server/ws-router.ts
+```
+
+Use whichever matches the existing pattern for sidebar invalidation.
+
+**Step 3: Typecheck + test.**
+
+```bash
+bun run tsc --noEmit
+bun test
+```
+
+Expected: all green (prior tests should still pass; no new server test added here).
+
+**Step 4: Commit.**
+
+```bash
+git add src/server/ws-router.ts
+git commit -m "feat(import): handle sessions.importClaude over WebSocket"
+```
+
+---
+
+## Task 9: Client state hook wiring
+
+**Files:**
+- Modify: `src/client/app/useKannaState.ts`
+
+The hook exposes WS command senders. Add `importClaudeSessions` that sends the new command and returns the ack result.
+
+**Step 1: Locate the existing command-sender pattern.**
+
+```bash
+grep -n "project.create\|chat.create" src/client/app/useKannaState.ts
+```
+
+Copy the style used by `project.create`.
+
+**Step 2: Add the sender.**
+
+Inside the hook, near the other command senders:
+
+```ts
+  const importClaudeSessions = useCallback(async () => {
+    const result = await sendCommand({ type: "sessions.importClaude" })
+    return result as { imported: number; skipped: number; failed: number; newProjects: number }
+  }, [sendCommand])
+```
+
+Return `importClaudeSessions` from the hook's return object (add it alongside `createProject`, `removeProject`, etc.).
+
+**Step 3: Typecheck.**
+
+```bash
+bun run tsc --noEmit
+```
+
+**Step 4: Commit.**
+
+```bash
+git add src/client/app/useKannaState.ts
+git commit -m "feat(import): add importClaudeSessions state hook"
+```
+
+---
+
+## Task 10: Sidebar Import button
+
+**Files:**
+- Modify: `src/client/app/KannaSidebar.tsx` (or wherever Add Project button lives — confirm first)
+- Modify: `src/client/app/App.tsx` if needed to pass the handler
+
+**Step 1: Locate Add Project button.**
+
+```bash
+grep -rn "onOpenAddProjectModal\|NewProjectModal" src/client
+```
+
+The sidebar renders the Add Project button (likely as an icon-only button in a header row). Add a sibling button.
+
+**Step 2: Add Import button.**
+
+Import a suitable icon from `lucide-react`:
+
+```ts
+import { Download } from "lucide-react"
+```
+
+Inside the sidebar header, next to the Add Project button, add:
+
+```tsx
+<button
+  type="button"
+  className="<same classes as Add Project button>"
+  title="Import Claude Code sessions"
+  aria-label="Import Claude Code sessions"
+  disabled={isImporting}
+  onClick={handleImportClick}
+>
+  <Download size={16} />
+</button>
+```
+
+Wire `handleImportClick`:
+
+```ts
+const [isImporting, setIsImporting] = useState(false)
+
+const handleImportClick = async () => {
+  if (isImporting) return
+  const confirmed = window.confirm(
+    "Scan ~/.claude/projects/ and import all sessions into Kanna? Already-imported sessions are skipped.",
+  )
+  if (!confirmed) return
+  setIsImporting(true)
+  try {
+    const result = await importClaudeSessions()
+    alert(
+      `Imported ${result.imported}, skipped ${result.skipped}, failed ${result.failed}.`
+      + (result.newProjects > 0 ? ` (${result.newProjects} new projects)` : ""),
+    )
+  } catch (error) {
+    console.error("[kanna/import] failed", error)
+    alert("Import failed. See console for details.")
+  } finally {
+    setIsImporting(false)
+  }
+}
+```
+
+`importClaudeSessions` arrives from `useKannaState` — pass it through props if the sidebar doesn't already consume the hook directly (mirror how Add Project is wired).
+
+**Step 3: Typecheck + build.**
+
+```bash
+bun run check
+```
+
+Expected: success.
+
+**Step 4: Commit.**
+
+```bash
+git add src/client/app/KannaSidebar.tsx src/client/app/App.tsx
+git commit -m "feat(import): add Import button to sidebar header"
+```
+
+> Note: `window.confirm` / `window.alert` are used for minimal friction. Swap to a proper modal/toast later if the rest of the app uses a toast system — confirm by searching for existing toast components before rewriting.
+
+---
+
+## Task 11: Manual verification
+
+**Files:** none.
+
+**Step 1: Build + run dev.**
+
+```bash
+bun run dev
+```
+
+Visit `http://localhost:5174`.
+
+**Step 2: Verify preconditions.**
+
+```bash
+ls ~/.claude/projects/ | head
+```
+
+Expect at least one project directory with `.jsonl` files. If empty, copy one of your own sessions or create a minimal fixture before testing.
+
+**Step 3: Click Import.**
+
+- Confirm dialog appears
+- After accept, alert shows `Imported N, skipped 0, failed 0`
+- Sidebar refreshes — imported chats appear grouped under their project (project auto-created if needed)
+- Open an imported chat — transcript preloads (user messages, assistant text, tool calls render correctly)
+
+**Step 4: Verify dedup.**
+
+- Click Import again
+- Expect `Imported 0, skipped N`
+
+**Step 5: Verify resume.**
+
+- Open an imported chat
+- Send a follow-up message
+- Inspect `~/.claude/projects/<folder>/<same-session-id>.jsonl` — new lines should be appended by the Agent SDK (no new JSONL file created)
+
+**Step 6: Verify edge case — missing project.**
+
+- Temporarily rename a project directory whose sessions you've not imported
+- Click Import again — that session should count toward `failed` without crashing
+
+No commit for this task.
+
+---
+
+## Task 12: Docs update
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add import to Features section.**
+
+Under `## Features`, insert a bullet:
+
+```markdown
+- **Bulk import Claude Code sessions** — one-click import of existing `~/.claude/projects/` sessions with full transcript and seamless resume via the Claude Agent SDK
+```
+
+**Step 2: Commit.**
+
+```bash
+git add README.md
+git commit -m "docs: mention Claude Code session import feature"
+```
+
+---
+
+## Task 13: Final check
+
+```bash
+bun run check               # typecheck + build
+bun test                    # all unit tests
+git log --oneline           # verify commit history is clean and linear
+```
+
+All green → feature is ready for PR.
+
+---
+
+## Deferred / explicitly out of scope
+
+- Process scan / live CLI session detection
+- Separate "CLI sessions" sidebar section before import
+- Codex session import (Codex uses a different format in `~/.codex/sessions/`)
+- Bulk undo / unimport (use per-chat delete)
+- Progress streaming via WS events (single ack is sufficient for v1)
+- Toast-based progress UI (using `confirm`/`alert` for v1; switch to in-app toasts if the codebase adds them)
+
+## Skills referenced
+
+- `superpowers:executing-plans` — to run this plan task-by-task
+- `superpowers:subagent-driven-development` — if executing with fresh subagents per task
+- `superpowers:test-driven-development` — each task follows red-green-commit
+- `superpowers:verification-before-completion` — Task 11 gates completion on browser verification

--- a/docs/plans/2026-04-20-slash-command-picker-design.md
+++ b/docs/plans/2026-04-20-slash-command-picker-design.md
@@ -1,0 +1,193 @@
+# Slash Command Picker Design
+
+**Date:** 2026-04-20
+**Scope:** Claude Code-style `/` command picker in Kanna chat input for the Claude provider.
+
+## Goal
+
+When the user types `/` in the chat input, show a popup picker listing every slash command the active Claude session exposes — built-ins (`/help`, `/clear`, `/compact`, `/model`, `/init`, `/review`, ...), user-custom (`~/.claude/commands/*.md`), project-custom (`.claude/commands/*.md`), plugin commands, and MCP commands. Match Claude Code TUI behavior: filter as the user types, arrow keys navigate, Enter selects, the full `/name [args]` string is sent to the agent on submit.
+
+## Non-Goals (v1)
+
+- Codex provider support. `/` types literal when Codex is the active provider.
+- Hot-reload of newly authored `.md` command files mid-session.
+- Kanna-side intercept of `/clear`, `/model`, `/compact`, etc. The SDK owns dispatch.
+- Argument preview UI richer than the `argumentHint` hint string.
+- Multi-step sub-pickers (model list, agent list). The SDK owns these.
+- Command execution history or "recents".
+
+## Data Source
+
+The Claude Agent SDK exposes `Query.supportedCommands(): Promise<SlashCommand[]>` where
+
+```ts
+type SlashCommand = {
+  name: string          // without leading slash
+  description: string
+  argumentHint: string  // e.g. "<file>"
+}
+```
+
+This single call returns the full unified list across all sources. No filesystem scan.
+
+## Architecture
+
+### Lifecycle
+
+1. `AgentCoordinator` creates a Claude session via `query({...})` (existing, `src/server/agent.ts:614`).
+2. After the query object is created, the harness calls `q.supportedCommands()`.
+3. Result is emitted as a new `SessionCommandsLoadedEvent` and appended to `turns.jsonl`.
+4. `ReadModels` attach `slashCommands: SlashCommand[]` to the chat snapshot.
+5. Client receives the snapshot over the existing WS subscription and writes it into a Zustand store.
+6. `ChatInput` reads from the store via `useSlashCommands(chatId)` and drives the picker.
+
+### Execution
+
+- User selects a command → input becomes `/<name> ` (trailing space only when `argumentHint` is non-empty).
+- User presses Enter → existing send path. The full string (`/review pr-123`) is forwarded verbatim to `sendPrompt()` → SDK dispatches it.
+- Local-output commands return `SDKLocalCommandOutputMessage` with `subtype: "local_command_output"`. Rendered as assistant-style text in the transcript. Confirm Kanna's transcript hydrator handles this subtype; add a small case if not.
+
+## Server Changes
+
+### `src/server/events.ts`
+
+```ts
+export type SessionCommandsLoadedEvent = {
+  type: "session.commands_loaded"
+  chatId: string
+  sessionId: string
+  commands: Array<{ name: string; description: string; argumentHint: string }>
+  timestamp: number
+}
+```
+
+Appended to the existing `turns.jsonl` (no new event file).
+
+### `src/server/agent.ts`
+
+- Extend the Claude harness return type with `getSupportedCommands: () => Promise<SlashCommand[]>`.
+- Implementation: `async () => { try { return await q.supportedCommands() } catch (e) { log.warn(...); return [] } }`.
+
+### `AgentCoordinator`
+
+- On Claude session start: await `getSupportedCommands()`, emit `SessionCommandsLoadedEvent`.
+- On resume: refetch after the SDK reports the resumed session is ready; emit a fresh event so plugin/command changes between runs are reflected.
+- Codex provider: skip (v1 scope).
+
+### `src/server/read-models.ts`
+
+- Extend the chat snapshot with `slashCommands: SlashCommand[]`.
+- Replay collapses multiple `SessionCommandsLoadedEvent`s to the most recent per `chatId`.
+- Snapshot compaction stores the latest list in `snapshot.json`. No growth concern.
+
+### `src/shared/types.ts`
+
+```ts
+export type SlashCommand = {
+  name: string
+  description: string
+  argumentHint: string
+}
+```
+
+Mirror the SDK type locally so the client bundle does not pull the SDK.
+
+### `src/shared/protocol.ts`
+
+No new WS message type. The list rides on the existing chat snapshot broadcast.
+
+## Client Changes
+
+### Zustand store — `src/client/stores/slash-commands.ts`
+
+```ts
+type State = {
+  byChatId: Record<string, SlashCommand[]>
+  setForChat: (chatId: string, cmds: SlashCommand[]) => void
+  clear: (chatId: string) => void
+}
+```
+
+The socket snapshot handler calls `setForChat(chatId, snapshot.slashCommands ?? [])` on every push.
+
+### Hook — `src/client/hooks/useSlashCommands.ts`
+
+```ts
+export function useSlashCommands(chatId: string): SlashCommand[]
+```
+
+Returns cached list or `[]`. Stable reference via selector equality.
+
+### Filter util — `src/client/lib/slash-commands.ts`
+
+```ts
+export function shouldShowPicker(
+  value: string,
+  caret: number,
+): { open: boolean; query: string }
+
+export function filterCommands(
+  list: SlashCommand[],
+  query: string,
+): SlashCommand[]
+```
+
+- `shouldShowPicker`: regex `^\/(\S*)$` on the substring from start to caret. Open when it matches and caret is inside the first token.
+- `filterCommands`: case-insensitive match on `name`. Rank prefix matches first, then substring, then alphabetical.
+
+### Picker component — `src/client/components/chat-ui/SlashCommandPicker.tsx`
+
+Mounted as a child of `ChatInput.tsx`, positioned absolutely above the textarea.
+
+**Row layout**
+
+```
+/name  <argumentHint>       description (muted, truncated)
+```
+
+The highlighted row gets `bg-accent` and shows the full description when space allows.
+
+**Behavior**
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | move selection |
+| `Enter` / `Tab` | accept → insert `/<name>[ ]` |
+| `Esc` | close picker, keep input |
+| any printable | passthrough, filter updates |
+
+- Cap visible rows at 8, scrollable.
+- Empty state: a non-selectable "No matching commands" row.
+- Accept: replaces the `/<query>` span at the caret with `/<name>` (+ trailing space if `argumentHint` is non-empty), caret moves to end, picker closes. It reopens only if the user deletes back into the `/token`.
+
+### `ChatInput.tsx`
+
+- New local state: `pickerOpen`, `pickerQuery`, `pickerIndex`.
+- Derive `pickerOpen` and `pickerQuery` from `shouldShowPicker(value, caret)` on every change.
+- Memoize filtered list.
+- Intercept `↑ ↓ Enter Tab Esc` in `onKeyDown` when `pickerOpen`. Otherwise the existing send logic runs.
+- Short-circuit render: if `list.length === 0 && query === ""`, do not mount the picker (avoid flash).
+
+## Tests
+
+- `src/client/lib/slash-commands.test.ts` — `shouldShowPicker`, `filterCommands` pure unit coverage.
+- `src/client/components/chat-ui/ChatInput.test.ts` — picker open on `/`, filter as typed, arrow navigation, Enter/Tab insertion, Esc dismiss, caret placement.
+- Server-side agent test — mock `query.supportedCommands`, assert event emitted, harness returns list, errors degrade to `[]`.
+- Read-model test — replay two `SessionCommandsLoadedEvent`s, snapshot reflects the latest.
+
+## Rollout Steps
+
+1. SDK probe + shared `SlashCommand` type + `SessionCommandsLoadedEvent`.
+2. Agent harness method + coordinator emit on session start and resume.
+3. Read-model extension + snapshot wiring.
+4. Zustand store + hook + socket handler populates store.
+5. `SlashCommandPicker` component + `ChatInput` integration + filter util.
+6. Unit tests + manual verification in `bun run dev`.
+
+## Risks and Follow-Ups
+
+- **`/model`, `/clear`, `/compact` output UX.** SDK may respond with text only. If the result is poor, v1.1 can intercept these client-side and trigger Kanna's existing model picker / transcript clear.
+- **`supportedCommands()` latency.** If the call is slow, the very first `/` press after a session start shows an empty picker briefly. Acceptable; eager fetch is issued immediately after query creation.
+- **Plugin / MCP invalidation mid-session.** Stale list until session restart. Acceptable v1.
+- **Resume freshness.** Refetching after resume is a cheap extra call and keeps the list current when plugins change between runs.
+- **Provider inconsistency.** Codex users see no picker. Picker short-circuits when the active provider is Codex so `/` types literal.

--- a/docs/plans/2026-04-20-slash-command-picker.md
+++ b/docs/plans/2026-04-20-slash-command-picker.md
@@ -1,0 +1,1036 @@
+# Slash Command Picker Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Claude Code-style `/` command picker to Kanna's chat input for Claude sessions. When the user types `/`, show a popup listing every SDK-reported slash command (built-ins + user + project + plugin + MCP). Arrow/Enter selects, text filters, Enter submits `/name args...` to the existing send path.
+
+**Architecture:** Server queries `@anthropic-ai/claude-agent-sdk` via `query.supportedCommands()` after session start, emits a new `session.commands_loaded` turn event, `ReadModels` attaches the latest list to the chat snapshot. Client caches in a Zustand store (populated from snapshot), reads via hook, renders a new `SlashCommandPicker` component mounted from `ChatInput.tsx`. Execution unchanged — SDK dispatches commands that arrive as prompts.
+
+**Tech Stack:** TypeScript, Bun, React 19, Zustand, Vitest/Bun tests, Tailwind, `@anthropic-ai/claude-agent-sdk`.
+
+**Worktree:** `/Users/cuongtran/Desktop/repo/kanna/.worktrees/slash-command-picker` (branch `feature/slash-command-picker`). Baseline `bun run check` passes (see `7a22349`).
+
+**Design reference:** `docs/plans/2026-04-20-slash-command-picker-design.md`.
+
+---
+
+## Task 1 — Shared `SlashCommand` type
+
+**Files:**
+- Modify: `src/shared/types.ts` (append near `ChatSnapshot` definition around line 872)
+
+**Step 1: Add type**
+
+In `src/shared/types.ts`, append:
+
+```ts
+export interface SlashCommand {
+  name: string
+  description: string
+  argumentHint: string
+}
+```
+
+Then extend `ChatSnapshot`:
+
+```ts
+export interface ChatSnapshot {
+  runtime: ChatRuntime
+  queuedMessages: QueuedChatMessage[]
+  messages: TranscriptEntry[]
+  history: ChatHistorySnapshot
+  availableProviders: ProviderCatalogEntry[]
+  slashCommands: SlashCommand[]
+}
+```
+
+**Step 2: Run typecheck**
+
+Run: `bun run check`
+Expected: FAIL — downstream consumers of `ChatSnapshot` missing new field.
+
+**Step 3: Add empty default at every construction site**
+
+The one known construction site is `deriveChatSnapshot` in `src/server/read-models.ts:178-188`. Add `slashCommands: []` to the returned object. Leave any other compile errors for Task 4.
+
+**Step 4: Re-run check**
+
+Run: `bun run check`
+Expected: PASS (or pass if only `read-models.ts` was broken — if new errors exist, fix them with `slashCommands: []` stub, no logic).
+
+**Step 5: Commit**
+
+```bash
+git add src/shared/types.ts src/server/read-models.ts
+git commit -m "feat(types): add SlashCommand type and ChatSnapshot.slashCommands"
+```
+
+---
+
+## Task 2 — `session.commands_loaded` event type
+
+**Files:**
+- Modify: `src/server/events.ts` (extend `TurnEvent` union near line 136-168)
+
+**Step 1: Extend `TurnEvent`**
+
+Add a new branch to the `TurnEvent` discriminated union in `src/server/events.ts`:
+
+```ts
+  | {
+      v: 2
+      type: "session_commands_loaded"
+      timestamp: number
+      chatId: string
+      commands: Array<{ name: string; description: string; argumentHint: string }>
+    }
+```
+
+**Step 2: Extend `ChatRecord`**
+
+Add an optional `slashCommands?: SlashCommand[]` field to `ChatRecord` (line 7). Import `SlashCommand` from `../shared/types`.
+
+**Step 3: Run typecheck**
+
+Run: `bun run check`
+Expected: PASS (new fields are additive, not referenced anywhere yet).
+
+**Step 4: Commit**
+
+```bash
+git add src/server/events.ts
+git commit -m "feat(events): add session_commands_loaded turn event"
+```
+
+---
+
+## Task 3 — `EventStore.recordSessionCommandsLoaded`
+
+**Files:**
+- Modify: `src/server/event-store.ts` (add method next to other `recordTurn*` methods around line 765-820)
+
+**Step 1: Locate reducer**
+
+Use LSP `workspace-symbols` or Grep for `case "turn_started":` in `src/server/event-store.ts` to find where `TurnEvent` is applied to state during replay. Note the file and function.
+
+**Step 2: Write failing test**
+
+Create `src/server/event-store.test.ts` (or add to existing test file if present — check first with `ls src/server/*.test.ts`). Add:
+
+```ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { EventStore } from "./event-store"
+
+describe("EventStore.recordSessionCommandsLoaded", () => {
+  let dir: string
+  let store: EventStore
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kanna-es-"))
+    store = new EventStore({ dataDir: dir })
+    await store.load()
+    await store.recordProjectOpened({ projectId: "p1", localPath: "/tmp/x", title: "x" })
+    await store.recordChatCreated({ chatId: "c1", projectId: "p1", title: "chat" })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  test("stores latest commands on chat record", async () => {
+    await store.recordSessionCommandsLoaded("c1", [
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+    ])
+    expect(store.getChat("c1")?.slashCommands).toEqual([
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+    ])
+  })
+
+  test("replaces commands on subsequent load", async () => {
+    await store.recordSessionCommandsLoaded("c1", [{ name: "a", description: "", argumentHint: "" }])
+    await store.recordSessionCommandsLoaded("c1", [{ name: "b", description: "", argumentHint: "" }])
+    expect(store.getChat("c1")?.slashCommands).toEqual([
+      { name: "b", description: "", argumentHint: "" },
+    ])
+  })
+})
+```
+
+(If existing tests use a different helper for store setup, copy that pattern instead. Check `src/server/event-store.test.ts` first.)
+
+**Step 3: Run failing test**
+
+Run: `bun test src/server/event-store.test.ts`
+Expected: FAIL — `recordSessionCommandsLoaded is not a function`.
+
+**Step 4: Implement**
+
+In `src/server/event-store.ts`, add a method next to the other `recordTurn*` methods:
+
+```ts
+async recordSessionCommandsLoaded(chatId: string, commands: SlashCommand[]) {
+  this.requireChat(chatId)
+  const event: TurnEvent = {
+    v: STORE_VERSION,
+    type: "session_commands_loaded",
+    timestamp: Date.now(),
+    chatId,
+    commands: commands.map((c) => ({ name: c.name, description: c.description, argumentHint: c.argumentHint })),
+  }
+  await this.append(this.turnsLogPath, event)
+}
+```
+
+Add `import type { SlashCommand } from "../shared/types"` at the top if missing.
+
+Locate the `TurnEvent` reducer (found in Step 1) and add a case:
+
+```ts
+case "session_commands_loaded": {
+  const chat = state.chatsById.get(event.chatId)
+  if (!chat) return
+  chat.slashCommands = event.commands.map((c) => ({ ...c }))
+  return
+}
+```
+
+**Step 5: Run test**
+
+Run: `bun test src/server/event-store.test.ts`
+Expected: PASS (both cases).
+
+**Step 6: Commit**
+
+```bash
+git add src/server/event-store.ts src/server/event-store.test.ts
+git commit -m "feat(event-store): record session_commands_loaded events"
+```
+
+---
+
+## Task 4 — Expose `supportedCommands` on the Claude harness
+
+**Files:**
+- Modify: `src/server/agent.ts` (`ClaudeSessionHandle` interface at line 73-82, `startClaudeSession` return around line 629-661)
+
+**Step 1: Extend the handle interface**
+
+In `src/server/agent.ts`, add a method to `ClaudeSessionHandle`:
+
+```ts
+getSupportedCommands: () => Promise<Array<{ name: string; description: string; argumentHint: string }>>
+```
+
+Also add it to the type alias in `AgentCoordinatorArgs.startClaudeSession` (line 103-110) so tests can inject a mock.
+
+**Step 2: Implement in `startClaudeSession`**
+
+In the returned object at `src/server/agent.ts:629-661`, add:
+
+```ts
+getSupportedCommands: async () => {
+  try {
+    return await q.supportedCommands()
+  } catch (error) {
+    console.warn("[kanna/claude] supportedCommands failed", error)
+    return []
+  }
+},
+```
+
+**Step 3: Run typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/agent.ts
+git commit -m "feat(agent): expose getSupportedCommands on Claude harness"
+```
+
+---
+
+## Task 5 — Coordinator emits `session_commands_loaded` on Claude session start
+
+**Files:**
+- Modify: `src/server/agent.ts` (`ensureClaudeSession` block around line 1048-1079)
+
+**Step 1: Write failing test**
+
+Add or extend a coordinator test. If no suitable file exists, create `src/server/agent.test.ts`:
+
+```ts
+import { describe, test, expect } from "bun:test"
+import { AgentCoordinator } from "./agent"
+// plus whatever the existing agent tests use for setup
+
+test("emits session_commands_loaded after starting a fresh Claude session", async () => {
+  // 1. Construct coordinator with an in-memory EventStore and a fake
+  //    startClaudeSession that returns getSupportedCommands resolving to
+  //    [{ name: "review", description: "Review", argumentHint: "<pr>" }].
+  // 2. Trigger a send that starts a Claude session.
+  // 3. Assert eventStore.getChat(chatId).slashCommands === the fake list.
+})
+```
+
+(Look at existing tests in `src/server/` or `src/client/` for the EventStore fixture pattern. Mirror it.)
+
+**Step 2: Run failing test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: FAIL — `slashCommands` empty / undefined.
+
+**Step 3: Wire emission after session start**
+
+In `ensureClaudeSession` at `src/server/agent.ts:1048-1079`, after `this.claudeSessions.set(args.chatId, session)` and `void this.runClaudeSession(session)`, add:
+
+```ts
+void (async () => {
+  try {
+    const commands = await started.getSupportedCommands()
+    await this.store.recordSessionCommandsLoaded(args.chatId, commands)
+    this.onStateChange?.(args.chatId)
+  } catch (error) {
+    console.warn("[kanna/agent] failed to load slash commands", error)
+  }
+})()
+```
+
+`this.store` is the `EventStore` handle the coordinator already holds; if the private field is named differently, use that.
+
+**Step 4: Run test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/agent.ts src/server/agent.test.ts
+git commit -m "feat(agent): emit session_commands_loaded on Claude session start"
+```
+
+---
+
+## Task 6 — Surface `slashCommands` on `ChatSnapshot`
+
+**Files:**
+- Modify: `src/server/read-models.ts` (`deriveChatSnapshot` at lines 152-188)
+
+**Step 1: Write failing test**
+
+Add to `src/server/read-models.test.ts` (or create it):
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { deriveChatSnapshot } from "./read-models"
+import { createEmptyState } from "./events"
+
+test("chat snapshot exposes slashCommands from chat record", () => {
+  const state = createEmptyState()
+  state.projectsById.set("p1", {
+    id: "p1", localPath: "/tmp/x", title: "x",
+    createdAt: 0, updatedAt: 0,
+  } as any)
+  state.chatsById.set("c1", {
+    id: "c1", projectId: "p1", title: "Chat",
+    createdAt: 0, updatedAt: 0,
+    unread: false, provider: "claude", planMode: false,
+    sessionToken: null, sourceHash: null,
+    lastTurnOutcome: null,
+    slashCommands: [{ name: "review", description: "r", argumentHint: "<pr>" }],
+  } as any)
+
+  const snapshot = deriveChatSnapshot(
+    state,
+    new Map(),
+    new Set(),
+    "c1",
+    () => ({
+      messages: [],
+      history: { hasOlder: false, olderCursor: null, recentLimit: 20 },
+    }),
+  )
+  expect(snapshot?.slashCommands).toEqual([
+    { name: "review", description: "r", argumentHint: "<pr>" },
+  ])
+})
+```
+
+**Step 2: Run failing test**
+
+Run: `bun test src/server/read-models.test.ts`
+Expected: FAIL — `slashCommands` is `[]` not the record's list.
+
+**Step 3: Implement**
+
+In `src/server/read-models.ts:178-188`, replace the returned `slashCommands: []` (added in Task 1) with:
+
+```ts
+slashCommands: (chat.slashCommands ?? []).map((c) => ({ ...c })),
+```
+
+**Step 4: Run test**
+
+Run: `bun test src/server/read-models.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/read-models.ts src/server/read-models.test.ts
+git commit -m "feat(read-models): expose slashCommands on ChatSnapshot"
+```
+
+---
+
+## Task 7 — Snapshot file persistence
+
+**Files:**
+- Modify: `src/server/event-store.ts` — search for `writeSnapshot`/`readSnapshot` and the `SnapshotFile` shape in `src/server/events.ts`.
+
+**Step 1: Extend `SnapshotFile`**
+
+In `src/server/events.ts`, extend `SnapshotFile.chats` persistence — not the type if it re-uses `ChatRecord`. If `chats: ChatRecord[]` is already the field, the new `slashCommands?` field (from Task 2) flows through automatically. Verify by reading the `writeSnapshot` path.
+
+**Step 2: Write a round-trip test**
+
+In `src/server/event-store.test.ts`, add:
+
+```ts
+test("compaction preserves slashCommands", async () => {
+  await store.recordSessionCommandsLoaded("c1", [
+    { name: "review", description: "r", argumentHint: "<pr>" },
+  ])
+  await store.compact() // or whatever the public API is — check file
+  const reloaded = new EventStore({ dataDir: dir })
+  await reloaded.load()
+  expect(reloaded.getChat("c1")?.slashCommands).toEqual([
+    { name: "review", description: "r", argumentHint: "<pr>" },
+  ])
+})
+```
+
+**Step 3: Run test**
+
+Run: `bun test src/server/event-store.test.ts`
+Expected: PASS if `ChatRecord` passes through unchanged. FAIL means snapshot serialization drops the field — fix by explicitly including `slashCommands` in whatever projection `writeSnapshot` uses.
+
+**Step 4: Commit (if changes were needed)**
+
+```bash
+git add src/server/event-store.ts src/server/events.ts src/server/event-store.test.ts
+git commit -m "feat(event-store): persist slashCommands across compaction"
+```
+
+If no changes were needed, skip the commit and note that in the PR description.
+
+---
+
+## Task 8 — Client slash-commands store
+
+**Files:**
+- Create: `src/client/stores/slashCommandsStore.ts`
+- Test: `src/client/stores/slashCommandsStore.test.ts`
+
+**Step 1: Write failing test**
+
+```ts
+import { describe, test, expect, beforeEach } from "bun:test"
+import { useSlashCommandsStore } from "./slashCommandsStore"
+
+describe("slashCommandsStore", () => {
+  beforeEach(() => useSlashCommandsStore.setState({ byChatId: {} }))
+
+  test("setForChat stores list", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ])
+    expect(useSlashCommandsStore.getState().byChatId["c1"]).toHaveLength(1)
+  })
+
+  test("clear removes list", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [
+      { name: "review", description: "r", argumentHint: "" },
+    ])
+    useSlashCommandsStore.getState().clear("c1")
+    expect(useSlashCommandsStore.getState().byChatId["c1"]).toBeUndefined()
+  })
+})
+```
+
+**Step 2: Run failing test**
+
+Run: `bun test src/client/stores/slashCommandsStore.test.ts`
+Expected: FAIL — store file does not exist.
+
+**Step 3: Implement**
+
+```ts
+import { create } from "zustand"
+import type { SlashCommand } from "../../shared/types"
+
+interface State {
+  byChatId: Record<string, SlashCommand[]>
+  setForChat: (chatId: string, commands: SlashCommand[]) => void
+  clear: (chatId: string) => void
+}
+
+export const useSlashCommandsStore = create<State>((set) => ({
+  byChatId: {},
+  setForChat: (chatId, commands) =>
+    set((state) => ({ byChatId: { ...state.byChatId, [chatId]: commands } })),
+  clear: (chatId) =>
+    set((state) => {
+      const { [chatId]: _removed, ...rest } = state.byChatId
+      return { byChatId: rest }
+    }),
+}))
+```
+
+**Step 4: Run test**
+
+Run: `bun test src/client/stores/slashCommandsStore.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/stores/slashCommandsStore.ts src/client/stores/slashCommandsStore.test.ts
+git commit -m "feat(client): add slash commands store"
+```
+
+---
+
+## Task 9 — Populate the store from the chat snapshot
+
+**Files:**
+- Modify: `src/client/app/useKannaState.ts` (subscribe handler around line 789-821)
+
+**Step 1: Wire store update**
+
+Inside the `socket.subscribe<ChatSnapshot | null>(...)` callback at line 789, add after `setChatReady(true)`:
+
+```ts
+if (snapshot) {
+  useSlashCommandsStore.getState().setForChat(
+    snapshot.runtime.chatId,
+    snapshot.slashCommands ?? [],
+  )
+}
+```
+
+Add the import at the top:
+
+```ts
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+```
+
+**Step 2: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/app/useKannaState.ts
+git commit -m "feat(client): populate slash commands store from snapshot"
+```
+
+---
+
+## Task 10 — `useSlashCommands` hook
+
+**Files:**
+- Create: `src/client/hooks/useSlashCommands.ts`
+- Test: `src/client/hooks/useSlashCommands.test.ts`
+
+**Step 1: Write failing test**
+
+```ts
+import { describe, test, expect } from "bun:test"
+import { renderHook, act } from "@testing-library/react"
+import { useSlashCommands } from "./useSlashCommands"
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+
+test("returns commands for chat", () => {
+  act(() => useSlashCommandsStore.getState().setForChat("c1", [
+    { name: "review", description: "r", argumentHint: "" },
+  ]))
+  const { result } = renderHook(() => useSlashCommands("c1"))
+  expect(result.current).toHaveLength(1)
+})
+
+test("returns empty array for unknown chat", () => {
+  const { result } = renderHook(() => useSlashCommands("unknown"))
+  expect(result.current).toEqual([])
+})
+```
+
+(If `@testing-library/react` is not already a dep, test without the renderer: call `useSlashCommandsStore.getState()` directly through a small selector export and omit this test file — replace with a selector unit test.)
+
+**Step 2: Implement**
+
+```ts
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+import type { SlashCommand } from "../../shared/types"
+
+const EMPTY: SlashCommand[] = []
+
+export function useSlashCommands(chatId: string | null): SlashCommand[] {
+  return useSlashCommandsStore((state) =>
+    chatId ? state.byChatId[chatId] ?? EMPTY : EMPTY,
+  )
+}
+```
+
+**Step 3: Run test**
+
+Run: `bun test src/client/hooks/useSlashCommands.test.ts`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/client/hooks/useSlashCommands.ts src/client/hooks/useSlashCommands.test.ts
+git commit -m "feat(client): add useSlashCommands hook"
+```
+
+---
+
+## Task 11 — Pure filter / trigger utils
+
+**Files:**
+- Create: `src/client/lib/slash-commands.ts`
+- Test: `src/client/lib/slash-commands.test.ts`
+
+**Step 1: Write failing tests**
+
+```ts
+import { describe, test, expect } from "bun:test"
+import { shouldShowPicker, filterCommands } from "./slash-commands"
+
+describe("shouldShowPicker", () => {
+  test("opens when value starts with / and caret inside token", () => {
+    expect(shouldShowPicker("/rev", 4)).toEqual({ open: true, query: "rev" })
+  })
+  test("opens on bare slash", () => {
+    expect(shouldShowPicker("/", 1)).toEqual({ open: true, query: "" })
+  })
+  test("closes after space", () => {
+    expect(shouldShowPicker("/review ", 8)).toEqual({ open: false, query: "" })
+  })
+  test("closes when caret before slash", () => {
+    expect(shouldShowPicker("/rev", 0)).toEqual({ open: false, query: "" })
+  })
+  test("closes when first char not slash", () => {
+    expect(shouldShowPicker("hi /rev", 7)).toEqual({ open: false, query: "" })
+  })
+})
+
+describe("filterCommands", () => {
+  const all = [
+    { name: "review", description: "r", argumentHint: "" },
+    { name: "reset", description: "s", argumentHint: "" },
+    { name: "init", description: "i", argumentHint: "" },
+  ]
+  test("empty query returns all, alphabetical", () => {
+    expect(filterCommands(all, "").map((c) => c.name)).toEqual(["init", "reset", "review"])
+  })
+  test("prefix matches rank before substring", () => {
+    const list = [
+      { name: "unreview", description: "", argumentHint: "" },
+      { name: "review", description: "", argumentHint: "" },
+    ]
+    expect(filterCommands(list, "rev").map((c) => c.name)).toEqual(["review", "unreview"])
+  })
+  test("case-insensitive", () => {
+    expect(filterCommands(all, "REV").map((c) => c.name)).toEqual(["review"])
+  })
+})
+```
+
+**Step 2: Run failing tests**
+
+Run: `bun test src/client/lib/slash-commands.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+import type { SlashCommand } from "../../shared/types"
+
+export function shouldShowPicker(
+  value: string,
+  caret: number,
+): { open: boolean; query: string } {
+  if (caret <= 0) return { open: false, query: "" }
+  const upToCaret = value.slice(0, caret)
+  const match = /^\/(\S*)$/.exec(upToCaret)
+  if (!match) return { open: false, query: "" }
+  return { open: true, query: match[1] ?? "" }
+}
+
+export function filterCommands(list: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.toLowerCase()
+  const byName = (a: SlashCommand, b: SlashCommand) => a.name.localeCompare(b.name)
+  if (q === "") return [...list].sort(byName)
+
+  const prefix: SlashCommand[] = []
+  const substring: SlashCommand[] = []
+  for (const cmd of list) {
+    const name = cmd.name.toLowerCase()
+    if (name.startsWith(q)) prefix.push(cmd)
+    else if (name.includes(q)) substring.push(cmd)
+  }
+  return [...prefix.sort(byName), ...substring.sort(byName)]
+}
+```
+
+**Step 4: Run tests**
+
+Run: `bun test src/client/lib/slash-commands.test.ts`
+Expected: PASS (all cases).
+
+**Step 5: Commit**
+
+```bash
+git add src/client/lib/slash-commands.ts src/client/lib/slash-commands.test.ts
+git commit -m "feat(client): add slash command filter and picker-open utils"
+```
+
+---
+
+## Task 12 — `SlashCommandPicker` component
+
+**Files:**
+- Create: `src/client/components/chat-ui/SlashCommandPicker.tsx`
+- Test: `src/client/components/chat-ui/SlashCommandPicker.test.tsx` (only if existing chat-ui tests use `.tsx` React testing; otherwise defer to Task 13's integration tests)
+
+**Step 1: Implement the component**
+
+```tsx
+import { useEffect, useRef } from "react"
+import type { SlashCommand } from "../../../shared/types"
+import { cn } from "../../lib/utils"
+
+interface Props {
+  items: SlashCommand[]
+  activeIndex: number
+  onSelect: (command: SlashCommand) => void
+  onHoverIndex: (index: number) => void
+}
+
+export function SlashCommandPicker({ items, activeIndex, onSelect, onHoverIndex }: Props) {
+  const listRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const el = listRef.current?.children.item(activeIndex) as HTMLElement | null
+    el?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
+
+  if (items.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+        No matching commands
+      </div>
+    )
+  }
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
+    >
+      {items.map((cmd, i) => (
+        <li
+          key={cmd.name}
+          role="option"
+          aria-selected={i === activeIndex}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            onSelect(cmd)
+          }}
+          onMouseEnter={() => onHoverIndex(i)}
+          className={cn(
+            "flex items-baseline gap-2 px-3 py-1.5 cursor-pointer text-sm",
+            i === activeIndex && "bg-accent text-accent-foreground",
+          )}
+        >
+          <span className="font-mono">/{cmd.name}</span>
+          {cmd.argumentHint && (
+            <span className="text-muted-foreground font-mono text-xs">{cmd.argumentHint}</span>
+          )}
+          {cmd.description && (
+            <span className="ml-auto text-muted-foreground text-xs truncate">{cmd.description}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+**Step 2: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/components/chat-ui/SlashCommandPicker.tsx
+git commit -m "feat(client): add SlashCommandPicker component"
+```
+
+---
+
+## Task 13 — Wire picker into `ChatInput`
+
+**Files:**
+- Modify: `src/client/components/chat-ui/ChatInput.tsx` (keyboard handler at 555-586, render area around 725)
+- Test: extend `src/client/components/chat-ui/ChatInput.test.ts`
+
+**Step 1: Write failing tests**
+
+Extend `ChatInput.test.ts`:
+
+```ts
+// pseudocode — mirror the existing test style in that file
+test("typing / opens picker with full list", () => {
+  // render ChatInput with chatId="c1" and preload slash-commands store
+  // fire change to "/" and assert picker rows rendered
+})
+
+test("typing /rev filters", () => {
+  // preload list with review, init; type "/rev"; assert only review shown
+})
+
+test("Enter accepts highlighted command", () => {
+  // preload list, type "/", press Enter → input becomes "/review "
+  // (trailing space since argumentHint is non-empty)
+})
+
+test("Escape closes picker without clearing input", () => {
+  // preload list, type "/rev", press Escape → picker gone, value still "/rev"
+})
+
+test("picker does not intercept Enter when closed", () => {
+  // type "hi", press Enter → onSubmit called
+})
+```
+
+Use whatever render helper the existing tests in this file use. If the file is vanilla DOM assertions without React rendering, mirror that approach instead.
+
+**Step 2: Run failing tests**
+
+Run: `bun test src/client/components/chat-ui/ChatInput.test.ts`
+Expected: FAIL.
+
+**Step 3: Hook state into `ChatInput`**
+
+At the top of the `ChatInput` component body, add:
+
+```tsx
+const slashCommands = useSlashCommands(chatId ?? null)
+const [pickerIndex, setPickerIndex] = useState(0)
+const textareaRef = useRef<HTMLTextAreaElement>(null) // reuse existing
+const caret = textareaRef.current?.selectionStart ?? value.length
+
+const pickerState = useMemo(
+  () => shouldShowPicker(value, caret),
+  [value, caret],
+)
+const filteredCommands = useMemo(
+  () => (pickerState.open ? filterCommands(slashCommands, pickerState.query) : []),
+  [pickerState.open, pickerState.query, slashCommands],
+)
+const pickerOpen = pickerState.open && slashCommands.length > 0
+
+useEffect(() => {
+  if (pickerOpen) setPickerIndex(0)
+}, [pickerOpen, pickerState.query])
+```
+
+Imports:
+
+```tsx
+import { useSlashCommands } from "../../hooks/useSlashCommands"
+import { SlashCommandPicker } from "./SlashCommandPicker"
+import { filterCommands, shouldShowPicker } from "../../lib/slash-commands"
+```
+
+**Step 4: Intercept keyboard in `handleKeyDown`**
+
+Place at the very top of `handleKeyDown` (before the existing `Tab` handling):
+
+```tsx
+if (pickerOpen) {
+  if (event.key === "Escape") {
+    event.preventDefault()
+    // close by forcing caret past the token — simpler: clear filtered list via a local `dismissed` flag.
+    // Use a ref-based suppress: setPickerDismissed(true) until value changes.
+    setPickerDismissed(true)
+    return
+  }
+  if (event.key === "ArrowDown") {
+    event.preventDefault()
+    setPickerIndex((i) => Math.min(filteredCommands.length - 1, i + 1))
+    return
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault()
+    setPickerIndex((i) => Math.max(0, i - 1))
+    return
+  }
+  if (event.key === "Enter" || event.key === "Tab") {
+    event.preventDefault()
+    const cmd = filteredCommands[pickerIndex]
+    if (cmd) acceptCommand(cmd)
+    return
+  }
+}
+```
+
+Add supporting state + effect + accept helper above `handleKeyDown`:
+
+```tsx
+const [pickerDismissed, setPickerDismissed] = useState(false)
+useEffect(() => { setPickerDismissed(false) }, [value])
+
+function acceptCommand(cmd: SlashCommand) {
+  const prefix = `/${cmd.name}`
+  const next = cmd.argumentHint ? `${prefix} ` : prefix
+  setValue(next)
+  if (chatId) setDraft(chatId, next)
+  requestAnimationFrame(() => {
+    textareaRef.current?.focus()
+    textareaRef.current?.setSelectionRange(next.length, next.length)
+  })
+}
+```
+
+Update `pickerOpen` to also respect `pickerDismissed`:
+
+```tsx
+const pickerOpen = pickerState.open && slashCommands.length > 0 && !pickerDismissed
+```
+
+**Step 5: Render the picker**
+
+Near the textarea container (find the existing wrapper around line 725 where the textarea is rendered; it already has `onKeyDown={handleKeyDown}`), wrap it in a relative-positioned container if not already, and render:
+
+```tsx
+{pickerOpen && (
+  <SlashCommandPicker
+    items={filteredCommands}
+    activeIndex={pickerIndex}
+    onSelect={acceptCommand}
+    onHoverIndex={setPickerIndex}
+  />
+)}
+```
+
+Place it as a sibling of the textarea inside the relative wrapper so it floats above with `absolute bottom-full`.
+
+**Step 6: Run tests**
+
+Run: `bun test src/client/components/chat-ui/ChatInput.test.ts`
+Expected: PASS.
+
+**Step 7: Typecheck + build**
+
+Run: `bun run check`
+Expected: PASS.
+
+**Step 8: Commit**
+
+```bash
+git add src/client/components/chat-ui/ChatInput.tsx src/client/components/chat-ui/ChatInput.test.ts
+git commit -m "feat(chat-ui): wire slash command picker into ChatInput"
+```
+
+---
+
+## Task 14 — Manual verification
+
+**Step 1: Start dev server**
+
+```bash
+bun run dev
+```
+
+**Step 2: Verify in browser**
+
+- Open a Claude chat, wait for session start.
+- Type `/` in the input — picker appears with the session's commands.
+- Type `rev` — filters to `/review` (or whichever commands have `rev`).
+- `↓ ↑` navigate, `Enter` inserts `/review ` (with trailing space since `argumentHint` exists).
+- Press `Enter` with no picker open on non-slash input — sends normally.
+- `Esc` while picker open — picker closes, input preserved.
+- Switch to a Codex chat — typing `/` does not open a picker.
+
+**Step 3: Stop dev server**
+
+`Ctrl+C`.
+
+**Step 4: If any step fails**
+
+Open a debugging session with `superpowers:systematic-debugging`. Do not skip.
+
+---
+
+## Task 15 — Refetch on resume
+
+**Files:**
+- Modify: `src/server/agent.ts` — wherever a resumed session becomes active after `sessionToken` is set.
+
+**Step 1: Locate the resume flow**
+
+Grep for `sessionToken` usage in `startClaudeSession` and the coordinator. Resume happens when `query({ resume: sessionToken })` is used.
+
+**Step 2: Emit a fresh load**
+
+Wherever the coordinator transitions from "starting" → "ready" for a resumed session (where the old `supportedCommands()` result may be stale), call `getSupportedCommands()` again and `recordSessionCommandsLoaded`.
+
+If the existing eager emission in Task 5 is already *after* session construction for both new and resumed sessions, this task is a no-op — verify by reading the code path and note it in the commit message.
+
+**Step 3: Commit (if changes were needed)**
+
+```bash
+git add src/server/agent.ts
+git commit -m "feat(agent): refetch supported commands on session resume"
+```
+
+---
+
+## Task 16 — Final verification + PR prep
+
+**Step 1: Full check**
+
+```bash
+bun run check
+bun test
+```
+
+Both: PASS.
+
+**Step 2: Commit any incidental formatting**
+
+Only if files changed (e.g. Prettier on save). Otherwise skip.
+
+**Step 3: Report completion**
+
+Announce: worktree at `.worktrees/slash-command-picker`, branch `feature/slash-command-picker`, all tasks complete, tests green. Offer to run `superpowers:finishing-a-development-branch` for merge / PR path.
+
+---
+
+## Skills to consult
+
+- `superpowers:test-driven-development` — always for every task that touches logic.
+- `superpowers:systematic-debugging` — if anything misbehaves in manual verification.
+- `superpowers:verification-before-completion` — before announcing Task 16 done.
+- `superpowers:finishing-a-development-branch` — after Task 16.

--- a/docs/plans/2026-04-21-pm2-update-reloader-design.md
+++ b/docs/plans/2026-04-21-pm2-update-reloader-design.md
@@ -1,0 +1,151 @@
+# pm2 Update Reloader Design
+
+Date: 2026-04-21
+Scope: dev-only deploy workflow on macOS.
+
+## Goals
+
+1. Replace the launchd job (`io.silentium.kanna`) used by `scripts/deploy.sh` with pm2 as the process supervisor for the author's local dev machine.
+2. Keep the in-app "Update" button working, but wire it to a pm2 reload pipeline (git pull → build → `pm2 reload`) when running under pm2.
+3. Abstract the update path so the reload mechanism can be swapped without touching `UpdateManager`.
+
+End-user install flow (`bunx kanna`, `bun install -g kanna-code`) is unchanged. The existing supervisor-fork path in `bin/kanna` + `cli-supervisor.ts` remains the default.
+
+## Non-goals
+
+- Shipping pm2 as a runtime dependency for end users.
+- Daemon mode / background process for end users.
+- Git-based update flow for end users (they stay on npm-registry self-update).
+- Auto-rollback on failed build.
+
+## Current state
+
+- `bin/kanna` forks `cli-supervisor.ts` (parent) → `cli.ts` (child).
+- Supervisor restarts child on exit code 75 (startup self-update) or 76 (UI-triggered update).
+- `update-manager.ts` drives the UI: checks npm registry via `fetchLatestVersion`, installs via `installVersion` (`bun install -g kanna-code@<ver>`), then child exits 76 → supervisor respawns.
+- `scripts/deploy.sh` symlinks the global install to the repo, runs `bun run build`, then `launchctl kickstart -k gui/<uid>/io.silentium.kanna` to restart the launchd job.
+
+## Architecture
+
+### New interfaces — `src/server/update-strategy.ts`
+
+```ts
+export interface UpdateChecker {
+  check(): Promise<{ latestVersion: string | null; updateAvailable: boolean }>
+}
+
+export interface UpdateReloader {
+  reload(): Promise<void>
+}
+```
+
+### Implementations
+
+| Impl | Purpose |
+|------|---------|
+| `NpmChecker` | Wraps `fetchLatestPackageVersion` + `compareVersions`. Default. |
+| `GitChecker` | `git fetch origin main` then compares `git rev-parse HEAD` vs `origin/main`. `latestVersion` = short SHA. |
+| `SupervisorExitReloader` | Runs current `installPackageVersion` then `process.exit(CLI_UI_UPDATE_RESTART_EXIT_CODE)`. |
+| `Pm2Reloader` | git pull → conditional `bun install` → `bun run build` → `pm2.reload("kanna")`. Fail-fast, throws on any non-zero step. |
+
+### Selection
+
+Factory `createUpdateStrategy()` reads `KANNA_RELOADER`:
+
+- unset / `"supervisor"` → `{ checker: NpmChecker, reloader: SupervisorExitReloader }` (default, unchanged behavior).
+- `"pm2"` → `{ checker: GitChecker, reloader: Pm2Reloader }`.
+- anything else → throw at startup.
+
+`Pm2Reloader` reads `KANNA_REPO_DIR` (set by `deploy.sh`) to resolve the working directory for git/build commands.
+
+### UpdateManager changes
+
+`UpdateManagerDeps` swaps `fetchLatestVersion` + `installVersion` for `checker: UpdateChecker` + `reloader: UpdateReloader`. `checkForUpdates()` delegates to `checker.check()`. `installUpdate()` delegates to `reloader.reload()` and surfaces thrown errors via `UpdateSnapshot.error` + `install_failed` error code. Existing devMode, concurrent-install, caching, and listener semantics preserved.
+
+Wiring in `cli.ts`: call `createUpdateStrategy()` where UpdateManager is constructed today; pass `checker` and `reloader` into `new UpdateManager(...)`.
+
+### pm2 reload internals
+
+Uses the `pm2` npm package programmatic API:
+
+```ts
+import pm2 from "pm2"
+await new Promise<void>((resolve, reject) => {
+  pm2.connect((err) => {
+    if (err) return reject(err)
+    pm2.reload("kanna", (reloadErr) => {
+      pm2.disconnect()
+      reloadErr ? reject(reloadErr) : resolve()
+    })
+  })
+})
+```
+
+Shell steps (`git pull`, `bun install`, `bun run build`) run via `spawn` with stdio captured. On non-zero exit the reloader throws `Error` with `"<step> failed: <stderr tail>"`.
+
+## pm2 config — `scripts/pm2.config.cjs.tmpl`
+
+Template rendered by `deploy.sh` (envsubst) to produce `scripts/pm2.config.cjs`:
+
+```js
+module.exports = {
+  apps: [{
+    name: "kanna",
+    script: "./src/server/cli.ts",
+    interpreter: "bun",
+    cwd: "${REPO_DIR}",
+    env: {
+      KANNA_RELOADER: "pm2",
+      KANNA_REPO_DIR: "${REPO_DIR}",
+      KANNA_DISABLE_SELF_UPDATE: "1",
+      KANNA_CLI_MODE: "child",
+    },
+    autorestart: true,
+    max_memory_restart: "1G",
+    kill_timeout: 5000,
+  }]
+}
+```
+
+`KANNA_CLI_MODE=child` makes `bin/kanna` skip the supervisor branch — pm2 is the supervisor.
+
+## `scripts/deploy.sh`
+
+- Keep: symlink `$HOME/.bun/install/global/node_modules/kanna-code` → `$REPO_DIR`; `bun install` if lockfile changed; `bun run build`.
+- Replace launchd block with: pm2 install check → render pm2 config from template → `pm2 reload` if process exists, else `pm2 start` → `pm2 save`.
+- One-shot by hand (not scripted): `launchctl bootout gui/$(id -u)/io.silentium.kanna` to remove the old launchd job; `pm2 startup` to register pm2 itself for boot.
+
+## Error handling
+
+Fail-fast pipeline (Q9 option A): any step failure aborts, surfaces stderr tail in `UpdateSnapshot.error`, pm2 keeps running the old build. No auto-rollback.
+
+## Testing
+
+### Unit — `src/server/update-strategy.test.ts`
+
+- `createUpdateStrategy()` env matrix: unset, `"supervisor"`, `"pm2"`, unknown.
+- `NpmChecker` — mocked `fetchLatestVersion`.
+- `GitChecker` — stubbed spawn returning canned `git rev-parse` / `git fetch` output; updateAvailable when SHAs differ.
+- `Pm2Reloader.reload()` — stubbed spawn + pm2 API; verify pipeline order; verify throws with captured stderr on non-zero exit; verify skips `bun install` when lockfile unchanged.
+- `SupervisorExitReloader` — stubbed `installVersion` + `process.exit`; exit code 76 on success, throws on install failure.
+
+### Unit — `src/server/update-manager.test.ts`
+
+Update existing tests to inject fake `checker` + `reloader` fixtures. Preserve all scenarios (devMode, concurrent install, error path, listener notifications).
+
+### Manual verification
+
+1. Run `./scripts/deploy.sh`; `pm2 list` shows `kanna` online.
+2. Commit + push a change; click Update in UI → pipeline runs, pm2 reloads, new code live.
+3. Push a syntax error; click Update → red banner with build-failure stderr tail; pm2 keeps serving old build.
+4. `pm2 delete kanna`, run `kanna` in a terminal → supervisor path still works (regression).
+
+## Rollout
+
+- Ship behind `KANNA_RELOADER`; unset = no behavior change for end users or other contributors.
+- Old `deploy.sh` preserved in git history.
+- Manual one-shots noted in PR body: unload old launchd plist, run `pm2 startup`.
+
+## Open questions
+
+None blocking implementation.

--- a/docs/plans/2026-04-21-pm2-update-reloader.md
+++ b/docs/plans/2026-04-21-pm2-update-reloader.md
@@ -1,0 +1,1204 @@
+# pm2 Update Reloader Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the launchd-based dev deploy on macOS with pm2, and abstract the in-app update button behind swappable checker + reloader interfaces so the pm2 reload pipeline (git pull → build → `pm2 reload`) can coexist with the current npm-registry self-update path.
+
+**Architecture:** New `src/server/update-strategy.ts` defines `UpdateChecker` and `UpdateReloader` interfaces with a factory that selects impls from the `KANNA_RELOADER` env var. `UpdateManager` swaps its `fetchLatestVersion` + `installVersion` deps for `checker` + `reloader`. The supervisor-exit + npm-install path becomes a concrete `SupervisorExitReloader` + `NpmChecker` (default, zero behavior change). The pm2 path adds `GitChecker` + `Pm2Reloader`, wired via a templated `scripts/pm2.config.cjs` and a rewritten `scripts/deploy.sh`.
+
+**Tech Stack:** Bun, TypeScript, `bun:test`, pm2 (programmatic API via the `pm2` npm package), git, envsubst.
+
+**Design doc:** `docs/plans/2026-04-21-pm2-update-reloader-design.md`
+
+---
+
+## Preconditions
+
+- Worktree at `.worktrees/pm2-reloader`, branch `feature/pm2-reloader`.
+- `bun install` already run, baseline `bun test` = 586 pass / 0 fail.
+- Work is dev-only scope — end-user npm install path must remain default.
+
+Run all test commands from the worktree root: `/Users/cuongtran/Desktop/repo/kanna/.worktrees/pm2-reloader`.
+
+---
+
+## Task 1: Create `UpdateChecker` + `NpmChecker` (TDD)
+
+**Files:**
+- Create: `src/server/update-strategy.ts`
+- Create: `src/server/update-strategy.test.ts`
+
+**Step 1: Write the failing tests**
+
+```ts
+// src/server/update-strategy.test.ts
+import { describe, expect, test } from "bun:test"
+import { NpmChecker } from "./update-strategy"
+
+describe("NpmChecker", () => {
+  test("reports update available when latest is newer", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => "0.13.0",
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "0.13.0", updateAvailable: true })
+  })
+
+  test("reports no update when versions match", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.13.0",
+      fetchLatestVersion: async () => "0.13.0",
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "0.13.0", updateAvailable: false })
+  })
+
+  test("propagates fetch errors", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => { throw new Error("registry down") },
+    })
+    await expect(checker.check()).rejects.toThrow("registry down")
+  })
+})
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `bun test src/server/update-strategy.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// src/server/update-strategy.ts
+import { compareVersions } from "./cli-runtime"
+import { PACKAGE_NAME } from "../shared/branding"
+
+export interface UpdateChecker {
+  check(): Promise<{ latestVersion: string | null; updateAvailable: boolean }>
+}
+
+export interface UpdateReloader {
+  reload(): Promise<void>
+}
+
+export interface NpmCheckerDeps {
+  currentVersion: string
+  fetchLatestVersion: (packageName: string) => Promise<string>
+}
+
+export class NpmChecker implements UpdateChecker {
+  constructor(private deps: NpmCheckerDeps) {}
+
+  async check() {
+    const latestVersion = await this.deps.fetchLatestVersion(PACKAGE_NAME)
+    const updateAvailable = compareVersions(this.deps.currentVersion, latestVersion) < 0
+    return { latestVersion, updateAvailable }
+  }
+}
+```
+
+**Step 4: Run test to verify passing**
+
+Run: `bun test src/server/update-strategy.test.ts`
+Expected: PASS (3 tests).
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "feat(update-strategy): add UpdateChecker interface and NpmChecker impl"
+```
+
+---
+
+## Task 2: `SupervisorExitReloader` (TDD)
+
+**Files:**
+- Modify: `src/server/update-strategy.ts`
+- Modify: `src/server/update-strategy.test.ts`
+
+**Step 1: Add failing tests**
+
+```ts
+// append to src/server/update-strategy.test.ts
+import { SupervisorExitReloader } from "./update-strategy"
+
+describe("SupervisorExitReloader", () => {
+  test("installs target version then signals UI restart exit", async () => {
+    const calls: Array<{ packageName: string; version: string }> = []
+    let exitCode: number | null = null
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => "0.13.0",
+      installVersion: (packageName, version) => {
+        calls.push({ packageName, version })
+        return { ok: true, errorCode: null, userTitle: null, userMessage: null }
+      },
+      exit: (code) => { exitCode = code },
+    })
+
+    await reloader.reload()
+    expect(calls).toEqual([{ packageName: "kanna-code", version: "0.13.0" }])
+    expect(exitCode).toBe(76)
+  })
+
+  test("throws with structured error when install fails", async () => {
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => "0.13.0",
+      installVersion: () => ({
+        ok: false,
+        errorCode: "version_not_live_yet",
+        userTitle: "Update not live yet",
+        userMessage: "This update is still propagating. Try again in a few minutes.",
+      }),
+      exit: () => {},
+    })
+
+    await expect(reloader.reload()).rejects.toMatchObject({
+      message: "This update is still propagating. Try again in a few minutes.",
+      errorCode: "version_not_live_yet",
+      userTitle: "Update not live yet",
+    })
+  })
+
+  test("throws when target version cannot be resolved", async () => {
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => null,
+      installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+      exit: () => {},
+    })
+    await expect(reloader.reload()).rejects.toThrow(/target version/i)
+  })
+})
+```
+
+**Step 2: Run to verify failure**
+
+Run: `bun test src/server/update-strategy.test.ts`
+Expected: FAIL — `SupervisorExitReloader` not exported.
+
+**Step 3: Implement**
+
+Add to `src/server/update-strategy.ts`:
+
+```ts
+import type { UpdateInstallErrorCode } from "../shared/types"
+import type { UpdateInstallAttemptResult } from "./cli-runtime"
+import { CLI_UI_UPDATE_RESTART_EXIT_CODE } from "./restart"
+
+export class UpdateInstallError extends Error {
+  constructor(
+    message: string,
+    public readonly errorCode: UpdateInstallErrorCode | null,
+    public readonly userTitle: string | null,
+  ) {
+    super(message)
+    this.name = "UpdateInstallError"
+  }
+}
+
+export interface SupervisorExitReloaderDeps {
+  targetVersion: () => string | null
+  installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
+  exit: (code: number) => void
+}
+
+export class SupervisorExitReloader implements UpdateReloader {
+  constructor(private deps: SupervisorExitReloaderDeps) {}
+
+  async reload() {
+    const version = this.deps.targetVersion()
+    if (!version) {
+      throw new UpdateInstallError(
+        "Unable to determine target version.",
+        "install_failed",
+        "Update failed",
+      )
+    }
+    const result = this.deps.installVersion(PACKAGE_NAME, version)
+    if (!result.ok) {
+      throw new UpdateInstallError(
+        result.userMessage ?? "Unable to install the latest version.",
+        result.errorCode,
+        result.userTitle,
+      )
+    }
+    this.deps.exit(CLI_UI_UPDATE_RESTART_EXIT_CODE)
+  }
+}
+```
+
+**Step 4: Verify passing**
+
+Run: `bun test src/server/update-strategy.test.ts`
+Expected: PASS (6 tests total).
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "feat(update-strategy): add SupervisorExitReloader wrapping current install+exit"
+```
+
+---
+
+## Task 3: `createUpdateStrategy` factory (TDD env matrix, supervisor-only for now)
+
+**Files:**
+- Modify: `src/server/update-strategy.ts`
+- Modify: `src/server/update-strategy.test.ts`
+
+**Step 1: Failing tests**
+
+```ts
+// append
+import { createUpdateStrategy } from "./update-strategy"
+
+describe("createUpdateStrategy", () => {
+  const baseDeps = {
+    currentVersion: "0.12.0",
+    fetchLatestVersion: async () => "0.13.0",
+    installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+    latestVersionHint: () => "0.13.0",
+    exit: () => {},
+  }
+
+  test("defaults to npm + supervisor-exit when env unset", () => {
+    const strategy = createUpdateStrategy({ reloaderEnv: undefined, ...baseDeps })
+    expect(strategy.checker).toBeInstanceOf(NpmChecker)
+    expect(strategy.reloader).toBeInstanceOf(SupervisorExitReloader)
+  })
+
+  test("uses npm + supervisor-exit when env=supervisor", () => {
+    const strategy = createUpdateStrategy({ reloaderEnv: "supervisor", ...baseDeps })
+    expect(strategy.checker).toBeInstanceOf(NpmChecker)
+    expect(strategy.reloader).toBeInstanceOf(SupervisorExitReloader)
+  })
+
+  test("throws on unknown reloader value", () => {
+    expect(() => createUpdateStrategy({ reloaderEnv: "bogus", ...baseDeps })).toThrow(/unknown.*reloader/i)
+  })
+})
+```
+
+**Step 2: Run — verify failure.** `bun test src/server/update-strategy.test.ts`.
+
+**Step 3: Implement**
+
+Add to `src/server/update-strategy.ts`:
+
+```ts
+export interface CreateUpdateStrategyDeps {
+  reloaderEnv: string | undefined
+  currentVersion: string
+  fetchLatestVersion: (packageName: string) => Promise<string>
+  installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
+  latestVersionHint: () => string | null
+  exit: (code: number) => void
+  repoDir?: string
+}
+
+export function createUpdateStrategy(deps: CreateUpdateStrategyDeps): {
+  checker: UpdateChecker
+  reloader: UpdateReloader
+} {
+  const mode = deps.reloaderEnv ?? "supervisor"
+  if (mode === "supervisor") {
+    return {
+      checker: new NpmChecker({
+        currentVersion: deps.currentVersion,
+        fetchLatestVersion: deps.fetchLatestVersion,
+      }),
+      reloader: new SupervisorExitReloader({
+        targetVersion: deps.latestVersionHint,
+        installVersion: deps.installVersion,
+        exit: deps.exit,
+      }),
+    }
+  }
+  throw new Error(`Unknown KANNA_RELOADER value: ${mode}`)
+}
+```
+
+(pm2 branch added in Task 8.)
+
+**Step 4: Run — verify passing.** All 9 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "feat(update-strategy): add createUpdateStrategy factory keyed on KANNA_RELOADER"
+```
+
+---
+
+## Task 4: Refactor `UpdateManager` to depend on `checker` + `reloader` (TDD)
+
+**Files:**
+- Modify: `src/server/update-manager.ts`
+- Modify: `src/server/update-manager.test.ts`
+
+**Step 1: Rewrite tests first**
+
+Replace the contents of `src/server/update-manager.test.ts` with fake checker + reloader fixtures. Preserve all four existing scenarios (`detects available updates`, `bypasses cache when force is true`, `surfaces install failures without clearing the running version`, `always exposes an available reload action in dev mode`) but injecting fakes rather than `fetchLatestVersion`/`installVersion`.
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { UpdateManager } from "./update-manager"
+import { UpdateInstallError, type UpdateChecker, type UpdateReloader } from "./update-strategy"
+
+class FakeChecker implements UpdateChecker {
+  calls = 0
+  constructor(private results: Array<{ latestVersion: string | null; updateAvailable: boolean }>) {}
+  async check() {
+    const result = this.results[Math.min(this.calls, this.results.length - 1)]
+    this.calls += 1
+    return result
+  }
+}
+
+class FakeReloader implements UpdateReloader {
+  calls = 0
+  constructor(private onReload: () => Promise<void> = async () => {}) {}
+  async reload() {
+    this.calls += 1
+    await this.onReload()
+  }
+}
+
+describe("UpdateManager", () => {
+  test("detects available updates", async () => {
+    const manager = new UpdateManager({
+      currentVersion: "0.12.0",
+      checker: new FakeChecker([{ latestVersion: "0.13.0", updateAvailable: true }]),
+      reloader: new FakeReloader(),
+    })
+    const snapshot = await manager.checkForUpdates({ force: true })
+    expect(snapshot.status).toBe("available")
+    expect(snapshot.updateAvailable).toBe(true)
+    expect(snapshot.latestVersion).toBe("0.13.0")
+    expect(snapshot.installAction).toBe("restart")
+    expect(snapshot.reloadRequestedAt).toBeNull()
+  })
+
+  test("bypasses cache when force is true", async () => {
+    const checker = new FakeChecker([
+      { latestVersion: "0.12.1", updateAvailable: true },
+      { latestVersion: "0.13.0", updateAvailable: true },
+    ])
+    const manager = new UpdateManager({
+      currentVersion: "0.12.0",
+      checker,
+      reloader: new FakeReloader(),
+    })
+    await manager.checkForUpdates()
+    await manager.checkForUpdates({ force: true })
+    expect(checker.calls).toBe(2)
+    expect(manager.getSnapshot().latestVersion).toBe("0.13.0")
+  })
+
+  test("surfaces reloader failures without clearing the running version", async () => {
+    const reloader = new FakeReloader(async () => {
+      throw new UpdateInstallError(
+        "This update is still propagating. Try again in a few minutes.",
+        "version_not_live_yet",
+        "Update not live yet",
+      )
+    })
+    const manager = new UpdateManager({
+      currentVersion: "0.12.0",
+      checker: new FakeChecker([{ latestVersion: "0.13.0", updateAvailable: true }]),
+      reloader,
+    })
+    await manager.checkForUpdates({ force: true })
+    const result = await manager.installUpdate()
+    expect(result).toEqual({
+      ok: false,
+      action: "restart",
+      errorCode: "version_not_live_yet",
+      userTitle: "Update not live yet",
+      userMessage: "This update is still propagating. Try again in a few minutes.",
+    })
+    expect(reloader.calls).toBe(1)
+    expect(manager.getSnapshot().status).toBe("error")
+    expect(manager.getSnapshot().currentVersion).toBe("0.12.0")
+  })
+
+  test("always exposes an available reload action in dev mode", async () => {
+    const manager = new UpdateManager({
+      currentVersion: "0.12.0",
+      checker: new FakeChecker([{ latestVersion: "9.9.9", updateAvailable: true }]),
+      reloader: new FakeReloader(),
+      devMode: true,
+    })
+    expect(manager.getSnapshot()).toMatchObject({
+      status: "available",
+      updateAvailable: true,
+      installAction: "restart",
+      reloadRequestedAt: null,
+    })
+    const result = await manager.installUpdate()
+    expect(result).toEqual({
+      ok: true,
+      action: "restart",
+      errorCode: null,
+      userTitle: null,
+      userMessage: null,
+    })
+    expect(manager.getSnapshot().status).toBe("restart_pending")
+    expect(typeof manager.getSnapshot().reloadRequestedAt).toBe("number")
+  })
+})
+```
+
+**Step 2: Run — verify failure**
+
+Run: `bun test src/server/update-manager.test.ts`
+Expected: FAIL — `UpdateManager` still expects `fetchLatestVersion` / `installVersion`.
+
+**Step 3: Rewrite `UpdateManager`**
+
+Replace `src/server/update-manager.ts`:
+
+```ts
+import type { UpdateInstallResult, UpdateSnapshot } from "../shared/types"
+import { UpdateInstallError, type UpdateChecker, type UpdateReloader } from "./update-strategy"
+
+const UPDATE_CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface UpdateManagerDeps {
+  currentVersion: string
+  checker: UpdateChecker
+  reloader: UpdateReloader
+  devMode?: boolean
+}
+
+export class UpdateManager {
+  private readonly deps: UpdateManagerDeps
+  private readonly listeners = new Set<(snapshot: UpdateSnapshot) => void>()
+  private snapshot: UpdateSnapshot
+  private checkPromise: Promise<UpdateSnapshot> | null = null
+  private installPromise: Promise<UpdateInstallResult> | null = null
+
+  constructor(deps: UpdateManagerDeps) {
+    this.deps = deps
+    this.snapshot = {
+      currentVersion: deps.currentVersion,
+      latestVersion: deps.devMode ? `${deps.currentVersion}-dev` : null,
+      status: deps.devMode ? "available" : "idle",
+      updateAvailable: Boolean(deps.devMode),
+      lastCheckedAt: deps.devMode ? Date.now() : null,
+      error: null,
+      installAction: "restart",
+      reloadRequestedAt: null,
+    }
+  }
+
+  getSnapshot() { return this.snapshot }
+
+  onChange(listener: (snapshot: UpdateSnapshot) => void) {
+    this.listeners.add(listener)
+    return () => { this.listeners.delete(listener) }
+  }
+
+  async checkForUpdates(options: { force?: boolean } = {}) {
+    if (this.deps.devMode) return this.snapshot
+    if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") return this.snapshot
+    if (this.checkPromise) return this.checkPromise
+    if (!options.force && this.snapshot.lastCheckedAt && Date.now() - this.snapshot.lastCheckedAt < UPDATE_CACHE_TTL_MS) {
+      return this.snapshot
+    }
+
+    this.setSnapshot({ ...this.snapshot, status: "checking", error: null, reloadRequestedAt: null })
+
+    const checkPromise = this.runCheck()
+    this.checkPromise = checkPromise
+    try { return await checkPromise }
+    finally { if (this.checkPromise === checkPromise) this.checkPromise = null }
+  }
+
+  async installUpdate(): Promise<UpdateInstallResult> {
+    if (this.deps.devMode) {
+      this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })
+      this.setSnapshot({
+        ...this.snapshot,
+        status: "restart_pending",
+        updateAvailable: false,
+        error: null,
+        reloadRequestedAt: Date.now(),
+      })
+      return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+    }
+
+    if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") {
+      return { ok: this.snapshot.updateAvailable, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+    }
+
+    if (this.installPromise) return this.installPromise
+
+    const installPromise = this.runInstall()
+    this.installPromise = installPromise
+    try { return await installPromise }
+    finally { if (this.installPromise === installPromise) this.installPromise = null }
+  }
+
+  private async runCheck() {
+    try {
+      const { latestVersion, updateAvailable } = await this.deps.checker.check()
+      const nextSnapshot: UpdateSnapshot = {
+        ...this.snapshot,
+        latestVersion,
+        updateAvailable,
+        status: updateAvailable ? "available" : "up_to_date",
+        lastCheckedAt: Date.now(),
+        error: null,
+        reloadRequestedAt: null,
+      }
+      this.setSnapshot(nextSnapshot)
+      return nextSnapshot
+    } catch (error) {
+      const nextSnapshot: UpdateSnapshot = {
+        ...this.snapshot,
+        status: "error",
+        lastCheckedAt: Date.now(),
+        error: error instanceof Error ? error.message : String(error),
+        reloadRequestedAt: null,
+      }
+      this.setSnapshot(nextSnapshot)
+      return nextSnapshot
+    }
+  }
+
+  private async runInstall(): Promise<UpdateInstallResult> {
+    if (!this.snapshot.updateAvailable) {
+      const snapshot = await this.checkForUpdates({ force: true })
+      if (!snapshot.updateAvailable) {
+        return { ok: false, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+      }
+    }
+
+    this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })
+
+    try {
+      await this.deps.reloader.reload()
+    } catch (error) {
+      const installError = error instanceof UpdateInstallError ? error : null
+      const message = error instanceof Error ? error.message : String(error)
+      this.setSnapshot({
+        ...this.snapshot,
+        status: "error",
+        error: installError?.message ?? message,
+        reloadRequestedAt: null,
+      })
+      return {
+        ok: false,
+        action: "restart",
+        errorCode: installError?.errorCode ?? "install_failed",
+        userTitle: installError?.userTitle ?? "Update failed",
+        userMessage: installError?.message ?? message,
+      }
+    }
+
+    this.setSnapshot({
+      ...this.snapshot,
+      currentVersion: this.snapshot.latestVersion ?? this.snapshot.currentVersion,
+      status: "restart_pending",
+      updateAvailable: false,
+      error: null,
+      reloadRequestedAt: Date.now(),
+    })
+    return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+  }
+
+  private setSnapshot(snapshot: UpdateSnapshot) {
+    this.snapshot = snapshot
+    for (const listener of this.listeners) listener(snapshot)
+  }
+}
+```
+
+**Step 4: Verify passing**
+
+Run: `bun test src/server/update-manager.test.ts`
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-manager.ts src/server/update-manager.test.ts
+git commit -m "refactor(update-manager): depend on UpdateChecker + UpdateReloader abstractions"
+```
+
+---
+
+## Task 5: Wire `server.ts` + `cli.ts` to the factory
+
+**Files:**
+- Modify: `src/server/server.ts:105-112`
+- Modify: `src/server/cli.ts` (where UpdateManager deps flow from)
+
+**Step 1: Update `server.ts`**
+
+Replace the `new UpdateManager({ ... })` block with factory wiring:
+
+```ts
+import { createUpdateStrategy } from "./update-strategy"
+
+// inside startKannaServer, where update manager is built:
+const updateManager = options.update
+  ? (() => {
+      const strategy = createUpdateStrategy({
+        reloaderEnv: process.env.KANNA_RELOADER,
+        currentVersion: options.update.version,
+        fetchLatestVersion: options.update.fetchLatestVersion,
+        installVersion: options.update.installVersion,
+        latestVersionHint: () => managerRef.current?.getSnapshot().latestVersion ?? null,
+        exit: (code) => process.exit(code),
+        repoDir: process.env.KANNA_REPO_DIR,
+      })
+      const manager = new UpdateManager({
+        currentVersion: options.update.version,
+        checker: strategy.checker,
+        reloader: strategy.reloader,
+        devMode: getRuntimeProfile() === "dev",
+      })
+      managerRef.current = manager
+      return manager
+    })()
+  : null
+```
+
+Declare `const managerRef: { current: UpdateManager | null } = { current: null }` just above — `latestVersionHint` needs a forward reference into the manager's own snapshot.
+
+**Step 2: Update `cli.ts`**
+
+The existing `exit: (code) => process.exit(code)` path in the factory would exit the child directly and bypass `cli.ts`'s graceful shutdown (which calls `result.stop()` then exits). To preserve that, replace `exit` wiring with a signal into the existing `resolveExitAction("ui_restart")` listener — the `restart_pending` snapshot already drives that. So: in `SupervisorExitReloader`, instead of calling `process.exit` directly, rely on the UpdateManager's own `restart_pending` transition.
+
+Change plan: `SupervisorExitReloader` does NOT call `exit` itself. Remove `exit` from `SupervisorExitReloaderDeps` and its test. `UpdateManager.installUpdate` already sets `restart_pending` after reload resolves, and `cli.ts:25-29` already listens for that and calls `resolveExitAction("ui_restart")` which drives the graceful shutdown path.
+
+Roll back Task 2's `exit` dep: remove from `SupervisorExitReloaderDeps`, `createUpdateStrategy`, tests. Run `bun test src/server/update-strategy.test.ts` + `bun test src/server/update-manager.test.ts` — all pass.
+
+Then in `server.ts` wiring, drop `exit` from factory deps. Commit each sub-step.
+
+**Step 3: Verify full test suite passes**
+
+Run: `bun test`
+Expected: 586 pass, 0 fail (same baseline).
+
+Run: `bun run check`
+Expected: no TypeScript errors, build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/server.ts src/server/cli.ts src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "refactor(server): wire UpdateManager through createUpdateStrategy factory"
+```
+
+---
+
+## Task 6: Add `pm2` dependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `bun.lock`
+
+**Step 1: Install**
+
+Run: `bun add pm2@latest`
+Expected: `pm2` added to `dependencies`.
+
+**Step 2: Verify build still works**
+
+Run: `bun run check`
+Expected: no errors.
+
+Run: `bun test`
+Expected: 586 pass.
+
+**Step 3: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "chore(deps): add pm2 for dev reloader"
+```
+
+---
+
+## Task 7: `GitChecker` (TDD)
+
+**Files:**
+- Modify: `src/server/update-strategy.ts`
+- Modify: `src/server/update-strategy.test.ts`
+
+**Step 1: Failing tests**
+
+Create `GitChecker` with injected `runGit: (args: string[]) => Promise<string>` for stubbing.
+
+```ts
+// append to test file
+import { GitChecker } from "./update-strategy"
+
+describe("GitChecker", () => {
+  const makeRunGit = (responses: Record<string, string>) => async (args: string[]) => {
+    const key = args.join(" ")
+    if (!(key in responses)) throw new Error(`unexpected git call: ${key}`)
+    return responses[key]
+  }
+
+  test("reports update when HEAD differs from upstream", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: makeRunGit({
+        "fetch origin main": "",
+        "rev-parse HEAD": "abc123def456\n",
+        "rev-parse origin/main": "deadbeef99887\n",
+      }),
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "deadbee", updateAvailable: true })
+  })
+
+  test("reports no update when HEAD matches upstream", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: makeRunGit({
+        "fetch origin main": "",
+        "rev-parse HEAD": "abc123def456\n",
+        "rev-parse origin/main": "abc123def456\n",
+      }),
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "abc123d", updateAvailable: false })
+  })
+
+  test("propagates git fetch errors", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: async () => { throw new Error("fetch failed: network") },
+    })
+    await expect(checker.check()).rejects.toThrow(/fetch failed/)
+  })
+})
+```
+
+**Step 2: Run — verify failure.** `bun test src/server/update-strategy.test.ts`.
+
+**Step 3: Implement**
+
+Add to `src/server/update-strategy.ts`:
+
+```ts
+export interface GitCheckerDeps {
+  repoDir: string
+  branch: string
+  runGit: (args: string[]) => Promise<string>
+}
+
+export class GitChecker implements UpdateChecker {
+  constructor(private deps: GitCheckerDeps) {}
+
+  async check() {
+    await this.deps.runGit(["fetch", "origin", this.deps.branch])
+    const headRaw = await this.deps.runGit(["rev-parse", "HEAD"])
+    const upstreamRaw = await this.deps.runGit(["rev-parse", `origin/${this.deps.branch}`])
+    const head = headRaw.trim()
+    const upstream = upstreamRaw.trim()
+    return {
+      latestVersion: upstream.slice(0, 7),
+      updateAvailable: head !== upstream,
+    }
+  }
+}
+```
+
+Also export a default `runGit` helper using `Bun.spawn` (see Task 8 for the shared spawn helper; keep this task scoped to the class — the factory will wire in a real `runGit` in Task 8).
+
+**Step 4: Run — verify passing.** All strategy tests green.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "feat(update-strategy): add GitChecker for pm2 mode update detection"
+```
+
+---
+
+## Task 8: `Pm2Reloader` + pm2 branch in factory (TDD)
+
+**Files:**
+- Modify: `src/server/update-strategy.ts`
+- Modify: `src/server/update-strategy.test.ts`
+
+**Step 1: Failing tests**
+
+Design the reloader with all side effects injected: `runCommand(command: string, args: string[]): Promise<void>`, `triggerPm2Reload(processName: string): Promise<void>`, and `lockfileChanged(repoDir: string): Promise<boolean>`.
+
+```ts
+import { Pm2Reloader, UpdateInstallError } from "./update-strategy"
+
+describe("Pm2Reloader", () => {
+  function makeReloader(overrides: Partial<{
+    lockfileChanged: boolean
+    commandErrors: Record<string, string>
+    reloadError: Error | null
+  }> = {}) {
+    const calls: string[] = []
+    const reloader = new Pm2Reloader({
+      repoDir: "/tmp/repo",
+      processName: "kanna",
+      runCommand: async (command, args) => {
+        const line = [command, ...args].join(" ")
+        calls.push(line)
+        if (overrides.commandErrors?.[line]) {
+          throw new Error(overrides.commandErrors[line])
+        }
+      },
+      lockfileChanged: async () => overrides.lockfileChanged ?? false,
+      triggerPm2Reload: async () => {
+        calls.push("pm2.reload kanna")
+        if (overrides.reloadError) throw overrides.reloadError
+      },
+    })
+    return { reloader, calls }
+  }
+
+  test("runs git pull, build, then pm2 reload when lockfile unchanged", async () => {
+    const { reloader, calls } = makeReloader({ lockfileChanged: false })
+    await reloader.reload()
+    expect(calls).toEqual([
+      "git pull --ff-only",
+      "bun run build",
+      "pm2.reload kanna",
+    ])
+  })
+
+  test("inserts bun install when lockfile changed", async () => {
+    const { reloader, calls } = makeReloader({ lockfileChanged: true })
+    await reloader.reload()
+    expect(calls).toEqual([
+      "git pull --ff-only",
+      "bun install",
+      "bun run build",
+      "pm2.reload kanna",
+    ])
+  })
+
+  test("aborts before reload when git pull fails", async () => {
+    const { reloader, calls } = makeReloader({
+      commandErrors: { "git pull --ff-only": "merge conflict in src/foo.ts" },
+    })
+    await expect(reloader.reload()).rejects.toThrow(/git pull failed/i)
+    expect(calls).toEqual(["git pull --ff-only"])
+  })
+
+  test("aborts before reload when build fails", async () => {
+    const { reloader, calls } = makeReloader({
+      commandErrors: { "bun run build": "tsc error TS2345" },
+    })
+    await expect(reloader.reload()).rejects.toThrow(/build failed/i)
+    expect(calls).toEqual(["git pull --ff-only", "bun run build"])
+  })
+
+  test("surfaces pm2 reload failures", async () => {
+    const { reloader } = makeReloader({ reloadError: new Error("pm2 daemon not running") })
+    await expect(reloader.reload()).rejects.toThrow(/pm2 reload failed/i)
+  })
+})
+
+describe("createUpdateStrategy pm2 branch", () => {
+  test("returns GitChecker + Pm2Reloader for KANNA_RELOADER=pm2", () => {
+    const strategy = createUpdateStrategy({
+      reloaderEnv: "pm2",
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => "ignored",
+      installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+      latestVersionHint: () => null,
+      repoDir: "/tmp/repo",
+    })
+    expect(strategy.checker).toBeInstanceOf(GitChecker)
+    expect(strategy.reloader).toBeInstanceOf(Pm2Reloader)
+  })
+
+  test("throws when pm2 mode selected without repoDir", () => {
+    expect(() =>
+      createUpdateStrategy({
+        reloaderEnv: "pm2",
+        currentVersion: "0.12.0",
+        fetchLatestVersion: async () => "ignored",
+        installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+        latestVersionHint: () => null,
+      }),
+    ).toThrow(/KANNA_REPO_DIR/)
+  })
+})
+```
+
+**Step 2: Run — verify failure.**
+
+**Step 3: Implement**
+
+Add to `src/server/update-strategy.ts`:
+
+```ts
+export interface Pm2ReloaderDeps {
+  repoDir: string
+  processName: string
+  runCommand: (command: string, args: string[]) => Promise<void>
+  lockfileChanged: () => Promise<boolean>
+  triggerPm2Reload: (processName: string) => Promise<void>
+}
+
+export class Pm2Reloader implements UpdateReloader {
+  constructor(private deps: Pm2ReloaderDeps) {}
+
+  async reload() {
+    await this.step("git pull", ["git", "pull", "--ff-only"])
+    if (await this.deps.lockfileChanged()) {
+      await this.step("bun install", ["bun", "install"])
+    }
+    await this.step("bun run build", ["bun", "run", "build"])
+    try {
+      await this.deps.triggerPm2Reload(this.deps.processName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new UpdateInstallError(
+        `pm2 reload failed: ${message}`,
+        "install_failed",
+        "Update failed",
+      )
+    }
+  }
+
+  private async step(label: string, argv: string[]) {
+    const [command, ...args] = argv
+    try {
+      await this.deps.runCommand(command, args)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new UpdateInstallError(
+        `${label} failed: ${message}`,
+        "install_failed",
+        "Update failed",
+      )
+    }
+  }
+}
+```
+
+And extend `createUpdateStrategy`:
+
+```ts
+if (mode === "pm2") {
+  if (!deps.repoDir) {
+    throw new Error("KANNA_RELOADER=pm2 requires KANNA_REPO_DIR to be set")
+  }
+  const repoDir = deps.repoDir
+  return {
+    checker: new GitChecker({
+      repoDir,
+      branch: "main",
+      runGit: (args) => runCommandCapture("git", args, repoDir),
+    }),
+    reloader: new Pm2Reloader({
+      repoDir,
+      processName: "kanna",
+      runCommand: (command, args) => runCommandThrow(command, args, repoDir),
+      lockfileChanged: () => detectLockfileChange(repoDir),
+      triggerPm2Reload,
+    }),
+  }
+}
+```
+
+Helpers in the same file:
+
+- `runCommandCapture(command, args, cwd)` — `Bun.spawn({ cmd: [command, ...args], cwd, stdout: "pipe", stderr: "pipe" })`, awaits exit, returns stdout; throws on non-zero with stderr tail (last 500 chars).
+- `runCommandThrow(command, args, cwd)` — same but void return.
+- `detectLockfileChange(repoDir)` — `git diff --name-only HEAD@{1} HEAD -- bun.lock package.json`; non-empty output → true. (HEAD@{1} = pre-pull ref from reflog.)
+- `triggerPm2Reload(name)` — wraps `import("pm2")` + `pm2.connect` + `pm2.reload` + `pm2.disconnect` in a promise.
+
+**Step 4: Run — verify passing.** All strategy tests + integration.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/update-strategy.ts src/server/update-strategy.test.ts
+git commit -m "feat(update-strategy): add Pm2Reloader with git-pull+build+pm2.reload pipeline"
+```
+
+---
+
+## Task 9: Create `scripts/pm2.config.cjs.tmpl`
+
+**Files:**
+- Create: `scripts/pm2.config.cjs.tmpl`
+- Modify: `.gitignore` (add `scripts/pm2.config.cjs` — the rendered output).
+
+**Step 1: Write template**
+
+```js
+// scripts/pm2.config.cjs.tmpl
+module.exports = {
+  apps: [
+    {
+      name: "kanna",
+      script: "./src/server/cli.ts",
+      interpreter: "bun",
+      cwd: "${REPO_DIR}",
+      env: {
+        KANNA_RELOADER: "pm2",
+        KANNA_REPO_DIR: "${REPO_DIR}",
+        KANNA_DISABLE_SELF_UPDATE: "1",
+        KANNA_CLI_MODE: "child",
+      },
+      autorestart: true,
+      max_memory_restart: "1G",
+      kill_timeout: 5000,
+    },
+  ],
+}
+```
+
+**Step 2: Add rendered file to `.gitignore`**
+
+Append:
+
+```
+scripts/pm2.config.cjs
+```
+
+**Step 3: Commit**
+
+```bash
+git add scripts/pm2.config.cjs.tmpl .gitignore
+git commit -m "feat(dev): add pm2 ecosystem template for local dev deploy"
+```
+
+---
+
+## Task 10: Rewrite `scripts/deploy.sh`
+
+**Files:**
+- Modify: `scripts/deploy.sh`
+
+**Step 1: Replace content**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GLOBAL_LINK="$HOME/.bun/install/global/node_modules/kanna-code"
+PM2_NAME="kanna"
+PM2_TEMPLATE="$REPO_DIR/scripts/pm2.config.cjs.tmpl"
+PM2_CONFIG="$REPO_DIR/scripts/pm2.config.cjs"
+
+cd "$REPO_DIR"
+
+if [[ ! -L "$GLOBAL_LINK" ]]; then
+  echo "→ Linking $GLOBAL_LINK → $REPO_DIR"
+  rm -rf "$GLOBAL_LINK"
+  mkdir -p "$(dirname "$GLOBAL_LINK")"
+  ln -s "$REPO_DIR" "$GLOBAL_LINK"
+fi
+
+if [[ ! -d node_modules ]] || [[ package.json -nt node_modules ]] || [[ bun.lock -nt node_modules ]]; then
+  echo "→ bun install"
+  bun install
+fi
+
+echo "→ bun run build"
+bun run build
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "→ bun install -g pm2"
+  bun install -g pm2
+fi
+
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "✗ envsubst not found (install gettext: brew install gettext)" >&2
+  exit 1
+fi
+
+echo "→ render $PM2_CONFIG"
+REPO_DIR="$REPO_DIR" envsubst '${REPO_DIR}' < "$PM2_TEMPLATE" > "$PM2_CONFIG"
+
+if pm2 describe "$PM2_NAME" >/dev/null 2>&1; then
+  echo "→ pm2 reload $PM2_NAME"
+  pm2 reload "$PM2_CONFIG" --update-env
+else
+  echo "→ pm2 start $PM2_NAME"
+  pm2 start "$PM2_CONFIG"
+fi
+
+pm2 save
+echo "✓ kanna running under pm2"
+```
+
+**Step 2: Syntax check**
+
+Run: `bash -n scripts/deploy.sh`
+Expected: exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/deploy.sh
+git commit -m "feat(dev): swap launchd for pm2 in deploy.sh"
+```
+
+---
+
+## Task 11: Manual verification
+
+**No files.** Checklist only.
+
+**Step 1:** Unload the old launchd plist once:
+```bash
+launchctl bootout gui/$(id -u)/io.silentium.kanna || true
+```
+
+**Step 2:** Run deploy in the worktree:
+```bash
+cd /Users/cuongtran/Desktop/repo/kanna/.worktrees/pm2-reloader
+./scripts/deploy.sh
+pm2 list
+```
+Expected: `kanna` shows `online`.
+
+**Step 3:** Happy path — commit a small, safe change (e.g., a comment in `src/shared/branding.ts`), push the branch, then click "Update" in the running UI. Verify:
+- UI transitions through `checking` → `available` → `updating` → `restart_pending`.
+- pm2 logs (`pm2 logs kanna --lines 50`) show `git pull`, `bun run build`, then fresh process startup.
+- UI reconnects and reflects the change.
+
+**Step 4:** Failure path — introduce a deliberate TypeScript syntax error on the branch, push, click Update. Verify:
+- UI shows red error banner with stderr tail from `bun run build`.
+- `pm2 list` shows `kanna` still `online` serving the old build.
+- Fix the error, push, click Update again → recovers.
+
+**Step 5:** Regression — `pm2 delete kanna`, then in a plain terminal run `kanna` (symlinked to worktree build). Supervisor path should still respond to update button as before (npm-registry check). This verifies unset `KANNA_RELOADER` keeps old behavior.
+
+**Step 6:** Commit the verification notes (optional): if anything unexpected was found, document in the plan's "Results" section.
+
+---
+
+## Final checks before PR
+
+Run:
+
+```bash
+bun run check   # tsc + vite build
+bun test
+```
+
+Expected: 0 TypeScript errors, all tests pass (at least 586 + the new ones from Tasks 1-3, 7, 8 — roughly 601-610 total).
+
+Then follow `superpowers:finishing-a-development-branch` to close out.

--- a/docs/superpowers/plans/2026-04-20-at-mention-file-picker.md
+++ b/docs/superpowers/plans/2026-04-20-at-mention-file-picker.md
@@ -1,0 +1,1389 @@
+# `@` File Mention Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Claude Code-style `@` file/directory picker to Kanna's chat input. Typing `@` at a word boundary opens a fuzzy-searchable picker populated from the project's git-tracked + untracked files (with ripgrep / readdir fallbacks). Selecting a row inserts `@relative/path` text and registers a `kind: "mention"` attachment. The server renders mentions inside the existing `<kanna-attachments>` block so both Claude and Codex sessions receive them.
+
+**Architecture:** Additive. New server module `project-paths.ts` owns file indexing + fuzzy filter; new route `GET /api/projects/:id/paths?query=`. A new `"mention"` variant on `AttachmentKind` flows through the existing attachment hint renderer in `src/server/agent.ts`. Client adds `mention-suggestions.ts`, `useMentionSuggestions`, `MentionPicker.tsx`, and a branch in `AttachmentCard.tsx`; `ChatInput.tsx` wires them.
+
+**Tech Stack:** TypeScript, Bun, React 19, Zustand, Vitest/bun:test, Tailwind, Bun.spawn for git subprocesses.
+
+**Design reference:** `docs/superpowers/specs/2026-04-20-at-mention-file-picker-design.md`.
+
+**Baseline:** Branch `main`, clean tree at `16eee47`. Before starting, create a feature branch: `git checkout -b feature/at-mention-picker`. Verify `bun run check` passes.
+
+---
+
+## Task 1 — Shared `"mention"` attachment kind
+
+**Files:**
+- Modify: `src/shared/types.ts` (lines 9-20)
+
+- [ ] **Step 1: Extend `AttachmentKind`**
+
+Edit `src/shared/types.ts`:
+
+```ts
+export type AttachmentKind = "image" | "file" | "mention"
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run check`
+Expected: PASS. The addition is a union widening — existing narrowings (`kind === "image"` / `kind === "file"`) are still valid. If a `switch (kind)` exhaustive check fails somewhere, note the file and add a `case "mention":` branch that falls through to the default (no-op for now).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat(types): add \"mention\" variant to AttachmentKind"
+```
+
+---
+
+## Task 2 — Server path indexer (`project-paths.ts`)
+
+**Files:**
+- Create: `src/server/project-paths.ts`
+- Create: `src/server/project-paths.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/server/project-paths.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { $ } from "bun"
+import { clearProjectPathCache, listProjectPaths } from "./project-paths"
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  clearProjectPathCache()
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe("listProjectPaths", () => {
+  test("empty query returns top-level entries with dirs suffixed", async () => {
+    const root = await makeTempDir("kanna-paths-empty-")
+    await writeFile(path.join(root, "a.txt"), "a")
+    await mkdir(path.join(root, "src"))
+    await writeFile(path.join(root, "src", "b.ts"), "b")
+
+    const paths = await listProjectPaths({ projectId: "p1", localPath: root, query: "" })
+    const names = paths.map((p) => p.path).sort()
+    expect(names).toEqual(["a.txt", "src/"])
+    expect(paths.find((p) => p.path === "src/")?.kind).toBe("dir")
+    expect(paths.find((p) => p.path === "a.txt")?.kind).toBe("file")
+  })
+
+  test("git repo: returns tracked files + derived dirs", async () => {
+    const root = await makeTempDir("kanna-paths-git-")
+    await $`git init -q`.cwd(root)
+    await $`git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init`.cwd(root)
+    await mkdir(path.join(root, "src"))
+    await writeFile(path.join(root, "src", "agent.ts"), "x")
+    await writeFile(path.join(root, "README.md"), "r")
+    await $`git add .`.cwd(root)
+    await $`git -c user.email=t@t -c user.name=t commit -q -m add`.cwd(root)
+
+    const paths = await listProjectPaths({ projectId: "p2", localPath: root, query: "agent" })
+    const names = paths.map((p) => p.path)
+    expect(names).toContain("src/agent.ts")
+  })
+
+  test("git repo: respects .gitignore for untracked files", async () => {
+    const root = await makeTempDir("kanna-paths-ignore-")
+    await $`git init -q`.cwd(root)
+    await writeFile(path.join(root, ".gitignore"), "node_modules\n")
+    await mkdir(path.join(root, "node_modules"))
+    await writeFile(path.join(root, "node_modules", "junk.js"), "x")
+    await writeFile(path.join(root, "app.ts"), "x")
+
+    const paths = await listProjectPaths({ projectId: "p3", localPath: root, query: "junk" })
+    expect(paths.map((p) => p.path)).not.toContain("node_modules/junk.js")
+  })
+
+  test("fuzzy ranking: prefix matches before substring matches", async () => {
+    const root = await makeTempDir("kanna-paths-rank-")
+    await writeFile(path.join(root, "review.ts"), "")
+    await writeFile(path.join(root, "unreview.ts"), "")
+
+    const paths = await listProjectPaths({ projectId: "p4", localPath: root, query: "rev" })
+    expect(paths.map((p) => p.path)).toEqual(["review.ts", "unreview.ts"])
+  })
+
+  test("respects limit", async () => {
+    const root = await makeTempDir("kanna-paths-limit-")
+    for (let i = 0; i < 10; i++) {
+      await writeFile(path.join(root, `file-${i}.txt`), "")
+    }
+
+    const paths = await listProjectPaths({ projectId: "p5", localPath: root, query: "file", limit: 3 })
+    expect(paths.length).toBe(3)
+  })
+
+  test("cache returns from memory on repeat call", async () => {
+    const root = await makeTempDir("kanna-paths-cache-")
+    await writeFile(path.join(root, "a.txt"), "")
+
+    const first = await listProjectPaths({ projectId: "p6", localPath: root, query: "a" })
+    await writeFile(path.join(root, "b.txt"), "") // added after first call
+    const second = await listProjectPaths({ projectId: "p6", localPath: root, query: "b" })
+
+    expect(first.map((p) => p.path)).toContain("a.txt")
+    // b.txt was added after cache built and no .git/index triggered invalidation,
+    // but since this is non-git, the 5s TTL won't have elapsed so b.txt should
+    // NOT appear yet.
+    expect(second.map((p) => p.path)).not.toContain("b.txt")
+  })
+})
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `bun test src/server/project-paths.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `project-paths.ts`**
+
+Create `src/server/project-paths.ts`:
+
+```ts
+import path from "node:path"
+import { readdir, stat } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { spawn } from "bun"
+
+export interface ProjectPath {
+  path: string
+  kind: "file" | "dir"
+}
+
+interface CacheEntry {
+  files: string[]       // relative, forward slashes
+  dirs: string[]        // relative, forward slashes, no trailing separator
+  gitIndexMtime: number | null
+  builtAt: number
+}
+
+const CACHE = new Map<string, CacheEntry>()
+const CACHE_TTL_MS = 5 * 60 * 1000
+const MAX_WALK_ENTRIES = 10_000
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+const DEFAULT_WALK_EXCLUDES = new Set([
+  ".git", "node_modules", ".next", "dist", "build", ".svn", ".hg", ".jj", ".sl",
+])
+
+export function clearProjectPathCache(projectId?: string) {
+  if (projectId) CACHE.delete(projectId)
+  else CACHE.clear()
+}
+
+export async function listProjectPaths(args: {
+  projectId: string
+  localPath: string
+  query: string
+  limit?: number
+}): Promise<ProjectPath[]> {
+  const limit = Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+  const query = args.query ?? ""
+
+  if (query === "") {
+    return listTopLevelEntries(args.localPath, limit)
+  }
+
+  const entry = await getOrBuildCache(args.projectId, args.localPath)
+  return fuzzyRank(entry, query, limit)
+}
+
+async function listTopLevelEntries(localPath: string, limit: number): Promise<ProjectPath[]> {
+  try {
+    const entries = await readdir(localPath, { withFileTypes: true })
+    const result: ProjectPath[] = []
+    for (const e of entries) {
+      if (DEFAULT_WALK_EXCLUDES.has(e.name)) continue
+      if (e.name.startsWith(".")) continue
+      result.push(e.isDirectory()
+        ? { path: `${e.name}/`, kind: "dir" }
+        : { path: e.name, kind: "file" })
+    }
+    result.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1
+      return a.path.localeCompare(b.path)
+    })
+    return result.slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+async function getOrBuildCache(projectId: string, localPath: string): Promise<CacheEntry> {
+  const existing = CACHE.get(projectId)
+  const gitIndexMtime = getGitIndexMtime(localPath)
+  const now = Date.now()
+
+  if (existing) {
+    const gitChanged = gitIndexMtime !== null && gitIndexMtime !== existing.gitIndexMtime
+    const expired = now - existing.builtAt > CACHE_TTL_MS
+    if (!gitChanged && !expired) return existing
+  }
+
+  const built = await buildCacheEntry(localPath)
+  const next: CacheEntry = { ...built, gitIndexMtime, builtAt: now }
+  CACHE.set(projectId, next)
+  return next
+}
+
+function getGitIndexMtime(localPath: string): number | null {
+  const indexPath = path.join(localPath, ".git", "index")
+  try {
+    const { statSync } = require("node:fs") as typeof import("node:fs")
+    return statSync(indexPath).mtimeMs
+  } catch {
+    return null
+  }
+}
+
+async function buildCacheEntry(localPath: string): Promise<Pick<CacheEntry, "files" | "dirs">> {
+  const gitFiles = await listGitFiles(localPath)
+  const files = gitFiles ?? await walkDirectory(localPath)
+  const dirs = deriveDirectories(files)
+  return { files, dirs }
+}
+
+async function listGitFiles(localPath: string): Promise<string[] | null> {
+  if (!existsSync(path.join(localPath, ".git"))) return null
+
+  const tracked = await runGit(localPath, ["-c", "core.quotepath=false", "ls-files"])
+  if (tracked === null) return null
+
+  const untracked = await runGit(localPath, [
+    "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard",
+  ])
+
+  const all = new Set<string>()
+  for (const line of tracked) all.add(line)
+  for (const line of untracked ?? []) all.add(line)
+  return [...all].filter((p) => p.length > 0).map((p) => p.replaceAll("\\", "/"))
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string[] | null> {
+  try {
+    const proc = spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+    const stdout = await new Response(proc.stdout).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return null
+    return stdout.split("\n").filter(Boolean)
+  } catch {
+    return null
+  }
+}
+
+async function walkDirectory(root: string): Promise<string[]> {
+  const out: string[] = []
+  const queue: string[] = [""]
+  while (queue.length > 0 && out.length < MAX_WALK_ENTRIES) {
+    const rel = queue.shift()!
+    const abs = path.join(root, rel)
+    let entries: Awaited<ReturnType<typeof readdir>>
+    try {
+      entries = await readdir(abs, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (DEFAULT_WALK_EXCLUDES.has(e.name)) continue
+      const nextRel = rel === "" ? e.name : `${rel}/${e.name}`
+      if (e.isDirectory()) {
+        queue.push(nextRel)
+      } else if (e.isFile()) {
+        out.push(nextRel)
+        if (out.length >= MAX_WALK_ENTRIES) break
+      }
+    }
+  }
+  return out
+}
+
+function deriveDirectories(files: string[]): string[] {
+  const dirs = new Set<string>()
+  for (const f of files) {
+    let idx = f.lastIndexOf("/")
+    while (idx > 0) {
+      dirs.add(f.slice(0, idx))
+      idx = f.lastIndexOf("/", idx - 1)
+    }
+  }
+  return [...dirs]
+}
+
+function fuzzyRank(entry: CacheEntry, query: string, limit: number): ProjectPath[] {
+  const q = query.toLowerCase()
+  const prefix: ProjectPath[] = []
+  const substring: ProjectPath[] = []
+
+  for (const f of entry.files) {
+    const hay = f.toLowerCase()
+    if (hay.startsWith(q)) prefix.push({ path: f, kind: "file" })
+    else if (hay.includes(q)) substring.push({ path: f, kind: "file" })
+  }
+  for (const d of entry.dirs) {
+    const hay = d.toLowerCase()
+    const withSlash = `${d}/`
+    if (hay.startsWith(q)) prefix.push({ path: withSlash, kind: "dir" })
+    else if (hay.includes(q)) substring.push({ path: withSlash, kind: "dir" })
+  }
+
+  const byPath = (a: ProjectPath, b: ProjectPath) => a.path.localeCompare(b.path)
+  prefix.sort(byPath)
+  substring.sort(byPath)
+  return [...prefix, ...substring].slice(0, limit)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/server/project-paths.test.ts`
+Expected: PASS (all cases).
+
+If the `cache returns from memory` test fails because writes happened too fast for the TTL check, that test is still valid — it asserts that a freshly-added file does NOT appear in the second call. If the test is flaky, replace the assertion with: `expect(CACHE.has("p6")).toBe(true)` by exporting a helper. Keep it simple and adjust only if needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/project-paths.ts src/server/project-paths.test.ts
+git commit -m "feat(server): add project-paths module for @ mention suggestions"
+```
+
+---
+
+## Task 3 — HTTP route `/api/projects/:id/paths`
+
+**Files:**
+- Modify: `src/server/server.ts` (add import + route handler + call site around line 228)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `src/server/uploads.test.ts` (reuses existing `startKannaServer` setup) or create `src/server/paths-route.test.ts` if preferred. Use the latter for isolation:
+
+Create `src/server/paths-route.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { startKannaServer } from "./server"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+async function makeProject(): Promise<{ projectDir: string; dataDir: string }> {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-data-"))
+  const projectDir = await mkdtemp(path.join(tmpdir(), "kanna-proj-"))
+  tempDirs.push(dataDir, projectDir)
+  process.env.KANNA_DATA_DIR = dataDir
+  return { projectDir, dataDir }
+}
+
+describe("GET /api/projects/:id/paths", () => {
+  test("returns 404 for unknown project", async () => {
+    const { projectDir } = await makeProject()
+    await mkdir(path.join(projectDir, "src"))
+    await writeFile(path.join(projectDir, "src", "a.ts"), "")
+
+    const server = await startKannaServer({ port: 0 })
+    try {
+      const response = await fetch(`http://localhost:${server.port}/api/projects/does-not-exist/paths`)
+      expect(response.status).toBe(404)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("returns top-level entries for empty query", async () => {
+    const { projectDir } = await makeProject()
+    await mkdir(path.join(projectDir, "src"))
+    await writeFile(path.join(projectDir, "README.md"), "")
+
+    const server = await startKannaServer({ port: 0 })
+    try {
+      const project = server.store.openProject({ localPath: projectDir, title: "t" })
+      const response = await fetch(`http://localhost:${server.port}/api/projects/${project.id}/paths`)
+      expect(response.status).toBe(200)
+      const payload = await response.json() as { paths: Array<{ path: string; kind: string }> }
+      const names = payload.paths.map((p) => p.path)
+      expect(names).toContain("README.md")
+      expect(names).toContain("src/")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("respects ?query= and ?limit=", async () => {
+    const { projectDir } = await makeProject()
+    for (let i = 0; i < 5; i++) await writeFile(path.join(projectDir, `file-${i}.txt`), "")
+
+    const server = await startKannaServer({ port: 0 })
+    try {
+      const project = server.store.openProject({ localPath: projectDir, title: "t" })
+      const response = await fetch(
+        `http://localhost:${server.port}/api/projects/${project.id}/paths?query=file&limit=2`,
+      )
+      const payload = await response.json() as { paths: Array<{ path: string }> }
+      expect(payload.paths.length).toBe(2)
+    } finally {
+      await server.stop()
+    }
+  })
+})
+```
+
+**Note:** Before writing the test, verify how existing tests set up the data directory — read `src/server/uploads.test.ts` around the `startKannaServer` call and mirror its pattern. If `KANNA_DATA_DIR` isn't the correct env var, check `src/shared/branding.ts` and `src/server/paths.ts` for the actual env var name. Adjust the test accordingly. Also verify how `store.openProject` signature looks — Grep for `openProject` in `src/server/event-store.ts`.
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `bun test src/server/paths-route.test.ts`
+Expected: FAIL — route returns 404 (fallthrough to static serve) for all requests.
+
+- [ ] **Step 3: Implement handler**
+
+Edit `src/server/server.ts`:
+
+Add to imports at top:
+
+```ts
+import { listProjectPaths } from "./project-paths"
+```
+
+Add a new handler function after `handleProjectUploadDelete` (after line ~450):
+
+```ts
+async function handleProjectPaths(req: Request, url: URL, store: EventStore) {
+  if (req.method !== "GET") return null
+  const match = url.pathname.match(/^\/api\/projects\/([^/]+)\/paths$/)
+  if (!match) return null
+
+  const project = store.getProject(match[1])
+  if (!project) {
+    return Response.json({ error: "Project not found" }, { status: 404 })
+  }
+
+  const query = url.searchParams.get("query") ?? ""
+  const limitRaw = url.searchParams.get("limit")
+  const limit = limitRaw !== null ? Number.parseInt(limitRaw, 10) : undefined
+
+  try {
+    const paths = await listProjectPaths({
+      projectId: project.id,
+      localPath: project.localPath,
+      query,
+      limit: Number.isFinite(limit) ? limit : undefined,
+    })
+    return Response.json({ paths })
+  } catch (error) {
+    console.error("[paths] list failed:", error)
+    return Response.json({ error: "Failed to list paths" }, { status: 500 })
+  }
+}
+```
+
+Wire it into the request handler block (near line 228, next to `handleProjectFileContent`):
+
+```ts
+const projectPathsResponse = await handleProjectPaths(req, url, store)
+if (projectPathsResponse) {
+  return projectPathsResponse
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/server/paths-route.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/server.ts src/server/paths-route.test.ts
+git commit -m "feat(server): add GET /api/projects/:id/paths route"
+```
+
+---
+
+## Task 4 — Verify agent hint renders `kind="mention"`
+
+**Files:**
+- Modify: `src/server/agent.test.ts` (append a new test)
+
+- [ ] **Step 1: Read the existing test to mirror its style**
+
+Read: `src/server/agent.test.ts` lines 140-210 (the existing attachment-hint tests).
+
+- [ ] **Step 2: Add failing test**
+
+Append to `src/server/agent.test.ts` inside the existing describe block that covers `buildAttachmentHintText` (or create a new describe if none):
+
+```ts
+test("buildAttachmentHintText renders kind=\"mention\" attachments", () => {
+  const prompt = buildAttachmentHintText([
+    {
+      id: "m1",
+      kind: "mention",
+      displayName: "src/agent.ts",
+      absolutePath: "/tmp/project/src/agent.ts",
+      relativePath: "./src/agent.ts",
+      contentUrl: "",
+      mimeType: "",
+      size: 0,
+    },
+  ])
+  expect(prompt).toContain("kind=\"mention\"")
+  expect(prompt).toContain("path=\"/tmp/project/src/agent.ts\"")
+  expect(prompt).toContain("project_path=\"./src/agent.ts\"")
+})
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: PASS immediately — `buildAttachmentHintText` at `src/server/agent.ts:211-223` already emits `kind="${attachment.kind}"` unconditionally, so mentions flow through. This task exists to lock in that invariant.
+
+If FAIL, check the imports at the top of `agent.test.ts` for `buildAttachmentHintText` and add it if missing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/agent.test.ts
+git commit -m "test(agent): lock in kind=\"mention\" rendering in attachment hint"
+```
+
+---
+
+## Task 5 — Client pure utils (`mention-suggestions.ts`)
+
+**Files:**
+- Create: `src/client/lib/mention-suggestions.ts`
+- Create: `src/client/lib/mention-suggestions.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/client/lib/mention-suggestions.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { applyMentionToInput, shouldShowMentionPicker } from "./mention-suggestions"
+
+describe("shouldShowMentionPicker", () => {
+  test("opens on bare @ at start", () => {
+    expect(shouldShowMentionPicker("@", 1)).toEqual({ open: true, query: "", tokenStart: 0 })
+  })
+
+  test("opens on @src at start", () => {
+    expect(shouldShowMentionPicker("@src", 4)).toEqual({ open: true, query: "src", tokenStart: 0 })
+  })
+
+  test("opens on @src after space", () => {
+    expect(shouldShowMentionPicker("hi @src", 7)).toEqual({ open: true, query: "src", tokenStart: 3 })
+  })
+
+  test("opens after newline", () => {
+    expect(shouldShowMentionPicker("hi\n@src", 7)).toEqual({ open: true, query: "src", tokenStart: 3 })
+  })
+
+  test("does not open on mid-word @ (email-like)", () => {
+    expect(shouldShowMentionPicker("foo@bar", 7)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open when caret before @", () => {
+    expect(shouldShowMentionPicker("@src", 0)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open after space breaks the token", () => {
+    expect(shouldShowMentionPicker("@src foo", 8)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open on empty input", () => {
+    expect(shouldShowMentionPicker("", 0)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+})
+
+describe("applyMentionToInput", () => {
+  test("replaces @query at start with @pickedPath", () => {
+    const result = applyMentionToInput({
+      value: "@src",
+      caret: 4,
+      tokenStart: 0,
+      pickedPath: "src/agent.ts",
+    })
+    expect(result.value).toBe("@src/agent.ts")
+    expect(result.caret).toBe("@src/agent.ts".length)
+  })
+
+  test("replaces mid-input token", () => {
+    const result = applyMentionToInput({
+      value: "hi @src tail",
+      caret: 7,
+      tokenStart: 3,
+      pickedPath: "src/agent.ts",
+    })
+    expect(result.value).toBe("hi @src/agent.ts tail")
+    expect(result.caret).toBe("hi @src/agent.ts".length)
+  })
+
+  test("preserves bare @ with empty query", () => {
+    const result = applyMentionToInput({
+      value: "@",
+      caret: 1,
+      tokenStart: 0,
+      pickedPath: "README.md",
+    })
+    expect(result.value).toBe("@README.md")
+    expect(result.caret).toBe("@README.md".length)
+  })
+
+  test("handles dir paths (trailing slash)", () => {
+    const result = applyMentionToInput({
+      value: "@src",
+      caret: 4,
+      tokenStart: 0,
+      pickedPath: "src/",
+    })
+    expect(result.value).toBe("@src/")
+    expect(result.caret).toBe("@src/".length)
+  })
+})
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `bun test src/client/lib/mention-suggestions.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/client/lib/mention-suggestions.ts`:
+
+```ts
+export interface MentionTrigger {
+  open: boolean
+  query: string
+  tokenStart: number
+}
+
+const CLOSED: MentionTrigger = { open: false, query: "", tokenStart: -1 }
+
+export function shouldShowMentionPicker(value: string, caret: number): MentionTrigger {
+  if (caret <= 0) return CLOSED
+  const upToCaret = value.slice(0, caret)
+
+  let atIndex = -1
+  for (let i = upToCaret.length - 1; i >= 0; i--) {
+    const ch = upToCaret[i]
+    if (ch === "@") { atIndex = i; break }
+    if (ch === " " || ch === "\n" || ch === "\t") return CLOSED
+  }
+  if (atIndex === -1) return CLOSED
+
+  const before = atIndex === 0 ? "" : upToCaret[atIndex - 1]
+  if (before !== "" && before !== " " && before !== "\n" && before !== "\t") return CLOSED
+
+  return { open: true, query: upToCaret.slice(atIndex + 1), tokenStart: atIndex }
+}
+
+export function applyMentionToInput(args: {
+  value: string
+  caret: number
+  tokenStart: number
+  pickedPath: string
+}): { value: string; caret: number } {
+  const before = args.value.slice(0, args.tokenStart)
+  const after = args.value.slice(args.caret)
+  const replacement = `@${args.pickedPath}`
+  const nextValue = `${before}${replacement}${after}`
+  const nextCaret = before.length + replacement.length
+  return { value: nextValue, caret: nextCaret }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/client/lib/mention-suggestions.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/lib/mention-suggestions.ts src/client/lib/mention-suggestions.test.ts
+git commit -m "feat(client): add mention-suggestions trigger and apply utils"
+```
+
+---
+
+## Task 6 — Client fetch hook (`useMentionSuggestions`)
+
+**Files:**
+- Create: `src/client/hooks/useMentionSuggestions.ts`
+- Create: `src/client/hooks/useMentionSuggestions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/client/hooks/useMentionSuggestions.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { fetchProjectPaths, type ProjectPath } from "./useMentionSuggestions"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("fetchProjectPaths", () => {
+  test("requests the expected URL and returns paths", async () => {
+    let receivedUrl: string | null = null
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      receivedUrl = typeof input === "string" ? input : input.toString()
+      return new Response(
+        JSON.stringify({ paths: [{ path: "a.ts", kind: "file" }] }),
+        { headers: { "Content-Type": "application/json" } },
+      )
+    }) as typeof fetch
+
+    const result = await fetchProjectPaths({ projectId: "p1", query: "a", signal: new AbortController().signal })
+    expect(receivedUrl).toBe("/api/projects/p1/paths?query=a")
+    expect(result).toEqual([{ path: "a.ts", kind: "file" }])
+  })
+
+  test("escapes query", async () => {
+    let receivedUrl: string | null = null
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      receivedUrl = typeof input === "string" ? input : input.toString()
+      return new Response(JSON.stringify({ paths: [] }), { headers: { "Content-Type": "application/json" } })
+    }) as typeof fetch
+
+    await fetchProjectPaths({ projectId: "p1", query: "a b/c", signal: new AbortController().signal })
+    expect(receivedUrl).toBe("/api/projects/p1/paths?query=a+b%2Fc")
+  })
+
+  test("returns empty array on non-ok response", async () => {
+    globalThis.fetch = (async () => new Response("{}", { status: 500 })) as typeof fetch
+    const result = await fetchProjectPaths({ projectId: "p1", query: "x", signal: new AbortController().signal })
+    expect(result).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `bun test src/client/hooks/useMentionSuggestions.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/client/hooks/useMentionSuggestions.ts`:
+
+```ts
+import { useEffect, useRef, useState } from "react"
+
+export interface ProjectPath {
+  path: string
+  kind: "file" | "dir"
+}
+
+interface State {
+  items: ProjectPath[]
+  loading: boolean
+  error: string | null
+}
+
+const DEBOUNCE_MS = 120
+
+export async function fetchProjectPaths(args: {
+  projectId: string
+  query: string
+  signal: AbortSignal
+}): Promise<ProjectPath[]> {
+  const params = new URLSearchParams({ query: args.query })
+  try {
+    const response = await fetch(`/api/projects/${args.projectId}/paths?${params.toString()}`, {
+      signal: args.signal,
+    })
+    if (!response.ok) return []
+    const payload = await response.json() as { paths?: ProjectPath[] }
+    return payload.paths ?? []
+  } catch {
+    return []
+  }
+}
+
+export function useMentionSuggestions(args: {
+  projectId: string | null
+  query: string
+  enabled: boolean
+}): State {
+  const [state, setState] = useState<State>({ items: [], loading: false, error: null })
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!args.enabled || !args.projectId) {
+      setState({ items: [], loading: false, error: null })
+      return
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    abortRef.current?.abort()
+
+    setState((s) => ({ ...s, loading: true, error: null }))
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    debounceRef.current = setTimeout(async () => {
+      const items = await fetchProjectPaths({
+        projectId: args.projectId!,
+        query: args.query,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      setState({ items, loading: false, error: null })
+    }, DEBOUNCE_MS)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      controller.abort()
+    }
+  }, [args.enabled, args.projectId, args.query])
+
+  return state
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/client/hooks/useMentionSuggestions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/client/hooks/useMentionSuggestions.ts src/client/hooks/useMentionSuggestions.test.ts
+git commit -m "feat(client): add useMentionSuggestions hook"
+```
+
+---
+
+## Task 7 — `MentionPicker` component
+
+**Files:**
+- Create: `src/client/components/chat-ui/MentionPicker.tsx`
+
+- [ ] **Step 1: Implement component**
+
+Create `src/client/components/chat-ui/MentionPicker.tsx`:
+
+```tsx
+import { useEffect, useRef } from "react"
+import { AtSign, Folder, FileText } from "lucide-react"
+import type { ProjectPath } from "../../hooks/useMentionSuggestions"
+import { cn } from "../../lib/utils"
+
+interface MentionPickerProps {
+  items: ProjectPath[]
+  activeIndex: number
+  loading: boolean
+  onSelect: (path: ProjectPath) => void
+  onHoverIndex: (index: number) => void
+}
+
+const SKELETON_ROWS = 4
+
+export function MentionPicker({ items, activeIndex, loading, onSelect, onHoverIndex }: MentionPickerProps) {
+  const listRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const el = listRef.current?.children.item(activeIndex) as HTMLElement | null
+    el?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
+
+  if (items.length === 0 && loading) {
+    return (
+      <ul
+        aria-busy="true"
+        aria-label="Loading file suggestions"
+        className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover shadow-md overflow-hidden"
+      >
+        {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+          <li
+            key={i}
+            className="flex items-center gap-2 px-3 py-1.5"
+            data-testid="mention-picker-skeleton-row"
+          >
+            <span className="h-3.5 w-3.5 rounded bg-muted animate-pulse" />
+            <span className="h-3 w-40 max-w-full rounded bg-muted animate-pulse" />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+        No matching files
+      </div>
+    )
+  }
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
+    >
+      {items.map((item, i) => {
+        const Icon = item.kind === "dir" ? Folder : FileText
+        return (
+          <li
+            key={`${item.kind}:${item.path}`}
+            role="option"
+            aria-selected={i === activeIndex}
+            onMouseDown={(event) => {
+              event.preventDefault()
+              onSelect(item)
+            }}
+            onMouseEnter={() => onHoverIndex(i)}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 cursor-pointer text-sm",
+              i === activeIndex && "bg-accent text-accent-foreground",
+            )}
+          >
+            <AtSign className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="font-mono truncate">{item.path}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/client/components/chat-ui/MentionPicker.tsx
+git commit -m "feat(client): add MentionPicker component"
+```
+
+---
+
+## Task 8 — Render mention attachments in `AttachmentCard`
+
+**Files:**
+- Modify: `src/client/components/messages/AttachmentCard.tsx`
+
+- [ ] **Step 1: Read existing file**
+
+Read `src/client/components/messages/AttachmentCard.tsx` end to end so you understand the existing `AttachmentFileCard` shape.
+
+- [ ] **Step 2: Add mention branch**
+
+Modify `AttachmentFileCard` (around line 90-118) so mentions render without the size/mime line (they're always zero/empty). Replace the body text block:
+
+```tsx
+        <div className="min-w-0">
+          <div className="max-w-[150px] truncate text-[13px] font-medium text-foreground">{attachment.displayName}</div>
+          {attachment.kind === "mention" ? (
+            <div className="truncate text-[11px] text-muted-foreground">
+              @mention
+            </div>
+          ) : (
+            <div className="truncate text-[11px] text-muted-foreground">
+              {attachment.mimeType} · {formatAttachmentSize(attachment.size)}
+            </div>
+          )}
+        </div>
+```
+
+Also, for mentions, swap the icon: update `getAttachmentIcon` call site (near the top of `AttachmentFileCard`) to special-case mentions:
+
+Find the line that computes `Icon = getAttachmentIcon(classifyAttachmentIcon(attachment))`. Before it, add:
+
+```tsx
+  const iconKind: AttachmentIconKind = attachment.kind === "mention" ? "text" : classifyAttachmentIcon(attachment)
+  const Icon = getAttachmentIcon(iconKind)
+```
+
+And replace the existing `Icon` computation with the two lines above (delete the original). Import `AttachmentIconKind` if it isn't already imported (line 18 should already have `type AttachmentIconKind`).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/client/components/messages/AttachmentCard.tsx
+git commit -m "feat(client): render \"mention\" attachments without mime/size metadata"
+```
+
+---
+
+## Task 9 — Wire `MentionPicker` into `ChatInput`
+
+**Files:**
+- Modify: `src/client/components/chat-ui/ChatInput.tsx`
+- Modify: `src/client/components/chat-ui/ChatInput.test.ts`
+
+- [ ] **Step 1: Read the current `ChatInput.tsx` handleKeyDown and render sections**
+
+Re-read `src/client/components/chat-ui/ChatInput.tsx` lines 220-260 (state block) and 606-660 (keyboard) and 762-770 (picker render). Your wiring should mirror the slash picker but use mention state.
+
+- [ ] **Step 2: Add mention state (above the existing slash-picker state)**
+
+Inside the `ChatInputInner` body, add imports at the top of the file:
+
+```tsx
+import { MentionPicker } from "./MentionPicker"
+import { shouldShowMentionPicker, applyMentionToInput } from "../../lib/mention-suggestions"
+import { useMentionSuggestions, type ProjectPath } from "../../hooks/useMentionSuggestions"
+```
+
+Add new state alongside the slash-picker state (near lines 229-231):
+
+```tsx
+  const [mentionIndex, setMentionIndex] = useState(0)
+  const [mentionDismissed, setMentionDismissed] = useState(false)
+
+  const mentionTrigger = useMemo(
+    () => shouldShowMentionPicker(value, caret),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value, caret, caretVersion],
+  )
+  const mentionState = useMentionSuggestions({
+    projectId: projectId ?? null,
+    query: mentionTrigger.query,
+    enabled: mentionTrigger.open && !mentionDismissed,
+  })
+  const mentionOpen =
+    mentionTrigger.open &&
+    !mentionDismissed &&
+    !pickerOpen &&
+    (mentionState.items.length > 0 || mentionState.loading)
+
+  useEffect(() => {
+    if (mentionOpen) setMentionIndex(0)
+  }, [mentionOpen, mentionTrigger.query])
+
+  useEffect(() => {
+    // Reset dismissed flag when the user edits past the current token
+    if (!mentionTrigger.open) setMentionDismissed(false)
+  }, [mentionTrigger.open, mentionTrigger.tokenStart])
+```
+
+- [ ] **Step 3: Add accept helper**
+
+Add inside `ChatInputInner`, next to `acceptCommand`:
+
+```tsx
+  function acceptMention(item: ProjectPath) {
+    if (!projectId) {
+      setMentionDismissed(true)
+      return
+    }
+    const { value: nextValue, caret: nextCaret } = applyMentionToInput({
+      value,
+      caret,
+      tokenStart: mentionTrigger.tokenStart,
+      pickedPath: item.path,
+    })
+    setValue(nextValue)
+    if (chatId) setDraft(chatId, nextValue)
+
+    const relativeForAttachment = item.path.endsWith("/") ? item.path.slice(0, -1) : item.path
+    const absolutePath = `${projectId ? "" : ""}` // placeholder; actual absolute path comes from the server-side render via relativePath
+    const alreadyMentioned = attachments.some(
+      (a) => a.kind === "mention" && a.relativePath === `./${relativeForAttachment}`,
+    )
+    if (!alreadyMentioned) {
+      setAttachments((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          kind: "mention",
+          displayName: relativeForAttachment,
+          absolutePath: "",
+          relativePath: `./${relativeForAttachment}`,
+          contentUrl: "",
+          mimeType: "",
+          size: 0,
+          status: "uploaded",
+        },
+      ])
+    }
+    setMentionDismissed(true)
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(nextCaret, nextCaret)
+    })
+  }
+```
+
+**Note on `absolutePath`:** The mention attachment is sent to the server with only `relativePath`; the server resolves to absolute via `project.localPath` in a follow-up task if needed. For v1 leave `absolutePath` empty and let the server fill it. If `buildAttachmentHintText` renders an empty `path=""` attribute, the agent gets the `project_path` which is sufficient for Read to work. If you need stricter behavior, extend the agent.ts submit path to fill `absolutePath = path.join(project.localPath, relativePath.slice(2))` before building the hint — see Task 9.5 optional.
+
+- [ ] **Step 4: Intercept mention keys in `handleKeyDown`**
+
+Place this block at the top of `handleKeyDown`, **before** the existing slash-picker `if (pickerOpen)` check:
+
+```tsx
+    if (mentionOpen) {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        setMentionDismissed(true)
+        return
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        setMentionIndex((i) => Math.min(mentionState.items.length - 1, i + 1))
+        return
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault()
+        setMentionIndex((i) => Math.max(0, i - 1))
+        return
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault()
+        const item = mentionState.items[mentionIndex]
+        if (item) acceptMention(item)
+        return
+      }
+    }
+```
+
+- [ ] **Step 5: Render the picker**
+
+Inside the JSX where `SlashCommandPicker` is rendered (around line 763), add a sibling:
+
+```tsx
+            {mentionOpen && (
+              <MentionPicker
+                items={mentionState.items}
+                activeIndex={mentionIndex}
+                loading={mentionState.loading}
+                onSelect={acceptMention}
+                onHoverIndex={setMentionIndex}
+              />
+            )}
+```
+
+Place it as a sibling of `SlashCommandPicker` so both live inside the same relative container and float above the textarea.
+
+- [ ] **Step 6: Write failing ChatInput tests**
+
+Append to `src/client/components/chat-ui/ChatInput.test.ts`:
+
+```ts
+describe("mention picker wiring", () => {
+  test("shouldShowMentionPicker trigger flows through into pickerOpen selection", () => {
+    // Unit test for the composition — pure logic
+    const { shouldShowMentionPicker } = require("../../lib/mention-suggestions")
+    expect(shouldShowMentionPicker("hello @src", 10)).toEqual({
+      open: true,
+      query: "src",
+      tokenStart: 6,
+    })
+  })
+})
+```
+
+This is the minimum assertion that the wiring contract holds. The full integration test (typing `@` → picker appears → enter → attachment added) requires a React render harness; since existing chat-ui tests are mostly pure-function style, defer full integration to manual verification in Task 10. If the existing file already uses `@testing-library/react`, add a render-based test:
+
+```ts
+// only add if render harness exists
+test("typing @ opens the mention picker", async () => {
+  // ... render ChatInput with chatId="c1", projectId="p1"
+  // ... mock /api/projects/p1/paths to return [{ path: "src/a.ts", kind: "file" }]
+  // ... userEvent.type(textarea, "@")
+  // ... expect rendered role="listbox" with that row
+})
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `bun test src/client/components/chat-ui/ChatInput.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Typecheck + build**
+
+Run: `bun run check`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/client/components/chat-ui/ChatInput.tsx src/client/components/chat-ui/ChatInput.test.ts
+git commit -m "feat(chat-ui): wire @ mention picker into ChatInput"
+```
+
+---
+
+## Task 9.5 (Optional) — Server fills `absolutePath` for mention attachments
+
+**Files:**
+- Modify: `src/server/agent.ts` (or wherever `ChatAttachment[]` is normalized before `buildAttachmentHintText`)
+
+**When to do this:** Only if manual verification (Task 10) shows that the agent doesn't read mentioned files reliably with `absolutePath=""`.
+
+- [ ] **Step 1: Locate the attachment normalization call site**
+
+Grep for `buildAttachmentHintText(` in `src/server/agent.ts`. You'll find 1-2 call sites in the send path.
+
+- [ ] **Step 2: Add server-side fill**
+
+Before calling `buildAttachmentHintText`, map mentions to have absolute paths:
+
+```ts
+const filledAttachments = attachments.map((attachment) => {
+  if (attachment.kind !== "mention" || attachment.absolutePath) return attachment
+  const relative = attachment.relativePath.startsWith("./")
+    ? attachment.relativePath.slice(2)
+    : attachment.relativePath
+  return {
+    ...attachment,
+    absolutePath: path.resolve(project.localPath, relative),
+  }
+})
+```
+
+Pass `filledAttachments` into `buildAttachmentHintText` instead of the raw `attachments`.
+
+- [ ] **Step 3: Extend existing agent test**
+
+Add to `src/server/agent.test.ts`:
+
+```ts
+test("mention attachments get server-filled absolutePath", () => {
+  // Construct a minimal test that passes a mention attachment with empty
+  // absolutePath into whichever exported function handles send-path
+  // normalization. Assert the rendered prompt contains the resolved path.
+})
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `bun test src/server/agent.test.ts && bun run check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agent.ts src/server/agent.test.ts
+git commit -m "feat(agent): resolve absolutePath for mention attachments server-side"
+```
+
+---
+
+## Task 10 — Manual verification
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+bun run dev
+```
+
+- [ ] **Step 2: Verify behaviors**
+
+Open a Kanna chat on a git project:
+
+1. Type `@` at the start — picker opens with top-level entries (files and dirs).
+2. Type `@src` — picker fuzzy-filters to entries starting with `src`.
+3. `↑` / `↓` navigate, `Enter` accepts — input becomes `@src/agent.ts`, attachment chip appears.
+4. `Esc` while picker open — picker closes, input preserved.
+5. Type `foo@bar` (mid-word `@`) — picker does NOT open.
+6. Type `/` at start — slash picker opens, `@` picker does NOT fight for focus.
+7. Send the message. In the transcript, confirm the attachment chip renders. Check server logs (or hydrated prompt) contain `<attachment kind="mention" ... />`.
+8. Confirm the agent responds to the referenced file (Claude calls Read on it, or Codex acknowledges the path).
+9. Open a Codex chat and repeat step 1-3. Picker should work the same.
+10. Open a chat on a non-git directory. Picker still returns paths (readdir walk).
+
+- [ ] **Step 3: If any step fails**
+
+Invoke the `superpowers:systematic-debugging` skill. Do not skip.
+
+- [ ] **Step 4: Stop dev server**
+
+`Ctrl+C`.
+
+---
+
+## Task 11 — Final verification + PR prep
+
+- [ ] **Step 1: Full check + test**
+
+```bash
+bun run check
+bun test
+```
+
+Both: PASS.
+
+- [ ] **Step 2: Commit any incidental formatting**
+
+If any files changed from save-on-format, commit with `chore: format`. Otherwise skip.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feature/at-mention-picker
+```
+
+- [ ] **Step 4: Report completion**
+
+Announce: branch `feature/at-mention-picker`, all tasks complete, tests green. Offer to run `superpowers:finishing-a-development-branch` for merge / PR path.
+
+---
+
+## Skills to consult
+
+- `superpowers:test-driven-development` — every task that touches logic.
+- `superpowers:systematic-debugging` — if anything misbehaves in Task 10.
+- `superpowers:verification-before-completion` — before announcing Task 11 done.
+- `superpowers:finishing-a-development-branch` — after Task 11.

--- a/docs/superpowers/plans/2026-04-22-auto-continue-on-rate-limit.md
+++ b/docs/superpowers/plans/2026-04-22-auto-continue-on-rate-limit.md
@@ -1,0 +1,2858 @@
+# Auto-Continue on Rate-Limit Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When Claude or Codex returns a rate-limit error with a reset time, offer (or silently schedule) a `"continue"` user message at that time and auto-send it when the timer fires.
+
+**Architecture:** A new event-sourced subsystem under `src/server/auto-continue/`. Provider-specific `LimitDetector`s convert structured SDK / JSON-RPC errors into `{ resetAt, tz }` tuples; a `ScheduleManager` owns in-memory `setTimeout`s and is the single wall-clock authority. Persistence is a new `schedules.jsonl` log plus a field on the chat snapshot; on startup the manager rehydrates timers from replayed state. The chat transcript gains one new entry kind (`auto_continue_prompt`) whose live state is looked up in `chat.schedules[scheduleId]`. A new Zustand preference gates whether the server auto-accepts or emits a proposal.
+
+**Tech Stack:** Bun 1.3.5 + TypeScript 5.8 + React 19 + Zustand (with `persist`) + event-sourced JSONL server + Claude Agent SDK + Codex App Server JSON-RPC. Tests run via `bun test`.
+
+---
+
+## File Structure
+
+**New files**
+
+| Path | Responsibility |
+|---|---|
+| `src/server/auto-continue/events.ts` | `AutoContinueEvent` discriminated union + snapshot entry type. |
+| `src/server/auto-continue/limit-detector.ts` | `ClaudeLimitDetector` + `CodexLimitDetector` — pure functions from error → `LimitDetection \| null`. |
+| `src/server/auto-continue/schedule-manager.ts` | Owns `Map<scheduleId, Timeout>`. Arms / clears / rehydrates / fires. Takes an injected `Clock` for tests. |
+| `src/server/auto-continue/limit-detector.test.ts` | Unit tests with captured real error shapes. |
+| `src/server/auto-continue/schedule-manager.test.ts` | Unit tests with fake clock. |
+| `src/server/auto-continue/read-model.ts` | `deriveChatSchedules(events)` — pure reducer that projects the event log into `chat.schedules` / `chat.liveSchedule`. |
+| `src/server/auto-continue/read-model.test.ts` | State-machine transition tests. |
+| `src/client/components/chat-ui/AutoContinueCard.tsx` | Four-state React card (proposed / scheduled / fired / cancelled). |
+| `src/client/components/chat-ui/AutoContinueCard.test.tsx` | Component tests for rendering + input validation + WS dispatch. |
+| `src/client/lib/autoContinueTime.ts` | `formatLocal(ms, tz)` / `parseLocal(input, tz)` — `dd/mm/yyyy hh:mm`. |
+| `src/client/lib/autoContinueTime.test.ts` | Pure format/parse tests. |
+
+**Modified files**
+
+| Path | What changes |
+|---|---|
+| `src/shared/types.ts` | New `AutoContinuePromptEntry` transcript kind, extend `TranscriptEntry`, extend `UserPromptEntry` with `autoContinue?: { scheduleId: string }`, extend `ChatSnapshot` with `schedules` + `liveScheduleId`. |
+| `src/shared/protocol.ts` | Three new `ClientCommand` variants: `autoContinue.accept`, `autoContinue.reschedule`, `autoContinue.cancel`. |
+| `src/server/events.ts` | Export `AutoContinueEvent` through `StoreEvent`; extend `StoreState` with `schedulesByChatId`. Extend `SnapshotFile.v` → `3` with `schedules` field + bump `STORE_VERSION`. |
+| `src/server/event-store.ts` | New `schedulesLogPath`, extend `applyEvent` switch, extend `createSnapshot`, expose `appendAutoContinueEvent`. |
+| `src/server/read-models.ts` | In `deriveChatSnapshot`: add `schedules` + `liveScheduleId` fields. |
+| `src/server/agent.ts` | Constructor takes `ScheduleManager` + `autoResumePreference: () => boolean`; detect limit errors in both runtime catch blocks (Claude stream + Codex run). |
+| `src/server/ws-router.ts` | Route three new commands; on chat.delete, cancel live schedules. |
+| `src/server/cli-runtime.ts` (or wherever `AgentCoordinator` + `EventStore` are wired) | Instantiate `ScheduleManager`; call `rehydrate()` after event replay. |
+| `src/client/stores/preferences.ts` (new file) | Zustand store with `autoResumeOnRateLimit: boolean`. |
+| `src/client/app/SettingsPage.tsx` | Toggle row in General section. |
+| `src/client/lib/parseTranscript.ts` | Handle `auto_continue_prompt` entry; add `autoContinue?: { scheduleId }` to user-prompt passthrough. |
+| `src/client/components/chat-ui/KannaTranscript.tsx` (or renderer) | Render `auto_continue_prompt` messages via `AutoContinueCard` + render "auto-sent" badge on user prompts carrying `autoContinue`. |
+
+---
+
+## Task 1: Shared types for auto-continue
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+- [ ] **Step 1: Add `AutoContinueSchedule` + `AutoContinuePromptEntry` + extend unions**
+
+Open `src/shared/types.ts`. Bump the store version and add the new types.
+
+Change line 1:
+
+```ts
+export const STORE_VERSION = 3 as const
+```
+
+After the `PendingToolSnapshot` interface (near end of file), append:
+
+```ts
+export type AutoContinueScheduleState = "proposed" | "scheduled" | "fired" | "cancelled"
+
+export interface AutoContinueSchedule {
+  scheduleId: string
+  state: AutoContinueScheduleState
+  scheduledAt: number | null
+  tz: string
+  resetAt: number
+  detectedAt: number
+}
+
+export interface AutoContinuePromptEntry extends TranscriptEntryBase {
+  kind: "auto_continue_prompt"
+  scheduleId: string
+}
+```
+
+Find the `TranscriptEntry` union (`export type TranscriptEntry =`) and add `| AutoContinuePromptEntry` as the last variant.
+
+Find `UserPromptEntry` (line ~479) and add one optional field:
+
+```ts
+export interface UserPromptEntry extends TranscriptEntryBase {
+  kind: "user_prompt"
+  content: string
+  attachments?: ChatAttachment[]
+  steered?: boolean
+  autoContinue?: { scheduleId: string }
+}
+```
+
+Find `ChatSnapshot` (line ~878) and add two fields:
+
+```ts
+export interface ChatSnapshot {
+  runtime: ChatRuntime
+  queuedMessages: QueuedChatMessage[]
+  messages: TranscriptEntry[]
+  history: ChatHistorySnapshot
+  availableProviders: ProviderCatalogEntry[]
+  slashCommands: SlashCommand[]
+  slashCommandsLoading: boolean
+  schedules: Record<string, AutoContinueSchedule>
+  liveScheduleId: string | null
+}
+```
+
+In `HydratedTranscriptMessage`, add:
+
+```ts
+  | ({ kind: "auto_continue_prompt"; scheduleId: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+```
+
+In the `user_prompt` branch of `HydratedTranscriptMessage` (the object literal variant), add `autoContinue?: { scheduleId: string }`.
+
+- [ ] **Step 2: Run type-check to make sure nothing else breaks**
+
+Run: `bun run check`
+Expected: errors only in the files we plan to modify next (agent.ts, read-models.ts, parseTranscript.ts, etc.). No syntax errors in `types.ts` itself.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat(auto-continue): add shared types and bump STORE_VERSION"
+```
+
+---
+
+## Task 2: AutoContinueEvent shape
+
+**Files:**
+- Create: `src/server/auto-continue/events.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/auto-continue/events.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import type { AutoContinueEvent } from "./events"
+
+describe("AutoContinueEvent", () => {
+  test("covers the five lifecycle kinds", () => {
+    const kinds: AutoContinueEvent["kind"][] = [
+      "auto_continue_proposed",
+      "auto_continue_accepted",
+      "auto_continue_rescheduled",
+      "auto_continue_cancelled",
+      "auto_continue_fired",
+    ]
+    expect(kinds.length).toBe(5)
+  })
+
+  test("proposed event carries reset + tz metadata", () => {
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: "c1",
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    }
+    expect(event.tz).toBe("Asia/Saigon")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/events.test.ts`
+Expected: FAIL — module `./events` not found.
+
+- [ ] **Step 3: Create the events module**
+
+Create `src/server/auto-continue/events.ts`:
+
+```ts
+export type AutoContinueEvent =
+  | {
+      v: 3
+      kind: "auto_continue_proposed"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      detectedAt: number
+      resetAt: number
+      tz: string
+      turnId: string
+    }
+  | {
+      v: 3
+      kind: "auto_continue_accepted"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      scheduledAt: number
+      tz: string
+      source: "user" | "auto_setting"
+      resetAt: number
+      detectedAt: number
+    }
+  | {
+      v: 3
+      kind: "auto_continue_rescheduled"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      scheduledAt: number
+    }
+  | {
+      v: 3
+      kind: "auto_continue_cancelled"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      reason: "user" | "chat_deleted"
+    }
+  | {
+      v: 3
+      kind: "auto_continue_fired"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      firedAt: number
+    }
+```
+
+Note: `auto_continue_accepted` carries `resetAt` and `detectedAt` redundantly so the read model can project full `AutoContinueSchedule` state without having to fold the earlier `proposed` event first (important for the auto-resume path, which emits `accepted` directly without a `proposed`).
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/auto-continue/events.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/auto-continue/events.ts src/server/auto-continue/events.test.ts
+git commit -m "feat(auto-continue): define AutoContinueEvent union"
+```
+
+---
+
+## Task 3: Pure read-model reducer
+
+**Files:**
+- Create: `src/server/auto-continue/read-model.ts`
+- Test: `src/server/auto-continue/read-model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/auto-continue/read-model.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { deriveChatSchedules } from "./read-model"
+import type { AutoContinueEvent } from "./events"
+
+function proposed(chatId: string, scheduleId: string, at = 1_000): AutoContinueEvent {
+  return {
+    v: 3,
+    kind: "auto_continue_proposed",
+    timestamp: at,
+    chatId,
+    scheduleId,
+    detectedAt: at,
+    resetAt: at + 10_000,
+    tz: "Asia/Saigon",
+    turnId: "turn-1",
+  }
+}
+
+function accepted(chatId: string, scheduleId: string, at = 2_000, source: "user" | "auto_setting" = "user"): AutoContinueEvent {
+  return {
+    v: 3,
+    kind: "auto_continue_accepted",
+    timestamp: at,
+    chatId,
+    scheduleId,
+    scheduledAt: at + 10_000,
+    tz: "Asia/Saigon",
+    source,
+    resetAt: at + 10_000,
+    detectedAt: at,
+  }
+}
+
+describe("deriveChatSchedules", () => {
+  test("empty event list returns empty map + null live", () => {
+    const result = deriveChatSchedules([])
+    expect(result.schedules).toEqual({})
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("proposed event yields state=proposed with liveScheduleId set", () => {
+    const result = deriveChatSchedules([proposed("c1", "s1")])
+    expect(result.schedules["s1"].state).toBe("proposed")
+    expect(result.schedules["s1"].scheduledAt).toBeNull()
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("accept after propose promotes to scheduled", () => {
+    const result = deriveChatSchedules([proposed("c1", "s1"), accepted("c1", "s1")])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].scheduledAt).toBe(12_000)
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("accept with source=auto_setting without prior proposed still produces scheduled", () => {
+    const result = deriveChatSchedules([accepted("c1", "s1", 1_500, "auto_setting")])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].resetAt).toBe(11_500)
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("cancelled schedule is terminal and not live", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_cancelled", timestamp: 3_000, chatId: "c1", scheduleId: "s1", reason: "user" },
+    ])
+    expect(result.schedules["s1"].state).toBe("cancelled")
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("fired schedule is terminal and retains scheduledAt", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_fired", timestamp: 12_000, chatId: "c1", scheduleId: "s1", firedAt: 12_000 },
+    ])
+    expect(result.schedules["s1"].state).toBe("fired")
+    expect(result.schedules["s1"].scheduledAt).toBe(12_000)
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("live schedule tracks most recent non-terminal", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1", 1_000),
+      { v: 3, kind: "auto_continue_cancelled", timestamp: 1_100, chatId: "c1", scheduleId: "s1", reason: "user" },
+      proposed("c1", "s2", 2_000),
+    ])
+    expect(result.schedules["s1"].state).toBe("cancelled")
+    expect(result.schedules["s2"].state).toBe("proposed")
+    expect(result.liveScheduleId).toBe("s2")
+  })
+
+  test("reschedule updates scheduledAt without changing state", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_rescheduled", timestamp: 2_500, chatId: "c1", scheduleId: "s1", scheduledAt: 20_000 },
+    ])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].scheduledAt).toBe(20_000)
+  })
+
+  test("events for different chats produce independent results", () => {
+    const events = [proposed("c1", "s1"), proposed("c2", "s2")]
+    expect(deriveChatSchedules(events, "c1").liveScheduleId).toBe("s1")
+    expect(deriveChatSchedules(events, "c2").liveScheduleId).toBe("s2")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/read-model.test.ts`
+Expected: FAIL — `deriveChatSchedules` not exported.
+
+- [ ] **Step 3: Implement the reducer**
+
+Create `src/server/auto-continue/read-model.ts`:
+
+```ts
+import type { AutoContinueSchedule } from "../../shared/types"
+import type { AutoContinueEvent } from "./events"
+
+export interface ChatSchedulesProjection {
+  schedules: Record<string, AutoContinueSchedule>
+  liveScheduleId: string | null
+}
+
+const EMPTY: ChatSchedulesProjection = { schedules: {}, liveScheduleId: null }
+
+export function deriveChatSchedules(
+  events: readonly AutoContinueEvent[],
+  chatId?: string
+): ChatSchedulesProjection {
+  const schedules: Record<string, AutoContinueSchedule> = {}
+  for (const event of events) {
+    if (chatId && event.chatId !== chatId) continue
+    applyOne(schedules, event)
+  }
+
+  let liveScheduleId: string | null = null
+  let liveOrder = -1
+  let order = 0
+  for (const event of events) {
+    order += 1
+    if (chatId && event.chatId !== chatId) continue
+    const schedule = schedules[event.scheduleId]
+    if (!schedule) continue
+    if (schedule.state !== "proposed" && schedule.state !== "scheduled") continue
+    if (order > liveOrder) {
+      liveOrder = order
+      liveScheduleId = schedule.scheduleId
+    }
+  }
+
+  return schedules === EMPTY.schedules && liveScheduleId === null
+    ? EMPTY
+    : { schedules, liveScheduleId }
+}
+
+function applyOne(schedules: Record<string, AutoContinueSchedule>, event: AutoContinueEvent) {
+  switch (event.kind) {
+    case "auto_continue_proposed":
+      schedules[event.scheduleId] = {
+        scheduleId: event.scheduleId,
+        state: "proposed",
+        scheduledAt: null,
+        tz: event.tz,
+        resetAt: event.resetAt,
+        detectedAt: event.detectedAt,
+      }
+      return
+    case "auto_continue_accepted":
+      schedules[event.scheduleId] = {
+        scheduleId: event.scheduleId,
+        state: "scheduled",
+        scheduledAt: event.scheduledAt,
+        tz: event.tz,
+        resetAt: event.resetAt,
+        detectedAt: event.detectedAt,
+      }
+      return
+    case "auto_continue_rescheduled": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) return
+      schedules[event.scheduleId] = { ...existing, scheduledAt: event.scheduledAt }
+      return
+    }
+    case "auto_continue_cancelled": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) return
+      schedules[event.scheduleId] = { ...existing, state: "cancelled" }
+      return
+    }
+    case "auto_continue_fired": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) {
+        schedules[event.scheduleId] = {
+          scheduleId: event.scheduleId,
+          state: "fired",
+          scheduledAt: event.firedAt,
+          tz: "system",
+          resetAt: event.firedAt,
+          detectedAt: event.firedAt,
+        }
+        return
+      }
+      schedules[event.scheduleId] = { ...existing, state: "fired", scheduledAt: event.firedAt }
+      return
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/auto-continue/read-model.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/auto-continue/read-model.ts src/server/auto-continue/read-model.test.ts
+git commit -m "feat(auto-continue): pure read-model reducer with tests"
+```
+
+---
+
+## Task 4: Limit detector — Claude
+
+**Files:**
+- Create: `src/server/auto-continue/limit-detector.ts`
+- Test: `src/server/auto-continue/limit-detector.test.ts`
+
+**Background:** The Claude Agent SDK surfaces rate-limit failures as JS `Error`s whose message embeds a JSON payload. The payload has `type: "error"` and `error.type: "rate_limit_error"` with a `headers['anthropic-ratelimit-unified-reset']` ISO-8601 timestamp. Some errors also attach a `.status === 429` and `.headers` map. When no IANA tz is present in the payload, fall back to `"system"` (display uses the server's local zone).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/server/auto-continue/limit-detector.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { ClaudeLimitDetector } from "./limit-detector"
+
+const detector = new ClaudeLimitDetector()
+
+function anthropicError(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  const error = new Error(JSON.stringify(body)) as Error & { status?: number; headers?: Record<string, string> }
+  error.status = 429
+  error.headers = headers
+  return error
+}
+
+describe("ClaudeLimitDetector", () => {
+  test("returns null for non-rate-limit errors", () => {
+    const err = new Error("Something unrelated went wrong")
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+
+  test("detects rate limit with ISO reset timestamp in headers", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = anthropicError(
+      { type: "error", error: { type: "rate_limit_error", message: "You've hit your limit · resets 12am (Asia/Saigon)" } },
+      { "anthropic-ratelimit-unified-reset": resetIso, "x-anthropic-timezone": "Asia/Saigon" }
+    )
+    const detection = detector.detect("c1", err)
+    expect(detection).not.toBeNull()
+    expect(detection!.chatId).toBe("c1")
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("falls back to tz=system when no timezone header is present", () => {
+    const resetIso = "2026-04-23T05:00:00Z"
+    const err = anthropicError(
+      { type: "error", error: { type: "rate_limit_error" } },
+      { "anthropic-ratelimit-unified-reset": resetIso }
+    )
+    const detection = detector.detect("c1", err)
+    expect(detection!.tz).toBe("system")
+  })
+
+  test("returns null when the payload is rate-limit but no reset timestamp can be parsed", () => {
+    const err = anthropicError({ type: "error", error: { type: "rate_limit_error" } })
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+
+  test("parses resetAt from the message body when headers are absent", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = new Error(JSON.stringify({
+      type: "error",
+      error: {
+        type: "rate_limit_error",
+        resets_at: resetIso,
+        timezone: "Asia/Saigon",
+      },
+    }))
+    const detection = detector.detect("c1", err)
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("does not match on status-only errors (400, 500, etc.)", () => {
+    const err = anthropicError({ type: "error", error: { type: "overloaded_error" } })
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/limit-detector.test.ts`
+Expected: FAIL — `ClaudeLimitDetector` not exported.
+
+- [ ] **Step 3: Implement the detector**
+
+Create `src/server/auto-continue/limit-detector.ts`:
+
+```ts
+export interface LimitDetection {
+  chatId: string
+  resetAt: number
+  tz: string
+  raw: unknown
+}
+
+export interface LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null
+}
+
+interface ErrorLike {
+  message?: string
+  status?: number
+  headers?: Record<string, string>
+}
+
+function extractHeaders(error: unknown): Record<string, string> {
+  if (error && typeof error === "object" && "headers" in error) {
+    const headers = (error as ErrorLike).headers
+    if (headers && typeof headers === "object") return headers
+  }
+  return {}
+}
+
+function parseBody(error: unknown): Record<string, unknown> | null {
+  if (!error || typeof error !== "object") return null
+  const message = (error as ErrorLike).message
+  if (!message) return null
+  try {
+    const parsed = JSON.parse(message)
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function parseIsoMillis(value: unknown): number | null {
+  if (typeof value !== "string" || !value) return null
+  const millis = new Date(value).getTime()
+  return Number.isFinite(millis) ? millis : null
+}
+
+export class ClaudeLimitDetector implements LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null {
+    const body = parseBody(error)
+    const inner = body && typeof body.error === "object" && body.error !== null
+      ? (body.error as Record<string, unknown>)
+      : null
+    const isRateLimit = inner?.type === "rate_limit_error"
+      || (error as ErrorLike | null)?.status === 429 && inner?.type === "rate_limit_error"
+    if (!isRateLimit) return null
+
+    const headers = extractHeaders(error)
+    const resetAt = parseIsoMillis(headers["anthropic-ratelimit-unified-reset"])
+      ?? parseIsoMillis(inner?.resets_at)
+      ?? parseIsoMillis(inner?.reset_at)
+    if (resetAt === null) return null
+
+    const tz = headers["x-anthropic-timezone"]
+      ?? (typeof inner?.timezone === "string" ? (inner.timezone as string) : null)
+      ?? "system"
+
+    return { chatId, resetAt, tz, raw: error }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/auto-continue/limit-detector.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/auto-continue/limit-detector.ts src/server/auto-continue/limit-detector.test.ts
+git commit -m "feat(auto-continue): Claude limit detector"
+```
+
+---
+
+## Task 5: Limit detector — Codex
+
+**Files:**
+- Modify: `src/server/auto-continue/limit-detector.ts`
+- Modify: `src/server/auto-continue/limit-detector.test.ts`
+
+**Background:** The Codex App Server returns JSON-RPC errors. Rate-limit errors have `error.code === -32001` or `error.data.code === "rate_limit"` (confirm against captured examples at integration time). The reset timestamp is in `error.data.resets_at_ms` (epoch ms) or `error.data.resets_at` (ISO). Timezone is in `error.data.timezone`. If only the epoch-ms form is present, tz falls back to `"system"`.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `src/server/auto-continue/limit-detector.test.ts`:
+
+```ts
+import { CodexLimitDetector } from "./limit-detector"
+
+const codex = new CodexLimitDetector()
+
+describe("CodexLimitDetector", () => {
+  test("returns null for non-rate-limit JSON-RPC errors", () => {
+    const err = { code: -32601, message: "Method not found" }
+    expect(codex.detect("c1", err)).toBeNull()
+  })
+
+  test("detects rate limit from error.data.code with epoch-ms reset", () => {
+    const err = {
+      code: -32001,
+      message: "Rate limited",
+      data: { code: "rate_limit", resets_at_ms: 2_000_000, timezone: "Asia/Saigon" },
+    }
+    const detection = codex.detect("c1", err)
+    expect(detection!.resetAt).toBe(2_000_000)
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("detects rate limit with ISO resets_at", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = {
+      code: -32001,
+      message: "Rate limited",
+      data: { code: "rate_limit", resets_at: resetIso },
+    }
+    const detection = codex.detect("c1", err)
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("system")
+  })
+
+  test("returns null when no reset timestamp can be parsed", () => {
+    const err = { code: -32001, data: { code: "rate_limit" } }
+    expect(codex.detect("c1", err)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/limit-detector.test.ts`
+Expected: FAIL — `CodexLimitDetector` not exported.
+
+- [ ] **Step 3: Implement the detector**
+
+Append to `src/server/auto-continue/limit-detector.ts`:
+
+```ts
+interface JsonRpcErrorLike {
+  code?: number
+  message?: string
+  data?: Record<string, unknown>
+}
+
+export class CodexLimitDetector implements LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null {
+    if (!error || typeof error !== "object") return null
+    const rpc = error as JsonRpcErrorLike
+    const data = rpc.data && typeof rpc.data === "object" ? rpc.data : null
+    const isRateLimit = data?.code === "rate_limit" || rpc.code === -32001
+    if (!isRateLimit) return null
+
+    let resetAt: number | null = null
+    if (typeof data?.resets_at_ms === "number" && Number.isFinite(data.resets_at_ms)) {
+      resetAt = data.resets_at_ms
+    } else {
+      resetAt = parseIsoMillis(data?.resets_at)
+    }
+    if (resetAt === null) return null
+
+    const tz = typeof data?.timezone === "string" ? (data.timezone as string) : "system"
+    return { chatId, resetAt, tz, raw: error }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/auto-continue/limit-detector.test.ts`
+Expected: PASS (10 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/auto-continue/limit-detector.ts src/server/auto-continue/limit-detector.test.ts
+git commit -m "feat(auto-continue): Codex limit detector"
+```
+
+---
+
+## Task 6: Extend EventStore with schedules.jsonl
+
+**Files:**
+- Modify: `src/server/events.ts`
+- Modify: `src/server/event-store.ts`
+- Test: `src/server/event-store.test.ts` (append cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/server/event-store.test.ts`:
+
+```ts
+import type { AutoContinueEvent } from "./auto-continue/events"
+
+describe("EventStore auto-continue schedules", () => {
+  test("appends and replays AutoContinueEvent sequence", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/p1")
+    const chat = await store.createChat(project.id)
+
+    const proposed: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: chat.id,
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    }
+    const accepted: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: 1_100,
+      chatId: chat.id,
+      scheduleId: "s1",
+      scheduledAt: 2_000,
+      tz: "Asia/Saigon",
+      source: "user",
+      resetAt: 2_000,
+      detectedAt: 1_000,
+    }
+    await store.appendAutoContinueEvent(proposed)
+    await store.appendAutoContinueEvent(accepted)
+
+    const rehydrated = new EventStore(dataDir)
+    await rehydrated.initialize()
+    const events = rehydrated.getAutoContinueEvents(chat.id)
+    expect(events).toHaveLength(2)
+    expect(events[0].kind).toBe("auto_continue_proposed")
+    expect(events[1].kind).toBe("auto_continue_accepted")
+  })
+
+  test("snapshot compaction retains auto-continue events", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/p1")
+    const chat = await store.createChat(project.id)
+
+    await store.appendAutoContinueEvent({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: chat.id,
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    })
+    await store.compact()
+
+    const rehydrated = new EventStore(dataDir)
+    await rehydrated.initialize()
+    expect(rehydrated.getAutoContinueEvents(chat.id)).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/event-store.test.ts`
+Expected: FAIL — `appendAutoContinueEvent` and `getAutoContinueEvents` not exposed.
+
+- [ ] **Step 3: Extend the event union and state**
+
+Edit `src/server/events.ts`:
+
+Add import line at top:
+
+```ts
+import type { AutoContinueEvent } from "./auto-continue/events"
+```
+
+Extend `StoreEvent`:
+
+```ts
+export type StoreEvent = ProjectEvent | ChatEvent | MessageEvent | QueuedMessageEvent | TurnEvent | AutoContinueEvent
+```
+
+Extend `StoreState`:
+
+```ts
+export interface StoreState {
+  projectsById: Map<string, ProjectRecord>
+  projectIdsByPath: Map<string, string>
+  chatsById: Map<string, ChatRecord>
+  queuedMessagesByChatId: Map<string, QueuedChatMessage[]>
+  sidebarProjectOrder: string[]
+  autoContinueEventsByChatId: Map<string, AutoContinueEvent[]>
+}
+```
+
+Extend `SnapshotFile` and bump version to 3:
+
+```ts
+export interface SnapshotFile {
+  v: 3
+  generatedAt: number
+  projects: ProjectRecord[]
+  chats: ChatRecord[]
+  sidebarProjectOrder?: string[]
+  queuedMessages?: Array<{ chatId: string; entries: QueuedChatMessage[] }>
+  messages?: Array<{ chatId: string; entries: TranscriptEntry[] }>
+  autoContinueEvents?: Array<{ chatId: string; events: AutoContinueEvent[] }>
+}
+```
+
+Update `createEmptyState`:
+
+```ts
+export function createEmptyState(): StoreState {
+  return {
+    projectsById: new Map(),
+    projectIdsByPath: new Map(),
+    chatsById: new Map(),
+    queuedMessagesByChatId: new Map(),
+    sidebarProjectOrder: [],
+    autoContinueEventsByChatId: new Map(),
+  }
+}
+```
+
+- [ ] **Step 4: Extend EventStore with append/get + replay/snapshot**
+
+Edit `src/server/event-store.ts`:
+
+Add near other `private readonly ... LogPath` lines:
+
+```ts
+  private readonly schedulesLogPath: string
+```
+
+Set it in the constructor:
+
+```ts
+    this.schedulesLogPath = path.join(this.dataDir, "schedules.jsonl")
+```
+
+In `initialize()` after existing `ensureFile` calls:
+
+```ts
+    await this.ensureFile(this.schedulesLogPath)
+```
+
+In `clearStorage()` add `Bun.write(this.schedulesLogPath, "")` to the Promise.all list.
+
+In `replayLogs()` extend the sourceIndex list so schedules replay alongside others. Add:
+
+```ts
+      ...await this.loadReplayEvents(this.schedulesLogPath, 5),
+```
+
+Add entries to `getReplayEventPriority` switch:
+
+```ts
+    case "auto_continue_proposed":
+    case "auto_continue_accepted":
+    case "auto_continue_rescheduled":
+    case "auto_continue_cancelled":
+    case "auto_continue_fired":
+      return 11
+```
+
+Note: `getReplayEventPriority` currently switches on `event.type`. `AutoContinueEvent` uses `kind` instead. Change the priority lookup to handle both:
+
+```ts
+function getReplayEventPriority(event: StoreEvent) {
+  const discriminator = "type" in event ? event.type : event.kind
+  switch (discriminator) {
+    // ... existing cases
+    case "auto_continue_proposed":
+    case "auto_continue_accepted":
+    case "auto_continue_rescheduled":
+    case "auto_continue_cancelled":
+    case "auto_continue_fired":
+      return 11
+  }
+}
+```
+
+Similarly extend `applyEvent`:
+
+```ts
+  private applyEvent(event: StoreEvent) {
+    if ("kind" in event && event.kind.startsWith("auto_continue_")) {
+      this.applyAutoContinueEvent(event)
+      return
+    }
+    switch ((event as { type: string }).type) {
+      // ... existing cases unchanged
+    }
+  }
+
+  private applyAutoContinueEvent(event: AutoContinueEvent) {
+    const existing = this.state.autoContinueEventsByChatId.get(event.chatId) ?? []
+    existing.push(event)
+    this.state.autoContinueEventsByChatId.set(event.chatId, existing)
+  }
+```
+
+Add the loadSnapshot hydration branch (inside `loadSnapshot()` after `messages` branch):
+
+```ts
+      if (parsed.autoContinueEvents?.length) {
+        for (const entry of parsed.autoContinueEvents) {
+          this.state.autoContinueEventsByChatId.set(entry.chatId, [...entry.events])
+        }
+      }
+```
+
+Add the resetState reset:
+
+```ts
+    this.state.autoContinueEventsByChatId.clear()
+```
+
+Add new public methods at the bottom of `EventStore`:
+
+```ts
+  async appendAutoContinueEvent(event: AutoContinueEvent) {
+    const payload = `${JSON.stringify(event)}\n`
+    this.writeChain = this.writeChain.then(async () => {
+      await appendFile(this.schedulesLogPath, payload, "utf8")
+      this.applyAutoContinueEvent(event)
+    })
+    return this.writeChain
+  }
+
+  getAutoContinueEvents(chatId: string): AutoContinueEvent[] {
+    const list = this.state.autoContinueEventsByChatId.get(chatId)
+    return list ? [...list] : []
+  }
+
+  listAutoContinueChats(): string[] {
+    return [...this.state.autoContinueEventsByChatId.keys()]
+  }
+```
+
+Add import:
+
+```ts
+import type { AutoContinueEvent } from "./auto-continue/events"
+```
+
+Extend `createSnapshot()`:
+
+```ts
+  private createSnapshot(): SnapshotFile {
+    return {
+      v: STORE_VERSION,
+      generatedAt: Date.now(),
+      // ... existing fields unchanged
+      autoContinueEvents: [...this.state.autoContinueEventsByChatId.entries()].map(([chatId, events]) => ({
+        chatId,
+        events: [...events],
+      })),
+    }
+  }
+```
+
+Extend `compact()` to clear the new log:
+
+```ts
+    await Promise.all([
+      Bun.write(this.projectsLogPath, ""),
+      Bun.write(this.chatsLogPath, ""),
+      Bun.write(this.messagesLogPath, ""),
+      Bun.write(this.queuedMessagesLogPath, ""),
+      Bun.write(this.turnsLogPath, ""),
+      Bun.write(this.schedulesLogPath, ""),
+    ])
+```
+
+In `shouldCompact()`, include the new file size.
+
+- [ ] **Step 5: Run the test**
+
+Run: `bun test src/server/event-store.test.ts`
+Expected: PASS (existing tests + 2 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/events.ts src/server/event-store.ts src/server/event-store.test.ts
+git commit -m "feat(auto-continue): persist schedule events in schedules.jsonl"
+```
+
+---
+
+## Task 7: ScheduleManager with fake clock
+
+**Files:**
+- Create: `src/server/auto-continue/schedule-manager.ts`
+- Test: `src/server/auto-continue/schedule-manager.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/server/auto-continue/schedule-manager.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { ScheduleManager, type Clock } from "./schedule-manager"
+import type { AutoContinueEvent } from "./events"
+
+class FakeClock implements Clock {
+  private current = 0
+  private scheduled: Array<{ fireAt: number; fn: () => void; id: number }> = []
+  private nextId = 1
+
+  now() {
+    return this.current
+  }
+
+  setTimeout(fn: () => void, delayMs: number): number {
+    const id = this.nextId
+    this.nextId += 1
+    this.scheduled.push({ fireAt: this.current + Math.max(0, delayMs), fn, id })
+    return id
+  }
+
+  clearTimeout(id: number): void {
+    this.scheduled = this.scheduled.filter((entry) => entry.id !== id)
+  }
+
+  advance(ms: number) {
+    this.current += ms
+    const due = this.scheduled.filter((entry) => entry.fireAt <= this.current)
+    this.scheduled = this.scheduled.filter((entry) => entry.fireAt > this.current)
+    for (const { fn } of due) fn()
+  }
+
+  pending() {
+    return this.scheduled.length
+  }
+}
+
+function event(kind: AutoContinueEvent["kind"], overrides: Partial<AutoContinueEvent> = {}): AutoContinueEvent {
+  const base = { v: 3 as const, timestamp: 0, chatId: "c1", scheduleId: "s1" }
+  switch (kind) {
+    case "auto_continue_proposed":
+      return { ...base, kind, detectedAt: 0, resetAt: 1_000, tz: "UTC", turnId: "t1", ...overrides } as AutoContinueEvent
+    case "auto_continue_accepted":
+      return { ...base, kind, scheduledAt: 1_000, tz: "UTC", source: "user", resetAt: 1_000, detectedAt: 0, ...overrides } as AutoContinueEvent
+    case "auto_continue_rescheduled":
+      return { ...base, kind, scheduledAt: 2_000, ...overrides } as AutoContinueEvent
+    case "auto_continue_cancelled":
+      return { ...base, kind, reason: "user", ...overrides } as AutoContinueEvent
+    case "auto_continue_fired":
+      return { ...base, kind, firedAt: 1_000, ...overrides } as AutoContinueEvent
+  }
+}
+
+describe("ScheduleManager", () => {
+  test("proposed event does not arm a timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (chatId, scheduleId) => { fired.push(`${chatId}:${scheduleId}`) },
+    })
+    manager.onEvent(event("auto_continue_proposed"))
+    expect(clock.pending()).toBe(0)
+    expect(fired).toEqual([])
+  })
+
+  test("accepted event arms a timer that fires at scheduledAt", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (chatId, scheduleId) => { fired.push(`${chatId}:${scheduleId}`) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    expect(clock.pending()).toBe(1)
+    clock.advance(1_000)
+    expect(fired).toEqual(["c1:s1"])
+  })
+
+  test("rescheduled replaces the pending timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    manager.onEvent(event("auto_continue_rescheduled", { scheduledAt: 3_000 }))
+    clock.advance(1_000)
+    expect(fired).toEqual([])
+    clock.advance(2_000)
+    expect(fired).toEqual(["s1"])
+  })
+
+  test("cancelled clears the pending timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    manager.onEvent(event("auto_continue_cancelled"))
+    clock.advance(1_000)
+    expect(fired).toEqual([])
+  })
+
+  test("rehydrate arms future schedules and fires past-due ones", async () => {
+    const clock = new FakeClock()
+    clock.advance(5_000)
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.rehydrate([
+      event("auto_continue_accepted", { scheduleId: "past", scheduledAt: 1_000 }),
+      event("auto_continue_accepted", { scheduleId: "future", scheduledAt: 10_000 }),
+    ])
+    await Promise.resolve()
+    expect(fired).toEqual(["past"])
+    expect(clock.pending()).toBe(1)
+    clock.advance(5_000)
+    expect(fired).toEqual(["past", "future"])
+  })
+
+  test("rehydrate skips terminal states", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.rehydrate([
+      event("auto_continue_accepted", { scheduleId: "done", scheduledAt: 1_000 }),
+      event("auto_continue_fired", { scheduleId: "done" }),
+      event("auto_continue_accepted", { scheduleId: "cancelled", scheduledAt: 1_000 }),
+      event("auto_continue_cancelled", { scheduleId: "cancelled" }),
+    ])
+    clock.advance(10_000)
+    expect(fired).toEqual([])
+  })
+
+  test("firing a timer does not double-fire on subsequent events", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    clock.advance(1_000)
+    manager.onEvent(event("auto_continue_fired"))
+    expect(fired).toEqual(["s1"])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/schedule-manager.test.ts`
+Expected: FAIL — `ScheduleManager` not defined.
+
+- [ ] **Step 3: Implement ScheduleManager**
+
+Create `src/server/auto-continue/schedule-manager.ts`:
+
+```ts
+import type { AutoContinueEvent } from "./events"
+import { deriveChatSchedules } from "./read-model"
+
+export interface Clock {
+  now(): number
+  setTimeout(fn: () => void, delayMs: number): number
+  clearTimeout(id: number): void
+}
+
+export const realClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (fn, delayMs) => setTimeout(fn, delayMs) as unknown as number,
+  clearTimeout: (id) => clearTimeout(id as unknown as NodeJS.Timeout),
+}
+
+export interface ScheduleManagerArgs {
+  clock?: Clock
+  fire: (chatId: string, scheduleId: string) => Promise<void>
+  onError?: (error: unknown) => void
+}
+
+export class ScheduleManager {
+  private readonly clock: Clock
+  private readonly fireFn: ScheduleManagerArgs["fire"]
+  private readonly onError: (error: unknown) => void
+  private readonly timers = new Map<string, number>()
+  private readonly pendingByScheduleId = new Map<string, { chatId: string; scheduledAt: number }>()
+
+  constructor(args: ScheduleManagerArgs) {
+    this.clock = args.clock ?? realClock
+    this.fireFn = args.fire
+    this.onError = args.onError ?? ((error) => console.error("[kanna/schedule-manager]", error))
+  }
+
+  rehydrate(events: readonly AutoContinueEvent[]) {
+    const byChat = new Map<string, AutoContinueEvent[]>()
+    for (const event of events) {
+      const list = byChat.get(event.chatId) ?? []
+      list.push(event)
+      byChat.set(event.chatId, list)
+    }
+    for (const [chatId, chatEvents] of byChat.entries()) {
+      const projection = deriveChatSchedules(chatEvents, chatId)
+      for (const schedule of Object.values(projection.schedules)) {
+        if (schedule.state !== "scheduled") continue
+        if (schedule.scheduledAt === null) continue
+        this.arm(chatId, schedule.scheduleId, schedule.scheduledAt)
+      }
+    }
+  }
+
+  onEvent(event: AutoContinueEvent) {
+    switch (event.kind) {
+      case "auto_continue_proposed":
+        return
+      case "auto_continue_accepted":
+        this.arm(event.chatId, event.scheduleId, event.scheduledAt)
+        return
+      case "auto_continue_rescheduled":
+        this.arm(event.chatId, event.scheduleId, event.scheduledAt)
+        return
+      case "auto_continue_cancelled":
+      case "auto_continue_fired":
+        this.clear(event.scheduleId)
+        return
+    }
+  }
+
+  private arm(chatId: string, scheduleId: string, scheduledAt: number) {
+    this.clear(scheduleId)
+    this.pendingByScheduleId.set(scheduleId, { chatId, scheduledAt })
+    const delay = Math.max(0, scheduledAt - this.clock.now())
+    const timerId = this.clock.setTimeout(() => {
+      this.timers.delete(scheduleId)
+      this.pendingByScheduleId.delete(scheduleId)
+      void (async () => {
+        try {
+          await this.fireFn(chatId, scheduleId)
+        } catch (error) {
+          this.onError(error)
+        }
+      })()
+    }, delay)
+    this.timers.set(scheduleId, timerId)
+  }
+
+  private clear(scheduleId: string) {
+    const timerId = this.timers.get(scheduleId)
+    if (timerId !== undefined) {
+      this.clock.clearTimeout(timerId)
+      this.timers.delete(scheduleId)
+    }
+    this.pendingByScheduleId.delete(scheduleId)
+  }
+
+  shutdown() {
+    for (const timerId of this.timers.values()) {
+      this.clock.clearTimeout(timerId)
+    }
+    this.timers.clear()
+    this.pendingByScheduleId.clear()
+  }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/auto-continue/schedule-manager.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/auto-continue/schedule-manager.ts src/server/auto-continue/schedule-manager.test.ts
+git commit -m "feat(auto-continue): ScheduleManager with injectable clock"
+```
+
+---
+
+## Task 8: Expose schedules on chat snapshot
+
+**Files:**
+- Modify: `src/server/read-models.ts`
+- Test: `src/server/read-models.test.ts` (create if it doesn't exist, or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Check whether `src/server/read-models.test.ts` exists. If not, create it:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { deriveChatSnapshot } from "./read-models"
+import { createEmptyState } from "./events"
+
+describe("deriveChatSnapshot schedules", () => {
+  test("empty schedules produces empty map and null live id", () => {
+    const state = createEmptyState()
+    state.projectsById.set("p1", {
+      id: "p1", localPath: "/tmp/p", title: "P", createdAt: 0, updatedAt: 0,
+    })
+    state.chatsById.set("c1", {
+      id: "c1", projectId: "p1", title: "Chat", createdAt: 0, updatedAt: 0,
+      unread: false, provider: null, planMode: false, sessionToken: null, sourceHash: null, lastTurnOutcome: null,
+    })
+
+    const snapshot = deriveChatSnapshot(
+      state,
+      new Map(),
+      new Set(),
+      new Set(),
+      "c1",
+      () => ({ messages: [], history: { hasOlder: false, olderCursor: null, recentLimit: 0 } }),
+    )
+    expect(snapshot!.schedules).toEqual({})
+    expect(snapshot!.liveScheduleId).toBeNull()
+  })
+
+  test("proposed event projects to schedules + liveScheduleId", () => {
+    const state = createEmptyState()
+    state.projectsById.set("p1", {
+      id: "p1", localPath: "/tmp/p", title: "P", createdAt: 0, updatedAt: 0,
+    })
+    state.chatsById.set("c1", {
+      id: "c1", projectId: "p1", title: "Chat", createdAt: 0, updatedAt: 0,
+      unread: false, provider: null, planMode: false, sessionToken: null, sourceHash: null, lastTurnOutcome: null,
+    })
+    state.autoContinueEventsByChatId.set("c1", [{
+      v: 3, kind: "auto_continue_proposed", timestamp: 1, chatId: "c1", scheduleId: "s1",
+      detectedAt: 1, resetAt: 2_000, tz: "Asia/Saigon", turnId: "t1",
+    }])
+
+    const snapshot = deriveChatSnapshot(
+      state,
+      new Map(),
+      new Set(),
+      new Set(),
+      "c1",
+      () => ({ messages: [], history: { hasOlder: false, olderCursor: null, recentLimit: 0 } }),
+    )
+    expect(snapshot!.schedules["s1"].state).toBe("proposed")
+    expect(snapshot!.liveScheduleId).toBe("s1")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/read-models.test.ts`
+Expected: FAIL — `deriveChatSnapshot` returns snapshot without `schedules` + `liveScheduleId`.
+
+- [ ] **Step 3: Extend `deriveChatSnapshot`**
+
+Edit `src/server/read-models.ts`:
+
+Add import:
+
+```ts
+import { deriveChatSchedules } from "./auto-continue/read-model"
+```
+
+Inside `deriveChatSnapshot`, after building `transcript`:
+
+```ts
+  const autoContinueEvents = state.autoContinueEventsByChatId.get(chat.id) ?? []
+  const { schedules, liveScheduleId } = deriveChatSchedules(autoContinueEvents, chat.id)
+```
+
+Add to the returned object:
+
+```ts
+    schedules,
+    liveScheduleId,
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/server/read-models.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/read-models.ts src/server/read-models.test.ts
+git commit -m "feat(auto-continue): project schedules onto ChatSnapshot"
+```
+
+---
+
+## Task 9: WS protocol — three new commands
+
+**Files:**
+- Modify: `src/shared/protocol.ts`
+
+- [ ] **Step 1: Add command variants**
+
+Edit `src/shared/protocol.ts`. Inside `ClientCommand`, after the `message.dequeue` variant:
+
+```ts
+  | { type: "autoContinue.accept"; chatId: string; scheduleId: string; scheduledAt: number }
+  | { type: "autoContinue.reschedule"; chatId: string; scheduleId: string; scheduledAt: number }
+  | { type: "autoContinue.cancel"; chatId: string; scheduleId: string }
+```
+
+- [ ] **Step 2: Run type-check to verify nothing else breaks**
+
+Run: `bun run check`
+Expected: type errors only where WS router / client stores will later handle these commands.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/protocol.ts
+git commit -m "feat(auto-continue): add three WS commands for schedule lifecycle"
+```
+
+---
+
+## Task 10: Client preferences store — `autoResumeOnRateLimit`
+
+**Files:**
+- Create: `src/client/stores/preferences.ts`
+- Test: `src/client/stores/preferences.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/client/stores/preferences.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from "bun:test"
+import { usePreferencesStore } from "./preferences"
+
+describe("usePreferencesStore", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    usePreferencesStore.setState({ autoResumeOnRateLimit: false })
+  })
+
+  test("autoResumeOnRateLimit defaults to false", () => {
+    expect(usePreferencesStore.getState().autoResumeOnRateLimit).toBe(false)
+  })
+
+  test("setAutoResumeOnRateLimit updates state", () => {
+    usePreferencesStore.getState().setAutoResumeOnRateLimit(true)
+    expect(usePreferencesStore.getState().autoResumeOnRateLimit).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/client/stores/preferences.test.ts`
+Expected: FAIL — `./preferences` module missing.
+
+- [ ] **Step 3: Implement the store**
+
+Create `src/client/stores/preferences.ts`:
+
+```ts
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+interface PreferencesState {
+  autoResumeOnRateLimit: boolean
+  setAutoResumeOnRateLimit: (value: boolean) => void
+}
+
+interface PersistedPreferencesState {
+  autoResumeOnRateLimit?: boolean
+}
+
+function migratePreferencesState(
+  persistedState: Partial<PersistedPreferencesState> | undefined,
+): Pick<PreferencesState, "autoResumeOnRateLimit"> {
+  return {
+    autoResumeOnRateLimit: Boolean(persistedState?.autoResumeOnRateLimit),
+  }
+}
+
+export const usePreferencesStore = create<PreferencesState>()(
+  persist(
+    (set) => ({
+      autoResumeOnRateLimit: false,
+      setAutoResumeOnRateLimit: (value) => set({ autoResumeOnRateLimit: value }),
+    }),
+    {
+      name: "kanna-preferences",
+      version: 1,
+      migrate: (persistedState) => migratePreferencesState(
+        persistedState as Partial<PersistedPreferencesState> | undefined,
+      ),
+    },
+  ),
+)
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/client/stores/preferences.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/stores/preferences.ts src/client/stores/preferences.test.ts
+git commit -m "feat(auto-continue): client preferences store with autoResumeOnRateLimit"
+```
+
+---
+
+## Task 11: Surface preference to the server via WS
+
+The server reads `autoResumeOnRateLimit` out-of-band — the client sends its current value with every message-send command. Simplest path: extend `chat.send` and `message.enqueue` with an optional `autoResumeOnRateLimit?: boolean`, and the `AgentCoordinator` caches it per chat.
+
+**Files:**
+- Modify: `src/shared/protocol.ts`
+- Modify: `src/client/lib/socket.ts` (or wherever `chat.send` and `message.enqueue` are built — search for usages)
+
+- [ ] **Step 1: Extend protocol commands**
+
+Edit `src/shared/protocol.ts`. In the `chat.send` command, add:
+
+```ts
+  autoResumeOnRateLimit?: boolean
+```
+
+Do the same for `message.enqueue`.
+
+- [ ] **Step 2: Extend the send-helper on the client**
+
+Find the client helper that builds a `chat.send` command (search `Grep` for `"chat.send"` under `src/client`). Wherever it builds the command object, read from the preferences store and add:
+
+```ts
+import { usePreferencesStore } from "../stores/preferences"
+
+const autoResumeOnRateLimit = usePreferencesStore.getState().autoResumeOnRateLimit
+// ...
+{
+  type: "chat.send",
+  // ...
+  autoResumeOnRateLimit,
+}
+```
+
+Do the same in the helper that builds `message.enqueue`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/protocol.ts src/client/
+git commit -m "feat(auto-continue): thread autoResumeOnRateLimit preference through WS commands"
+```
+
+---
+
+## Task 12: Wire `ScheduleManager` into AgentCoordinator
+
+**Files:**
+- Modify: `src/server/agent.ts`
+- Test: `src/server/agent.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src/server/agent.test.ts` and append:
+
+```ts
+import { ClaudeLimitDetector } from "./auto-continue/limit-detector"
+import { ScheduleManager, type Clock } from "./auto-continue/schedule-manager"
+import type { AutoContinueEvent } from "./auto-continue/events"
+
+function makeLimitError() {
+  const err = new Error(JSON.stringify({
+    type: "error",
+    error: { type: "rate_limit_error" },
+  })) as Error & { status?: number; headers?: Record<string, string> }
+  err.status = 429
+  err.headers = {
+    "anthropic-ratelimit-unified-reset": new Date(5_000).toISOString(),
+    "x-anthropic-timezone": "Asia/Saigon",
+  }
+  return err
+}
+
+describe("AgentCoordinator rate-limit detection (manual mode)", () => {
+  test("emits auto_continue_proposed when Claude throws a rate-limit error and autoResumeOnRateLimit is false", async () => {
+    // Harness: build an AgentCoordinator with a fake startClaudeSession that synthesizes makeLimitError(),
+    //          pipe appended AutoContinueEvents into a captured array, assert exactly one "auto_continue_proposed".
+    //
+    // Copy the existing test harness in agent.test.ts (look for `buildAgent` or `createTestAgent`) and inject:
+    //   - claudeLimitDetector: new ClaudeLimitDetector()
+    //   - codexLimitDetector: new CodexLimitDetector()
+    //   - scheduleManager: new ScheduleManager({ clock: fakeClock, fire })
+    //   - getAutoResumePreference: () => false
+    //
+    // Then drive a send(), force the synthetic stream to throw makeLimitError(), and assert.
+  })
+
+  test("auto-resume on: emits auto_continue_accepted directly with source=auto_setting", async () => {
+    // Same as above but with getAutoResumePreference: () => true.
+    // Assert: no auto_continue_proposed event; exactly one auto_continue_accepted with source === "auto_setting".
+  })
+})
+```
+
+The existing `agent.test.ts` has test harnesses — use the same pattern to construct a coordinator with a fake Claude session that throws on the first stream iteration. The two test bodies are fully specified in Step 3 below once the wiring is done.
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: FAIL — constructor does not accept the new dependencies.
+
+- [ ] **Step 3: Extend `AgentCoordinator`**
+
+Edit `src/server/agent.ts`. Add imports:
+
+```ts
+import type { AutoContinueEvent } from "./auto-continue/events"
+import { ClaudeLimitDetector, CodexLimitDetector, type LimitDetector } from "./auto-continue/limit-detector"
+import type { ScheduleManager } from "./auto-continue/schedule-manager"
+```
+
+Extend `AgentCoordinatorArgs`:
+
+```ts
+  claudeLimitDetector?: LimitDetector
+  codexLimitDetector?: LimitDetector
+  scheduleManager?: ScheduleManager
+  getAutoResumePreference?: () => boolean
+```
+
+Add class fields:
+
+```ts
+  private readonly claudeLimitDetector: LimitDetector
+  private readonly codexLimitDetector: LimitDetector
+  private readonly scheduleManager: ScheduleManager | null
+  private readonly getAutoResumePreference: () => boolean
+  private readonly autoResumeByChat = new Map<string, boolean>()
+```
+
+In the constructor:
+
+```ts
+    this.claudeLimitDetector = args.claudeLimitDetector ?? new ClaudeLimitDetector()
+    this.codexLimitDetector = args.codexLimitDetector ?? new CodexLimitDetector()
+    this.scheduleManager = args.scheduleManager ?? null
+    this.getAutoResumePreference = args.getAutoResumePreference ?? (() => false)
+```
+
+In `send(command)` and `enqueue(command)` where `command.autoResumeOnRateLimit` is known, cache it:
+
+```ts
+    if (typeof command.autoResumeOnRateLimit === "boolean") {
+      this.autoResumeByChat.set(chatId, command.autoResumeOnRateLimit)
+    }
+```
+
+Add a private helper:
+
+```ts
+  private resolveAutoResumeFor(chatId: string): boolean {
+    const cached = this.autoResumeByChat.get(chatId)
+    if (typeof cached === "boolean") return cached
+    return this.getAutoResumePreference()
+  }
+
+  private async handleLimitError(chatId: string, detector: LimitDetector, error: unknown, turnId: string) {
+    const detection = detector.detect(chatId, error)
+    if (!detection) return false
+
+    const state = this.store.getAutoContinueEvents(chatId)
+    const live = deriveChatSchedules(state, chatId).liveScheduleId
+    if (live !== null) return true
+
+    const autoResume = this.resolveAutoResumeFor(chatId)
+    const now = Date.now()
+    const scheduleId = crypto.randomUUID()
+
+    if (autoResume) {
+      const event: AutoContinueEvent = {
+        v: 3,
+        kind: "auto_continue_accepted",
+        timestamp: now,
+        chatId,
+        scheduleId,
+        scheduledAt: detection.resetAt,
+        tz: detection.tz,
+        source: "auto_setting",
+        resetAt: detection.resetAt,
+        detectedAt: now,
+      }
+      await this.store.appendAutoContinueEvent(event)
+      this.scheduleManager?.onEvent(event)
+    } else {
+      const event: AutoContinueEvent = {
+        v: 3,
+        kind: "auto_continue_proposed",
+        timestamp: now,
+        chatId,
+        scheduleId,
+        detectedAt: now,
+        resetAt: detection.resetAt,
+        tz: detection.tz,
+        turnId,
+      }
+      await this.store.appendAutoContinueEvent(event)
+      this.scheduleManager?.onEvent(event)
+    }
+
+    await this.store.appendMessage(chatId, timestamped({
+      kind: "auto_continue_prompt",
+      scheduleId,
+    } as Omit<TranscriptEntry, "_id" | "createdAt">))
+
+    return true
+  }
+```
+
+Add import for `deriveChatSchedules`:
+
+```ts
+import { deriveChatSchedules } from "./auto-continue/read-model"
+```
+
+Insert a call into the two catch blocks.
+
+For the Claude stream catch (line ~1329):
+
+```ts
+    } catch (error) {
+      const active = this.activeTurns.get(session.chatId)
+      if (active && !active.cancelRequested) {
+        const handled = await this.handleLimitError(session.chatId, this.claudeLimitDetector, error, active.turn?.id ?? "")
+        if (!handled) {
+          const message = error instanceof Error ? error.message : String(error)
+          await this.store.appendMessage(
+            session.chatId,
+            timestamped({
+              kind: "result",
+              subtype: "error",
+              isError: true,
+              durationMs: 0,
+              result: message,
+            })
+          )
+          await this.store.recordTurnFailed(session.chatId, message)
+        } else {
+          await this.store.recordTurnFailed(session.chatId, "rate_limit")
+        }
+      }
+    }
+```
+
+For the Codex / `runTurn` catch (line ~1421), do the same with `this.codexLimitDetector`.
+
+- [ ] **Step 4: Fill in the tests and run them**
+
+Replace the pseudo-test bodies with concrete ones modelled on the existing `agent.test.ts` harness. Each test:
+
+1. Builds a fake Claude session whose `query()` generator throws `makeLimitError()` on first iteration.
+2. Calls `agent.send({ chatId, content: "hi", autoResumeOnRateLimit: <false|true> })`.
+3. `await Promise.resolve()` and any drain awaits the harness exposes.
+4. Asserts `store.getAutoContinueEvents(chatId)` contains exactly one event with the expected `kind` and (for auto-resume) `source === "auto_setting"`.
+
+Run: `bun test src/server/agent.test.ts`
+Expected: PASS (including the two new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agent.ts src/server/agent.test.ts
+git commit -m "feat(auto-continue): detect rate-limit errors and emit schedule events"
+```
+
+---
+
+## Task 13: Wire firing path — enqueue "continue" with metadata
+
+**Files:**
+- Modify: `src/server/auto-continue/schedule-manager.ts` (test already written)
+- Modify: `src/server/cli-runtime.ts` (or wherever `AgentCoordinator` is instantiated — search `Grep` for `new AgentCoordinator(`)
+
+- [ ] **Step 1: Write an integration test**
+
+Append to `src/server/agent.test.ts`:
+
+```ts
+describe("AgentCoordinator auto-continue firing", () => {
+  test("firing enqueues a 'continue' user message carrying autoContinue metadata", async () => {
+    // Build coordinator with a FakeClock-driven ScheduleManager whose fire() calls agent.fireAutoContinue(chatId, scheduleId).
+    // Send a message that triggers makeLimitError() in auto-resume mode.
+    // Advance the clock past resetAt.
+    // Assert:
+    //   - store.getAutoContinueEvents(chatId) contains an "auto_continue_fired" event.
+    //   - The next queued message for chatId has content === "continue".
+    //   - A user_prompt entry with autoContinue?.scheduleId is appended to the transcript.
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: FAIL — `fireAutoContinue` not defined.
+
+- [ ] **Step 3: Implement `fireAutoContinue` on `AgentCoordinator`**
+
+Append to `src/server/agent.ts`:
+
+```ts
+  async fireAutoContinue(chatId: string, scheduleId: string) {
+    const now = Date.now()
+    const fired: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_fired",
+      timestamp: now,
+      chatId,
+      scheduleId,
+      firedAt: now,
+    }
+    await this.store.appendAutoContinueEvent(fired)
+
+    await this.store.appendMessage(chatId, timestamped({
+      kind: "user_prompt",
+      content: "continue",
+      autoContinue: { scheduleId },
+    } as Omit<TranscriptEntry, "_id" | "createdAt">))
+
+    try {
+      await this.enqueueMessage(chatId, "continue", [])
+      await this.maybeStartNextQueuedMessage(chatId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await this.store.appendMessage(
+        chatId,
+        timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: `Auto-continue failed: ${message}`,
+        }),
+      )
+    }
+
+    this.emitStateChange(chatId)
+  }
+```
+
+- [ ] **Step 4: Wire `ScheduleManager.fire` to `agent.fireAutoContinue`**
+
+In `src/server/cli-runtime.ts` (or whichever bootstrap file — run `Grep` for `new AgentCoordinator(` to find it), construct the manager AFTER the coordinator and inject it back:
+
+```ts
+import { ScheduleManager } from "./auto-continue/schedule-manager"
+import { usePreferencesStore } from "../client/stores/preferences" // only if server-side preference is needed; otherwise drop and rely on per-command flag
+
+const scheduleManager = new ScheduleManager({
+  fire: async (chatId, scheduleId) => {
+    await agent.fireAutoContinue(chatId, scheduleId)
+  },
+})
+// Expose it to agent — either re-assign a setter or construct agent with a forward-ref lambda.
+```
+
+Because `AgentCoordinator` already accepts `scheduleManager` in its constructor, build it via a two-step reference-passing pattern:
+
+```ts
+let agent!: AgentCoordinator
+const scheduleManager = new ScheduleManager({
+  fire: async (chatId, scheduleId) => {
+    await agent.fireAutoContinue(chatId, scheduleId)
+  },
+})
+agent = new AgentCoordinator({
+  store,
+  onStateChange,
+  scheduleManager,
+  // ... other existing args
+})
+
+// After event replay:
+scheduleManager.rehydrate(
+  store.listAutoContinueChats().flatMap((chatId) => store.getAutoContinueEvents(chatId))
+)
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `bun test src/server/agent.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/agent.ts src/server/cli-runtime.ts src/server/agent.test.ts
+git commit -m "feat(auto-continue): fire schedules by enqueueing 'continue' user message"
+```
+
+---
+
+## Task 14: WS router — three new commands + cancel-on-delete
+
+**Files:**
+- Modify: `src/server/ws-router.ts`
+- Test: extend `src/server/ws-router.test.ts` (create if absent — search first)
+
+- [ ] **Step 1: Write a failing test**
+
+Append / create tests for each of the three commands. Minimum per command:
+
+- State guard: reject `accept` when `schedules[sid].state !== "proposed"`.
+- State guard: reject `reschedule` when `state !== "scheduled"`.
+- State guard: reject `cancel` when `state !== "proposed" && state !== "scheduled"`.
+- Time guard: reject when `scheduledAt <= Date.now()`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/ws-router.test.ts`
+Expected: FAIL — commands not routed.
+
+- [ ] **Step 3: Implement the three cases in `ws-router.ts`**
+
+Edit `src/server/ws-router.ts`. Add after the existing `message.dequeue` case:
+
+```ts
+        case "autoContinue.accept": {
+          await agent.acceptAutoContinue(command.chatId, command.scheduleId, command.scheduledAt)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "autoContinue.reschedule": {
+          await agent.rescheduleAutoContinue(command.chatId, command.scheduleId, command.scheduledAt)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "autoContinue.cancel": {
+          await agent.cancelAutoContinue(command.chatId, command.scheduleId, "user")
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+```
+
+In the `chat.delete` case, before `send ack`, cancel all live schedules:
+
+```ts
+          for (const scheduleId of agent.listLiveSchedules(command.chatId)) {
+            await agent.cancelAutoContinue(command.chatId, scheduleId, "chat_deleted")
+          }
+```
+
+- [ ] **Step 4: Implement the three coordinator methods**
+
+Add to `AgentCoordinator`:
+
+```ts
+  async acceptAutoContinue(chatId: string, scheduleId: string, scheduledAt: number) {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const projection = deriveChatSchedules(events, chatId)
+    const schedule = projection.schedules[scheduleId]
+    if (!schedule) throw new Error("Schedule not found")
+    if (schedule.state !== "proposed") throw new Error("Schedule not pending")
+    if (scheduledAt <= Date.now()) throw new Error("scheduledAt must be in the future")
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      scheduledAt,
+      tz: schedule.tz,
+      source: "user",
+      resetAt: schedule.resetAt,
+      detectedAt: schedule.detectedAt,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  async rescheduleAutoContinue(chatId: string, scheduleId: string, scheduledAt: number) {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const schedule = deriveChatSchedules(events, chatId).schedules[scheduleId]
+    if (!schedule || schedule.state !== "scheduled") throw new Error("Schedule not active")
+    if (scheduledAt <= Date.now()) throw new Error("scheduledAt must be in the future")
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_rescheduled",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      scheduledAt,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  async cancelAutoContinue(chatId: string, scheduleId: string, reason: "user" | "chat_deleted") {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const schedule = deriveChatSchedules(events, chatId).schedules[scheduleId]
+    if (!schedule) return
+    if (schedule.state !== "proposed" && schedule.state !== "scheduled") return
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_cancelled",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      reason,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  listLiveSchedules(chatId: string): string[] {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const projection = deriveChatSchedules(events, chatId)
+    return Object.values(projection.schedules)
+      .filter((s) => s.state === "proposed" || s.state === "scheduled")
+      .map((s) => s.scheduleId)
+  }
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `bun test src/server/ws-router.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/ws-router.ts src/server/agent.ts src/server/ws-router.test.ts
+git commit -m "feat(auto-continue): WS commands for accept/reschedule/cancel + chat-delete cleanup"
+```
+
+---
+
+## Task 15: Client time helpers — `formatLocal` / `parseLocal`
+
+**Files:**
+- Create: `src/client/lib/autoContinueTime.ts`
+- Test: `src/client/lib/autoContinueTime.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/client/lib/autoContinueTime.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { formatLocal, parseLocal } from "./autoContinueTime"
+
+describe("formatLocal / parseLocal", () => {
+  test("formatLocal in UTC produces dd/mm/yyyy hh:mm", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 17, 5), "UTC")
+    expect(result).toBe("22/04/2026 17:05")
+  })
+
+  test("formatLocal with Asia/Saigon shifts to +07:00", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 17, 0), "Asia/Saigon")
+    expect(result).toBe("23/04/2026 00:00")
+  })
+
+  test("formatLocal with tz=system uses runtime zone (smoke test)", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 12, 0), "system")
+    expect(result).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}$/)
+  })
+
+  test("parseLocal accepts well-formed dd/mm/yyyy hh:mm", () => {
+    const millis = parseLocal("23/04/2026 00:00", "Asia/Saigon")
+    expect(millis).toBe(Date.UTC(2026, 3, 22, 17, 0))
+  })
+
+  test("parseLocal rejects malformed input", () => {
+    expect(parseLocal("22-04-2026 17:05", "UTC")).toBeNull()
+    expect(parseLocal("32/04/2026 17:05", "UTC")).toBeNull()
+    expect(parseLocal("22/04/2026", "UTC")).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/client/lib/autoContinueTime.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `src/client/lib/autoContinueTime.ts`:
+
+```ts
+function resolveTimeZone(tz: string): string | undefined {
+  if (tz === "system") return undefined
+  return tz
+}
+
+export function formatLocal(epochMs: number, tz: string): string {
+  const timeZone = resolveTimeZone(tz)
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(epochMs))
+  const part = (type: string) => parts.find((p) => p.type === type)?.value ?? "00"
+  let hour = part("hour")
+  if (hour === "24") hour = "00"
+  return `${part("day")}/${part("month")}/${part("year")} ${hour}:${part("minute")}`
+}
+
+const PATTERN = /^(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})$/
+
+function offsetMinutes(tz: string, referenceUtcMs: number): number {
+  if (tz === "system") return -new Date(referenceUtcMs).getTimezoneOffset()
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(new Date(referenceUtcMs))
+  const p = (type: string) => Number(parts.find((x) => x.type === type)?.value ?? 0)
+  let hour = p("hour")
+  if (hour === 24) hour = 0
+  const asUtc = Date.UTC(p("year"), p("month") - 1, p("day"), hour, p("minute"), p("second"))
+  return Math.round((asUtc - referenceUtcMs) / 60_000)
+}
+
+export function parseLocal(input: string, tz: string): number | null {
+  const match = PATTERN.exec(input.trim())
+  if (!match) return null
+  const [, ddStr, mmStr, yyyyStr, hhStr, minStr] = match
+  const dd = Number(ddStr)
+  const mm = Number(mmStr)
+  const yyyy = Number(yyyyStr)
+  const hh = Number(hhStr)
+  const min = Number(minStr)
+  if (mm < 1 || mm > 12 || dd < 1 || dd > 31 || hh > 23 || min > 59) return null
+
+  const guess = Date.UTC(yyyy, mm - 1, dd, hh, min)
+  const offMin = offsetMinutes(tz, guess)
+  const corrected = guess - offMin * 60_000
+  const offMinAfter = offsetMinutes(tz, corrected)
+  return corrected - (offMinAfter - offMin) * 60_000
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/client/lib/autoContinueTime.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/lib/autoContinueTime.ts src/client/lib/autoContinueTime.test.ts
+git commit -m "feat(auto-continue): dd/mm/yyyy hh:mm time helpers with tz support"
+```
+
+---
+
+## Task 16: AutoContinueCard component
+
+**Files:**
+- Create: `src/client/components/chat-ui/AutoContinueCard.tsx`
+- Test: `src/client/components/chat-ui/AutoContinueCard.test.tsx`
+
+Assume the codebase has a `Button` + `Input` primitive (seen in `SettingsPage.tsx`: `../components/ui/button`, `../components/ui/input`). Check if a React-testing setup exists; if not, tests for this file may be skipped and replaced with a stub smoke test that imports the component.
+
+- [ ] **Step 1: Write a failing render test**
+
+Create `src/client/components/chat-ui/AutoContinueCard.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { AutoContinueCard } from "./AutoContinueCard"
+
+describe("AutoContinueCard", () => {
+  test("proposed state renders Schedule and Dismiss buttons", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "proposed",
+          scheduledAt: null,
+          tz: "Asia/Saigon",
+          resetAt: Date.UTC(2026, 3, 22, 17, 0),
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Schedule")
+    expect(html).toContain("Dismiss")
+  })
+
+  test("scheduled state renders Change time and Cancel buttons", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "scheduled",
+          scheduledAt: Date.UTC(2026, 3, 22, 17, 0),
+          tz: "Asia/Saigon",
+          resetAt: Date.UTC(2026, 3, 22, 17, 0),
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Change time")
+    expect(html).toContain("Cancel")
+  })
+
+  test("fired state renders Auto-continued line without controls", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "fired",
+          scheduledAt: 1_000,
+          tz: "Asia/Saigon",
+          resetAt: 1_000,
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Auto-continued")
+    expect(html).not.toContain("Cancel")
+  })
+
+  test("cancelled state renders Auto-continue cancelled line", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "cancelled",
+          scheduledAt: null,
+          tz: "Asia/Saigon",
+          resetAt: 1_000,
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Auto-continue cancelled")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/client/components/chat-ui/AutoContinueCard.test.tsx`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the card**
+
+Create `src/client/components/chat-ui/AutoContinueCard.tsx`:
+
+```tsx
+import { useMemo, useState } from "react"
+import type { AutoContinueSchedule } from "../../../shared/types"
+import { formatLocal, parseLocal } from "../../lib/autoContinueTime"
+import { Button } from "../ui/button"
+import { Input } from "../ui/input"
+
+export interface AutoContinueCardProps {
+  schedule: AutoContinueSchedule
+  onAccept: (scheduledAtMs: number) => void
+  onReschedule: (scheduledAtMs: number) => void
+  onCancel: () => void
+}
+
+export function AutoContinueCard({ schedule, onAccept, onReschedule, onCancel }: AutoContinueCardProps) {
+  const [draft, setDraft] = useState<string>(() => formatLocal(
+    schedule.scheduledAt ?? schedule.resetAt,
+    schedule.tz,
+  ))
+  const [editing, setEditing] = useState(false)
+
+  const parsed = useMemo(() => parseLocal(draft, schedule.tz), [draft, schedule.tz])
+  const isFuture = parsed !== null && parsed > Date.now()
+  const inputInvalid = parsed === null ? "Use format dd/mm/yyyy hh:mm" :
+    !isFuture ? "Time must be in the future" : null
+
+  if (schedule.state === "fired") {
+    const at = formatLocal(schedule.scheduledAt ?? schedule.resetAt, schedule.tz)
+    return <div className="rounded border px-3 py-2 text-sm">Auto-continued at {at}</div>
+  }
+
+  if (schedule.state === "cancelled") {
+    return <div className="rounded border px-3 py-2 text-sm opacity-70">Auto-continue cancelled</div>
+  }
+
+  if (schedule.state === "proposed") {
+    const passed = schedule.resetAt <= Date.now()
+    return (
+      <div className="rounded border px-3 py-2 text-sm space-y-2">
+        <div className="font-medium">Rate limit hit — schedule auto-continue?</div>
+        {passed && <div className="text-amber-500">Reset time has passed — accept to continue now.</div>}
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="dd/mm/yyyy hh:mm"
+        />
+        {inputInvalid && <div className="text-xs text-red-500">{inputInvalid}</div>}
+        <div className="flex gap-2">
+          <Button disabled={!isFuture} onClick={() => parsed !== null && onAccept(parsed)}>Schedule</Button>
+          <Button variant="ghost" onClick={onCancel}>Dismiss</Button>
+        </div>
+      </div>
+    )
+  }
+
+  // scheduled
+  const displayAt = formatLocal(schedule.scheduledAt ?? schedule.resetAt, schedule.tz)
+  if (!editing) {
+    const tzLabel = schedule.tz === "system" ? "local" : schedule.tz
+    return (
+      <div className="rounded border px-3 py-2 text-sm flex items-center justify-between gap-2">
+        <div>Auto-continue at {displayAt} ({tzLabel})</div>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={() => setEditing(true)}>Change time</Button>
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded border px-3 py-2 text-sm space-y-2">
+      <Input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        placeholder="dd/mm/yyyy hh:mm"
+      />
+      {inputInvalid && <div className="text-xs text-red-500">{inputInvalid}</div>}
+      <div className="flex gap-2">
+        <Button disabled={!isFuture} onClick={() => { if (parsed !== null) { onReschedule(parsed); setEditing(false) } }}>Save</Button>
+        <Button variant="ghost" onClick={() => setEditing(false)}>Back</Button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/client/components/chat-ui/AutoContinueCard.test.tsx`
+Expected: PASS. If React SSR fails under Bun's test environment, replace `renderToStaticMarkup` with a simple type-check-only smoke import and note that visual verification must be done in dev mode.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/components/chat-ui/AutoContinueCard.tsx src/client/components/chat-ui/AutoContinueCard.test.tsx
+git commit -m "feat(auto-continue): AutoContinueCard with four render states"
+```
+
+---
+
+## Task 17: Hook into transcript rendering
+
+**Files:**
+- Modify: `src/client/lib/parseTranscript.ts`
+- Modify: the renderer that maps `HydratedTranscriptMessage` kinds to JSX (search for a `switch (message.kind)` in `KannaTranscript.tsx` or similar)
+
+- [ ] **Step 1: Extend `parseTranscript`**
+
+Edit `src/client/lib/parseTranscript.ts`. In the `user_prompt` branch, pass `autoContinue`:
+
+```ts
+      case "user_prompt":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "user_prompt",
+          content: entry.content,
+          attachments: entry.attachments ?? [],
+          steered: entry.steered,
+          autoContinue: entry.autoContinue,
+        })
+        break
+```
+
+Add a new branch before the `default`:
+
+```ts
+      case "auto_continue_prompt":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "auto_continue_prompt",
+          scheduleId: entry.scheduleId,
+        })
+        break
+```
+
+- [ ] **Step 2: Add a parseTranscript test**
+
+Append to `src/client/lib/parseTranscript.test.ts`:
+
+```ts
+test("auto_continue_prompt entries hydrate with scheduleId", () => {
+  const output = processTranscriptMessages([{
+    _id: "m1",
+    createdAt: 1,
+    kind: "auto_continue_prompt",
+    scheduleId: "s1",
+  }])
+  expect(output[0].kind).toBe("auto_continue_prompt")
+  expect((output[0] as { scheduleId: string }).scheduleId).toBe("s1")
+})
+
+test("user_prompt carries autoContinue metadata", () => {
+  const output = processTranscriptMessages([{
+    _id: "m1",
+    createdAt: 1,
+    kind: "user_prompt",
+    content: "continue",
+    autoContinue: { scheduleId: "s1" },
+  }])
+  expect(output[0].kind).toBe("user_prompt")
+  expect((output[0] as { autoContinue?: { scheduleId: string } }).autoContinue?.scheduleId).toBe("s1")
+})
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `bun test src/client/lib/parseTranscript.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Render `AutoContinueCard` in the transcript**
+
+Find the transcript message-renderer (search `Grep` for `case "user_prompt":` under `src/client/components`). In its switch, add:
+
+```tsx
+case "auto_continue_prompt": {
+  const schedule = chatSnapshot.schedules[message.scheduleId]
+  if (!schedule) return null
+  return (
+    <AutoContinueCard
+      key={message.id}
+      schedule={schedule}
+      onAccept={(scheduledAt) => sendCommand({ type: "autoContinue.accept", chatId, scheduleId: message.scheduleId, scheduledAt })}
+      onReschedule={(scheduledAt) => sendCommand({ type: "autoContinue.reschedule", chatId, scheduleId: message.scheduleId, scheduledAt })}
+      onCancel={() => sendCommand({ type: "autoContinue.cancel", chatId, scheduleId: message.scheduleId })}
+    />
+  )
+}
+```
+
+In the `user_prompt` case, if `message.autoContinue` is set, append a small "auto-sent" badge next to the content.
+
+- [ ] **Step 5: Smoke-test in dev mode**
+
+Run: `bun dev`, then open the app, synthesize a rate-limit error (see Task 18 end-to-end test), and confirm:
+- Card renders in proposed state.
+- Schedule button sends the correct WS command.
+- User prompt generated by firing has the "auto-sent" badge.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/client/lib/parseTranscript.ts src/client/lib/parseTranscript.test.ts src/client/components/
+git commit -m "feat(auto-continue): render AutoContinueCard + auto-sent badge in transcript"
+```
+
+---
+
+## Task 18: Settings page toggle
+
+**Files:**
+- Modify: `src/client/app/SettingsPage.tsx`
+- Test: `src/client/app/SettingsPage.test.tsx` (extend)
+
+- [ ] **Step 1: Add a failing test**
+
+Append to `src/client/app/SettingsPage.test.tsx` (or similar):
+
+```ts
+test("renders the Auto-resume on rate limit toggle", () => {
+  // Render <SettingsPage /> with the provider mocks and assert that the toggle label is present.
+  // See the existing tests in this file for the required provider shape.
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/client/app/SettingsPage.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the toggle**
+
+Edit `src/client/app/SettingsPage.tsx`. Import:
+
+```ts
+import { usePreferencesStore } from "../stores/preferences"
+```
+
+In the General section, add a toggle row using the existing styling conventions:
+
+```tsx
+const autoResumeOnRateLimit = usePreferencesStore((state) => state.autoResumeOnRateLimit)
+const setAutoResumeOnRateLimit = usePreferencesStore((state) => state.setAutoResumeOnRateLimit)
+
+// ...
+
+<section>
+  <h3 className="text-sm font-medium">Auto-resume on rate limit</h3>
+  <p className="text-xs text-muted-foreground">
+    When you hit a rate limit, automatically schedule "continue" at the reset time instead of asking.
+    You can still cancel each one from the chat.
+  </p>
+  <label className="mt-2 inline-flex items-center gap-2">
+    <input
+      type="checkbox"
+      checked={autoResumeOnRateLimit}
+      onChange={(event) => setAutoResumeOnRateLimit(event.target.checked)}
+    />
+    Enabled
+  </label>
+</section>
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `bun test src/client/app/SettingsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/app/SettingsPage.tsx src/client/app/SettingsPage.test.tsx
+git commit -m "feat(auto-continue): add Auto-resume toggle to Settings page"
+```
+
+---
+
+## Task 19: End-to-end test — detection → card → accept → fire
+
+**Files:**
+- Create: `src/server/auto-continue/e2e.test.ts`
+
+- [ ] **Step 1: Write the end-to-end test**
+
+Create `src/server/auto-continue/e2e.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { EventStore } from "../event-store"
+import { AgentCoordinator } from "../agent"
+import { ScheduleManager, type Clock } from "./schedule-manager"
+import { ClaudeLimitDetector, CodexLimitDetector } from "./limit-detector"
+
+class FakeClock implements Clock {
+  private current = 0
+  private scheduled: Array<{ fireAt: number; fn: () => void; id: number }> = []
+  private nextId = 1
+  now() { return this.current }
+  setTimeout(fn: () => void, delayMs: number) {
+    const id = this.nextId++
+    this.scheduled.push({ fireAt: this.current + delayMs, fn, id })
+    return id
+  }
+  clearTimeout(id: number) { this.scheduled = this.scheduled.filter((x) => x.id !== id) }
+  advance(ms: number) {
+    this.current += ms
+    const due = this.scheduled.filter((x) => x.fireAt <= this.current)
+    this.scheduled = this.scheduled.filter((x) => x.fireAt > this.current)
+    for (const entry of due) entry.fn()
+  }
+}
+
+describe("auto-continue end-to-end", () => {
+  test("rate limit → card → accept → fires 'continue' user message", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kanna-e2e-"))
+    try {
+      const store = new EventStore(dir)
+      await store.initialize()
+      const project = await store.openProject("/tmp/proj")
+      const chat = await store.createChat(project.id)
+
+      const clock = new FakeClock()
+      let agent!: AgentCoordinator
+      const scheduleManager = new ScheduleManager({
+        clock,
+        fire: async (chatId, scheduleId) => agent.fireAutoContinue(chatId, scheduleId),
+      })
+      agent = new AgentCoordinator({
+        store,
+        onStateChange: () => {},
+        claudeLimitDetector: new ClaudeLimitDetector(),
+        codexLimitDetector: new CodexLimitDetector(),
+        scheduleManager,
+        getAutoResumePreference: () => false,
+        startClaudeSession: async () => {
+          // stream a rate-limit error on first iteration
+          throw new Error(JSON.stringify({ type: "error", error: { type: "rate_limit_error" } }))
+        },
+        // Stub other required args — mirror defaults from existing tests.
+      } as never)
+
+      // Trigger send
+      await agent.send({ type: "chat.send", chatId: chat.id, content: "hi", autoResumeOnRateLimit: false })
+
+      // Expect proposed event
+      let events = store.getAutoContinueEvents(chat.id)
+      expect(events).toHaveLength(1)
+      expect(events[0].kind).toBe("auto_continue_proposed")
+      const scheduleId = events[0].scheduleId
+
+      // Accept
+      await agent.acceptAutoContinue(chat.id, scheduleId, clock.now() + 100)
+
+      events = store.getAutoContinueEvents(chat.id)
+      expect(events[1].kind).toBe("auto_continue_accepted")
+
+      // Advance clock
+      clock.advance(100)
+      await Promise.resolve()
+
+      events = store.getAutoContinueEvents(chat.id)
+      expect(events.some((e) => e.kind === "auto_continue_fired")).toBe(true)
+
+      const transcript = store.getMessages(chat.id)
+      const fired = transcript.find((entry) => entry.kind === "user_prompt" && (entry as { autoContinue?: { scheduleId: string } }).autoContinue?.scheduleId === scheduleId)
+      expect(fired).toBeDefined()
+      expect((fired as { content: string }).content).toBe("continue")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+```
+
+The exact stub for `startClaudeSession` depends on the existing harness. Copy from `src/server/agent.test.ts` helpers.
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/auto-continue/e2e.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/auto-continue/e2e.test.ts
+git commit -m "test(auto-continue): end-to-end detect → accept → fire flow"
+```
+
+---
+
+## Task 20: Final verification
+
+- [ ] **Step 1: Type-check and full test run**
+
+Run: `bun run check && bun test`
+Expected: all checks pass.
+
+- [ ] **Step 2: Manual smoke test in dev mode**
+
+Run: `bun dev`, open Kanna in a browser, and manually:
+
+1. Pick a chat.
+2. Temporarily expose a debug hook that throws a synthetic rate-limit error for one turn (e.g., via a `KANNA_DEBUG_RATE_LIMIT=1` env var in the agent — add this only locally, do NOT commit).
+3. Confirm:
+   - Card appears with the default reset time.
+   - Editing the time and clicking Schedule sends the correct WS command.
+   - Scheduled state shows tz-labelled time.
+   - Cancel transitions to the cancelled terminal state.
+4. Toggle **Settings → Auto-resume on rate limit** to ON and repeat step 2. Confirm no proposed card appears and the card renders in `scheduled` state immediately.
+5. Restart the dev server. Confirm pending schedules re-arm (advance wall clock or set reset far in the future).
+
+- [ ] **Step 3: Commit any doc/polish fixes uncovered during smoke**
+
+```bash
+git add -p
+git commit -m "chore(auto-continue): smoke-test polish"
+```
+
+---
+
+## Dependencies Between Tasks
+
+```
+1 (types) ───▶ 2 (events) ───▶ 3 (read-model) ───▶ 4/5 (detectors)
+                                              │
+                                              ├──▶ 6 (event store)  ─┐
+                                              │                      │
+                                              └──▶ 7 (schedule mgr)  │
+                                                                     ▼
+                                                                 8 (snapshot projection)
+                                                                     │
+                                                                     ▼
+                                    9 (protocol) ─▶ 10 (prefs) ─▶ 11 (wire prefs to WS)
+                                                                     │
+                                                                     ▼
+                                                                12 (detection)
+                                                                     │
+                                                                     ▼
+                                                                13 (firing)
+                                                                     │
+                                                                     ▼
+                                                                14 (WS router)
+                                                                     │
+                                    15 (time helpers) ──▶ 16 (card)  │
+                                                          │          │
+                                                          ▼          ▼
+                                                        17 (transcript) ─▶ 18 (settings toggle) ─▶ 19 (e2e) ─▶ 20 (verify)
+```
+
+Tasks 4 and 5 can run in parallel. Tasks 9, 10, and 15 can run in parallel once Task 3 is done. Everything else is sequential.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All 7 component sections (LimitDetector, ScheduleManager, Event types, Read model, Transcript/WS protocol, AutoContinueCard, Settings) have tasks. All 4 data-flow modes (manual, auto-resume, reschedule, cancel, rehydration) are covered in Tasks 7, 12, 13, 14. All 10 edge-case rows have corresponding guards in Tasks 12 (dedupe on liveScheduleId), 14 (state-guard cancel/reschedule + chat-delete cleanup), 13 (enqueue-failure handling), and 7 (rehydrate-past fires immediately).
+- **Placeholder scan:** Tasks 12 and 18 reference existing test harnesses rather than reproducing them verbatim — marked explicitly with the instruction to "copy from src/server/agent.test.ts" so the implementer knows exactly where to look.
+- **Type consistency:** `AutoContinueSchedule`, `AutoContinueEvent`, `ScheduleManager.Clock`, and the three WS command shapes are all spelled identically everywhere they appear. `scheduleId` (not `scheduleID`), `scheduledAt` (not `scheduled_at`), `resetAt` (not `reset_at`), `autoContinue` (not `auto_continue`) across TS; `auto_continue_*` snake_case only inside event `kind` strings.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-22-auto-continue-on-rate-limit.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-20-at-mention-file-picker-design.md
+++ b/docs/superpowers/specs/2026-04-20-at-mention-file-picker-design.md
@@ -1,0 +1,363 @@
+# `@` File Mention in Chat Input — Design
+
+**Status:** Draft
+**Author:** Kanna
+**Date:** 2026-04-20
+**Reference:** Claude Code's @-mention behavior in `/home/cuong/repo/claude-code-qa/src/hooks/fileSuggestions.ts` and `/home/cuong/repo/claude-code-qa/src/utils/attachments.ts`.
+
+## Goal
+
+Add a Claude Code-style `@` file picker to Kanna's chat input. When the user types `@` at a word boundary:
+
+1. A popup lists matching project files and directories.
+2. Fuzzy search filters as they type.
+3. Selecting a row inserts `@relative/path` text **and** registers a "mention" attachment on the current draft.
+4. On submit, the server renders mention attachments into the existing `<kanna-attachments>` prompt block so the agent sees them as first-class references.
+
+Works in both Claude and Codex sessions. Unlike uploads, mentions point at existing files under the project root — no copy into `.kanna/uploads/`.
+
+## Non-Goals
+
+- No file content inlining (let the agent Read on demand).
+- No directory expansion (agent can `ls` when it needs to).
+- No recent/most-used ranking. Bare `@` shows top-level project entries, like Claude Code.
+- No line-range syntax (`@file:10-20`) in v1.
+- No MCP resource mentions or agent mentions.
+- No slash-command conflict handling — triggers are disjoint (`/` at start vs. `@` at word boundary).
+
+## Architecture
+
+```
+Browser (React)
+  ChatInput.tsx
+    ├── <MentionPicker /> (new)             — list, arrows, Enter, Esc
+    └── useMentionSuggestions(projectId)    — debounced fetch hook
+        └── GET /api/projects/:id/paths?query=...
+Bun Server
+  server.ts
+    └── handleProjectPaths(req, url, store) — new handler
+        └── project-paths.ts (new)          — git ls-files + ripgrep fallback, cache
+  agent.ts
+    └── buildAttachmentHintText            — renders kind="mention" alongside file/image
+```
+
+### Components & Responsibilities
+
+| Unit | Path | Responsibility |
+|---|---|---|
+| `project-paths.ts` | `src/server/project-paths.ts` | List project files+dirs via git / ripgrep; fuzzy-filter; cache keyed by project id with `.git/index` mtime invalidation. |
+| `paths` HTTP handler | `src/server/server.ts` | Route `GET /api/projects/:id/paths?query=` → `project-paths.ts`. |
+| `ChatAttachment.kind = "mention"` | `src/shared/types.ts` | New attachment variant. `contentUrl` empty, `absolutePath`/`relativePath` required. |
+| `buildAttachmentHintText` | `src/server/agent.ts` | Already emits `<attachment kind="..." path="..." project_path="..." />`; additive — mentions flow through unchanged. |
+| `mention-suggestions.ts` | `src/client/lib/mention-suggestions.ts` | Pure utils: `shouldShowPicker(value, caret) -> { open, query, tokenStart }`, `applyMentionToInput({ value, caret, path, kind })`. |
+| `useMentionSuggestions.ts` | `src/client/hooks/useMentionSuggestions.ts` | Debounced fetch, cancellation on chat/project change, returns `{ items, loading }`. |
+| `MentionPicker.tsx` | `src/client/components/chat-ui/MentionPicker.tsx` | UI shell, mirrors `SlashCommandPicker.tsx` (skeleton rows, `No matching files`, hover + keyboard). |
+| `ChatInput.tsx` | `src/client/components/chat-ui/ChatInput.tsx` | Wire picker, add `"mention"` attachment to composer draft on accept. |
+
+### Data Flow — bare `@`
+
+```
+user types "@"
+  → shouldShowPicker → { open: true, query: "", tokenStart: n }
+  → useMentionSuggestions fires GET /api/projects/:id/paths?query=
+  → server returns top-level entries (readdir of project.localPath, dirs with trailing /)
+  → MentionPicker renders rows
+```
+
+### Data Flow — typing `@src/a`
+
+```
+user extends to "@src/a"
+  → shouldShowPicker → { open: true, query: "src/a" }
+  → debounce 120ms → GET /api/projects/:id/paths?query=src/a
+  → server runs fuzzy match on cached index (git ls-files + untracked)
+  → picker shows top 50 ranked results
+```
+
+### Data Flow — accept
+
+```
+user presses Enter on "src/agent.ts"
+  → applyMentionToInput: replaces "@src/a" with "@src/agent.ts" (keeps @)
+  → caret moves to end of inserted path
+  → attachment added:
+      { id, kind: "mention", displayName: "src/agent.ts",
+        absolutePath: "<project>/src/agent.ts",
+        relativePath: "./src/agent.ts",
+        contentUrl: "", mimeType: "", size: 0 }
+  → picker closes
+```
+
+### Data Flow — submit
+
+```
+onSubmit(value, { attachments: [...mentions, ...uploads] })
+  → server agent.ts buildPromptText + buildAttachmentHintText
+  → prompt tail:
+      <kanna-attachments>
+        <attachment kind="mention" path="/.../src/agent.ts" project_path="./src/agent.ts" ... />
+      </kanna-attachments>
+```
+
+## Server — path indexing
+
+### `src/server/project-paths.ts`
+
+```ts
+export interface ProjectPath {
+  path: string        // relative to project.localPath, forward slashes
+  kind: "file" | "dir"
+}
+
+export async function listProjectPaths(args: {
+  projectId: string
+  localPath: string
+  query: string
+  limit?: number      // default 50
+}): Promise<ProjectPath[]>
+```
+
+Behavior:
+
+1. **Empty query** → `readdir(localPath)` at top level; dirs get trailing `/` (reported as `kind:"dir"`).
+2. **Non-empty query** → use cached index:
+   - If no cache for `projectId`, build synchronously on first call, then background-refresh on mtime change.
+   - Index = tracked files (`git ls-files`) + untracked non-ignored files (`git ls-files --others --exclude-standard`) + derived directories (unique parent dirs up to root).
+   - Non-git → ripgrep `--files --follow --hidden --glob '!.git/' --glob '!node_modules/'` (plus a short fixed exclude list from Claude Code's ripgrep args).
+3. **Fuzzy match** — same ranking as existing `filterCommands` in `src/client/lib/slash-commands.ts`: prefix matches before substring matches, alphabetical within each bucket, case-insensitive.
+4. **Limit** — cap at 50 to match the UI footprint (picker overlays the input).
+
+### Caching
+
+```ts
+interface ProjectPathCache {
+  projectId: string
+  root: string
+  files: string[]
+  dirs: string[]
+  gitIndexMtime: number | null   // for invalidation; null for non-git
+  builtAt: number
+}
+```
+
+- In-memory `Map<projectId, ProjectPathCache>` at module scope.
+- Invalidation: on each request, stat `<root>/.git/index`. If mtime differs, rebuild.
+- Time floor: also rebuild if `Date.now() - builtAt > 5 min`, to pick up new untracked files in non-git roots.
+- `clearProjectPathCache(projectId)` exposed for tests and chat-reset flows.
+
+### HTTP handler
+
+Added to `src/server/server.ts` next to `handleProjectFileContent`:
+
+```ts
+async function handleProjectPaths(req: Request, url: URL, store: EventStore) {
+  const match = url.pathname.match(/^\/api\/projects\/([^/]+)\/paths$/)
+  if (!match || req.method !== "GET") return null
+
+  const project = store.getProject(match[1])
+  if (!project) return Response.json({ error: "Project not found" }, { status: 404 })
+
+  const query = url.searchParams.get("query") ?? ""
+  const limit = Number(url.searchParams.get("limit") ?? 50)
+
+  const paths = await listProjectPaths({
+    projectId: project.id, localPath: project.localPath, query, limit,
+  })
+  return Response.json({ paths })
+}
+```
+
+### Auth
+
+This endpoint reuses the same auth gate as `handleProjectFileContent`. It does not expose file contents — only paths — but it still leaks project structure, so gate behind the existing `requireAuth` wrapper used elsewhere in `server.ts`.
+
+## Shared types
+
+Extend `ChatAttachment` in `src/shared/types.ts`:
+
+```ts
+export type ChatAttachmentKind = "image" | "file" | "mention"
+
+export interface ChatAttachment {
+  id: string
+  kind: ChatAttachmentKind
+  displayName: string
+  absolutePath: string
+  relativePath: string
+  contentUrl: string   // "" for mentions
+  mimeType: string     // "" for mentions
+  size: number         // 0 for mentions
+}
+```
+
+Downstream code already handles unknown-kind attachments via `buildAttachmentHintText` emitting the `kind` attribute verbatim, so the change is largely additive. Rendering in `AttachmentFileCard` / `AttachmentImageCard` needs a `kind === "mention"` branch (see below).
+
+## Client
+
+### Trigger
+
+`shouldShowPicker(value, caret)` in `mention-suggestions.ts`:
+
+- Open when the token immediately before `caret` starts with `@` AND is preceded by start-of-string or whitespace.
+- Token extends from `@` up to (but not including) the next whitespace.
+- `query` is the substring after `@`.
+- Exposes `tokenStart` (index of `@`) so accept can replace the right slice.
+
+Closes when caret is before the `@`, or the token is broken by a space.
+
+### Fetching
+
+`useMentionSuggestions(projectId, query)`:
+
+- Debounce 120ms on `query` change.
+- On `projectId` change, clear cached results and cancel in-flight.
+- Returns `{ items: ProjectPath[], loading: boolean, error: string | null }`.
+- Zustand-backed cache per `${projectId}:${query}` to avoid re-fetch when cursor bounces.
+
+### Picker UI (`MentionPicker.tsx`)
+
+Mirrors `SlashCommandPicker.tsx`:
+
+- Absolute positioned `bottom-full left-0 mb-2`, `max-h-64 overflow-auto`.
+- Row = `<span class="font-mono">{path}</span>` + trailing `/` on dirs (already in the string).
+- Skeleton rows while `loading && items.length === 0`.
+- Empty result → "No matching files".
+- Hover sets active index; `onMouseDown` accepts.
+
+### Accept
+
+```ts
+function applyMentionToInput(args: {
+  value: string
+  caret: number
+  tokenStart: number
+  pickedPath: string   // relative, dirs end with "/"
+}): { value: string; caret: number }
+```
+
+Replaces `[tokenStart, caret)` with `@${pickedPath}`. New caret = `tokenStart + pickedPath.length + 1`.
+
+Also adds a composer attachment:
+
+```ts
+setAttachments(prev => [
+  ...prev,
+  {
+    id: crypto.randomUUID(),
+    kind: "mention",
+    displayName: pickedPath,
+    absolutePath: path.posix.join(project.localPath, pickedPath),
+    relativePath: `./${pickedPath}`,
+    contentUrl: "", mimeType: "", size: 0,
+    status: "uploaded",      // ComposerAttachment discriminator — skips upload pipeline
+  },
+])
+```
+
+Duplicate-guard: if the same `relativePath` already exists as a mention, skip the add.
+
+### Attachment chip rendering
+
+`AttachmentFileCard` gets a `kind === "mention"` branch: distinct icon (lucide `FileText` or `AtSign`), no download URL, clicking opens the file via the existing `/api/projects/:id/files/:relativePath/content` route. Remove button removes both the chip **and** does NOT delete any server state (nothing to delete).
+
+### Keyboard
+
+Added to top of `ChatInput.handleKeyDown` before the slash-picker block (slash picker already handles its own triggers):
+
+- If `mentionOpen`: Esc dismisses (keeps input), ArrowUp/Down navigate, Enter/Tab accept.
+- Mention and slash pickers are mutually exclusive because their triggers differ (`/` at position 0 vs. `@` after a word boundary); if both think they're open, slash wins (current position 0 always implies empty token before).
+
+### Persistence
+
+Mention attachments persist in the chat input draft (`chatInputStore.setAttachmentDrafts`) alongside uploads. No extra store needed — the existing draft list already handles arbitrary `ChatAttachment` objects.
+
+## Error & edge cases
+
+| Case | Behavior |
+|---|---|
+| No project open (new chat without projectId) | Picker silently suppressed. |
+| Project is not a git repo | Falls back to ripgrep; if ripgrep missing, readdir walk capped at 10k entries. |
+| Path was selected but file deleted before submit | Server sees `<attachment path="...missing..." />`; agent gets a clear missing-file signal. No client-side pre-validation needed for v1. |
+| Huge repos (>100k files) | Cache builds once, subsequent queries do in-memory filter in <5ms. First build is the slow case; acceptable given it's cached. |
+| Path with spaces | Inserted verbatim (`@dir/with spaces/file.ts`). Since the token ends at whitespace, the user must either avoid spaces or manually wrap. v1 does not support quoted `@"path with spaces"`. |
+| Duplicate mention of same path | Ignored on accept (no duplicate chip). |
+
+## Testing
+
+### Server — `project-paths.test.ts`
+
+- `empty query returns top-level entries` — mkdtemp, write files, assert result.
+- `git query returns tracked + untracked minus ignored` — init git, add files, add .gitignore, assert.
+- `non-git falls back to readdir walk` — mkdtemp without .git, assert.
+- `cache invalidates on .git/index mtime change` — stub mtime, assert rebuild.
+- `fuzzy ranking: prefix before substring` — assert order.
+- `limit respected` — assert.
+
+### Server — `server.test.ts`
+
+- `GET /api/projects/:id/paths returns 404 for unknown project`.
+- `GET returns JSON { paths }` for valid project.
+- `GET respects ?query= and ?limit=`.
+
+### Server — `agent.test.ts`
+
+- `mention attachments render in <kanna-attachments> with kind="mention"`.
+- `mention attachments do not fetch content from contentUrl` (ensure no HTTP call).
+
+### Client — `mention-suggestions.test.ts`
+
+- `shouldShowPicker` — bare `@`, `@src/`, mid-word `a@b` (should not open), caret before `@` (should not open), after space `hi @foo` (should open).
+- `applyMentionToInput` — correct slice replacement, caret placement, multi-line input.
+
+### Client — `useMentionSuggestions.test.ts`
+
+- Debounces 120ms.
+- Cancels stale fetches on projectId change.
+- Caches by `${projectId}:${query}`.
+
+### Client — `MentionPicker.test.tsx`
+
+- Renders skeleton rows on `loading && !items.length`.
+- Renders "No matching files" on `!loading && !items.length`.
+- ArrowDown/Enter accept.
+
+### Client — `ChatInput.test.ts`
+
+- Typing `@` opens picker.
+- Accepting inserts `@path` and adds mention chip.
+- Removing chip leaves text intact (user must edit manually).
+- Submit forwards mention attachments in `onSubmit` options.
+
+## Observability
+
+No new analytics in v1. The existing chat-send logs already show attachment count and kind via `buildAttachmentHintText`.
+
+## Migration / backward compatibility
+
+Purely additive:
+
+- `ChatAttachmentKind` gets a new variant — existing persisted drafts with `kind: "file"` / `"image"` continue to work.
+- Snapshot serialization carries the new field by virtue of `ChatRecord` passthrough, same as slash-commands (see `docs/plans/2026-04-20-slash-command-picker.md` Task 7).
+- No changes to the event log schema.
+
+## Implementation order
+
+1. Shared type `ChatAttachmentKind` + "mention".
+2. Server `project-paths.ts` + tests.
+3. Server HTTP handler + tests.
+4. Agent hint renderer (should just work; add assertion test).
+5. Client `mention-suggestions.ts` + tests.
+6. Client `useMentionSuggestions.ts` + tests.
+7. Client `MentionPicker.tsx`.
+8. Attachment card: `kind === "mention"` branch.
+9. Wire into `ChatInput.tsx` + tests.
+10. Manual verification in `bun run dev`.
+
+## Open questions
+
+None blocking. Flagged for future:
+
+- Quoted `@"path with spaces"` support.
+- Line-range syntax `@file:10-20`.
+- Recent-mentions ranking.
+- Directory selection triggering an automatic `ls` attachment payload.

--- a/docs/superpowers/specs/2026-04-22-auto-continue-on-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-04-22-auto-continue-on-rate-limit-design.md
@@ -1,0 +1,261 @@
+# Auto-Continue on Rate-Limit Reset — Design
+
+**Status:** Draft
+**Author:** Kanna
+**Date:** 2026-04-22
+
+## Goal
+
+When a chat hits a provider rate limit (e.g. *"You've hit your limit · resets 12am (Asia/Saigon)"*), Kanna should offer — or, with a setting on, silently schedule — an automatic `continue` message at the reset time so the conversation resumes without the user babysitting the clock.
+
+Concretely:
+
+1. Detect rate-limit errors from the **Claude Agent SDK** and the **Codex App Server** in a structured way (no text regex).
+2. Render a new `AutoContinueCard` in the affected chat's transcript that:
+   - In manual mode: asks the user whether to schedule `"continue"` at the parsed reset time, with an editable `dd/mm/yyyy hh:mm` text field.
+   - In auto-resume mode: shows a slim "Auto-continue scheduled at …" card with Cancel / Change time controls.
+3. Persist schedules in the event log so they survive pm2 reloads / reboots; catch up past-due ones immediately on startup.
+4. When a schedule fires, enqueue the literal string `"continue"` as a user message in the same chat. The resulting transcript entry is rendered with an "auto-sent" badge.
+5. Add a global setting `autoResumeOnRateLimit: boolean` (default `false`) in the Settings page; when on, the prompt step is skipped and a schedule is created automatically.
+
+## Non-Goals
+
+- No text pattern matching on assistant output. Detection is only through typed SDK / JSON-RPC error payloads.
+- No configurable message text. The fired message is always the literal word `"continue"`.
+- No global "rate limit" banner. Per-chat cards only, matching the existing `AskUserQuestion` layout.
+- No server-side retry of failed auto-continues. If enqueue throws, surface an error entry and stop.
+- No cross-account aggregation. If multiple chats on the same account hit the limit, each gets its own schedule.
+- No mobile-specific UI tuning in v1 beyond what the existing transcript renderer already provides.
+- No notification / sound / desktop alert on fire. The transcript update is the signal.
+
+## Architecture
+
+```
+Browser (React)
+  ChatTranscript
+    └── AutoContinueCard (new)       — renders proposed/scheduled/fired/cancelled states
+  SettingsPage
+    └── Auto-resume toggle (new)     — autoResumeOnRateLimit
+
+    ↕ WebSocket (existing WSRouter)
+
+Bun Server
+  auto-continue/
+    ├── limit-detector.ts            — ClaudeLimitDetector + CodexLimitDetector
+    ├── events.ts                    — AutoContinueEvent union
+    └── schedule-manager.ts          — in-memory timers, rehydrate, fire
+  agent.ts
+    └── on SDK error → LimitDetector.detect() → EventStore.append(...)
+  event-store.ts
+    └── schedules.jsonl + snapshot integration
+  read-models.ts
+    └── chat.schedules + chat.liveSchedule projections
+  ws-router.ts
+    └── commands: acceptAutoContinue, rescheduleAutoContinue, cancelAutoContinue
+
+~/.kanna/data/
+  └── schedules.jsonl (new)
+```
+
+**New files**
+
+- `src/server/auto-continue/limit-detector.ts`
+- `src/server/auto-continue/events.ts`
+- `src/server/auto-continue/schedule-manager.ts`
+- `src/client/components/chat-ui/AutoContinueCard.tsx`
+
+**Modified files**
+
+- `src/shared/types.ts` — transcript entry kind, `PendingAutoContinueSnapshot`, settings type.
+- `src/shared/protocol.ts` — WS command + event payloads.
+- `src/server/event-store.ts` — register new event kinds, extend snapshot.
+- `src/server/read-models.ts` — add `chat.schedules` + `chat.liveSchedule` projections.
+- `src/server/agent.ts` — wire `LimitDetector` into the error path; metadata on auto-fired user messages.
+- `src/server/ws-router.ts` — route the three new commands.
+- `src/client/app/SettingsPage.tsx` — add the toggle.
+- `src/client/stores/preferences.ts` — surface the setting.
+- `src/client/lib/parseTranscript.ts` — render the new transcript entry kind.
+
+## Components
+
+### 1. `LimitDetector` (per provider)
+
+```ts
+type LimitDetection = {
+  chatId: string
+  resetAt: number    // epoch ms
+  tz: string         // IANA timezone from provider; "system" fallback
+  raw: unknown       // original error for diagnostics
+}
+
+interface LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null
+}
+```
+
+- `ClaudeLimitDetector` — inspects Claude Agent SDK error objects. Identifies rate-limit errors by status code / typed error class and extracts the reset timestamp and timezone from the structured payload.
+- `CodexLimitDetector` — same contract against Codex App Server JSON-RPC error payloads.
+- If the payload lacks a timezone, set `tz = "system"` and format using the server's local zone for display.
+- Returns `null` for non-limit errors — the caller falls through to the existing error path.
+
+The detectors are pure functions over the error object. No network, no state.
+
+### 2. `ScheduleManager`
+
+```ts
+class ScheduleManager {
+  constructor(
+    private eventStore: EventStore,
+    private agent: AgentCoordinator,
+    private clock: Clock,                   // injectable
+  )
+
+  rehydrate(): void                         // called once after event replay
+  onEvent(event: AutoContinueEvent): void   // subscribed to EventStore
+
+  private fire(chatId: string, scheduleId: string): Promise<void>
+}
+```
+
+Owns `Map<scheduleId, NodeJS.Timeout>`. Single source of wall-clock timers for this feature.
+
+- On `auto_continue_accepted` or `auto_continue_rescheduled`: clear any existing timer for that `scheduleId`, then `setTimeout(fire, scheduledAt - clock.now())`. If the delta is `≤ 0`, fire on next tick.
+- On `auto_continue_cancelled` or `auto_continue_fired`: clear the timer and delete the map entry.
+- `rehydrate()`: walks each entry in every chat's `schedules` map. Entries whose state is `proposed`, `fired`, or `cancelled` are skipped. Entries in `scheduled` state re-arm a `setTimeout` (or fire immediately if `scheduledAt ≤ now`).
+- `fire(chatId, scheduleId)`:
+  1. `eventStore.append({ kind: "auto_continue_fired", chatId, scheduleId, firedAt: now })`
+  2. `agent.enqueueUserMessage(chatId, "continue", { autoContinue: true, scheduleId })`
+  3. If enqueue throws, append a chat error entry and still mark the schedule fired — no retries.
+
+### 3. Event types
+
+```ts
+type AutoContinueEvent =
+  | { kind: "auto_continue_proposed";    chatId; scheduleId; detectedAt; resetAt; tz; turnId }
+  | { kind: "auto_continue_accepted";    chatId; scheduleId; scheduledAt; tz; source: "user" | "auto_setting" }
+  | { kind: "auto_continue_rescheduled"; chatId; scheduleId; scheduledAt }
+  | { kind: "auto_continue_cancelled";   chatId; scheduleId; reason: "user" | "chat_deleted" }
+  | { kind: "auto_continue_fired";       chatId; scheduleId; firedAt }
+```
+
+- `scheduleId` is a fresh UUID per schedule.
+- Stored in `~/.kanna/data/schedules.jsonl`, replayed on startup, folded into `snapshot.json` alongside other derived state.
+- All timestamps are epoch ms. `tz` is for display only.
+
+### 4. Read model (`chat.schedules`)
+
+Each chat may accumulate multiple schedules over time (one per rate-limit encounter). The transcript carries one `auto_continue_prompt` entry per schedule; the renderer looks up the live state by `scheduleId`:
+
+```ts
+chat.schedules: Record<scheduleId, {
+  state: "proposed" | "scheduled" | "fired" | "cancelled"
+  scheduledAt: number | null     // null while state=proposed
+  tz: string
+  resetAt: number                // parsed from detector, for display
+}>
+```
+
+Computed from the latest event per `scheduleId`. A schedule entry is permanent once created — terminal states (`fired` / `cancelled`) remain in the map so past cards in the transcript keep rendering correctly.
+
+A helper `chat.liveSchedule: scheduleId | null` points at the most recent schedule whose state is `proposed` or `scheduled` (or `null` if none). This is what the detector path checks to decide whether to drop a duplicate detection.
+
+### 5. Transcript entry + WS protocol
+
+- New transcript entry kind `auto_continue_prompt`, carrying the `scheduleId`. The renderer pulls live state from `chat.schedules[scheduleId]`.
+- The user message produced when a schedule fires carries `meta: { autoContinue: true, scheduleId }` so the transcript renderer applies the "auto-sent" badge.
+- New WS commands (client → server):
+  - `acceptAutoContinue(scheduleId, scheduledAt)`
+  - `rescheduleAutoContinue(scheduleId, scheduledAt)`
+  - `cancelAutoContinue(scheduleId)`
+- Each is validated against current schedule state. Stale or illegal transitions return an error result; no event is appended.
+
+### 6. `AutoContinueCard` (client)
+
+One component, four states off `chat.schedules[scheduleId].state` (the `scheduleId` comes from the transcript entry):
+
+- **`proposed`** — title "Rate limit hit — schedule auto-continue?", default reset time shown as `dd/mm/yyyy hh:mm`, editable text input with inline validation, buttons **Schedule** / **Dismiss**.
+- **`scheduled`** — "Auto-continue at `dd/mm/yyyy hh:mm (Asia/Saigon)`" + **Change time** / **Cancel**. Change time swaps the display line for an inline editable text input with Save / Back.
+- **`fired`** — collapsed "Auto-continued at `dd/mm/yyyy hh:mm`". No controls.
+- **`cancelled`** — collapsed "Auto-continue cancelled". No controls.
+
+Time format helper `formatLocal(epochMs, tz): string` produces `dd/mm/yyyy hh:mm` rendered in `tz` (or the system zone when `tz === "system"`). Parser `parseLocal(input, tz): number | null` accepts the same format; rejects on malformed input or past times.
+
+### 7. Settings
+
+- `autoResumeOnRateLimit: boolean` in the user preferences store (default `false`).
+- Rendered on `SettingsPage.tsx` as a single toggle with help text: *"When you hit a rate limit, automatically schedule 'continue' at the reset time instead of asking. You can still cancel each one from the chat."*
+- Server reads the setting synchronously inside the error-handling path in `agent.ts`. Toggling it mid-session does not affect existing schedules.
+
+## Data Flow
+
+### Manual mode (autoResume = false)
+
+1. User sends a message in chat `C1`.
+2. Claude Agent SDK returns a rate-limit error during the turn.
+3. `AgentCoordinator` calls `ClaudeLimitDetector.detect(C1, error)` → `{ resetAt, tz: "Asia/Saigon" }`.
+4. `EventStore.append(auto_continue_proposed{ C1, S1, resetAt, tz, turnId })`.
+5. Read model recomputes → `chat.schedules[S1] = { state: "proposed", ... }`, `chat.liveSchedule = S1`.
+6. WSRouter broadcasts the chat snapshot; `AutoContinueCard` renders in the transcript.
+7. User either:
+   - Clicks **Schedule** with the default time → client sends `acceptAutoContinue(S1, resetAt)`.
+   - Edits the text input to a new `dd/mm/yyyy hh:mm` → client sends `acceptAutoContinue(S1, parsed)`.
+   - Clicks **Dismiss** → client sends `cancelAutoContinue(S1, reason: "user")`.
+8. Server validates (state still `proposed`, time `> now`) → appends `auto_continue_accepted`.
+9. `ScheduleManager` observes the event → arms a `setTimeout`.
+10. When the timer fires → appends `auto_continue_fired` → `agent.enqueueUserMessage(C1, "continue", { autoContinue: true, scheduleId: S1 })`.
+11. Normal chat turn runs; the transcript's user-message entry carries the `autoContinue` badge.
+
+### Auto-resume mode (autoResume = true)
+
+Step 4 emits `auto_continue_accepted` directly (no `proposed`), with `source: "auto_setting"` and `scheduledAt = resetAt`. Everything else is identical. The card renders in `scheduled` state from the start.
+
+### Reschedule
+
+Client sends `rescheduleAutoContinue(S1, newScheduledAt)` → server validates state is `scheduled` and time `> now` → appends `auto_continue_rescheduled` → `ScheduleManager` clears the old timer and arms a new one.
+
+### Cancel
+
+Client sends `cancelAutoContinue(S1)` → appends `auto_continue_cancelled(reason: "user")` → `ScheduleManager` clears the timer. Card renders in terminal `cancelled` state.
+
+### Startup rehydration
+
+On server boot, after event replay, `ScheduleManager.rehydrate()` walks every entry in every `chat.schedules` map:
+
+- State `scheduled` with `scheduledAt ≤ now` → fire immediately.
+- State `scheduled` with `scheduledAt > now` → arm a `setTimeout`.
+- State `proposed` → do nothing; the card is still shown, user can accept on reconnect.
+- State `fired` / `cancelled` → do nothing.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Limit detected on a chat that already has a `proposed` / `scheduled` schedule (`chat.liveSchedule != null`) | Drop the new detection. No new event, no card. The user already has a pending decision for this chat. |
+| Invalid `dd/mm/yyyy hh:mm` input | Client-side inline validation, Schedule / Save button disabled. |
+| User enters a time in the past | Rejected client-side with "Time must be in the future"; server also rejects the command. |
+| Timer fires while the chat has a running turn or queued messages | `enqueueUserMessage` handles queueing; no feature-specific logic needed. |
+| Chat deleted with a live schedule | `deleteChat` appends `auto_continue_cancelled(reason: "chat_deleted")` for each live schedule so `ScheduleManager` clears its timer. |
+| Clock skew / DST / timezone changes | `scheduledAt` is epoch ms; firing is pure epoch math. `tz` is only for display. |
+| `enqueueUserMessage` throws at fire time (provider not configured, etc.) | Append a chat error entry "Auto-continue failed: <reason>"; still mark the schedule `fired`. No retry. |
+| User disables `autoResumeOnRateLimit` while a schedule is live | Live schedules keep firing. The setting only gates new detections. |
+| Multiple provider errors in flight for the same chat | First detector to fire wins and emits the schedule. Subsequent detections in the same turn see `chat.liveSchedule != null` and are dropped. |
+| `proposed` event whose `resetAt` passed while Kanna was off | Card still shows; helper text reads "Reset time has passed — accept to continue now." |
+| Detector cannot find a `tz` in the error payload | `tz = "system"`; display uses server local zone. Firing still uses epoch math. |
+
+## Testing
+
+- **Unit: `LimitDetector`** — captured real SDK / JSON-RPC error shapes for Claude and Codex. Assert parsed `resetAt` + `tz`; `null` for non-limit errors; `tz = "system"` when absent.
+- **Unit: `ScheduleManager`** — fake clock. Arm / fire / reschedule / cancel / rehydrate-past / rehydrate-future / rehydrate-after-fired / rehydrate-after-cancelled.
+- **Integration: `EventStore`** — append + replay round-trip for each new event kind; snapshot compaction retains latest per-chat per-schedule state.
+- **Unit: read model** — state machine transitions from every ordered subset of events.
+- **Unit: WS router** — each command validates current state; rejects stale / illegal / past-time transitions; no side effects on rejection.
+- **Integration: `AgentCoordinator`** — rate-limit error emits `auto_continue_proposed`; in auto-resume mode emits `auto_continue_accepted`; a fired schedule enqueues `"continue"` with `{ autoContinue: true, scheduleId }`.
+- **Component: `AutoContinueCard`** — renders all four states; text-input validation; dispatches correct WS commands.
+- **End-to-end (`bun test`)** — fake chat receives synthesized rate-limit error → card appears → client sends accept → fake clock advances → `"continue"` appears with auto-continue badge → chat turn runs.
+- **Settings** — toggling `autoResumeOnRateLimit` flips the event emitted by the detector path; existing schedules unaffected.
+
+## Open Questions
+
+None at spec time. Subject to validation during `writing-plans`:
+
+- Exact Claude Agent SDK error shape and Codex App Server JSON-RPC error shape for rate limits — confirm the fields containing reset timestamp and timezone exist, and whether they're always present.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kanna-code",
+  "name": "@cuongtranba/kanna",
   "type": "module",
   "version": "0.32.3",
   "description": "A beautiful web UI for Claude Code",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jakemor/kanna.git"
+    "url": "git+https://github.com/cuongtranba/kanna.git"
   },
   "bin": {
     "kanna": "./bin/kanna"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
+    "pm2": "6.0.14",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-markdown": "^10.1.0",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-GLOBAL_LINK="$HOME/.bun/install/global/node_modules/kanna-code"
+GLOBAL_LINK="$HOME/.bun/install/global/node_modules/@cuongtranba/kanna"
 PM2_NAME="${KANNA_PM2_PROCESS_NAME:-kanna}"
 PM2_TEMPLATE="$REPO_DIR/scripts/pm2.config.cjs.tmpl"
 PM2_CONFIG="$REPO_DIR/scripts/pm2.config.cjs"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GLOBAL_LINK="$HOME/.bun/install/global/node_modules/kanna-code"
+LAUNCHD_LABEL="io.silentium.kanna"
+
+cd "$REPO_DIR"
+
+# One-time: replace global copy with symlink to repo
+if [[ ! -L "$GLOBAL_LINK" ]]; then
+  echo "→ Linking $GLOBAL_LINK → $REPO_DIR"
+  rm -rf "$GLOBAL_LINK"
+  mkdir -p "$(dirname "$GLOBAL_LINK")"
+  ln -s "$REPO_DIR" "$GLOBAL_LINK"
+fi
+
+# Install deps if lockfile changed
+if [[ ! -d node_modules ]] || [[ package.json -nt node_modules ]] || [[ bun.lock -nt node_modules ]]; then
+  echo "→ bun install"
+  bun install
+fi
+
+echo "→ bun run build"
+bun run build
+
+echo "→ launchctl kickstart -k gui/$(id -u)/$LAUNCHD_LABEL"
+launchctl kickstart -k "gui/$(id -u)/$LAUNCHD_LABEL"
+
+sleep 2
+PID=$(launchctl list | awk -v l="$LAUNCHD_LABEL" '$3==l{print $1}')
+echo "✓ kanna running (PID $PID)"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,8 +6,25 @@ GLOBAL_LINK="$HOME/.bun/install/global/node_modules/kanna-code"
 PM2_NAME="${KANNA_PM2_PROCESS_NAME:-kanna}"
 PM2_TEMPLATE="$REPO_DIR/scripts/pm2.config.cjs.tmpl"
 PM2_CONFIG="$REPO_DIR/scripts/pm2.config.cjs"
+PM2_ENV_FILE="$REPO_DIR/scripts/pm2.env"
 
 cd "$REPO_DIR"
+
+# Load local secrets (cloudflared token, password) from untracked file if present.
+if [[ -f "$PM2_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set -a; source "$PM2_ENV_FILE"; set +a
+fi
+
+# Compose args passed to ./bin/kanna. Tokens/password sourced from env.
+KANNA_ARGS="--no-open"
+if [[ -n "${KANNA_CLOUDFLARED_TOKEN:-}" ]]; then
+  KANNA_ARGS="$KANNA_ARGS --cloudflared $KANNA_CLOUDFLARED_TOKEN"
+fi
+if [[ -n "${KANNA_PASSWORD:-}" ]]; then
+  KANNA_ARGS="$KANNA_ARGS --password $KANNA_PASSWORD"
+fi
+export KANNA_ARGS
 
 if [[ ! -L "$GLOBAL_LINK" ]]; then
   echo "→ Linking $GLOBAL_LINK → $REPO_DIR"
@@ -35,7 +52,8 @@ if ! command -v envsubst >/dev/null 2>&1; then
 fi
 
 echo "→ render $PM2_CONFIG"
-REPO_DIR="$REPO_DIR" PM2_NAME="$PM2_NAME" envsubst '${REPO_DIR} ${PM2_NAME}' < "$PM2_TEMPLATE" > "$PM2_CONFIG"
+REPO_DIR="$REPO_DIR" PM2_NAME="$PM2_NAME" KANNA_ARGS="$KANNA_ARGS" \
+  envsubst '${REPO_DIR} ${PM2_NAME} ${KANNA_ARGS}' < "$PM2_TEMPLATE" > "$PM2_CONFIG"
 
 if pm2 describe "$PM2_NAME" >/dev/null 2>&1; then
   echo "→ pm2 reload $PM2_NAME"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GLOBAL_LINK="$HOME/.bun/install/global/node_modules/kanna-code"
-LAUNCHD_LABEL="io.silentium.kanna"
+PM2_NAME="${KANNA_PM2_PROCESS_NAME:-kanna}"
+PM2_TEMPLATE="$REPO_DIR/scripts/pm2.config.cjs.tmpl"
+PM2_CONFIG="$REPO_DIR/scripts/pm2.config.cjs"
 
 cd "$REPO_DIR"
 
-# One-time: replace global copy with symlink to repo
 if [[ ! -L "$GLOBAL_LINK" ]]; then
   echo "→ Linking $GLOBAL_LINK → $REPO_DIR"
   rm -rf "$GLOBAL_LINK"
@@ -15,7 +16,6 @@ if [[ ! -L "$GLOBAL_LINK" ]]; then
   ln -s "$REPO_DIR" "$GLOBAL_LINK"
 fi
 
-# Install deps if lockfile changed
 if [[ ! -d node_modules ]] || [[ package.json -nt node_modules ]] || [[ bun.lock -nt node_modules ]]; then
   echo "→ bun install"
   bun install
@@ -24,9 +24,26 @@ fi
 echo "→ bun run build"
 bun run build
 
-echo "→ launchctl kickstart -k gui/$(id -u)/$LAUNCHD_LABEL"
-launchctl kickstart -k "gui/$(id -u)/$LAUNCHD_LABEL"
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "→ bun install -g pm2"
+  bun install -g pm2
+fi
 
-sleep 2
-PID=$(launchctl list | awk -v l="$LAUNCHD_LABEL" '$3==l{print $1}')
-echo "✓ kanna running (PID $PID)"
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "✗ envsubst not found (install gettext: brew install gettext)" >&2
+  exit 1
+fi
+
+echo "→ render $PM2_CONFIG"
+REPO_DIR="$REPO_DIR" PM2_NAME="$PM2_NAME" envsubst '${REPO_DIR} ${PM2_NAME}' < "$PM2_TEMPLATE" > "$PM2_CONFIG"
+
+if pm2 describe "$PM2_NAME" >/dev/null 2>&1; then
+  echo "→ pm2 reload $PM2_NAME"
+  pm2 reload "$PM2_CONFIG" --update-env
+else
+  echo "→ pm2 start $PM2_NAME"
+  pm2 start "$PM2_CONFIG"
+fi
+
+pm2 save
+echo "✓ kanna running under pm2"

--- a/scripts/pm2.config.cjs.tmpl
+++ b/scripts/pm2.config.cjs.tmpl
@@ -2,8 +2,8 @@ module.exports = {
   apps: [
     {
       name: "${PM2_NAME}",
-      script: "./src/server/cli.ts",
-      interpreter: "bun",
+      script: "./bin/kanna",
+      interpreter: "none",
       cwd: "${REPO_DIR}",
       env: {
         KANNA_RELOADER: "pm2",

--- a/scripts/pm2.config.cjs.tmpl
+++ b/scripts/pm2.config.cjs.tmpl
@@ -4,6 +4,7 @@ module.exports = {
       name: "${PM2_NAME}",
       script: "./bin/kanna",
       interpreter: "none",
+      args: "${KANNA_ARGS}",
       cwd: "${REPO_DIR}",
       env: {
         KANNA_RELOADER: "pm2",

--- a/scripts/pm2.config.cjs.tmpl
+++ b/scripts/pm2.config.cjs.tmpl
@@ -1,0 +1,20 @@
+module.exports = {
+  apps: [
+    {
+      name: "${PM2_NAME}",
+      script: "./src/server/cli.ts",
+      interpreter: "bun",
+      cwd: "${REPO_DIR}",
+      env: {
+        KANNA_RELOADER: "pm2",
+        KANNA_REPO_DIR: "${REPO_DIR}",
+        KANNA_PM2_PROCESS_NAME: "${PM2_NAME}",
+        KANNA_DISABLE_SELF_UPDATE: "1",
+        KANNA_CLI_MODE: "child",
+      },
+      autorestart: true,
+      max_memory_restart: "1G",
+      kill_timeout: 5000,
+    },
+  ],
+}

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom"
 import { Flower } from "lucide-react"
-import { AppDialogProvider } from "../components/ui/app-dialog"
+import { AppDialogProvider, useAppDialog } from "../components/ui/app-dialog"
 import { Button } from "../components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card"
 import { Input } from "../components/ui/input"
@@ -57,7 +57,7 @@ function PasswordScreen({
           <div className="flex items-center gap-3">
             <Flower className="h-5 w-5 text-logo" />
             <div>
-              <CardTitle className="font-logo text-xl uppercase text-slate-600 dark:text-slate-100">{APP_NAME}</CardTitle>
+              <CardTitle className="font-logo text-xl uppercase text-foreground">{APP_NAME}</CardTitle>
             </div>
           </div>
           <CardDescription className="leading-6">
@@ -166,6 +166,7 @@ function KannaLayout() {
   const navigate = useNavigate()
   const params = useParams()
   const state = useKannaState(params.chatId ?? null)
+  const dialog = useAppDialog()
   const chatSoundPreference = useChatSoundPreferencesStore((store) => store.chatSoundPreference)
   const chatSoundId = useChatSoundPreferencesStore((store) => store.chatSoundId)
   const showMobileOpenButton = location.pathname === "/"
@@ -205,12 +206,18 @@ function KannaLayout() {
         `failed ${result.failed}`,
       ]
       const suffix = result.newProjects > 0 ? ` (${result.newProjects} new projects)` : ""
-      alert(`${parts.join(", ")}.${suffix}`)
+      await dialog.alert({
+        title: "Import complete",
+        description: `${parts.join(", ")}.${suffix}`,
+      })
     } catch (error) {
       console.error("[kanna/import] failed", error)
-      alert("Import failed. See console for details.")
+      await dialog.alert({
+        title: "Import failed",
+        description: "See console for details.",
+      })
     }
-  }, [state])
+  }, [dialog, state])
   const sidebarElement = useMemo(() => (
     <KannaSidebar
       data={state.sidebarData}
@@ -237,6 +244,7 @@ function KannaLayout() {
       editorLabel={state.editorLabel}
       updateSnapshot={state.updateSnapshot}
       onOpenChangelog={handleOpenChangelog}
+      onForceReload={() => { void state.handleForceReload() }}
     />
   ), [
     handleOpenChangelog,

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -195,6 +195,18 @@ function KannaLayout() {
   const handleOpenChangelog = useCallback(() => {
     navigate("/settings/changelog")
   }, [navigate])
+  const handleImportClaudeSessions = useCallback(async () => {
+    try {
+      const result = await state.importClaudeSessions()
+      alert(
+        `Imported ${result.imported}, skipped ${result.skipped}, failed ${result.failed}.`
+          + (result.newProjects > 0 ? ` (${result.newProjects} new projects)` : ""),
+      )
+    } catch (error) {
+      console.error("[kanna/import] failed", error)
+      alert("Import failed. See console for details.")
+    }
+  }, [state])
   const sidebarElement = useMemo(() => (
     <KannaSidebar
       data={state.sidebarData}
@@ -213,6 +225,7 @@ function KannaLayout() {
       keybindings={state.keybindings}
       onDeleteChat={handleSidebarDeleteChat}
       onOpenAddProjectModal={handleOpenAddProjectModal}
+      onImportClaudeSessions={handleImportClaudeSessions}
       onCopyPath={handleSidebarCopyPath}
       onOpenExternalPath={handleSidebarOpenExternalPath}
       onRemoveProject={handleSidebarRemoveProject}
@@ -224,6 +237,7 @@ function KannaLayout() {
   ), [
     handleOpenChangelog,
     handleOpenAddProjectModal,
+    handleImportClaudeSessions,
     handleSidebarCopyPath,
     handleSidebarCreateChat,
     handleSidebarDeleteChat,

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -198,10 +198,14 @@ function KannaLayout() {
   const handleImportClaudeSessions = useCallback(async () => {
     try {
       const result = await state.importClaudeSessions()
-      alert(
-        `Imported ${result.imported}, skipped ${result.skipped}, failed ${result.failed}.`
-          + (result.newProjects > 0 ? ` (${result.newProjects} new projects)` : ""),
-      )
+      const parts = [
+        `Imported ${result.imported}`,
+        `updated ${result.updated}`,
+        `skipped ${result.skipped}`,
+        `failed ${result.failed}`,
+      ]
+      const suffix = result.newProjects > 0 ? ` (${result.newProjects} new projects)` : ""
+      alert(`${parts.join(", ")}.${suffix}`)
     } catch (error) {
       console.error("[kanna/import] failed", error)
       alert("Import failed. See console for details.")

--- a/src/client/app/ChatPage/ChatTranscriptViewport.tsx
+++ b/src/client/app/ChatPage/ChatTranscriptViewport.tsx
@@ -285,7 +285,7 @@ export const ChatTranscriptViewport = memo(function ChatTranscriptViewport({
 
       {isPageFileDragActive ? (
         <div className="pointer-events-none absolute inset-0 z-30">
-          <div className="absolute inset-0 backdrop-blur-sm" />
+          <div className="absolute inset-0 bg-background/70" />
           <div className="absolute inset-6 ">
             <div className="flex h-full items-center justify-center">
               <div className="flex flex-col items-center justify-center gap-3 text-center">
@@ -302,13 +302,13 @@ export const ChatTranscriptViewport = memo(function ChatTranscriptViewport({
         className={cn(
           "absolute left-1/2 z-10 -translate-x-1/2 transition-all",
           showScrollButton
-            ? "scale-100 duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
-            : "pointer-events-none scale-60 opacity-0 blur-sm duration-300 ease-out",
+            ? "scale-100 opacity-100 duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]"
+            : "pointer-events-none scale-75 opacity-0 duration-200 ease-out",
         )}
       >
         <button
           onClick={scrollToBottom}
-          className="flex aspect-square cursor-pointer items-center gap-1.5 rounded-full border border-border bg-white px-2 text-sm text-primary transition-colors hover:bg-muted hover:text-foreground dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+          className="flex aspect-square cursor-pointer items-center gap-1.5 rounded-full border border-border bg-card px-2 text-sm text-foreground transition-colors hover:bg-muted"
         >
           <ArrowDown className="h-5 w-5" />
         </button>

--- a/src/client/app/ChatPage/ChatTranscriptViewport.tsx
+++ b/src/client/app/ChatPage/ChatTranscriptViewport.tsx
@@ -14,6 +14,7 @@ import {
   useStableResolvedRows,
 } from "../KannaTranscript"
 import type { KannaState } from "../useKannaState"
+import type { AutoContinueSchedule } from "../../../shared/types"
 import {
   CHAT_NAVBAR_OFFSET_PX,
   EMPTY_STATE_TEXT,
@@ -40,6 +41,10 @@ interface ChatTranscriptViewportProps {
   onOpenLocalLink: KannaState["handleOpenLocalLink"]
   onAskUserQuestionSubmit: KannaState["handleAskUserQuestion"]
   onExitPlanModeConfirm: KannaState["handleExitPlanMode"]
+  schedules: Record<string, AutoContinueSchedule>
+  onAutoContinueAccept: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueReschedule: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueCancel: (scheduleId: string) => void
   showScrollButton: boolean
   onIsAtEndChange: (isAtEnd: boolean) => void
   scrollToBottom: () => void
@@ -70,6 +75,10 @@ export const ChatTranscriptViewport = memo(function ChatTranscriptViewport({
   onOpenLocalLink,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  schedules,
+  onAutoContinueAccept,
+  onAutoContinueReschedule,
+  onAutoContinueCancel,
   showScrollButton,
   onIsAtEndChange,
   scrollToBottom,
@@ -180,9 +189,13 @@ export const ChatTranscriptViewport = memo(function ChatTranscriptViewport({
         onToolGroupExpandedChange={handleToolGroupExpandedChange}
         onAskUserQuestionSubmit={onAskUserQuestionSubmit}
         onExitPlanModeConfirm={onExitPlanModeConfirm}
+        schedules={schedules}
+        onAutoContinueAccept={onAutoContinueAccept}
+        onAutoContinueReschedule={onAutoContinueReschedule}
+        onAutoContinueCancel={onAutoContinueCancel}
       />
     </div>
-  ), [handleToolGroupExpandedChange, onAskUserQuestionSubmit, onExitPlanModeConfirm, toolGroupExpanded])
+  ), [handleToolGroupExpandedChange, onAskUserQuestionSubmit, onExitPlanModeConfirm, schedules, onAutoContinueAccept, onAutoContinueReschedule, onAutoContinueCancel, toolGroupExpanded])
 
   const listHeader = (
     <div className="mx-auto w-full max-w-[800px] pt-[72px]">

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -44,6 +44,10 @@ export {
   shouldAutoFollowTranscriptResize,
 } from "./utils"
 
+const TERMINAL_TOGGLE_DURATION_STYLE: CSSProperties = {
+  "--terminal-toggle-duration": `${TERMINAL_TOGGLE_ANIMATION_DURATION_MS}ms`,
+} as CSSProperties
+
 function useEmptyStateTyping(showEmptyState: boolean, activeChatId: string | null) {
   const [typedEmptyStateText, setTypedEmptyStateText] = useState("")
   const [isEmptyStateTypingComplete, setIsEmptyStateTypingComplete] = useState(false)
@@ -291,9 +295,7 @@ const DesktopSidebarPane = memo(function DesktopSidebarPane({
         data-right-sidebar-open={showRightSidebar ? "true" : "false"}
         data-right-sidebar-animated="false"
         data-right-sidebar-visual
-        style={{
-          "--terminal-toggle-duration": `${TERMINAL_TOGGLE_ANIMATION_DURATION_MS}ms`,
-        } as CSSProperties}
+        style={TERMINAL_TOGGLE_DURATION_STYLE}
       >
         {content}
       </div>
@@ -408,9 +410,7 @@ function ChatWorkspace({
           data-terminal-open={showTerminalPane ? "true" : "false"}
           data-terminal-animated="false"
           data-terminal-visual
-          style={{
-            "--terminal-toggle-duration": `${TERMINAL_TOGGLE_ANIMATION_DURATION_MS}ms`,
-          } as CSSProperties}
+          style={TERMINAL_TOGGLE_DURATION_STYLE}
         >
           <TerminalWorkspaceShell
             projectId={projectId}

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -27,6 +27,7 @@ import { useStickyChatFocus } from "../useStickyChatFocus"
 import { useTerminalToggleAnimation } from "../useTerminalToggleAnimation"
 import type { KannaState } from "../useKannaState"
 import { getNextMeasuredInputHeight, getTranscriptPaddingBottom } from "../useKannaState"
+import type { AutoContinueSchedule } from "../../../shared/types"
 import { ChatInputDock } from "./ChatInputDock"
 import { ChatTranscriptViewport } from "./ChatTranscriptViewport"
 import { TerminalWorkspaceShell } from "./TerminalWorkspaceShell"
@@ -47,6 +48,8 @@ export {
 const TERMINAL_TOGGLE_DURATION_STYLE: CSSProperties = {
   "--terminal-toggle-duration": `${TERMINAL_TOGGLE_ANIMATION_DURATION_MS}ms`,
 } as CSSProperties
+
+const EMPTY_SCHEDULES: Record<string, AutoContinueSchedule> = {}
 
 function useEmptyStateTyping(showEmptyState: boolean, activeChatId: string | null) {
   const [typedEmptyStateText, setTypedEmptyStateText] = useState("")
@@ -706,6 +709,24 @@ export function ChatPage() {
     await state.handleSend(content, options)
   }, [scrollToTranscriptEnd, state])
 
+  const handleAutoContinueAccept = useCallback((scheduleId: string, scheduledAt: number) => {
+    const chatId = state.activeChatId
+    if (!chatId) return
+    void state.socket.command({ type: "autoContinue.accept", chatId, scheduleId, scheduledAt }).catch(() => {})
+  }, [state.activeChatId, state.socket])
+
+  const handleAutoContinueReschedule = useCallback((scheduleId: string, scheduledAt: number) => {
+    const chatId = state.activeChatId
+    if (!chatId) return
+    void state.socket.command({ type: "autoContinue.reschedule", chatId, scheduleId, scheduledAt }).catch(() => {})
+  }, [state.activeChatId, state.socket])
+
+  const handleAutoContinueCancel = useCallback((scheduleId: string) => {
+    const chatId = state.activeChatId
+    if (!chatId) return
+    void state.socket.command({ type: "autoContinue.cancel", chatId, scheduleId }).catch(() => {})
+  }, [state.activeChatId, state.socket])
+
   useEffect(() => {
     return () => clearShowScrollTimeout()
   }, [clearShowScrollTimeout])
@@ -904,6 +925,10 @@ export function ChatPage() {
           onOpenLocalLink={state.handleOpenLocalLink}
           onAskUserQuestionSubmit={state.handleAskUserQuestion}
           onExitPlanModeConfirm={state.handleExitPlanMode}
+          schedules={state.chatSnapshot?.schedules ?? EMPTY_SCHEDULES}
+          onAutoContinueAccept={handleAutoContinueAccept}
+          onAutoContinueReschedule={handleAutoContinueReschedule}
+          onAutoContinueCancel={handleAutoContinueCancel}
           showScrollButton={showScrollToBottom && state.messages.length > 0}
           onIsAtEndChange={onIsAtEndChange}
           scrollToBottom={() => scrollToTranscriptEnd(true)}

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -27,7 +27,7 @@ import { useStickyChatFocus } from "../useStickyChatFocus"
 import { useTerminalToggleAnimation } from "../useTerminalToggleAnimation"
 import type { KannaState } from "../useKannaState"
 import { getNextMeasuredInputHeight, getTranscriptPaddingBottom } from "../useKannaState"
-import type { AutoContinueSchedule } from "../../../shared/types"
+import { EMPTY_SCHEDULES } from "../KannaTranscript"
 import { ChatInputDock } from "./ChatInputDock"
 import { ChatTranscriptViewport } from "./ChatTranscriptViewport"
 import { TerminalWorkspaceShell } from "./TerminalWorkspaceShell"
@@ -48,8 +48,6 @@ export {
 const TERMINAL_TOGGLE_DURATION_STYLE: CSSProperties = {
   "--terminal-toggle-duration": `${TERMINAL_TOGGLE_ANIMATION_DURATION_MS}ms`,
 } as CSSProperties
-
-const EMPTY_SCHEDULES: Record<string, AutoContinueSchedule> = {}
 
 function useEmptyStateTyping(showEmptyState: boolean, activeChatId: string | null) {
   const [typedEmptyStateText, setTypedEmptyStateText] = useState("")

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -3,6 +3,7 @@ import { Download, Flower, Loader2, PanelLeft, X, Menu, Plus, Settings } from "l
 import { useLocation, useNavigate } from "react-router-dom"
 import { APP_NAME } from "../../shared/branding"
 import { Button } from "../components/ui/button"
+import { useAppDialog } from "../components/ui/app-dialog"
 import { cn } from "../lib/utils"
 import { ChatRow } from "../components/chat-ui/sidebar/ChatRow"
 import { LocalProjectsSection } from "../components/chat-ui/sidebar/LocalProjectsSection"
@@ -42,6 +43,7 @@ interface KannaSidebarProps {
   editorLabel: string
   updateSnapshot: UpdateSnapshot | null
   onOpenChangelog: () => void
+  onForceReload: () => void
 }
 
 function KannaSidebarImpl({
@@ -69,6 +71,7 @@ function KannaSidebarImpl({
   editorLabel,
   updateSnapshot,
   onOpenChangelog,
+  onForceReload,
 }: KannaSidebarProps) {
   const location = useLocation()
   const navigate = useNavigate()
@@ -260,12 +263,15 @@ function KannaSidebarImpl({
   }, [activeChatId, activeVisibleCount])
 
   const [isImporting, setIsImporting] = useState(false)
+  const dialog = useAppDialog()
 
   const handleImport = useCallback(async () => {
     if (isImporting || !onImportClaudeSessions) return
-    const confirmed = window.confirm(
-      "Scan ~/.claude/projects/ and import all sessions into Kanna? Already-imported sessions are skipped.",
-    )
+    const confirmed = await dialog.confirm({
+      title: "Import Claude sessions",
+      description: "Scan ~/.claude/projects/ and import all sessions into Kanna? Already-imported sessions are skipped.",
+      confirmLabel: "Import",
+    })
     if (!confirmed) return
     setIsImporting(true)
     try {
@@ -275,7 +281,7 @@ function KannaSidebarImpl({
     } finally {
       setIsImporting(false)
     }
-  }, [isImporting, onImportClaudeSessions])
+  }, [dialog, isImporting, onImportClaudeSessions])
 
   const hasVisibleChats = activeVisibleCount > 0
   const isLocalProjectsActive = location.pathname === "/"
@@ -283,7 +289,7 @@ function KannaSidebarImpl({
   const isUtilityPageActive = isLocalProjectsActive || isSettingsActive
   const isConnecting = connectionStatus === "connecting" || !ready
   const statusLabel = isConnecting ? "Connecting" : connectionStatus === "connected" ? "Connected" : "Disconnected"
-  const statusDotClass = connectionStatus === "connected" ? "bg-emerald-500" : "bg-amber-500"
+  const statusDotClass = connectionStatus === "connected" ? "bg-success" : "bg-warning"
   const showUpdateButton = updateSnapshot?.updateAvailable === true
   const showDevBadge = updateSnapshot
     ? updateSnapshot.latestVersion === `${updateSnapshot.currentVersion}-dev`
@@ -295,7 +301,8 @@ function KannaSidebarImpl({
       {!open && showMobileOpenButton && (
         <Button
           variant="ghost"
-          size="icon"
+          size="icon-mobile"
+          aria-label="Open sidebar"
           className="fixed top-3 left-3 z-50 md:hidden"
           onClick={onOpen}
         >
@@ -312,6 +319,7 @@ function KannaSidebarImpl({
               size="icon"
               onClick={onExpand}
               title="Expand sidebar"
+              aria-label="Expand sidebar"
             >
               <PanelLeft className="h-5 w-5" />
             </Button>
@@ -336,6 +344,7 @@ function KannaSidebarImpl({
               className="size-10 rounded-lg hover:!border-border/0"
               onClick={onClose}
               title="Close sidebar"
+              aria-label="Close sidebar"
             >
               <X className="h-5 w-5" />
             </Button>
@@ -345,13 +354,14 @@ function KannaSidebarImpl({
               type="button"
               onClick={onCollapse}
               title="Collapse sidebar"
+              aria-label="Collapse sidebar"
               className="hidden md:flex group/sidebar-collapse relative items-center justify-center h-5 w-5 sm:h-6 sm:w-6"
             >
               <Flower className="absolute inset-0.5 h-4 w-4 sm:h-5 sm:w-5 text-logo transition-all duration-200 ease-out opacity-100 scale-100 group-hover/sidebar-collapse:opacity-0 group-hover/sidebar-collapse:scale-0" />
-              <PanelLeft className="absolute inset-0 h-4 w-4 sm:h-6 sm:w-6 text-slate-500 dark:text-slate-400 transition-all duration-200 ease-out opacity-0 scale-0 group-hover/sidebar-collapse:opacity-100 group-hover/sidebar-collapse:scale-80 hover:opacity-50" />
+              <PanelLeft className="absolute inset-0 h-4 w-4 sm:h-6 sm:w-6 text-muted-foreground transition-all duration-200 ease-out opacity-0 scale-0 group-hover/sidebar-collapse:opacity-100 group-hover/sidebar-collapse:scale-80 hover:opacity-50" />
             </button>
             <Flower className="h-5 w-5 sm:h-6 sm:w-6 text-logo md:hidden" />
-            <span className="font-logo text-base uppercase sm:text-md text-slate-600 dark:text-slate-100">{APP_NAME}</span>
+            <span className="font-logo text-base uppercase sm:text-md text-foreground">{APP_NAME}</span>
           </div>
           <div className="flex items-center justify-self-end md:justify-self-auto">
             <Button
@@ -363,6 +373,7 @@ function KannaSidebarImpl({
               }}
               className="size-10 rounded-lg hover:!border-border/0 md:hidden"
               title="New project"
+              aria-label="New project"
             >
               <Plus className="h-5 w-5" />
             </Button>
@@ -373,7 +384,8 @@ function KannaSidebarImpl({
               >
                 DEV
               </span>
-            ) : showUpdateButton ? (
+            ) : null}
+            {showUpdateButton ? (
               <Button
                 variant="outline"
                 size="sm"
@@ -385,7 +397,19 @@ function KannaSidebarImpl({
                 {isUpdating ? <Loader2 className="mr-1.5 h-3 w-3 animate-spin" /> : null}
                 UPDATE
               </Button>
-            ) : null}
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden md:inline-flex rounded-full !h-auto mr-1 py-0.5 px-2 bg-logo/20 hover:bg-logo text-logo border-logo/20 hover:text-foreground hover:border-logo/20 text-[11px] font-bold tracking-wider"
+                onClick={onForceReload}
+                disabled={isUpdating}
+                title="Re-deploy (pm2 reload)"
+              >
+                {isUpdating ? <Loader2 className="mr-1.5 h-3 w-3 animate-spin" /> : null}
+                RELOAD
+              </Button>
+            )}
             {onImportClaudeSessions ? (
               <Button
                 variant="ghost"
@@ -408,6 +432,7 @@ function KannaSidebarImpl({
               }}
               className="hidden md:inline-flex size-10 rounded-lg hover:!border-border/0"
               title="New project"
+              aria-label="New project"
             >
               <Plus className="size-4" />
             </Button>
@@ -444,7 +469,7 @@ function KannaSidebarImpl({
             ) : null}
 
             {!hasVisibleChats && !isConnecting && data.projectGroups.length === 0 ? (
-              <p className="text-sm text-slate-400 p-2 mt-6 text-center">No conversations yet</p>
+              <p className="text-sm text-muted-foreground p-2 mt-6 text-center">No conversations yet</p>
             ) : null}
 
             <LocalProjectsSection

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Flower, Loader2, PanelLeft, X, Menu, Plus, Settings } from "lucide-react"
+import { Download, Flower, Loader2, PanelLeft, X, Menu, Plus, Settings } from "lucide-react"
 import { useLocation, useNavigate } from "react-router-dom"
 import { APP_NAME } from "../../shared/branding"
 import { Button } from "../components/ui/button"
@@ -34,6 +34,7 @@ interface KannaSidebarProps {
   keybindings: KeybindingsSnapshot | null
   onDeleteChat: (chat: SidebarChatRow) => void
   onOpenAddProjectModal: () => void
+  onImportClaudeSessions?: () => Promise<void>
   onCopyPath: (localPath: string) => void
   onOpenExternalPath: (action: "open_finder" | "open_editor", localPath: string) => void
   onRemoveProject: (projectId: string) => void
@@ -60,6 +61,7 @@ function KannaSidebarImpl({
   keybindings,
   onDeleteChat,
   onOpenAddProjectModal,
+  onImportClaudeSessions,
   onCopyPath,
   onOpenExternalPath,
   onRemoveProject,
@@ -257,6 +259,24 @@ function KannaSidebarImpl({
     })
   }, [activeChatId, activeVisibleCount])
 
+  const [isImporting, setIsImporting] = useState(false)
+
+  const handleImport = useCallback(async () => {
+    if (isImporting || !onImportClaudeSessions) return
+    const confirmed = window.confirm(
+      "Scan ~/.claude/projects/ and import all sessions into Kanna? Already-imported sessions are skipped.",
+    )
+    if (!confirmed) return
+    setIsImporting(true)
+    try {
+      await onImportClaudeSessions()
+    } catch (error) {
+      console.error("[kanna/import] failed", error)
+    } finally {
+      setIsImporting(false)
+    }
+  }, [isImporting, onImportClaudeSessions])
+
   const hasVisibleChats = activeVisibleCount > 0
   const isLocalProjectsActive = location.pathname === "/"
   const isSettingsActive = location.pathname.startsWith("/settings")
@@ -364,6 +384,19 @@ function KannaSidebarImpl({
               >
                 {isUpdating ? <Loader2 className="mr-1.5 h-3 w-3 animate-spin" /> : null}
                 UPDATE
+              </Button>
+            ) : null}
+            {onImportClaudeSessions ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => void handleImport()}
+                disabled={isImporting}
+                className="hidden md:inline-flex size-10 rounded-lg hover:!border-border/0"
+                title="Import Claude Code sessions"
+                aria-label="Import Claude Code sessions"
+              >
+                <Download className="size-4" />
               </Button>
             ) : null}
             <Button

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -392,7 +392,7 @@ function KannaSidebarImpl({
                 size="icon"
                 onClick={() => void handleImport()}
                 disabled={isImporting}
-                className="hidden md:inline-flex size-10 rounded-lg hover:!border-border/0"
+                className="inline-flex size-10 rounded-lg hover:!border-border/0"
                 title="Import Claude Code sessions"
                 aria-label="Import Claude Code sessions"
               >

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -17,7 +17,9 @@ import { CompactSummaryMessage } from "../components/messages/CompactSummaryMess
 import { StatusMessage } from "../components/messages/StatusMessage"
 import { CollapsedToolGroup } from "../components/messages/CollapsedToolGroup"
 import { OpenLocalLinkProvider } from "../components/messages/shared"
+import { AutoContinueCard } from "../components/chat-ui/AutoContinueCard"
 import { CHAT_SELECTION_ZONE_ATTRIBUTE } from "./chatFocusPolicy"
+import type { AutoContinueSchedule } from "../../shared/types"
 
 const SPECIAL_TOOL_NAMES = new Set(["AskUserQuestion", "ExitPlanMode", "TodoWrite"])
 
@@ -225,6 +227,7 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
       return left.content === (right.kind === "user_prompt" ? right.content : null)
         && right.kind === "user_prompt"
         && left.steered === right.steered
+        && left.autoContinue?.scheduleId === right.autoContinue?.scheduleId
         && sameAttachmentArray(left.attachments, right.attachments)
     case "system_init":
       return right.kind === "system_init"
@@ -266,6 +269,8 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
       return true
     case "unknown":
       return right.kind === "unknown" && left.json === right.json
+    case "auto_continue_prompt":
+      return right.kind === "auto_continue_prompt" && left.scheduleId === right.scheduleId
   }
 }
 
@@ -348,6 +353,10 @@ interface TranscriptSingleRowProps {
     answers: AskUserQuestionAnswerMap
   ) => void
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
+  schedules: Record<string, AutoContinueSchedule>
+  onAutoContinueAccept: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueReschedule: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueCancel: (scheduleId: string) => void
 }
 
 const TranscriptSingleRow = memo(function TranscriptSingleRow({
@@ -364,13 +373,31 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
   isFinalStatus,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  schedules,
+  onAutoContinueAccept,
+  onAutoContinueReschedule,
+  onAutoContinueCancel,
 }: TranscriptSingleRowProps) {
   let rendered: React.ReactNode = null
 
   if (message.kind === "user_prompt") {
-    rendered = <UserMessage key={message.id} content={message.content} attachments={message.attachments} steered={message.steered} />
+    rendered = <UserMessage key={message.id} content={message.content} attachments={message.attachments} steered={message.steered} autoContinue={message.autoContinue} />
   } else {
     switch (message.kind) {
+      case "auto_continue_prompt": {
+        const schedule = schedules[message.scheduleId]
+        if (!schedule) { rendered = null; break }
+        rendered = (
+          <AutoContinueCard
+            key={message.id}
+            schedule={schedule}
+            onAccept={(scheduledAt) => onAutoContinueAccept(message.scheduleId, scheduledAt)}
+            onReschedule={(scheduledAt) => onAutoContinueReschedule(message.scheduleId, scheduledAt)}
+            onCancel={() => onAutoContinueCancel(message.scheduleId)}
+          />
+        )
+        break
+      }
       case "unknown":
         rendered = <RawJsonMessage key={message.id} json={message.json} />
         break
@@ -460,6 +487,10 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
   && prev.isFinalStatus === next.isFinalStatus
   && prev.onAskUserQuestionSubmit === next.onAskUserQuestionSubmit
   && prev.onExitPlanModeConfirm === next.onExitPlanModeConfirm
+  && prev.schedules === next.schedules
+  && prev.onAutoContinueAccept === next.onAutoContinueAccept
+  && prev.onAutoContinueReschedule === next.onAutoContinueReschedule
+  && prev.onAutoContinueCancel === next.onAutoContinueCancel
   && sameMessage(prev.message, next.message)
 ))
 
@@ -574,6 +605,10 @@ interface KannaTranscriptProps {
     answers: AskUserQuestionAnswerMap
   ) => void
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
+  schedules?: Record<string, AutoContinueSchedule>
+  onAutoContinueAccept?: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueReschedule?: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueCancel?: (scheduleId: string) => void
 }
 
 interface KannaTranscriptRowProps {
@@ -586,6 +621,10 @@ interface KannaTranscriptRowProps {
     answers: AskUserQuestionAnswerMap
   ) => void
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
+  schedules: Record<string, AutoContinueSchedule>
+  onAutoContinueAccept: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueReschedule: (scheduleId: string, scheduledAt: number) => void
+  onAutoContinueCancel: (scheduleId: string) => void
 }
 
 export const KannaTranscriptRow = memo(function KannaTranscriptRow({
@@ -594,6 +633,10 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   onToolGroupExpandedChange,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  schedules,
+  onAutoContinueAccept,
+  onAutoContinueReschedule,
+  onAutoContinueCancel,
 }: KannaTranscriptRowProps) {
   if (row.kind === "tool-group") {
     return (
@@ -624,6 +667,10 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
       isFinalStatus={row.isFinalStatus}
       onAskUserQuestionSubmit={onAskUserQuestionSubmit}
       onExitPlanModeConfirm={onExitPlanModeConfirm}
+      schedules={schedules}
+      onAutoContinueAccept={onAutoContinueAccept}
+      onAutoContinueReschedule={onAutoContinueReschedule}
+      onAutoContinueCancel={onAutoContinueCancel}
     />
   )
 }, (prev, next) => {
@@ -631,6 +678,10 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   if (prev.onToolGroupExpandedChange !== next.onToolGroupExpandedChange) return false
   if (prev.onAskUserQuestionSubmit !== next.onAskUserQuestionSubmit) return false
   if (prev.onExitPlanModeConfirm !== next.onExitPlanModeConfirm) return false
+  if (prev.schedules !== next.schedules) return false
+  if (prev.onAutoContinueAccept !== next.onAutoContinueAccept) return false
+  if (prev.onAutoContinueReschedule !== next.onAutoContinueReschedule) return false
+  if (prev.onAutoContinueCancel !== next.onAutoContinueCancel) return false
   if (prev.row.kind !== next.row.kind) return false
   if (prev.row.id !== next.row.id) return false
 
@@ -661,6 +712,9 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   return false
 })
 
+const EMPTY_SCHEDULES: Record<string, AutoContinueSchedule> = {}
+const NOOP = () => undefined
+
 function KannaTranscriptImpl({
   messages,
   isLoading,
@@ -669,6 +723,10 @@ function KannaTranscriptImpl({
   onOpenLocalLink,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  schedules = EMPTY_SCHEDULES,
+  onAutoContinueAccept = NOOP,
+  onAutoContinueReschedule = NOOP,
+  onAutoContinueCancel = NOOP,
 }: KannaTranscriptProps) {
   const [toolGroupExpanded, setToolGroupExpanded] = useState<Record<string, boolean>>({})
   const rows = useMemo(() => buildResolvedTranscriptRows(messages, {
@@ -700,6 +758,10 @@ function KannaTranscriptImpl({
             onToolGroupExpandedChange={handleToolGroupExpandedChange}
             onAskUserQuestionSubmit={onAskUserQuestionSubmit}
             onExitPlanModeConfirm={onExitPlanModeConfirm}
+            schedules={schedules}
+            onAutoContinueAccept={onAutoContinueAccept}
+            onAutoContinueReschedule={onAutoContinueReschedule}
+            onAutoContinueCancel={onAutoContinueCancel}
           />
         </div>
       ))}

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -269,6 +269,7 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
       return true
     case "unknown":
       return right.kind === "unknown" && left.json === right.json
+    // schedule state changes propagate via outer comparator's prev.schedules !== next.schedules check (line 681)
     case "auto_continue_prompt":
       return right.kind === "auto_continue_prompt" && left.scheduleId === right.scheduleId
   }
@@ -712,8 +713,10 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   return false
 })
 
-const EMPTY_SCHEDULES: Record<string, AutoContinueSchedule> = {}
-const NOOP = () => undefined
+export const EMPTY_SCHEDULES: Record<string, AutoContinueSchedule> = {}
+const NOOP_ACCEPT = (_scheduleId: string, _scheduledAt: number): void => {}
+const NOOP_RESCHEDULE = (_scheduleId: string, _scheduledAt: number): void => {}
+const NOOP_CANCEL = (_scheduleId: string): void => {}
 
 function KannaTranscriptImpl({
   messages,
@@ -724,9 +727,9 @@ function KannaTranscriptImpl({
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
   schedules = EMPTY_SCHEDULES,
-  onAutoContinueAccept = NOOP,
-  onAutoContinueReschedule = NOOP,
-  onAutoContinueCancel = NOOP,
+  onAutoContinueAccept = NOOP_ACCEPT,
+  onAutoContinueReschedule = NOOP_RESCHEDULE,
+  onAutoContinueCancel = NOOP_CANCEL,
 }: KannaTranscriptProps) {
   const [toolGroupExpanded, setToolGroupExpanded] = useState<Record<string, boolean>>({})
   const rows = useMemo(() => buildResolvedTranscriptRows(messages, {

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -21,7 +21,7 @@ const SAMPLE_RELEASES = [
     id: 1,
     name: "v0.8.1",
     tag_name: "v0.8.1",
-    html_url: "https://github.com/jakemor/kanna/releases/tag/v0.8.1",
+    html_url: "https://github.com/cuongtranba/kanna/releases/tag/v0.8.1",
     published_at: "2026-03-19T16:53:08Z",
     body: "## Improvements\n- Better cursor color",
     prerelease: false,
@@ -31,7 +31,7 @@ const SAMPLE_RELEASES = [
     id: 2,
     name: null,
     tag_name: "v0.9.0-beta.1",
-    html_url: "https://github.com/jakemor/kanna/releases/tag/v0.9.0-beta.1",
+    html_url: "https://github.com/cuongtranba/kanna/releases/tag/v0.9.0-beta.1",
     published_at: "2026-03-20T12:00:00Z",
     body: "",
     prerelease: true,
@@ -75,7 +75,7 @@ describe("fetchGithubReleases", () => {
       })
     })
 
-    expect(requestedUrl).toBe("https://api.github.com/repos/jakemor/kanna/releases")
+    expect(requestedUrl).toBe("https://api.github.com/repos/cuongtranba/kanna/releases")
     expect(requestedAcceptHeader).toBe("application/vnd.github+json")
     expect(releases).toEqual([SAMPLE_RELEASES[0]])
   })
@@ -209,7 +209,7 @@ describe("ChangelogSection", () => {
     expect(html).toContain("v0.8.1")
     expect(html).toContain("Better cursor color")
     expect(html).toContain('aria-label="View release on GitHub"')
-    expect(html).toContain("https://github.com/jakemor/kanna/releases/tag/v0.8.1")
+    expect(html).toContain("https://github.com/cuongtranba/kanna/releases/tag/v0.8.1")
     expect(html).toContain("Prerelease")
     expect(html).toContain("No release notes were provided.")
     expect(html).toContain(formatPublishedDate("2026-03-19T16:53:08Z"))

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { renderToStaticMarkup } from "react-dom/server"
 import { RefreshCw } from "lucide-react"
 import {
+  AutoResumeToggleSection,
   ChangelogSection,
   fetchGithubReleases,
   formatPublishedDate,
@@ -14,6 +15,7 @@ import {
   shouldPreviewChatSoundChange,
 } from "./SettingsPage"
 import { SettingsHeaderButton } from "../components/ui/settings-header-button"
+import { usePreferencesStore } from "../stores/preferences"
 import type { UpdateSnapshot } from "../../shared/types"
 
 const SAMPLE_RELEASES = [
@@ -279,10 +281,7 @@ describe("ChangelogSection", () => {
   })
 })
 
-import { usePreferencesStore } from "../stores/preferences"
-import { AutoResumeToggleSection } from "./SettingsPage"
-
-test("renders the Auto-resume on rate limit toggle bound to preferences store", () => {
+test("AutoResumeToggleSection renders checked and unchecked based on props", () => {
   // AutoResumeToggleSection is a pure prop-driven component exported from SettingsPage.
   // SettingsPage wires it to usePreferencesStore; here we test the component directly.
   usePreferencesStore.setState({ autoResumeOnRateLimit: false })
@@ -293,7 +292,7 @@ test("renders the Auto-resume on rate limit toggle bound to preferences store", 
       onChange={() => {}}
     />
   )
-  expect(htmlUnchecked).toContain("Auto-resume on rate limit")
+  expect(htmlUnchecked).toContain("Enabled")
   expect(htmlUnchecked).toContain('type="checkbox"')
   expect(htmlUnchecked).not.toContain("checked")
 
@@ -305,7 +304,7 @@ test("renders the Auto-resume on rate limit toggle bound to preferences store", 
       onChange={() => {}}
     />
   )
-  expect(htmlChecked).toContain("Auto-resume on rate limit")
+  expect(htmlChecked).toContain("Enabled")
   expect(htmlChecked).toContain('type="checkbox"')
   expect(htmlChecked).toContain("checked")
 })

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -278,3 +278,34 @@ describe("ChangelogSection", () => {
     expect(html).toContain("Updating")
   })
 })
+
+import { usePreferencesStore } from "../stores/preferences"
+import { AutoResumeToggleSection } from "./SettingsPage"
+
+test("renders the Auto-resume on rate limit toggle bound to preferences store", () => {
+  // AutoResumeToggleSection is a pure prop-driven component exported from SettingsPage.
+  // SettingsPage wires it to usePreferencesStore; here we test the component directly.
+  usePreferencesStore.setState({ autoResumeOnRateLimit: false })
+  const stateOff = usePreferencesStore.getState()
+  const htmlUnchecked = renderToStaticMarkup(
+    <AutoResumeToggleSection
+      checked={stateOff.autoResumeOnRateLimit}
+      onChange={() => {}}
+    />
+  )
+  expect(htmlUnchecked).toContain("Auto-resume on rate limit")
+  expect(htmlUnchecked).toContain('type="checkbox"')
+  expect(htmlUnchecked).not.toContain("checked")
+
+  usePreferencesStore.setState({ autoResumeOnRateLimit: true })
+  const stateOn = usePreferencesStore.getState()
+  const htmlChecked = renderToStaticMarkup(
+    <AutoResumeToggleSection
+      checked={stateOn.autoResumeOnRateLimit}
+      onChange={() => {}}
+    />
+  )
+  expect(htmlChecked).toContain("Auto-resume on rate limit")
+  expect(htmlChecked).toContain('type="checkbox"')
+  expect(htmlChecked).toContain("checked")
+})

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -201,6 +201,7 @@ describe("ChangelogSection", () => {
         currentVersion="1.0.0"
         onInstallUpdate={() => {}}
         onCheckForUpdates={() => {}}
+        onForceReload={() => {}}
       />
     )
 
@@ -229,6 +230,7 @@ describe("ChangelogSection", () => {
         currentVersion="1.0.0"
         onInstallUpdate={() => {}}
         onCheckForUpdates={() => {}}
+        onForceReload={() => {}}
       />
     )
 
@@ -252,6 +254,7 @@ describe("ChangelogSection", () => {
         currentVersion="1.0.0"
         onInstallUpdate={() => {}}
         onCheckForUpdates={() => {}}
+        onForceReload={() => {}}
       />
     )
 
@@ -273,6 +276,7 @@ describe("ChangelogSection", () => {
         currentVersion="1.0.0"
         onInstallUpdate={() => {}}
         onCheckForUpdates={() => {}}
+        onForceReload={() => {}}
       />
     )
 

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -225,6 +225,7 @@ export function ChangelogSection({
   currentVersion,
   onInstallUpdate,
   onCheckForUpdates,
+  onForceReload,
 }: {
   status: ChangelogStatus
   releases: GithubRelease[]
@@ -234,6 +235,7 @@ export function ChangelogSection({
   currentVersion: string
   onInstallUpdate: () => void
   onCheckForUpdates: () => void
+  onForceReload: () => void
 }) {
   const latestVersion = updateSnapshot?.latestVersion ?? releases[0]?.tag_name ?? "Unknown"
   const currentVersionLabel = updateSnapshot?.currentVersion ?? currentVersion
@@ -283,8 +285,15 @@ export function ChangelogSection({
         </div>
       ) : null}
 
-      {!canInstallUpdate && status === "success" ? (
-        <div className="flex justify-end">
+      {status === "success" ? (
+        <div className="flex justify-end gap-2">
+          <SettingsHeaderButton
+            variant="outline"
+            onClick={onForceReload}
+            disabled={isUpdating}
+          >
+            {isUpdating ? "Re-deploying…" : "Re-deploy"}
+          </SettingsHeaderButton>
           <SettingsHeaderButton
             variant="outline"
             onClick={onCheckForUpdates}
@@ -344,7 +353,7 @@ export function ChangelogSection({
                   aria-label="View release on GitHub"
                   className={cn(
                     buttonVariants({ variant: "ghost", size: "icon-sm" }),
-                    "h-8 w-8 shrink-0 rounded-md hover:!bg-transparent hover:border-border/0"
+                    "h-11 w-11 md:h-8 md:w-8 shrink-0 rounded-md hover:!bg-transparent hover:border-border/0"
                   )}
                 >
                   <GitHubIcon className="h-4 w-4" />
@@ -763,7 +772,7 @@ export function SettingsPage() {
         className={cn(
           "mt-2 block text-sm font-medium",
           llmValidationStatus === "valid"
-            ? "text-emerald-600 dark:text-emerald-400"
+            ? "text-success"
             : llmValidationStatus === "invalid"
               ? "text-destructive"
               : "hidden"
@@ -1348,6 +1357,9 @@ export function SettingsPage() {
                     }}
                     onCheckForUpdates={() => {
                       void state.handleCheckForUpdates({ force: true })
+                    }}
+                    onForceReload={() => {
+                      void state.handleForceReload()
                     }}
                   />
                 )}

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -121,7 +121,7 @@ const QUICK_RESPONSE_PROVIDER_OPTIONS: Array<{ value: LlmProviderKind; label: st
   { value: "custom", label: "Custom" },
 ]
 
-const GITHUB_RELEASES_URL = "https://api.github.com/repos/jakemor/kanna/releases"
+const GITHUB_RELEASES_URL = "https://api.github.com/repos/cuongtranba/kanna/releases"
 const CHANGELOG_CACHE_TTL_MS = 5 * 60 * 1000
 
 type GithubRelease = {

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -462,21 +462,14 @@ export function AutoResumeToggleSection({
   onChange: (value: boolean) => void
 }) {
   return (
-    <section>
-      <h3 className="text-sm font-medium">Auto-resume on rate limit</h3>
-      <p className="text-xs text-muted-foreground">
-        When you hit a rate limit, automatically schedule &quot;continue&quot; at the reset time instead of asking.
-        You can still cancel each one from the chat.
-      </p>
-      <label className="mt-2 inline-flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(event) => onChange(event.target.checked)}
-        />
-        Enabled
-      </label>
-    </section>
+    <label className="inline-flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      Enabled
+    </label>
   )
 }
 
@@ -1161,7 +1154,7 @@ export function SettingsPage() {
 
                       <SettingsRow
                         title="Auto-resume on rate limit"
-                        description="When you hit a rate limit, automatically schedule &quot;continue&quot; at the reset time instead of asking. You can still cancel each one from the chat."
+                        description={'When you hit a rate limit, automatically schedule "continue" at the reset time instead of asking. You can still cancel each one from the chat.'}
                       >
                         <AutoResumeToggleSection
                           checked={autoResumeOnRateLimit}

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -59,6 +59,7 @@ import {
 } from "../stores/terminalPreferencesStore"
 import { useChatPreferencesStore } from "../stores/chatPreferencesStore"
 import { CHAT_SOUND_OPTIONS, useChatSoundPreferencesStore, type ChatSoundId, type ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import { usePreferencesStore } from "../stores/preferences"
 import type { KannaState } from "./useKannaState"
 
 const sidebarItems = [
@@ -453,6 +454,32 @@ function SettingsRow({
   )
 }
 
+export function AutoResumeToggleSection({
+  checked,
+  onChange,
+}: {
+  checked: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <section>
+      <h3 className="text-sm font-medium">Auto-resume on rate limit</h3>
+      <p className="text-xs text-muted-foreground">
+        When you hit a rate limit, automatically schedule &quot;continue&quot; at the reset time instead of asking.
+        You can still cancel each one from the chat.
+      </p>
+      <label className="mt-2 inline-flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => onChange(event.target.checked)}
+        />
+        Enabled
+      </label>
+    </section>
+  )
+}
+
 export function SettingsPage() {
   const navigate = useNavigate()
   const { sectionId } = useParams<{ sectionId: string }>()
@@ -482,6 +509,8 @@ export function SettingsPage() {
   const setChatSoundId = useChatSoundPreferencesStore((store) => store.setChatSoundId)
   const keybindings = state.keybindings
   const llmProvider = state.llmProvider
+  const autoResumeOnRateLimit = usePreferencesStore((state) => state.autoResumeOnRateLimit)
+  const setAutoResumeOnRateLimit = usePreferencesStore((state) => state.setAutoResumeOnRateLimit)
   const defaultProvider = useChatPreferencesStore((store) => store.defaultProvider)
   const providerDefaults = useChatPreferencesStore((store) => store.providerDefaults)
   const setDefaultProvider = useChatPreferencesStore((store) => store.setDefaultProvider)
@@ -1128,6 +1157,16 @@ export function SettingsPage() {
                             {minColumnWidth === DEFAULT_TERMINAL_MIN_COLUMN_WIDTH ? " (default)" : ""}
                           </div>
                         </div>
+                      </SettingsRow>
+
+                      <SettingsRow
+                        title="Auto-resume on rate limit"
+                        description="When you hit a rate limit, automatically schedule &quot;continue&quot; at the reset time instead of asking. You can still cancel each one from the chat."
+                      >
+                        <AutoResumeToggleSection
+                          checked={autoResumeOnRateLimit}
+                          onChange={setAutoResumeOnRateLimit}
+                        />
                       </SettingsRow>
                     </div>
                   </>

--- a/src/client/app/socket.test.ts
+++ b/src/client/app/socket.test.ts
@@ -122,27 +122,31 @@ describe("KannaSocket", () => {
   let documentTarget: FakeEventTarget & { visibilityState: "visible" | "hidden" }
   let timers: FakeTimers
 
+  function setGlobal(key: "window" | "document" | "WebSocket", value: unknown) {
+    Object.defineProperty(globalThis, key, { value, configurable: true, writable: true })
+  }
+
   beforeEach(() => {
     FakeWebSocket.instances = []
     timers = new FakeTimers()
     windowTarget = new FakeEventTarget()
     documentTarget = Object.assign(new FakeEventTarget(), { visibilityState: "visible" as const })
 
-    ;(globalThis as any).window = Object.assign(windowTarget, {
+    setGlobal("window", Object.assign(windowTarget, {
       setTimeout: timers.setTimeout,
       clearTimeout: timers.clearTimeout,
       setInterval: timers.setInterval,
       clearInterval: timers.clearInterval,
       location: { protocol: "http:", host: "localhost:3211" },
-    })
-    ;(globalThis as any).document = documentTarget
-    ;(globalThis as any).WebSocket = FakeWebSocket
+    }))
+    setGlobal("document", documentTarget)
+    setGlobal("WebSocket", FakeWebSocket)
   })
 
   afterEach(() => {
-    ;(globalThis as any).window = originalWindow
-    ;(globalThis as any).document = originalDocument
-    ;(globalThis as any).WebSocket = originalWebSocket
+    setGlobal("window", originalWindow)
+    setGlobal("document", originalDocument)
+    setGlobal("WebSocket", originalWebSocket)
   })
 
   test("does not ping when the connection is already fresh", async () => {

--- a/src/client/app/useKannaState.test.ts
+++ b/src/client/app/useKannaState.test.ts
@@ -258,6 +258,8 @@ describe("getActiveChatSnapshot", () => {
       availableProviders: [],
       slashCommands: [],
       slashCommandsLoading: false,
+      schedules: {},
+      liveScheduleId: null,
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-1")).toEqual(snapshot)
@@ -286,6 +288,8 @@ describe("getActiveChatSnapshot", () => {
       availableProviders: [],
       slashCommands: [],
       slashCommandsLoading: false,
+      schedules: {},
+      liveScheduleId: null,
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-new")).toBeNull()

--- a/src/client/app/useKannaState.test.ts
+++ b/src/client/app/useKannaState.test.ts
@@ -256,6 +256,7 @@ describe("getActiveChatSnapshot", () => {
         recentLimit: 200,
       },
       availableProviders: [],
+      slashCommands: [],
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-1")).toEqual(snapshot)
@@ -282,6 +283,7 @@ describe("getActiveChatSnapshot", () => {
         recentLimit: 200,
       },
       availableProviders: [],
+      slashCommands: [],
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-new")).toBeNull()

--- a/src/client/app/useKannaState.test.ts
+++ b/src/client/app/useKannaState.test.ts
@@ -257,6 +257,7 @@ describe("getActiveChatSnapshot", () => {
       },
       availableProviders: [],
       slashCommands: [],
+      slashCommandsLoading: false,
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-1")).toEqual(snapshot)
@@ -284,6 +285,7 @@ describe("getActiveChatSnapshot", () => {
       },
       availableProviders: [],
       slashCommands: [],
+      slashCommandsLoading: false,
     }
 
     expect(getActiveChatSnapshot(snapshot, "chat-new")).toBeNull()

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -820,9 +820,11 @@ export function useKannaState(activeChatId: string | null): KannaState {
       setChatReady(true)
       setCommandError(null)
       if (snapshot) {
-        useSlashCommandsStore.getState().setForChat(
+        const store = useSlashCommandsStore.getState()
+        store.setForChat(snapshot.runtime.chatId, snapshot.slashCommands ?? [])
+        store.setLoadingForChat(
           snapshot.runtime.chatId,
-          snapshot.slashCommands ?? [],
+          snapshot.slashCommandsLoading ?? false,
         )
       }
     })

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -8,6 +8,7 @@ import { useRightSidebarStore } from "../stores/rightSidebarStore"
 import { useTerminalLayoutStore } from "../stores/terminalLayoutStore"
 import { getEditorPresetLabel, useTerminalPreferencesStore } from "../stores/terminalPreferencesStore"
 import { useChatInputStore } from "../stores/chatInputStore"
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
 import type { ChatSnapshot, LocalProjectsSnapshot, SidebarChatRow, SidebarData } from "../../shared/types"
 import type { AskUserQuestionItem } from "../components/messages/types"
 import { useAppDialog } from "../components/ui/app-dialog"
@@ -818,6 +819,12 @@ export function useKannaState(activeChatId: string | null): KannaState {
       setHasOlderHistory(snapshot?.history.hasOlder ?? false)
       setChatReady(true)
       setCommandError(null)
+      if (snapshot) {
+        useSlashCommandsStore.getState().setForChat(
+          snapshot.runtime.chatId,
+          snapshot.slashCommands ?? [],
+        )
+      }
     })
     return () => {
       logKannaState("unsubscribing from chat", {

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -526,6 +526,7 @@ export interface KannaState {
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleReorderProjectGroups: (projectIds: string[]) => Promise<void>
+  importClaudeSessions: () => Promise<{ imported: number; skipped: number; failed: number; newProjects: number }>
   handleCopyPath: (localPath: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
   handleOpenExternalPath: (action: "open_finder" | "open_editor", localPath: string) => Promise<void>
@@ -1459,6 +1460,11 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }, [socket])
 
+  const importClaudeSessions = useCallback(async () => {
+    const result = await socket.command<{ imported: number; skipped: number; failed: number; newProjects: number }>({ type: "sessions.importClaude" })
+    return result
+  }, [socket])
+
   const openExternal = useCallback(async (command: {
     action: "open_finder" | "open_terminal" | "open_editor"
     localPath: string
@@ -1646,6 +1652,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleDeleteChat,
     handleRemoveProject,
     handleReorderProjectGroups,
+    importClaudeSessions,
     handleCopyPath,
     handleOpenExternal,
     handleOpenExternalPath,

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -515,6 +515,7 @@ export interface KannaState {
   handleCreateProject: (project: ProjectRequest) => Promise<void>
   handleCheckForUpdates: (options?: { force?: boolean }) => Promise<void>
   handleInstallUpdate: () => Promise<void>
+  handleForceReload: () => Promise<void>
   handleReadLlmProvider: () => Promise<void>
   handleWriteLlmProvider: (value: Pick<LlmProviderSnapshot, "provider" | "apiKey" | "model" | "baseUrl">) => Promise<void>
   handleValidateLlmProvider: (value: Pick<LlmProviderSnapshot, "provider" | "apiKey" | "model" | "baseUrl">) => Promise<LlmProviderValidationResult>
@@ -1214,6 +1215,33 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }, [dialog, socket])
 
+  const handleForceReload = useCallback(async () => {
+    try {
+      const result = await socket.command<UpdateInstallResult>({ type: "update.reload" })
+      if (!result.ok) {
+        clearUiUpdateRestartPhase()
+        setCommandError(null)
+        await dialog.alert({
+          title: result.userTitle ?? "Re-deploy failed",
+          description: result.userMessage ?? "Kanna could not re-deploy. Try again later.",
+          closeLabel: "OK",
+        })
+        return
+      }
+
+      if (result.action === "reload") {
+        window.location.reload()
+        return
+      }
+
+      setUiUpdateRestartPhase("awaiting_disconnect")
+      setCommandError(null)
+    } catch (error) {
+      clearUiUpdateRestartPhase()
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }, [dialog, socket])
+
   const handleSignOut = useCallback(async () => {
     try {
       const response = await fetch("/auth/logout", {
@@ -1649,6 +1677,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleCreateProject,
     handleCheckForUpdates,
     handleInstallUpdate,
+    handleForceReload,
     handleReadLlmProvider,
     handleWriteLlmProvider,
     handleValidateLlmProvider,

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -9,6 +9,7 @@ import { useTerminalLayoutStore } from "../stores/terminalLayoutStore"
 import { getEditorPresetLabel, useTerminalPreferencesStore } from "../stores/terminalPreferencesStore"
 import { useChatInputStore } from "../stores/chatInputStore"
 import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+import { usePreferencesStore } from "../stores/preferences"
 import type { ChatSnapshot, LocalProjectsSnapshot, SidebarChatRow, SidebarData } from "../../shared/types"
 import type { AskUserQuestionItem } from "../components/messages/types"
 import { useAppDialog } from "../components/ui/app-dialog"
@@ -1269,6 +1270,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     const attachments = options?.attachments ?? []
     if (activeChatId && isProcessing) {
       try {
+        const autoResumeOnRateLimit = usePreferencesStore.getState().autoResumeOnRateLimit
         await socket.command<{ queuedMessageId: string }>({
           type: "message.enqueue",
           chatId: activeChatId,
@@ -1278,6 +1280,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
           model: options?.model,
           modelOptions: options?.modelOptions,
           planMode: options?.planMode,
+          autoResumeOnRateLimit,
         })
         setCommandError(null)
         return
@@ -1347,6 +1350,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
         throw new Error("Open a project first")
       }
 
+      const autoResumeOnRateLimit = usePreferencesStore.getState().autoResumeOnRateLimit
       const result = await socket.command<{ chatId?: string }>({
         type: "chat.send",
         chatId: activeChatId ?? undefined,
@@ -1358,6 +1362,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
         model: options?.model,
         modelOptions: options?.modelOptions,
         planMode: options?.planMode,
+        autoResumeOnRateLimit,
       })
       sendTrace.ackAt = performance.now()
       sendTrace.serverChatId = result.chatId ?? sendTrace.serverChatId

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -526,7 +526,7 @@ export interface KannaState {
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
   handleRemoveProject: (projectId: string) => Promise<void>
   handleReorderProjectGroups: (projectIds: string[]) => Promise<void>
-  importClaudeSessions: () => Promise<{ imported: number; skipped: number; failed: number; newProjects: number }>
+  importClaudeSessions: () => Promise<{ imported: number; updated: number; skipped: number; failed: number; newProjects: number }>
   handleCopyPath: (localPath: string) => Promise<void>
   handleOpenExternal: (action: "open_finder" | "open_terminal" | "open_editor") => Promise<void>
   handleOpenExternalPath: (action: "open_finder" | "open_editor", localPath: string) => Promise<void>
@@ -1461,7 +1461,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   }, [socket])
 
   const importClaudeSessions = useCallback(async () => {
-    const result = await socket.command<{ imported: number; skipped: number; failed: number; newProjects: number }>({ type: "sessions.importClaude" })
+    const result = await socket.command<{ imported: number; updated: number; skipped: number; failed: number; newProjects: number }>({ type: "sessions.importClaude" })
     return result
   }, [socket])
 

--- a/src/client/components/LocalDev.tsx
+++ b/src/client/components/LocalDev.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, type ComponentType, type ReactNode } from "react"
 import {
-  ArrowLeftRight,
   Check,
   ChevronRight,
   CodeXml,
@@ -46,11 +45,12 @@ function CopyButton({ text }: { text: string }) {
   return (
     <Button
       variant="ghost"
-      size="icon"
-      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+      size="icon-mobile"
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      className="text-muted-foreground hover:text-foreground"
       onClick={() => void handleCopy()}
     >
-      {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+      {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
     </Button>
   )
 }
@@ -91,18 +91,18 @@ function HowItWorksItem({
   iconClassName?: string
 }) {
   return (
-    <div className="flex flex-col items-center gap-0">
-      <div className="p-3 mb-2 rounded-xl bg-background border border-border">
-        <Icon className={iconClassName || "h-8 w-8 text-muted-foreground"} />
-      </div>
-      <span className="text-sm font-medium">{title}</span>
-      <span className="text-xs text-muted-foreground">{subtitle}</span>
+    <div className="flex flex-col items-start gap-1.5 min-w-0">
+      <Icon className={iconClassName || "h-5 w-5 text-muted-foreground"} />
+      <span className="text-sm font-medium text-foreground">{title}</span>
+      <span className="text-xs text-muted-foreground leading-tight">{subtitle}</span>
     </div>
   )
 }
 
 function HowItWorksConnector() {
-  return <ArrowLeftRight className="h-4 w-4 text-muted-foreground" />
+  return (
+    <div aria-hidden className="mt-5 h-px w-6 shrink-0 bg-border" />
+  )
 }
 
 function Step({
@@ -215,7 +215,7 @@ export function LocalDev({
               <div className="mb-10">
               <SectionHeader>How it works</SectionHeader>
               <InfoCard>
-                <div className="flex items-center justify-around gap-6 py-4 px-2">
+                <div className="flex items-start gap-4 py-2 px-2">
                   <HowItWorksItem icon={Terminal} title={`${APP_NAME} CLI`} subtitle="On Your Machine" />
                   <HowItWorksConnector />
                   <HowItWorksItem icon={Monitor} title={`${APP_NAME} Server`} subtitle="Local WebSocket" />
@@ -276,7 +276,7 @@ export function LocalDev({
               </Button>
             </div>
             {projects.length > 0 ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-4 3xl:grid-cols-5 gap-2">
+              <div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(min(260px,100%),1fr))]">
                 {projects.map((project) => (
                   <ProjectCard
                     key={project.localPath}

--- a/src/client/components/chat-ui/AutoContinueCard.test.tsx
+++ b/src/client/components/chat-ui/AutoContinueCard.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { AutoContinueCard } from "./AutoContinueCard"
+
+describe("AutoContinueCard", () => {
+  test("proposed state renders Schedule and Dismiss buttons", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "proposed",
+          scheduledAt: null,
+          tz: "Asia/Saigon",
+          resetAt: Date.UTC(2026, 3, 22, 17, 0),
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Schedule")
+    expect(html).toContain("Dismiss")
+  })
+
+  test("scheduled state renders Change time and Cancel buttons", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "scheduled",
+          scheduledAt: Date.UTC(2026, 3, 22, 17, 0),
+          tz: "Asia/Saigon",
+          resetAt: Date.UTC(2026, 3, 22, 17, 0),
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Change time")
+    expect(html).toContain("Cancel")
+  })
+
+  test("fired state renders Auto-continued line without controls", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "fired",
+          scheduledAt: 1_000,
+          tz: "Asia/Saigon",
+          resetAt: 1_000,
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Auto-continued")
+    expect(html).not.toContain("Cancel")
+  })
+
+  test("cancelled state renders Auto-continue cancelled line", () => {
+    const html = renderToStaticMarkup(
+      <AutoContinueCard
+        schedule={{
+          scheduleId: "s1",
+          state: "cancelled",
+          scheduledAt: null,
+          tz: "Asia/Saigon",
+          resetAt: 1_000,
+          detectedAt: 0,
+        }}
+        onAccept={() => {}}
+        onReschedule={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html).toContain("Auto-continue cancelled")
+  })
+})

--- a/src/client/components/chat-ui/AutoContinueCard.tsx
+++ b/src/client/components/chat-ui/AutoContinueCard.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from "react"
+import type { AutoContinueSchedule } from "../../../shared/types"
+import { formatLocal, parseLocal } from "../../lib/autoContinueTime"
+import { Button } from "../ui/button"
+import { Input } from "../ui/input"
+
+export interface AutoContinueCardProps {
+  schedule: AutoContinueSchedule
+  onAccept: (scheduledAtMs: number) => void
+  onReschedule: (scheduledAtMs: number) => void
+  onCancel: () => void
+}
+
+export function AutoContinueCard({ schedule, onAccept, onReschedule, onCancel }: AutoContinueCardProps) {
+  const [draft, setDraft] = useState<string>(() => formatLocal(
+    schedule.scheduledAt ?? schedule.resetAt,
+    schedule.tz,
+  ))
+  const [editing, setEditing] = useState(false)
+
+  const parsed = useMemo(() => parseLocal(draft, schedule.tz), [draft, schedule.tz])
+  const isFuture = parsed !== null && parsed > Date.now()
+  const inputInvalid = parsed === null ? "Use format dd/mm/yyyy hh:mm" :
+    !isFuture ? "Time must be in the future" : null
+
+  if (schedule.state === "fired") {
+    const at = formatLocal(schedule.scheduledAt ?? schedule.resetAt, schedule.tz)
+    return <div className="rounded border px-3 py-2 text-sm">Auto-continued at {at}</div>
+  }
+
+  if (schedule.state === "cancelled") {
+    return <div className="rounded border px-3 py-2 text-sm opacity-70">Auto-continue cancelled</div>
+  }
+
+  if (schedule.state === "proposed") {
+    const passed = schedule.resetAt <= Date.now()
+    return (
+      <div className="rounded border px-3 py-2 text-sm space-y-2">
+        <div className="font-medium">Rate limit hit — schedule auto-continue?</div>
+        {passed && <div className="text-amber-500">Reset time has passed — accept to continue now.</div>}
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="dd/mm/yyyy hh:mm"
+        />
+        {inputInvalid && <div className="text-xs text-red-500">{inputInvalid}</div>}
+        <div className="flex gap-2">
+          <Button disabled={!isFuture} onClick={() => parsed !== null && onAccept(parsed)}>Schedule</Button>
+          <Button variant="ghost" onClick={onCancel}>Dismiss</Button>
+        </div>
+      </div>
+    )
+  }
+
+  // scheduled
+  const displayAt = formatLocal(schedule.scheduledAt ?? schedule.resetAt, schedule.tz)
+  if (!editing) {
+    const tzLabel = schedule.tz === "system" ? "local" : schedule.tz
+    return (
+      <div className="rounded border px-3 py-2 text-sm flex items-center justify-between gap-2">
+        <div>Auto-continue at {displayAt} ({tzLabel})</div>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={() => setEditing(true)}>Change time</Button>
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded border px-3 py-2 text-sm space-y-2">
+      <Input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        placeholder="dd/mm/yyyy hh:mm"
+      />
+      {inputInvalid && <div className="text-xs text-red-500">{inputInvalid}</div>}
+      <div className="flex gap-2">
+        <Button disabled={!isFuture} onClick={() => { if (parsed !== null) { onReschedule(parsed); setEditing(false) } }}>Save</Button>
+        <Button variant="ghost" onClick={() => setEditing(false)}>Back</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/client/components/chat-ui/ChatInput.test.ts
+++ b/src/client/components/chat-ui/ChatInput.test.ts
@@ -137,3 +137,14 @@ describe("ChatInput", () => {
     expect(html).not.toContain('type="file" multiple="" class="hidden"')
   })
 })
+
+describe("mention picker wiring", () => {
+  test("shouldShowMentionPicker trigger produces the expected shape for mid-input @", async () => {
+    const { shouldShowMentionPicker } = await import("../../lib/mention-suggestions")
+    expect(shouldShowMentionPicker("hello @src", 10)).toEqual({
+      open: true,
+      query: "src",
+      tokenStart: 6,
+    })
+  })
+})

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { SlashCommandPicker } from "./SlashCommandPicker"
 import { applyCommandToInput, filterCommands, shouldShowPicker } from "../../lib/slash-commands"
-import { useSlashCommands } from "../../hooks/useSlashCommands"
+import { useSlashCommands, useSlashCommandsLoading } from "../../hooks/useSlashCommands"
 import type { SlashCommand } from "../../../shared/types"
 import { ArrowUp, Paperclip } from "lucide-react"
 import {
@@ -225,6 +225,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const providerPrefs = getEffectiveComposerState(composerState, activeProvider, providerDefaults)
   const selectedProvider = providerLocked ? activeProvider : composerState.provider
   const slashCommands = useSlashCommands(chatId ?? null)
+  const slashCommandsLoading = useSlashCommandsLoading(chatId ?? null)
   const [pickerIndex, setPickerIndex] = useState(0)
   const [pickerDismissed, setPickerDismissed] = useState(false)
   const [caretVersion, setCaretVersion] = useState(0)
@@ -245,7 +246,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   )
   const pickerOpen =
     pickerTrigger.open &&
-    slashCommands.length > 0 &&
+    (slashCommands.length > 0 || slashCommandsLoading) &&
     !pickerDismissed &&
     selectedProvider === "claude"
 
@@ -763,6 +764,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
               <SlashCommandPicker
                 items={filteredCommands}
                 activeIndex={pickerIndex}
+                loading={slashCommandsLoading}
                 onSelect={acceptCommand}
                 onHoverIndex={setPickerIndex}
               />

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -859,7 +859,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             </ScrollArea>
           ) : null}
 
-          <div className="relative flex items-end max-w-[840px] mx-auto border dark:bg-card/40 backdrop-blur-lg border-border rounded-[29px] pr-1.5">
+          <div className="relative flex items-end max-w-[840px] mx-auto border bg-background dark:bg-card/90 border-border rounded-[29px] pr-1.5 transition-colors focus-within:border-ring/60 focus-within:ring-2 focus-within:ring-ring/30">
             {pickerOpen && (
               <SlashCommandPicker
                 items={filteredCommands}
@@ -882,7 +882,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
               aria-label="Add attachment"
               className={cn(
                 buttonVariants({ variant: "ghost", size: "icon" }),
-                "relative md:hidden flex-shrink-0 ml-1 mb-1 h-10 w-10 rounded-full text-muted-foreground hover:text-foreground",
+                "relative md:hidden flex-shrink-0 ml-1 mb-1 h-11 w-11 rounded-full text-muted-foreground hover:text-foreground",
                 disabled && "pointer-events-none opacity-50",
               )}
             >
@@ -920,7 +920,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
               disabled={disabled}
-              className="flex-1 text-base p-3 md:p-4 !pr-2 pl-0 md:pl-6 resize-none max-h-[200px] outline-none bg-transparent border-0 shadow-none"
+              className="flex-1 text-base p-3 md:p-4 !pr-2 pl-0 md:pl-6 resize-none max-h-[200px] outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 bg-transparent border-0 shadow-none"
             />
             <Button
               type="button"
@@ -936,7 +936,8 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
               }}
               disabled={disabled || (!canCancel && !canSubmit) || hasPendingUploads}
               size="icon"
-              className="flex-shrink-0 bg-slate-600 text-white dark:bg-white dark:text-slate-900 rounded-full cursor-pointer h-10 w-10 md:h-11 md:w-11 mb-1 -mr-0.5 md:mr-0 md:mb-1.5 touch-manipulation disabled:bg-white/60 disabled:text-slate-700"
+              aria-label={canCancel ? "Stop" : "Send message"}
+              className="flex-shrink-0 bg-primary text-background rounded-full cursor-pointer h-11 w-11 mb-1 -mr-0.5 md:mr-0 md:mb-1.5 touch-manipulation disabled:opacity-50"
             >
               {hasTextToSend ? (
                 <ArrowUp className="h-5 w-5 md:h-6 md:w-6" />

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -229,7 +229,9 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const [pickerDismissed, setPickerDismissed] = useState(false)
   const [caretVersion, setCaretVersion] = useState(0)
 
-  useEffect(() => { setPickerDismissed(false) }, [value])
+  useEffect(() => {
+    if (!value.startsWith("/")) setPickerDismissed(false)
+  }, [value])
 
   const caret = textareaRef.current?.selectionStart ?? value.length
   const pickerTrigger = useMemo(
@@ -259,7 +261,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     })
     setValue(nextValue)
     if (chatId) setDraft(chatId, nextValue)
-    setPickerDismissed(false)
+    setPickerDismissed(true)
     requestAnimationFrame(() => {
       const el = textareaRef.current
       if (!el) return

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1,6 +1,9 @@
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { SlashCommandPicker } from "./SlashCommandPicker"
+import { MentionPicker } from "./MentionPicker"
 import { applyCommandToInput, filterCommands, shouldShowPicker } from "../../lib/slash-commands"
+import { applyMentionToInput, shouldShowMentionPicker } from "../../lib/mention-suggestions"
+import { useMentionSuggestions, type ProjectPath } from "../../hooks/useMentionSuggestions"
 import { useSlashCommands, useSlashCommandsLoading } from "../../hooks/useSlashCommands"
 import type { SlashCommand } from "../../../shared/types"
 import { ArrowUp, Paperclip } from "lucide-react"
@@ -254,6 +257,33 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     if (pickerOpen) setPickerIndex(0)
   }, [pickerOpen, pickerTrigger.query])
 
+  const [mentionIndex, setMentionIndex] = useState(0)
+  const [mentionDismissed, setMentionDismissed] = useState(false)
+
+  const mentionTrigger = useMemo(
+    () => shouldShowMentionPicker(value, caret),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value, caret, caretVersion],
+  )
+  const mentionState = useMentionSuggestions({
+    projectId: projectId ?? null,
+    query: mentionTrigger.query,
+    enabled: mentionTrigger.open && !mentionDismissed,
+  })
+  const mentionOpen =
+    mentionTrigger.open &&
+    !mentionDismissed &&
+    !pickerOpen &&
+    (mentionState.items.length > 0 || mentionState.loading)
+
+  useEffect(() => {
+    if (mentionOpen) setMentionIndex(0)
+  }, [mentionOpen, mentionTrigger.query])
+
+  useEffect(() => {
+    if (!mentionTrigger.open) setMentionDismissed(false)
+  }, [mentionTrigger.open, mentionTrigger.tokenStart])
+
   function acceptCommand(cmd: SlashCommand) {
     const { value: nextValue, caret: nextCaret } = applyCommandToInput({
       value,
@@ -263,6 +293,52 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     setValue(nextValue)
     if (chatId) setDraft(chatId, nextValue)
     setPickerDismissed(true)
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(nextCaret, nextCaret)
+    })
+  }
+
+  function acceptMention(item: ProjectPath) {
+    if (!projectId) {
+      setMentionDismissed(true)
+      return
+    }
+    const { value: nextValue, caret: nextCaret } = applyMentionToInput({
+      value,
+      caret,
+      tokenStart: mentionTrigger.tokenStart,
+      pickedPath: item.path,
+    })
+    setValue(nextValue)
+    if (chatId) setDraft(chatId, nextValue)
+
+    const relativeForAttachment = item.path.endsWith("/") ? item.path.slice(0, -1) : item.path
+    const alreadyMentioned = attachments.some(
+      (a) => a.kind === "mention" && a.relativePath === `./${relativeForAttachment}`,
+    )
+    if (!alreadyMentioned) {
+      const contentUrl = item.kind === "file"
+        ? `/api/projects/${projectId}/files/${encodeURIComponent(relativeForAttachment)}/content`
+        : ""
+      setAttachments((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          kind: "mention",
+          displayName: relativeForAttachment,
+          absolutePath: "",
+          relativePath: `./${relativeForAttachment}`,
+          contentUrl,
+          mimeType: "",
+          size: 0,
+          status: "uploaded",
+        },
+      ])
+    }
+    setMentionDismissed(true)
     requestAnimationFrame(() => {
       const el = textareaRef.current
       if (!el) return
@@ -604,6 +680,30 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   }
 
   function handleKeyDown(event: React.KeyboardEvent) {
+    if (mentionOpen) {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        setMentionDismissed(true)
+        return
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        setMentionIndex((i) => Math.min(mentionState.items.length - 1, i + 1))
+        return
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault()
+        setMentionIndex((i) => Math.max(0, i - 1))
+        return
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault()
+        const item = mentionState.items[mentionIndex]
+        if (item) acceptMention(item)
+        return
+      }
+    }
+
     if (pickerOpen) {
       if (event.key === "Escape") {
         event.preventDefault()
@@ -749,7 +849,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                     ) : (
                       <AttachmentFileCard
                         attachment={attachment}
-                        onClick={attachment.status === "uploaded" ? () => handleAttachmentPreview(attachment) : undefined}
+                        onClick={attachment.status === "uploaded" && attachment.contentUrl ? () => handleAttachmentPreview(attachment) : undefined}
                         onRemove={() => removeAttachment(attachment)}
                       />
                     )}
@@ -767,6 +867,15 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 loading={slashCommandsLoading}
                 onSelect={acceptCommand}
                 onHoverIndex={setPickerIndex}
+              />
+            )}
+            {mentionOpen && (
+              <MentionPicker
+                items={mentionState.items}
+                activeIndex={mentionIndex}
+                loading={mentionState.loading}
+                onSelect={acceptMention}
+                onHoverIndex={setMentionIndex}
               />
             )}
             <label

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1,4 +1,8 @@
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { SlashCommandPicker } from "./SlashCommandPicker"
+import { applyCommandToInput, filterCommands, shouldShowPicker } from "../../lib/slash-commands"
+import { useSlashCommands } from "../../hooks/useSlashCommands"
+import type { SlashCommand } from "../../../shared/types"
 import { ArrowUp, Paperclip } from "lucide-react"
 import {
   type AgentProvider,
@@ -220,6 +224,50 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const providerLocked = activeProvider !== null
   const providerPrefs = getEffectiveComposerState(composerState, activeProvider, providerDefaults)
   const selectedProvider = providerLocked ? activeProvider : composerState.provider
+  const slashCommands = useSlashCommands(chatId ?? null)
+  const [pickerIndex, setPickerIndex] = useState(0)
+  const [pickerDismissed, setPickerDismissed] = useState(false)
+  const [caretVersion, setCaretVersion] = useState(0)
+
+  useEffect(() => { setPickerDismissed(false) }, [value])
+
+  const caret = textareaRef.current?.selectionStart ?? value.length
+  const pickerTrigger = useMemo(
+    () => shouldShowPicker(value, caret),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value, caret, caretVersion],
+  )
+  const filteredCommands = useMemo(
+    () => (pickerTrigger.open ? filterCommands(slashCommands, pickerTrigger.query) : []),
+    [pickerTrigger.open, pickerTrigger.query, slashCommands],
+  )
+  const pickerOpen =
+    pickerTrigger.open &&
+    slashCommands.length > 0 &&
+    !pickerDismissed &&
+    selectedProvider === "claude"
+
+  useEffect(() => {
+    if (pickerOpen) setPickerIndex(0)
+  }, [pickerOpen, pickerTrigger.query])
+
+  function acceptCommand(cmd: SlashCommand) {
+    const { value: nextValue, caret: nextCaret } = applyCommandToInput({
+      value,
+      caret,
+      command: cmd,
+    })
+    setValue(nextValue)
+    if (chatId) setDraft(chatId, nextValue)
+    setPickerDismissed(false)
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(nextCaret, nextCaret)
+    })
+  }
+
   const providerConfig = availableProviders.find((provider) => provider.id === selectedProvider) ?? availableProviders[0]
   const showPlanMode = providerConfig?.supportsPlanMode ?? false
   const activeContextWindow = useMemo(() => {
@@ -553,6 +601,30 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   }
 
   function handleKeyDown(event: React.KeyboardEvent) {
+    if (pickerOpen) {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        setPickerDismissed(true)
+        return
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        setPickerIndex((i) => Math.min(filteredCommands.length - 1, i + 1))
+        return
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault()
+        setPickerIndex((i) => Math.max(0, i - 1))
+        return
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault()
+        const cmd = filteredCommands[pickerIndex]
+        if (cmd) acceptCommand(cmd)
+        return
+      }
+    }
+
     if (event.key === "Tab" && !event.shiftKey) {
       event.preventDefault()
       focusNextChatInput(textareaRef.current, document)
@@ -684,7 +756,15 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             </ScrollArea>
           ) : null}
 
-          <div className="flex items-end max-w-[840px] mx-auto border dark:bg-card/40 backdrop-blur-lg border-border rounded-[29px] pr-1.5">
+          <div className="relative flex items-end max-w-[840px] mx-auto border dark:bg-card/40 backdrop-blur-lg border-border rounded-[29px] pr-1.5">
+            {pickerOpen && (
+              <SlashCommandPicker
+                items={filteredCommands}
+                activeIndex={pickerIndex}
+                onSelect={acceptCommand}
+                onHoverIndex={setPickerIndex}
+              />
+            )}
             <label
               aria-label="Add attachment"
               className={cn(
@@ -720,7 +800,10 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 setValue(event.target.value)
                 if (chatId) setDraft(chatId, event.target.value)
                 autoResize()
+                setCaretVersion((v) => v + 1)
               }}
+              onSelect={() => setCaretVersion((v) => v + 1)}
+              onKeyUp={() => setCaretVersion((v) => v + 1)}
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
               disabled={disabled}

--- a/src/client/components/chat-ui/ChatNavbar.tsx
+++ b/src/client/components/chat-ui/ChatNavbar.tsx
@@ -59,12 +59,13 @@ export function ChatNavbar({
       )}
     >
       <div className="relative flex items-center gap-2 w-full">
-        <div className={`flex items-center gap-1 flex-shrink-0 border border-border rounded-full ${sidebarCollapsed ? 'px-1.5' : ''} p-1 backdrop-blur-lg`}>
+        <div className={`flex items-center gap-1 flex-shrink-0 border border-border rounded-full ${sidebarCollapsed ? 'px-1.5' : ''} p-1 bg-card/95`}>
           <Button
             variant="ghost"
-            size="icon"
+            size="icon-mobile"
             className="md:hidden"
             onClick={onOpenSidebar}
+            aria-label="Open sidebar"
           >
             <Menu className="size-4.5" />
           </Button>
@@ -79,6 +80,7 @@ export function ChatNavbar({
                 className="hidden md:flex"
                 onClick={onExpandSidebar}
                 title="Expand sidebar"
+                aria-label="Expand sidebar"
               >
                 <PanelLeft className="size-4.5" />
               </Button>
@@ -90,6 +92,7 @@ export function ChatNavbar({
             className="hover:!border-border/0 hover:!bg-transparent"
             onClick={onNewChat}
             title="Compose"
+            aria-label="New chat"
           >
             <SquarePen className="size-4.5" />
           </Button>
@@ -98,7 +101,7 @@ export function ChatNavbar({
         <div className="flex-1 min-w-0" />
 
         {localPath && (onOpenExternal || onToggleEmbeddedTerminal || onToggleRightSidebar) ? (
-          <div className="flex items-center  flex-shrink-0 border border-border rounded-full px-2 py-1 backdrop-blur-lg">
+          <div className="flex items-center  flex-shrink-0 border border-border rounded-full px-2 py-1 bg-card/95">
             {(onOpenExternal || onToggleEmbeddedTerminal) ? (
               <>
               {onOpenExternal ? (
@@ -109,6 +112,7 @@ export function ChatNavbar({
                       size="none"
                       onClick={() => onOpenExternal("open_finder")}
                       title="Open in Finder"
+                      aria-label="Open in Finder"
                       className="border border-border/0 hover:!border-border/0 pl-2 pr-1.5 h-9 hover:!bg-transparent"
                     >
                       <FolderOpen strokeWidth={2} className="h-4.5" />
@@ -124,6 +128,8 @@ export function ChatNavbar({
                       variant="ghost"
                       size="none"
                       onClick={onToggleEmbeddedTerminal}
+                      aria-label="Toggle terminal"
+                      aria-pressed={embeddedTerminalVisible}
                       className={cn(
                         "border border-border/0 hover:!border-border/0 px-1.5 h-9 hover:!bg-transparent",
                         embeddedTerminalVisible && "text-foreground"
@@ -143,6 +149,7 @@ export function ChatNavbar({
                       size="none"
                       onClick={() => onOpenExternal("open_editor")}
                       title={`Open in ${editorLabel}`}
+                      aria-label={`Open in ${editorLabel}`}
                       className="border border-border/0 hover:!border-border/0 px-1.5 h-9 hover:!bg-transparent"
                     >
                       <Code strokeWidth={2} className="h-4.5" />
@@ -159,6 +166,8 @@ export function ChatNavbar({
                   <Button
                     variant="ghost"
                     onClick={onToggleRightSidebar}
+                    aria-label={rightSidebarVisible ? "Close branch sidebar" : "Open branch sidebar"}
+                    aria-pressed={rightSidebarVisible}
                     className={cn(
                       "border flex flex-row items-center gap-1.5 h-9 border-border/0 pl-1.5 pr-2 hover:!border-border/0 hover:!bg-transparent",
                       rightSidebarVisible && "text-foreground"

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -313,7 +313,7 @@ export function ChatPreferenceControls({
               <span>{codexModelOptions?.fastMode ? "Fast Mode" : "Standard"}</span>
             </>
           )}
-          triggerClassName={codexModelOptions?.fastMode ? "text-emerald-500 dark:text-emerald-400" : undefined}
+          triggerClassName={codexModelOptions?.fastMode ? "text-success" : undefined}
         >
           {(close) => (
             <>
@@ -348,7 +348,7 @@ export function ChatPreferenceControls({
               <span>{planMode ? "Plan Mode" : "Full Access"}</span>
             </>
           )}
-          triggerClassName={planMode ? "text-blue-400 dark:text-blue-300" : undefined}
+          triggerClassName={planMode ? "text-info" : undefined}
         >
           {(close) => (
             <>

--- a/src/client/components/chat-ui/MentionPicker.tsx
+++ b/src/client/components/chat-ui/MentionPicker.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react"
+import { AtSign, Folder, FileText } from "lucide-react"
+import type { ProjectPath } from "../../hooks/useMentionSuggestions"
+import { cn } from "../../lib/utils"
+
+interface MentionPickerProps {
+  items: ProjectPath[]
+  activeIndex: number
+  loading: boolean
+  onSelect: (path: ProjectPath) => void
+  onHoverIndex: (index: number) => void
+}
+
+const SKELETON_ROWS = 4
+
+export function MentionPicker({ items, activeIndex, loading, onSelect, onHoverIndex }: MentionPickerProps) {
+  const listRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const el = listRef.current?.children.item(activeIndex) as HTMLElement | null
+    el?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
+
+  if (items.length === 0 && loading) {
+    return (
+      <ul
+        aria-busy="true"
+        aria-label="Loading file suggestions"
+        className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover shadow-md overflow-hidden"
+      >
+        {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+          <li
+            key={i}
+            className="flex items-center gap-2 px-3 py-1.5"
+            data-testid="mention-picker-skeleton-row"
+          >
+            <span className="h-3.5 w-3.5 rounded bg-muted animate-pulse" />
+            <span className="h-3 w-40 max-w-full rounded bg-muted animate-pulse" />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+        No matching files
+      </div>
+    )
+  }
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
+    >
+      {items.map((item, i) => {
+        const Icon = item.kind === "dir" ? Folder : FileText
+        return (
+          <li
+            key={`${item.kind}:${item.path}`}
+            role="option"
+            aria-selected={i === activeIndex}
+            onMouseDown={(event) => {
+              event.preventDefault()
+              onSelect(item)
+            }}
+            onMouseEnter={() => onHoverIndex(i)}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 cursor-pointer text-sm",
+              i === activeIndex && "bg-accent text-accent-foreground",
+            )}
+          >
+            <AtSign className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="font-mono truncate">{item.path}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/client/components/chat-ui/RightSidebar.tsx
+++ b/src/client/components/chat-ui/RightSidebar.tsx
@@ -117,7 +117,7 @@ function IconButton(props: {
           title={props.label}
           onClick={props.onClick}
           className={cn(
-            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+            "flex h-11 w-11 md:h-7 md:w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
             props.active && "bg-accent text-foreground"
           )}
         >
@@ -243,19 +243,19 @@ function CommitHistoryRow({ entry, isPendingPush = false }: { entry: ChatBranchH
       {entry.tags.length > 0 ? (
         <div className="flex shrink-0 flex-wrap justify-end gap-1">
           {entry.tags.map((tag) => (
-            <span key={tag} className="inline-flex items-center rounded-full bg-slate-900/10 border-black/10 dark:bg-white/10 border dark:border-white/10  px-2 py-0.5 text-[11px]">
+            <span key={tag} className="inline-flex items-center rounded-full bg-muted border border-border  px-2 py-0.5 text-[11px]">
               {tag}
             </span>
           ))}
           {isPendingPush ? (
-            <span className="inline-flex items-center rounded-full bg-slate-900/10 border-black/10 dark:bg-white/10 border dark:border-white/10  px-2 py-0.5 text-[11px]">
+            <span className="inline-flex items-center rounded-full bg-muted border border-border  px-2 py-0.5 text-[11px]">
               <ArrowUp className="size-3" />
             </span>
           ) : null}
         </div>
       ) : isPendingPush ? (
         <div className="flex shrink-0 flex-wrap justify-end gap-1">
-          <span className="inline-flex items-center rounded-full bg-slate-900/10 border-black/10 dark:bg-white/10 border dark:border-white/10  px-2 py-0.5 text-[11px]">
+          <span className="inline-flex items-center rounded-full bg-muted border border-border  px-2 py-0.5 text-[11px]">
             <ArrowUp className="size-3" />
           </span>
         </div>
@@ -507,7 +507,7 @@ function GitHubPublishModal({
                             className={cn(
                               "flex size-6 items-center justify-center rounded-md",
                               availability.available
-                                ? "text-emerald-600 dark:text-emerald-400"
+                                ? "text-success"
                                 : "text-destructive"
                             )}
                           >
@@ -528,7 +528,7 @@ function GitHubPublishModal({
                     onChange={(event) => setDescription(event.target.value)}
                     rows={3}
                     placeholder="Optional description"
-                    className="pl-9 outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
+                    className="pl-9 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   />
                 </div>
               </div>
@@ -843,9 +843,9 @@ function MergeBranchModal({
             ) : preview ? (
               <div className="flex items-start gap-2">
                 {preview.status === "up_to_date" ? (
-                  <Check className="mt-1 size-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                  <Check className="mt-1 size-3.5 shrink-0 text-success" />
                 ) : preview.status === "conflicts" ? (
-                  <AlertTriangle className="mt-1 size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <AlertTriangle className="mt-1 size-3.5 shrink-0 text-warning" />
                 ) : preview.status === "mergeable" ? (
                   <GitBranchPlus className="mt-1 size-3.5 shrink-0 text-muted-foreground" />
                 ) : (
@@ -1222,9 +1222,9 @@ function DiffFileCard({
             </div>
             <div className="flex shrink-0 items-center gap-2 select-none">
               <span className="whitespace-nowrap text-xs font-mono">
-                {file.additions > 0 ? <span className="text-emerald-600 dark:text-emerald-400">+{file.additions}</span> : null}
+                {file.additions > 0 ? <span className="text-success">+{file.additions}</span> : null}
                 {file.deletions > 0 ? (
-                  <span className={file.additions > 0 ? "ml-2 text-red-600 dark:text-red-400" : "text-red-600 dark:text-red-400"}>
+                  <span className={file.additions > 0 ? "ml-2 text-destructive" : "text-destructive"}>
                     -{file.deletions}
                   </span>
                 ) : null}
@@ -1318,7 +1318,7 @@ function DiffFileCard({
             event.stopPropagation()
             fileActions.onDiscardFile(file.path)
           }}
-          className="text-destructive dark:text-red-400 hover:bg-destructive/10 focus:bg-destructive/10 dark:hover:bg-red-500/20 dark:focus:bg-red-500/20"
+          className="text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
         >
           <Trash2 className="h-3.5 w-3.5" />
           <span className="text-xs font-medium">Discard Changes</span>
@@ -1837,7 +1837,7 @@ function RightSidebarImpl({
                   <div className="pointer-events-none sticky inset-x-0 bottom-11 py-1 pb-6 z-30 overflow-y-auto">
                   <div className="absolute inset-x-0 bottom-0 top-0 bg-gradient-to-t from-background to-transparent" />
                   <div className="pointer-events-auto relative">
-                    <div className="space-y-0 rounded-xl  backdrop-blur-md mx-auto max-w-[700px]">
+                    <div className="space-y-0 rounded-xl mx-auto max-w-[700px]">
                       <Input
                         value={summary}
                         onChange={(event) => {
@@ -1864,7 +1864,7 @@ function RightSidebarImpl({
                         onKeyDown={handleCommitKeyDown}
                         placeholder="Description"
                         rows={5}
-                        className="-mt-px rounded-t-none rounded-b-xl px-3 outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:border-border mb-2"
+                        className="-mt-px rounded-t-none rounded-b-xl px-3 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background mb-2"
                         disabled={isBusy || diffs.status !== "ready"}
                       />
                       <div className="w-full flex flex-row">

--- a/src/client/components/chat-ui/SlashCommandPicker.tsx
+++ b/src/client/components/chat-ui/SlashCommandPicker.tsx
@@ -5,17 +5,42 @@ import { cn } from "../../lib/utils"
 interface SlashCommandPickerProps {
   items: SlashCommand[]
   activeIndex: number
+  loading: boolean
   onSelect: (command: SlashCommand) => void
   onHoverIndex: (index: number) => void
 }
 
-export function SlashCommandPicker({ items, activeIndex, onSelect, onHoverIndex }: SlashCommandPickerProps) {
+const SKELETON_ROWS = 4
+
+export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHoverIndex }: SlashCommandPickerProps) {
   const listRef = useRef<HTMLUListElement>(null)
 
   useEffect(() => {
     const el = listRef.current?.children.item(activeIndex) as HTMLElement | null
     el?.scrollIntoView({ block: "nearest" })
   }, [activeIndex])
+
+  if (items.length === 0 && loading) {
+    return (
+      <ul
+        aria-busy="true"
+        aria-label="Loading slash commands"
+        className="absolute bottom-full left-0 mb-2 w-full max-w-md rounded-md border border-border bg-popover shadow-md overflow-hidden"
+      >
+        {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+          <li
+            key={i}
+            className="flex items-baseline gap-2 px-3 py-1.5"
+            data-testid="slash-picker-skeleton-row"
+          >
+            <span className="h-3 w-20 rounded bg-muted animate-pulse" />
+            <span className="h-3 w-12 rounded bg-muted/70 animate-pulse" />
+            <span className="ml-auto h-3 w-32 rounded bg-muted/60 animate-pulse" />
+          </li>
+        ))}
+      </ul>
+    )
+  }
 
   if (items.length === 0) {
     return (

--- a/src/client/components/chat-ui/SlashCommandPicker.tsx
+++ b/src/client/components/chat-ui/SlashCommandPicker.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react"
+import type { SlashCommand } from "../../../shared/types"
+import { cn } from "../../lib/utils"
+
+interface SlashCommandPickerProps {
+  items: SlashCommand[]
+  activeIndex: number
+  onSelect: (command: SlashCommand) => void
+  onHoverIndex: (index: number) => void
+}
+
+export function SlashCommandPicker({ items, activeIndex, onSelect, onHoverIndex }: SlashCommandPickerProps) {
+  const listRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const el = listRef.current?.children.item(activeIndex) as HTMLElement | null
+    el?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
+
+  if (items.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+        No matching commands
+      </div>
+    )
+  }
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
+    >
+      {items.map((cmd, i) => (
+        <li
+          key={cmd.name}
+          role="option"
+          aria-selected={i === activeIndex}
+          onMouseDown={(event) => {
+            event.preventDefault()
+            onSelect(cmd)
+          }}
+          onMouseEnter={() => onHoverIndex(i)}
+          className={cn(
+            "flex items-baseline gap-2 px-3 py-1.5 cursor-pointer text-sm",
+            i === activeIndex && "bg-accent text-accent-foreground",
+          )}
+        >
+          <span className="font-mono">/{cmd.name}</span>
+          {cmd.argumentHint && (
+            <span className="text-muted-foreground font-mono text-xs">{cmd.argumentHint}</span>
+          )}
+          {cmd.description && (
+            <span className="ml-auto text-muted-foreground text-xs truncate">{cmd.description}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/client/components/chat-ui/SlashCommandPicker.tsx
+++ b/src/client/components/chat-ui/SlashCommandPicker.tsx
@@ -11,6 +11,12 @@ interface SlashCommandPickerProps {
 }
 
 const SKELETON_ROWS = 4
+const DESCRIPTION_MAX_CHARS = 80
+
+function clampDescription(text: string) {
+  if (text.length <= DESCRIPTION_MAX_CHARS) return text
+  return `${text.slice(0, DESCRIPTION_MAX_CHARS - 1).trimEnd()}…`
+}
 
 export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHoverIndex }: SlashCommandPickerProps) {
   const listRef = useRef<HTMLUListElement>(null)
@@ -25,17 +31,17 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
       <ul
         aria-busy="true"
         aria-label="Loading slash commands"
-        className="absolute bottom-full left-0 mb-2 w-full max-w-md rounded-md border border-border bg-popover shadow-md overflow-hidden"
+        className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover shadow-md overflow-hidden"
       >
         {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
           <li
             key={i}
-            className="grid grid-cols-[10rem_6rem_1fr] items-center gap-2 px-3 py-1.5"
+            className="flex flex-col gap-1 px-3 py-1.5 sm:flex-row sm:items-center sm:gap-3"
             data-testid="slash-picker-skeleton-row"
           >
-            <span className="h-3 w-20 rounded bg-muted animate-pulse" />
-            <span className="h-3 w-12 rounded bg-muted/70 animate-pulse" />
-            <span className="h-3 w-32 rounded bg-muted/60 animate-pulse justify-self-end" />
+            <span className="h-3 w-28 rounded bg-muted animate-pulse" />
+            <span className="hidden h-3 w-16 rounded bg-muted/70 animate-pulse sm:inline-block" />
+            <span className="h-3 w-40 max-w-full rounded bg-muted/60 animate-pulse sm:ml-auto" />
           </li>
         ))}
       </ul>
@@ -44,7 +50,7 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
 
   if (items.length === 0) {
     return (
-      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
+      <div className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl rounded-md border border-border bg-popover p-2 text-sm text-muted-foreground shadow-md">
         No matching commands
       </div>
     )
@@ -54,7 +60,7 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
     <ul
       ref={listRef}
       role="listbox"
-      className="absolute bottom-full left-0 mb-2 w-full max-w-md max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md md:max-w-xl max-h-64 overflow-auto rounded-md border border-border bg-popover shadow-md"
     >
       {items.map((cmd, i) => (
         <li
@@ -67,17 +73,23 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
           }}
           onMouseEnter={() => onHoverIndex(i)}
           className={cn(
-            "grid grid-cols-[10rem_6rem_1fr] items-center gap-2 px-3 py-1.5 cursor-pointer text-sm",
+            "flex flex-col gap-0.5 px-3 py-1.5 cursor-pointer text-sm sm:flex-row sm:items-center sm:gap-3",
             i === activeIndex && "bg-accent text-accent-foreground",
           )}
         >
-          <span className="font-mono truncate whitespace-nowrap">/{cmd.name}</span>
-          <span className="text-muted-foreground font-mono text-xs truncate whitespace-nowrap">
-            {cmd.argumentHint ?? ""}
-          </span>
-          <span className="text-muted-foreground text-xs truncate whitespace-nowrap text-right">
-            {cmd.description ?? ""}
-          </span>
+          <div className="flex min-w-0 items-baseline gap-2">
+            <span className="font-mono break-all sm:whitespace-nowrap sm:break-normal">/{cmd.name}</span>
+            {cmd.argumentHint ? (
+              <span className="shrink-0 font-mono text-xs text-muted-foreground whitespace-nowrap">
+                {cmd.argumentHint}
+              </span>
+            ) : null}
+          </div>
+          {cmd.description ? (
+            <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground sm:text-right">
+              {clampDescription(cmd.description)}
+            </span>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/src/client/components/chat-ui/SlashCommandPicker.tsx
+++ b/src/client/components/chat-ui/SlashCommandPicker.tsx
@@ -30,12 +30,12 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
         {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
           <li
             key={i}
-            className="flex items-baseline gap-2 px-3 py-1.5"
+            className="grid grid-cols-[10rem_6rem_1fr] items-center gap-2 px-3 py-1.5"
             data-testid="slash-picker-skeleton-row"
           >
             <span className="h-3 w-20 rounded bg-muted animate-pulse" />
             <span className="h-3 w-12 rounded bg-muted/70 animate-pulse" />
-            <span className="ml-auto h-3 w-32 rounded bg-muted/60 animate-pulse" />
+            <span className="h-3 w-32 rounded bg-muted/60 animate-pulse justify-self-end" />
           </li>
         ))}
       </ul>
@@ -67,17 +67,17 @@ export function SlashCommandPicker({ items, activeIndex, loading, onSelect, onHo
           }}
           onMouseEnter={() => onHoverIndex(i)}
           className={cn(
-            "flex items-baseline gap-2 px-3 py-1.5 cursor-pointer text-sm",
+            "grid grid-cols-[10rem_6rem_1fr] items-center gap-2 px-3 py-1.5 cursor-pointer text-sm",
             i === activeIndex && "bg-accent text-accent-foreground",
           )}
         >
-          <span className="font-mono">/{cmd.name}</span>
-          {cmd.argumentHint && (
-            <span className="text-muted-foreground font-mono text-xs">{cmd.argumentHint}</span>
-          )}
-          {cmd.description && (
-            <span className="ml-auto text-muted-foreground text-xs truncate">{cmd.description}</span>
-          )}
+          <span className="font-mono truncate whitespace-nowrap">/{cmd.name}</span>
+          <span className="text-muted-foreground font-mono text-xs truncate whitespace-nowrap">
+            {cmd.argumentHint ?? ""}
+          </span>
+          <span className="text-muted-foreground text-xs truncate whitespace-nowrap text-right">
+            {cmd.description ?? ""}
+          </span>
         </li>
       ))}
     </ul>

--- a/src/client/components/chat-ui/TerminalPane.tsx
+++ b/src/client/components/chat-ui/TerminalPane.tsx
@@ -18,13 +18,7 @@ interface Props {
   onCommandSent?: () => void
 }
 
-const TERMINAL_THEME_LIGHT: ITheme = {
-  foreground: "#0f172a",
-  background: "transparent",
-  cursor: "#000000",
-  cursorAccent: "#ffffff",
-  selectionBackground: "rgba(221,228,236,0.55)",
-  selectionInactiveBackground: "rgba(221,228,236,0.38)",
+const TERMINAL_ANSI_LIGHT = {
   black: "#0f172a",
   red: "#dc2626",
   green: "#16a34a",
@@ -41,15 +35,9 @@ const TERMINAL_THEME_LIGHT: ITheme = {
   brightMagenta: "#a855f7",
   brightCyan: "#06b6d4",
   brightWhite: "#e2e8f0",
-}
+} as const
 
-const TERMINAL_THEME_DARK: ITheme = {
-  foreground: "#f8fafc",
-  background: "transparent",
-  cursor: "#ffffff",
-  cursorAccent: "#000000",
-  selectionBackground: "rgba(248,250,252,0.28)",
-  selectionInactiveBackground: "rgba(248,250,252,0.18)",
+const TERMINAL_ANSI_DARK = {
   black: "#0f172a",
   red: "#f87171",
   green: "#4ade80",
@@ -66,6 +54,27 @@ const TERMINAL_THEME_DARK: ITheme = {
   brightMagenta: "#d8b4fe",
   brightCyan: "#67e8f9",
   brightWhite: "#f8fafc",
+} as const
+
+function readCssVar(name: string, fallback: string): string {
+  if (typeof document === "undefined") return fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return value || fallback
+}
+
+function buildTerminalTheme(mode: "light" | "dark"): ITheme {
+  const ansi = mode === "dark" ? TERMINAL_ANSI_DARK : TERMINAL_ANSI_LIGHT
+  const fg = readCssVar("--foreground", mode === "dark" ? "#f8fafc" : "#0f172a")
+  const bg = readCssVar("--background", mode === "dark" ? "#000000" : "#ffffff")
+  return {
+    foreground: fg,
+    background: "transparent",
+    cursor: fg,
+    cursorAccent: bg,
+    selectionBackground: mode === "dark" ? "rgba(248,250,252,0.28)" : "rgba(221,228,236,0.55)",
+    selectionInactiveBackground: mode === "dark" ? "rgba(248,250,252,0.18)" : "rgba(221,228,236,0.38)",
+    ...ansi,
+  }
 }
 
 function getTerminalSize(terminal: Terminal) {
@@ -249,7 +258,7 @@ export function TerminalPane({
   const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null)
   const [metadata, setMetadata] = useState<Pick<TerminalSnapshot, "cwd" | "shell" | "status" | "exitCode"> | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const terminalTheme = resolvedTheme === "dark" ? TERMINAL_THEME_DARK : TERMINAL_THEME_LIGHT
+  const terminalTheme = buildTerminalTheme(resolvedTheme === "dark" ? "dark" : "light")
   const sendInput = (data: string) => {
     void socket.command({
       type: "terminal.input",

--- a/src/client/components/chat-ui/sidebar/ChatRow.tsx
+++ b/src/client/components/chat-ui/sidebar/ChatRow.tsx
@@ -40,7 +40,7 @@ function ChatRowImpl({
       data-chat-id={normalizedChatId}
       className={cn(
         "group flex items-center gap-2 pl-2.5 pr-0.5 py-0.5 rounded-lg cursor-pointer border-border/0 hover:border-border hover:bg-muted/20 active:scale-[0.985] border transition-all",
-        activeChatId === normalizedChatId ? "bg-muted hover:bg-muted border-border" : "border-border/0 dark:hover:border-slate-400/10 "
+        activeChatId === normalizedChatId ? "bg-muted hover:bg-muted border-border" : "border-border/0 dark:hover:border-border/40 "
       )}
       onClick={() => onSelectChat(chat.chatId)}
     >
@@ -49,15 +49,15 @@ function ChatRowImpl({
       ) : chat.status === "waiting_for_user" ? (
         <div className="relative ">
           <div className=" rounded-full z-0 size-3.5 flex items-center justify-center ">
-            <div className="absolute rounded-full z-0 size-2.5 bg-blue-400/80 animate-ping" />
-            <div className=" rounded-full z-0 size-2.5 bg-blue-400 ring-2 ring-muted/20 dark:ring-muted/50" />
+            <div className="absolute rounded-full z-0 size-2.5 bg-info/80 animate-ping" />
+            <div className=" rounded-full z-0 size-2.5 bg-info ring-2 ring-muted/20 dark:ring-muted/50" />
           </div>
         </div>
       ) : chat.unread ? (
         <div className="relative ">
           <div className=" rounded-full z-0 size-3.5 flex items-center justify-center ">
-            <div className="absolute rounded-full z-0 size-2.5 bg-emerald-400/80 animate-ping" />
-            <div className=" rounded-full z-0 size-2.5 bg-emerald-400 ring-2 ring-muted/20 dark:ring-muted/50" />
+            <div className="absolute rounded-full z-0 size-2.5 bg-success/80 animate-ping" />
+            <div className=" rounded-full z-0 size-2.5 bg-success ring-2 ring-muted/20 dark:ring-muted/50" />
           </div>
         </div>
       ) : null}
@@ -73,7 +73,7 @@ function ChatRowImpl({
           chat.title
         )}
       </span>
-      <div className="relative h-7 w-7 mr-[2px] shrink-0">
+      <div className="relative h-11 w-11 md:h-7 md:w-7 mr-[2px] shrink-0">
         {trailingLabel ? (
           showShortcutKeycap ? (
             <span className="hidden md:flex absolute inset-0 items-center justify-end pr-0.5 text-[11px] text-foreground transition-opacity group-hover:opacity-0">
@@ -91,7 +91,7 @@ function ChatRowImpl({
           variant="ghost"
           size="icon"
           className={cn(
-            "absolute inset-0 h-7 w-7 opacity-100 cursor-pointer rounded-sm hover:!bg-transparent !border-0",
+            "absolute inset-0 h-11 w-11 md:h-7 md:w-7 opacity-100 cursor-pointer rounded-sm hover:!bg-transparent !border-0",
             trailingLabel
               ? "md:opacity-0 md:group-hover:opacity-100"
               : "opacity-100 md:opacity-0 md:group-hover:opacity-100"
@@ -101,6 +101,7 @@ function ChatRowImpl({
             onDeleteChat(chat.chatId)
           }}
           title="Delete chat"
+          aria-label="Archive chat"
         >
           <Archive className="size-3.5" />
         </Button>

--- a/src/client/components/chat-ui/sidebar/LocalProjectsSection.tsx
+++ b/src/client/components/chat-ui/sidebar/LocalProjectsSection.tsx
@@ -106,17 +106,17 @@ const SortableProjectGroup = memo(function SortableProjectGroup({
       <div className="flex items-center gap-2">
         <span className="relative size-3.5 shrink-0 cursor-pointer">
           {collapsedSections.has(groupKey) ? (
-            <ChevronRight className="translate-y-[1px] size-3.5 shrink-0 text-slate-400 transition-all duration-200" />
+            <ChevronRight className="translate-y-[1px] size-3.5 shrink-0 text-muted-foreground transition-all duration-200" />
           ) : (
             <>
-              <FolderOpen className="absolute inset-0 translate-y-[1px] size-3.5 shrink-0 text-slate-400 dark:text-slate-500 transition-all duration-200 group-hover/section:opacity-0" />
-              <ChevronRight className="absolute inset-0 translate-y-[1px] size-3.5 shrink-0 rotate-90 text-slate-400 opacity-0 transition-all duration-200 group-hover/section:opacity-100" />
+              <FolderOpen className="absolute inset-0 translate-y-[1px] size-3.5 shrink-0 text-muted-foreground transition-all duration-200 group-hover/section:opacity-0" />
+              <ChevronRight className="absolute inset-0 translate-y-[1px] size-3.5 shrink-0 rotate-90 text-muted-foreground opacity-0 transition-all duration-200 group-hover/section:opacity-100" />
             </>
           )}
         </span>
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="truncate max-w-[150px] whitespace-nowrap text-sm text-slate-500 dark:text-slate-400">
+            <span className="truncate max-w-[150px] whitespace-nowrap text-sm text-muted-foreground">
               {getPathBasename(localPath)}
             </span>
           </TooltipTrigger>
@@ -142,9 +142,9 @@ const SortableProjectGroup = memo(function SortableProjectGroup({
               }}
             >
               {startingLocalPath === localPath ? (
-                <Loader2 className="size-4 text-slate-500 dark:text-slate-400 animate-spin" />
+                <Loader2 className="size-4 text-muted-foreground animate-spin" />
               ) : (
-                <SquarePen className="size-3.5 text-slate-500 dark:text-slate-400" />
+                <SquarePen className="size-3.5 text-muted-foreground" />
               )}
             </Button>
           </TooltipTrigger>

--- a/src/client/components/chat-ui/sidebar/Menus.tsx
+++ b/src/client/components/chat-ui/sidebar/Menus.tsx
@@ -60,7 +60,7 @@ export function ProjectSectionMenu({
             event.stopPropagation()
             onRemove()
           }}
-          className="text-destructive dark:text-red-400 hover:bg-destructive/10 focus:bg-destructive/10 dark:hover:bg-red-500/20 dark:focus:bg-red-500/20"
+          className="text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
         >
           <Trash2 className="h-3.5 w-3.5" />
           <span className="text-xs font-medium">Remove</span>

--- a/src/client/components/messages/AskUserQuestionMessage.tsx
+++ b/src/client/components/messages/AskUserQuestionMessage.tsx
@@ -87,7 +87,7 @@ function Checkbox({
         "flex-shrink-0 w-5 h-5 border-1 flex items-center justify-center",
         multiSelect ? "rounded" : "rounded-full",
         selected
-          ? "border-slate-500/0 bg-foreground"
+          ? "border-transparent bg-foreground"
           : "border-muted-foreground/50 bg-background",
         onClick && selected && "cursor-pointer"
       )}
@@ -342,7 +342,7 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
               onChange={(e) => handleCustomInputChange(currentQuestion, e.target.value)}
               onKeyDown={handleCustomInputEnter}
               placeholder="Other..."
-              className="flex-1 px-3 !py-1 pl-4 min-h-[55px] min-w-0 text-sm bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
+              className="flex-1 px-3 !py-1 pl-4 min-h-[55px] min-w-0 text-sm bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md text-foreground placeholder:text-muted-foreground"
             />
             <Checkbox
               selected={!!customInput}

--- a/src/client/components/messages/AttachmentCard.tsx
+++ b/src/client/components/messages/AttachmentCard.tsx
@@ -46,7 +46,7 @@ export function AttachmentImageCard({
         type="button"
         onClick={onClick}
         className={cn(
-          "group/image relative overflow-hidden rounded-xl border border-border/80 bg-background/85 shadow-sm backdrop-blur-md",
+          "group/image relative overflow-hidden rounded-xl border border-border/80 bg-background shadow-sm",
           isComposer ? "min-w-[80px]" : "min-w-[200px]",
         )}
       >

--- a/src/client/components/messages/AttachmentCard.tsx
+++ b/src/client/components/messages/AttachmentCard.tsx
@@ -94,28 +94,51 @@ export function AttachmentFileCard({
   onRemove,
   className,
 }: BaseAttachmentCardProps) {
-  const Icon = getAttachmentIcon(classifyAttachmentIcon(attachment))
+  const iconKind: AttachmentIconKind = attachment.kind === "mention" ? "text" : classifyAttachmentIcon(attachment)
+  const Icon = getAttachmentIcon(iconKind)
+  const isMention = attachment.kind === "mention"
+  const mentionLabel = isMention ? basename(attachment.displayName) : attachment.displayName
+  const mentionSubtitle = isMention ? parentPath(attachment.displayName) : ""
 
   return (
     <div className={cn("group relative", className)}>
       <button
         type="button"
         onClick={onClick}
+        title={isMention ? attachment.displayName : undefined}
         className="flex w-[200px] items-center gap-2 rounded-xl border border-border bg-background/85 p-1 pr-3 text-left transition-colors hover:bg-accent/50"
       >
         <div className="flex min-h-10 min-w-10 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
           <Icon className="size-5" />
         </div>
         <div className="min-w-0">
-          <div className="max-w-[150px] truncate text-[13px] font-medium text-foreground">{attachment.displayName}</div>
-          <div className="truncate text-[11px] text-muted-foreground">
-            {attachment.mimeType} · {formatAttachmentSize(attachment.size)}
-          </div>
+          <div className="max-w-[150px] truncate text-[13px] font-medium text-foreground">{mentionLabel}</div>
+          {isMention ? (
+            <div className="max-w-[150px] truncate text-[11px] text-muted-foreground">
+              {mentionSubtitle ? `@${mentionSubtitle}` : "@mention"}
+            </div>
+          ) : (
+            <div className="truncate text-[11px] text-muted-foreground">
+              {attachment.mimeType} · {formatAttachmentSize(attachment.size)}
+            </div>
+          )}
         </div>
       </button>
       {onRemove ? <RemoveButton displayName={attachment.displayName} onRemove={onRemove} /> : null}
     </div>
   )
+}
+
+function basename(relativePath: string): string {
+  const cleaned = relativePath.replace(/\/+$/, "")
+  const idx = cleaned.lastIndexOf("/")
+  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned
+}
+
+function parentPath(relativePath: string): string {
+  const cleaned = relativePath.replace(/\/+$/, "")
+  const idx = cleaned.lastIndexOf("/")
+  return idx >= 0 ? cleaned.slice(0, idx) : ""
 }
 
 function RemoveButton({ displayName, onRemove }: { displayName: string; onRemove: () => void }) {

--- a/src/client/components/messages/ExitPlanModeMessage.tsx
+++ b/src/client/components/messages/ExitPlanModeMessage.tsx
@@ -45,14 +45,15 @@ export function ExitPlanModeMessage({ message, onConfirm, isLatest }: Props) {
           <Button
             variant="ghost"
             size="icon"
+            aria-label={copied ? "Copied" : "Copy plan"}
             className={cn(
-              "absolute top-2 right-2 z-10 h-8 w-8 rounded-md text-muted-foreground opacity-0 group-hover/plan:opacity-100 transition-opacity",
+              "absolute top-2 right-2 z-10 h-11 w-11 md:h-8 md:w-8 rounded-md text-muted-foreground opacity-100 md:opacity-0 md:group-hover/plan:opacity-100 transition-opacity [@media(hover:none)]:!opacity-100",
               !copied && "hover:text-foreground",
               copied && "hover:!bg-transparent hover:!border-transparent"
             )}
             onClick={handleCopy}
           >
-            {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+            {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
           </Button>
         )}
         <div className={cn(
@@ -155,7 +156,7 @@ export function ExitPlanModeMessage({ message, onConfirm, isLatest }: Props) {
                 }}
                 placeholder="Describe what you'd like to change..."
                 rows={3}
-                className="w-full rounded-2xl border border-border bg-muted dark:bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground resize-none outline-none"
+                className="w-full rounded-2xl border border-border bg-muted dark:bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground resize-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               />
               <div className="flex items-center justify-end gap-2 mx-2">
                 <Button

--- a/src/client/components/messages/FileContentView.tsx
+++ b/src/client/components/messages/FileContentView.tsx
@@ -127,21 +127,21 @@ export function FileContentView({ content, isDiff = false, oldString, newString 
               {diffLines.map((line, i) => {
                 const bg =
                   line.type === "removed"
-                    ? "bg-red-500/10 dark:bg-red-500/15"
+                    ? "bg-destructive/10 dark:bg-destructive/15"
                     : line.type === "added"
-                      ? "bg-green-500/10 dark:bg-green-500/15"
+                      ? "bg-success/10 dark:bg-success/15"
                       : ""
 
                 const textColor =
                   line.type === "removed"
-                    ? "text-red-700 dark:text-red-400"
+                    ? "text-destructive"
                     : line.type === "added"
-                      ? "text-green-700 dark:text-green-400"
+                      ? "text-success"
                       : "text-foreground"
 
                 return (
                   <tr key={i} className={bg}>
-                    <td className={`px-2 py-0 select-none w-0 whitespace-nowrap ${line.type === "removed" ? "text-red-500/50" : line.type === "added" ? "text-green-500/50" : "text-muted-foreground/50"}`}>
+                    <td className={`px-2 py-0 select-none w-0 whitespace-nowrap ${line.type === "removed" ? "text-destructive/50" : line.type === "added" ? "text-success/50" : "text-muted-foreground/50"}`}>
                       {line.type === "removed" ? "-" : line.type === "added" ? "+" : " "}
                     </td>
                     <td className={`px-2 py-0 whitespace-pre select-all ${textColor}`}>

--- a/src/client/components/messages/ProcessingMessage.tsx
+++ b/src/client/components/messages/ProcessingMessage.tsx
@@ -24,7 +24,7 @@ export function ProcessingMessage({ status }: ProcessingMessageProps) {
     <MetaRow className="ml-[1px]">
       <MetaContent>
         {isFailed ? (
-          <X className="size-4.5 text-red-500" />
+          <X className="size-4.5 text-destructive" />
         ) : (
           <Loader2 className="size-4.5 animate-spin text-muted-icon" />
         )}

--- a/src/client/components/messages/SystemMessage.tsx
+++ b/src/client/components/messages/SystemMessage.tsx
@@ -63,10 +63,10 @@ interface McpServerWithTools {
 
 function StatusDot({ status }: { status: string }) {
   const color = status === "connected"
-    ? "bg-emerald-500"
+    ? "bg-success"
     : status === "pending"
-      ? "bg-yellow-500"
-      : "bg-red-500"
+      ? "bg-warning"
+      : "bg-destructive"
   return <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", color)} />
 }
 

--- a/src/client/components/messages/TextMessage.tsx
+++ b/src/client/components/messages/TextMessage.tsx
@@ -10,7 +10,7 @@ interface Props {
 export function TextMessage({ message }: Props) {
   return (
     // <VerticalLineContainer className="w-full">
-      <div className="text-pretty prose prose-sm dark:prose-invert px-0.5 w-full max-w-full space-y-4">
+      <div className="text-pretty prose prose-sm dark:prose-invert px-0.5 w-full max-w-[70ch] space-y-4">
         <Markdown remarkPlugins={[remarkGfm]} components={createMarkdownComponents()}>{message.text}</Markdown>
       </div>
     // </VerticalLineContainer>

--- a/src/client/components/messages/TodoWriteMessage.tsx
+++ b/src/client/components/messages/TodoWriteMessage.tsx
@@ -3,7 +3,7 @@ import { cn } from "../../lib/utils"
 import type { ProcessedToolCall } from "./types"
 
 const STATUS_CONFIG = {
-  completed:   { Icon: Check,   iconClass: "text-emerald-500",             textClass: "text-muted-foreground" },
+  completed:   { Icon: Check,   iconClass: "text-success",                  textClass: "text-muted-foreground" },
   in_progress: { Icon: Loader2, iconClass: "text-foreground animate-spin", textClass: "text-foreground font-medium" },
   pending:     { Icon: Circle,  iconClass: "text-muted-foreground",        textClass: "text-muted-foreground" },
 } as const

--- a/src/client/components/messages/UserMessage.tsx
+++ b/src/client/components/messages/UserMessage.tsx
@@ -12,6 +12,7 @@ interface Props {
   content: string
   attachments?: ChatAttachment[]
   steered?: boolean
+  autoContinue?: { scheduleId: string }
 }
 
 function parseSystemMessage(content: string) {
@@ -26,7 +27,7 @@ function parseSystemMessage(content: string) {
   }
 }
 
-export function UserMessage({ content, attachments = [], steered = false }: Props) {
+export function UserMessage({ content, attachments = [], steered = false, autoContinue }: Props) {
   const [selectedAttachmentId, setSelectedAttachmentId] = useState<string | null>(null)
   const parsedContent = useMemo(() => parseSystemMessage(content), [content])
   const imageAttachments = useMemo(
@@ -88,6 +89,9 @@ export function UserMessage({ content, attachments = [], steered = false }: Prop
               <Markdown remarkPlugins={[remarkGfm]} components={createMarkdownComponents()}>{parsedContent.body}</Markdown>
             </div>
           </div>
+        ) : null}
+        {autoContinue ? (
+          <span className="text-xs text-muted-foreground opacity-70">auto-sent</span>
         ) : null}
       </div>
       <AttachmentPreviewModal attachment={selectedAttachment} onOpenChange={(open) => !open && setSelectedAttachmentId(null)} />

--- a/src/client/components/messages/UserMessage.tsx
+++ b/src/client/components/messages/UserMessage.tsx
@@ -6,6 +6,7 @@ import { createMarkdownComponents } from "./shared"
 import { classifyAttachmentPreview } from "./attachmentPreview"
 import { AttachmentFileCard, AttachmentImageCard } from "./AttachmentCard"
 import { AttachmentPreviewModal } from "./AttachmentPreviewModal"
+import { Zap } from "lucide-react"
 
 interface Props {
   content: string
@@ -77,6 +78,12 @@ export function UserMessage({ content, attachments = [], steered = false }: Prop
         ) : null}
         {(parsedContent.body || (!parsedContent.body && attachments.length === 0 && content && !parsedContent.systemMessage)) ? (
           <div className="flex max-w-[85%] items-center gap-2 sm:max-w-[80%]">
+            {steered ? (
+              <Zap
+                aria-label="Sent mid-turn"
+                className="size-3.5 shrink-0 text-muted-foreground"
+              />
+            ) : null}
             <div className="min-w-0 flex-1 rounded-[20px] border border-border bg-muted px-3.5 py-1.5 text-primary prose prose-sm prose-invert [&_p]:whitespace-pre-line">
               <Markdown remarkPlugins={[remarkGfm]} components={createMarkdownComponents()}>{parsedContent.body}</Markdown>
             </div>

--- a/src/client/components/messages/UserMessage.tsx
+++ b/src/client/components/messages/UserMessage.tsx
@@ -71,7 +71,7 @@ export function UserMessage({ content, attachments = [], steered = false }: Prop
               <AttachmentFileCard
                 key={attachment.id}
                 attachment={attachment}
-                onClick={() => handleAttachmentClick(attachment)}
+                onClick={attachment.contentUrl ? () => handleAttachmentClick(attachment) : undefined}
               />
             ))}
           </div>

--- a/src/client/components/messages/shared.tsx
+++ b/src/client/components/messages/shared.tsx
@@ -170,14 +170,15 @@ export function MetaCodeBlock({ label, children, copyText }: { label: ReactNode;
         <Button
           variant="ghost"
           size="icon"
+          aria-label={copied ? "Copied" : "Copy code"}
           className={cn(
-            "absolute top-[4px] right-[4px] z-10 h-6.5 w-6.5 rounded-sm text-muted-foreground opacity-0 group-hover/codeblock:opacity-100 transition-opacity",
+            "absolute top-[4px] right-[4px] z-10 h-11 w-11 md:h-6.5 md:w-6.5 rounded-sm text-muted-foreground opacity-100 md:opacity-0 md:group-hover/codeblock:opacity-100 transition-opacity [@media(hover:none)]:!opacity-100",
             !copied && "hover:text-foreground",
             copied && "hover:!bg-transparent hover:!border-transparent"
           )}
           onClick={handleCopy}
         >
-          {copied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-4 w-4" />}
+          {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-4 w-4" />}
         </Button>
       </div>
     </div>
@@ -275,14 +276,15 @@ export const markdownComponents = {
         <Button
           variant="ghost"
           size="icon"
+          aria-label={copied ? "Copied" : "Copy code"}
           className={cn(
-            "absolute top-[35px] -translate-y-[50%] -translate-x-[1px] rounded-md right-1.5 h-8 w-8 text-muted-foreground opacity-0 group-hover/pre:opacity-100 transition-opacity",
+            "absolute top-[35px] -translate-y-[50%] -translate-x-[1px] rounded-md right-1.5 h-11 w-11 md:h-8 md:w-8 text-muted-foreground opacity-100 md:opacity-0 md:group-hover/pre:opacity-100 transition-opacity [@media(hover:none)]:!opacity-100",
             !copied && "hover:text-foreground",
             copied && "hover:!bg-transparent hover:!border-transparent"
           )}
           onClick={handleCopy}
         >
-          {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+          {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
         </Button>
       </div>
     )

--- a/src/client/components/ui/animated-shiny-text.tsx
+++ b/src/client/components/ui/animated-shiny-text.tsx
@@ -1,41 +1,28 @@
-import { ComponentPropsWithoutRef, CSSProperties, FC } from "react"
+import type { ComponentPropsWithoutRef, FC, ReactNode } from "react"
 
 import { cn } from "../../lib/utils"
 
-export interface AnimatedShinyTextProps extends ComponentPropsWithoutRef<"span"> {
+export type AnimatedShinyTextProps = ComponentPropsWithoutRef<"span"> & {
   shimmerWidth?: number
   animate?: boolean
+  children?: ReactNode
 }
 
 export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
   children,
   className,
-  shimmerWidth = 100,
   animate = true,
-  ...props
+  shimmerWidth: _shimmerWidth,
+  ...rest
 }) => {
   return (
     <span
-      style={
-        {
-          "--shiny-width": `${Math.min(shimmerWidth, 100)}px`,
-        } as CSSProperties
-      }
       className={cn(
-        "mx-auto max-w-md text-foreground/50",
-
-        // Only apply animation classes when animate is true
-        animate ? [
-          // Shine effect
-          "animate-shiny-text [background-size:var(--shiny-width)_100%] bg-clip-text [background-position:0_0] bg-no-repeat [transition:background-position_1s_cubic-bezier(.6,.6,0,1)_infinite]",
-
-          // Shine gradient
-          "bg-gradient-to-r from-transparent via-black/80 via-50% to-transparent dark:via-white/80",
-        ] : ["text-neutral"],
-
-        className
+        "mx-auto max-w-md text-foreground/60",
+        animate && "animate-shiny-pulse",
+        className,
       )}
-      {...props}
+      {...rest}
     >
       {children}
     </span>

--- a/src/client/components/ui/button.tsx
+++ b/src/client/components/ui/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
         sm: "h-9 rounded-full px-3",
         lg: "h-11 rounded-full px-8",
         icon: "h-9 w-9 rounded-full",
+        "icon-mobile": "h-11 w-11 rounded-full md:h-9 md:w-9",
         none: "",
         "icon-sm": "h-5.5 w-5.5 rounded-md",
       },

--- a/src/client/components/ui/dialog.tsx
+++ b/src/client/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/client/components/ui/input.tsx
+++ b/src/client/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         ref={ref}
         type={type}
         className={cn(
-          "flex w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}

--- a/src/client/components/ui/segmented-control.tsx
+++ b/src/client/components/ui/segmented-control.tsx
@@ -63,8 +63,8 @@ export function SegmentedControl<T extends string>({
               icon ? "grid grid-cols-[auto_auto] items-center gap-2" : "inline-flex items-center",
               sizeClasses[size],
               isActive
-                ? "bg-white dark:bg-muted text-slate-900 dark:text-slate-200 border-slate-300 dark:border-white/10 bg-slate-200 "
-                : "border-transparent text-slate-800 hover:text-slate-900 dark:text-muted-foreground dark:hover:text-foreground",
+                ? "bg-card text-foreground border-border"
+                : "border-transparent text-muted-foreground hover:text-foreground",
               option.disabled && "opacity-50 pointer-events-none",
               optionClassName,
             )}

--- a/src/client/components/ui/select.tsx
+++ b/src/client/components/ui/select.tsx
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
     className={cn(
       "flex h-9 w-full items-center justify-between gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors",
       "placeholder:text-muted-foreground",
-      "focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+      "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
       "disabled:cursor-not-allowed disabled:opacity-50",
       "[&>span]:line-clamp-1",
       className,

--- a/src/client/components/ui/tooltip.test.tsx
+++ b/src/client/components/ui/tooltip.test.tsx
@@ -14,6 +14,6 @@ describe("formatHotkeyLabel", () => {
 describe("HOTKEY_TOOLTIP_CONTENT_CLASSNAME", () => {
   test("includes expected styling hooks", () => {
     expect(HOTKEY_TOOLTIP_CONTENT_CLASSNAME).toContain("border-border")
-    expect(HOTKEY_TOOLTIP_CONTENT_CLASSNAME).toContain("backdrop-blur-md")
+    expect(HOTKEY_TOOLTIP_CONTENT_CLASSNAME).toContain("bg-card")
   })
 })

--- a/src/client/components/ui/tooltip.tsx
+++ b/src/client/components/ui/tooltip.tsx
@@ -4,7 +4,7 @@ import { cn } from "../../lib/utils"
 import { Kbd, KbdGroup } from "./kbd"
 
 const HOTKEY_TOOLTIP_CONTENT_CLASSNAME =
-  "z-50 overflow-hidden rounded-md border border-border backdrop-blur-md p-0.5 text-[11px] font-medium text-card-foreground shadow-sm animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+  "z-50 overflow-hidden rounded-md border border-border bg-card p-0.5 text-[11px] font-medium text-card-foreground shadow-sm animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/src/client/hooks/useMentionSuggestions.test.ts
+++ b/src/client/hooks/useMentionSuggestions.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { fetchProjectPaths, type ProjectPath } from "./useMentionSuggestions"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("fetchProjectPaths", () => {
+  test("requests the expected URL and returns paths", async () => {
+    let receivedUrl: string | null = null
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      receivedUrl = typeof input === "string" ? input : input.toString()
+      return new Response(
+        JSON.stringify({ paths: [{ path: "a.ts", kind: "file" }] satisfies ProjectPath[] }),
+        { headers: { "Content-Type": "application/json" } },
+      )
+    }) as typeof fetch
+
+    const result = await fetchProjectPaths({ projectId: "p1", query: "a", signal: new AbortController().signal })
+    expect(receivedUrl).toBe("/api/projects/p1/paths?query=a")
+    expect(result).toEqual([{ path: "a.ts", kind: "file" }])
+  })
+
+  test("escapes query", async () => {
+    let receivedUrl: string | null = null
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      receivedUrl = typeof input === "string" ? input : input.toString()
+      return new Response(JSON.stringify({ paths: [] }), { headers: { "Content-Type": "application/json" } })
+    }) as typeof fetch
+
+    await fetchProjectPaths({ projectId: "p1", query: "a b/c", signal: new AbortController().signal })
+    expect(receivedUrl).toBe("/api/projects/p1/paths?query=a+b%2Fc")
+  })
+
+  test("returns empty array on non-ok response", async () => {
+    globalThis.fetch = (async () => new Response("{}", { status: 500 })) as typeof fetch
+    const result = await fetchProjectPaths({ projectId: "p1", query: "x", signal: new AbortController().signal })
+    expect(result).toEqual([])
+  })
+})

--- a/src/client/hooks/useMentionSuggestions.ts
+++ b/src/client/hooks/useMentionSuggestions.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react"
+
+export interface ProjectPath {
+  path: string
+  kind: "file" | "dir"
+}
+
+interface State {
+  items: ProjectPath[]
+  loading: boolean
+  error: string | null
+}
+
+const DEBOUNCE_MS = 120
+
+export async function fetchProjectPaths(args: {
+  projectId: string
+  query: string
+  signal: AbortSignal
+}): Promise<ProjectPath[]> {
+  const params = new URLSearchParams({ query: args.query })
+  try {
+    const response = await fetch(`/api/projects/${args.projectId}/paths?${params.toString()}`, {
+      signal: args.signal,
+    })
+    if (!response.ok) return []
+    const payload = await response.json() as { paths?: ProjectPath[] }
+    return payload.paths ?? []
+  } catch {
+    return []
+  }
+}
+
+export function useMentionSuggestions(args: {
+  projectId: string | null
+  query: string
+  enabled: boolean
+}): State {
+  const [state, setState] = useState<State>({ items: [], loading: false, error: null })
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!args.enabled || !args.projectId) {
+      setState({ items: [], loading: false, error: null })
+      return
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    abortRef.current?.abort()
+
+    setState((s) => ({ ...s, loading: true, error: null }))
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    debounceRef.current = setTimeout(async () => {
+      const items = await fetchProjectPaths({
+        projectId: args.projectId!,
+        query: args.query,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      setState({ items, loading: false, error: null })
+    }, DEBOUNCE_MS)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      controller.abort()
+    }
+  }, [args.enabled, args.projectId, args.query])
+
+  return state
+}

--- a/src/client/hooks/useSlashCommands.test.ts
+++ b/src/client/hooks/useSlashCommands.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, test } from "bun:test"
 import { useSlashCommandsStore } from "../stores/slashCommandsStore"
-import { selectSlashCommands, useSlashCommands } from "./useSlashCommands"
+import {
+  selectSlashCommands,
+  selectSlashCommandsLoading,
+  useSlashCommands,
+  useSlashCommandsLoading,
+} from "./useSlashCommands"
 
 describe("useSlashCommands", () => {
   beforeEach(() => {
-    useSlashCommandsStore.setState({ byChatId: {} })
+    useSlashCommandsStore.setState({ byChatId: {}, loadingByChatId: {} })
   })
 
   test("selector returns cached commands for known chat", () => {
@@ -31,7 +36,21 @@ describe("useSlashCommands", () => {
     expect(a).toBe(b)
   })
 
-  test("hook is exported as a function", () => {
+  test("loading selector returns false when flag not set", () => {
+    expect(selectSlashCommandsLoading(useSlashCommandsStore.getState(), "c1")).toBe(false)
+  })
+
+  test("loading selector returns true once flag set", () => {
+    useSlashCommandsStore.getState().setLoadingForChat("c1", true)
+    expect(selectSlashCommandsLoading(useSlashCommandsStore.getState(), "c1")).toBe(true)
+  })
+
+  test("loading selector returns false for null chatId", () => {
+    expect(selectSlashCommandsLoading(useSlashCommandsStore.getState(), null)).toBe(false)
+  })
+
+  test("hooks are exported as functions", () => {
     expect(useSlashCommands).toBeTypeOf("function")
+    expect(useSlashCommandsLoading).toBeTypeOf("function")
   })
 })

--- a/src/client/hooks/useSlashCommands.test.ts
+++ b/src/client/hooks/useSlashCommands.test.ts
@@ -1,44 +1,37 @@
 import { beforeEach, describe, expect, test } from "bun:test"
 import { useSlashCommandsStore } from "../stores/slashCommandsStore"
-import { useSlashCommands } from "./useSlashCommands"
+import { selectSlashCommands, useSlashCommands } from "./useSlashCommands"
 
 describe("useSlashCommands", () => {
   beforeEach(() => {
     useSlashCommandsStore.setState({ byChatId: {} })
   })
 
-  test("returns empty array when no commands cached", () => {
-    // Hook is a thin wrapper over Zustand's selector. Since we cannot render a
-    // React hook in bun:test without @testing-library/react, exercise the
-    // selector by calling the store's selector API directly.
-    const { byChatId } = useSlashCommandsStore.getState()
-    const chatId = "missing"
-    const result = chatId ? byChatId[chatId] ?? [] : []
-    expect(result).toEqual([])
-  })
-
-  test("returns cached commands for a known chat", () => {
+  test("selector returns cached commands for known chat", () => {
     useSlashCommandsStore.getState().setForChat("c1", [
       { name: "review", description: "r", argumentHint: "<pr>" },
     ])
-    const { byChatId } = useSlashCommandsStore.getState()
-    expect(byChatId["c1"]).toEqual([
+    const result = selectSlashCommands(useSlashCommandsStore.getState(), "c1")
+    expect(result).toEqual([
       { name: "review", description: "r", argumentHint: "<pr>" },
     ])
   })
 
-  test("exports a stable empty array reference across calls with missing chatId", () => {
-    // Validates the EMPTY constant is module-level. Import the hook body
-    // implementation indirectly via two calls and compare references.
-    // Since we cannot run the hook, verify the implementation source uses a
-    // constant by checking behavior: repeated empty reads are equal.
-    useSlashCommandsStore.setState({ byChatId: {} })
-    const a = useSlashCommandsStore.getState().byChatId["x"] ?? []
-    const b = useSlashCommandsStore.getState().byChatId["x"] ?? []
-    expect(a).toEqual(b)
-    // Note: true reference stability only matters inside a React render.
-    // See useSlashCommands source.
-    // The hook itself is trivially typed; this smoke test keeps the file alive.
+  test("selector returns stable empty array for missing chatId", () => {
+    const state = useSlashCommandsStore.getState()
+    const a = selectSlashCommands(state, "missing")
+    const b = selectSlashCommands(state, "missing")
+    expect(a).toBe(b)
+  })
+
+  test("selector returns stable empty array for null chatId", () => {
+    const state = useSlashCommandsStore.getState()
+    const a = selectSlashCommands(state, null)
+    const b = selectSlashCommands(state, null)
+    expect(a).toBe(b)
+  })
+
+  test("hook is exported as a function", () => {
     expect(useSlashCommands).toBeTypeOf("function")
   })
 })

--- a/src/client/hooks/useSlashCommands.test.ts
+++ b/src/client/hooks/useSlashCommands.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+import { useSlashCommands } from "./useSlashCommands"
+
+describe("useSlashCommands", () => {
+  beforeEach(() => {
+    useSlashCommandsStore.setState({ byChatId: {} })
+  })
+
+  test("returns empty array when no commands cached", () => {
+    // Hook is a thin wrapper over Zustand's selector. Since we cannot render a
+    // React hook in bun:test without @testing-library/react, exercise the
+    // selector by calling the store's selector API directly.
+    const { byChatId } = useSlashCommandsStore.getState()
+    const chatId = "missing"
+    const result = chatId ? byChatId[chatId] ?? [] : []
+    expect(result).toEqual([])
+  })
+
+  test("returns cached commands for a known chat", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ])
+    const { byChatId } = useSlashCommandsStore.getState()
+    expect(byChatId["c1"]).toEqual([
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ])
+  })
+
+  test("exports a stable empty array reference across calls with missing chatId", () => {
+    // Validates the EMPTY constant is module-level. Import the hook body
+    // implementation indirectly via two calls and compare references.
+    // Since we cannot run the hook, verify the implementation source uses a
+    // constant by checking behavior: repeated empty reads are equal.
+    useSlashCommandsStore.setState({ byChatId: {} })
+    const a = useSlashCommandsStore.getState().byChatId["x"] ?? []
+    const b = useSlashCommandsStore.getState().byChatId["x"] ?? []
+    expect(a).toEqual(b)
+    // Note: true reference stability only matters inside a React render.
+    // See useSlashCommands source.
+    // The hook itself is trivially typed; this smoke test keeps the file alive.
+    expect(useSlashCommands).toBeTypeOf("function")
+  })
+})

--- a/src/client/hooks/useSlashCommands.ts
+++ b/src/client/hooks/useSlashCommands.ts
@@ -11,6 +11,18 @@ export function selectSlashCommands(
   return state.byChatId[chatId] ?? EMPTY
 }
 
+export function selectSlashCommandsLoading(
+  state: { loadingByChatId: Record<string, boolean> },
+  chatId: string | null,
+): boolean {
+  if (!chatId) return false
+  return state.loadingByChatId[chatId] ?? false
+}
+
 export function useSlashCommands(chatId: string | null): SlashCommand[] {
   return useSlashCommandsStore((state) => selectSlashCommands(state, chatId))
+}
+
+export function useSlashCommandsLoading(chatId: string | null): boolean {
+  return useSlashCommandsStore((state) => selectSlashCommandsLoading(state, chatId))
 }

--- a/src/client/hooks/useSlashCommands.ts
+++ b/src/client/hooks/useSlashCommands.ts
@@ -3,8 +3,14 @@ import type { SlashCommand } from "../../shared/types"
 
 const EMPTY: SlashCommand[] = []
 
+export function selectSlashCommands(
+  state: { byChatId: Record<string, SlashCommand[]> },
+  chatId: string | null,
+): SlashCommand[] {
+  if (!chatId) return EMPTY
+  return state.byChatId[chatId] ?? EMPTY
+}
+
 export function useSlashCommands(chatId: string | null): SlashCommand[] {
-  return useSlashCommandsStore((state) =>
-    chatId ? state.byChatId[chatId] ?? EMPTY : EMPTY,
-  )
+  return useSlashCommandsStore((state) => selectSlashCommands(state, chatId))
 }

--- a/src/client/hooks/useSlashCommands.ts
+++ b/src/client/hooks/useSlashCommands.ts
@@ -1,0 +1,10 @@
+import { useSlashCommandsStore } from "../stores/slashCommandsStore"
+import type { SlashCommand } from "../../shared/types"
+
+const EMPTY: SlashCommand[] = []
+
+export function useSlashCommands(chatId: string | null): SlashCommand[] {
+  return useSlashCommandsStore((state) =>
+    chatId ? state.byChatId[chatId] ?? EMPTY : EMPTY,
+  )
+}

--- a/src/client/hooks/useTheme.test.ts
+++ b/src/client/hooks/useTheme.test.ts
@@ -5,10 +5,14 @@ const originalDocument = globalThis.document
 const originalWindow = globalThis.window
 const originalGetComputedStyle = globalThis.getComputedStyle
 
+function setGlobal(key: "window" | "document" | "getComputedStyle", value: unknown) {
+  Object.defineProperty(globalThis, key, { value, configurable: true, writable: true })
+}
+
 afterEach(() => {
-  globalThis.document = originalDocument
-  globalThis.window = originalWindow
-  globalThis.getComputedStyle = originalGetComputedStyle
+  setGlobal("document", originalDocument)
+  setGlobal("window", originalWindow)
+  setGlobal("getComputedStyle", originalGetComputedStyle)
 })
 
 function createFakeDocument() {
@@ -61,9 +65,9 @@ describe("getAppleMobileWebAppStatusBarStyle", () => {
 describe("syncThemeMetadata", () => {
   test("updates theme-color and color-scheme from the active theme", () => {
     const fakeDocument = createFakeDocument()
-    globalThis.document = fakeDocument as typeof document
-    globalThis.window = {} as typeof window
-    globalThis.getComputedStyle = (() => ({ backgroundColor: "rgb(34, 34, 34)" })) as typeof getComputedStyle
+    setGlobal("document", fakeDocument)
+    setGlobal("window", {})
+    setGlobal("getComputedStyle", () => ({ backgroundColor: "rgb(34, 34, 34)" }))
 
     syncThemeMetadata("dark")
 

--- a/src/client/lib/autoContinueTime.test.ts
+++ b/src/client/lib/autoContinueTime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { formatLocal, parseLocal } from "./autoContinueTime"
+
+describe("formatLocal / parseLocal", () => {
+  test("formatLocal in UTC produces dd/mm/yyyy hh:mm", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 17, 5), "UTC")
+    expect(result).toBe("22/04/2026 17:05")
+  })
+
+  test("formatLocal with Asia/Saigon shifts to +07:00", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 17, 0), "Asia/Saigon")
+    expect(result).toBe("23/04/2026 00:00")
+  })
+
+  test("formatLocal with tz=system uses runtime zone (smoke test)", () => {
+    const result = formatLocal(Date.UTC(2026, 3, 22, 12, 0), "system")
+    expect(result).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}$/)
+  })
+
+  test("parseLocal accepts well-formed dd/mm/yyyy hh:mm", () => {
+    const millis = parseLocal("23/04/2026 00:00", "Asia/Saigon")
+    expect(millis).toBe(Date.UTC(2026, 3, 22, 17, 0))
+  })
+
+  test("parseLocal rejects malformed input", () => {
+    expect(parseLocal("22-04-2026 17:05", "UTC")).toBeNull()
+    expect(parseLocal("32/04/2026 17:05", "UTC")).toBeNull()
+    expect(parseLocal("22/04/2026", "UTC")).toBeNull()
+  })
+})

--- a/src/client/lib/autoContinueTime.ts
+++ b/src/client/lib/autoContinueTime.ts
@@ -1,0 +1,60 @@
+function resolveTimeZone(tz: string): string | undefined {
+  if (tz === "system") return undefined
+  return tz
+}
+
+export function formatLocal(epochMs: number, tz: string): string {
+  const timeZone = resolveTimeZone(tz)
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(epochMs))
+  const part = (type: string) => parts.find((p) => p.type === type)?.value ?? "00"
+  let hour = part("hour")
+  if (hour === "24") hour = "00"
+  return `${part("day")}/${part("month")}/${part("year")} ${hour}:${part("minute")}`
+}
+
+const PATTERN = /^(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})$/
+
+function offsetMinutes(tz: string, referenceUtcMs: number): number {
+  if (tz === "system") return -new Date(referenceUtcMs).getTimezoneOffset()
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(new Date(referenceUtcMs))
+  const p = (type: string) => Number(parts.find((x) => x.type === type)?.value ?? 0)
+  let hour = p("hour")
+  if (hour === 24) hour = 0
+  const asUtc = Date.UTC(p("year"), p("month") - 1, p("day"), hour, p("minute"), p("second"))
+  return Math.round((asUtc - referenceUtcMs) / 60_000)
+}
+
+export function parseLocal(input: string, tz: string): number | null {
+  const match = PATTERN.exec(input.trim())
+  if (!match) return null
+  const [, ddStr, mmStr, yyyyStr, hhStr, minStr] = match
+  const dd = Number(ddStr)
+  const mm = Number(mmStr)
+  const yyyy = Number(yyyyStr)
+  const hh = Number(hhStr)
+  const min = Number(minStr)
+  if (mm < 1 || mm > 12 || dd < 1 || dd > 31 || hh > 23 || min > 59) return null
+
+  const guess = Date.UTC(yyyy, mm - 1, dd, hh, min)
+  const offMin = offsetMinutes(tz, guess)
+  const corrected = guess - offMin * 60_000
+  const offMinAfter = offsetMinutes(tz, corrected)
+  return corrected - (offMinAfter - offMin) * 60_000
+}

--- a/src/client/lib/mention-suggestions.test.ts
+++ b/src/client/lib/mention-suggestions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import { applyMentionToInput, shouldShowMentionPicker } from "./mention-suggestions"
+
+describe("shouldShowMentionPicker", () => {
+  test("opens on bare @ at start", () => {
+    expect(shouldShowMentionPicker("@", 1)).toEqual({ open: true, query: "", tokenStart: 0 })
+  })
+
+  test("opens on @src at start", () => {
+    expect(shouldShowMentionPicker("@src", 4)).toEqual({ open: true, query: "src", tokenStart: 0 })
+  })
+
+  test("opens on @src after space", () => {
+    expect(shouldShowMentionPicker("hi @src", 7)).toEqual({ open: true, query: "src", tokenStart: 3 })
+  })
+
+  test("opens after newline", () => {
+    expect(shouldShowMentionPicker("hi\n@src", 7)).toEqual({ open: true, query: "src", tokenStart: 3 })
+  })
+
+  test("does not open on mid-word @ (email-like)", () => {
+    expect(shouldShowMentionPicker("foo@bar", 7)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open when caret before @", () => {
+    expect(shouldShowMentionPicker("@src", 0)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open after space breaks the token", () => {
+    expect(shouldShowMentionPicker("@src foo", 8)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+
+  test("does not open on empty input", () => {
+    expect(shouldShowMentionPicker("", 0)).toEqual({ open: false, query: "", tokenStart: -1 })
+  })
+})
+
+describe("applyMentionToInput", () => {
+  test("replaces @query at start with @pickedPath", () => {
+    const result = applyMentionToInput({
+      value: "@src",
+      caret: 4,
+      tokenStart: 0,
+      pickedPath: "src/agent.ts",
+    })
+    expect(result.value).toBe("@src/agent.ts")
+    expect(result.caret).toBe("@src/agent.ts".length)
+  })
+
+  test("replaces mid-input token", () => {
+    const result = applyMentionToInput({
+      value: "hi @src tail",
+      caret: 7,
+      tokenStart: 3,
+      pickedPath: "src/agent.ts",
+    })
+    expect(result.value).toBe("hi @src/agent.ts tail")
+    expect(result.caret).toBe("hi @src/agent.ts".length)
+  })
+
+  test("preserves bare @ with empty query", () => {
+    const result = applyMentionToInput({
+      value: "@",
+      caret: 1,
+      tokenStart: 0,
+      pickedPath: "README.md",
+    })
+    expect(result.value).toBe("@README.md")
+    expect(result.caret).toBe("@README.md".length)
+  })
+
+  test("handles dir paths (trailing slash)", () => {
+    const result = applyMentionToInput({
+      value: "@src",
+      caret: 4,
+      tokenStart: 0,
+      pickedPath: "src/",
+    })
+    expect(result.value).toBe("@src/")
+    expect(result.caret).toBe("@src/".length)
+  })
+})

--- a/src/client/lib/mention-suggestions.ts
+++ b/src/client/lib/mention-suggestions.ts
@@ -1,0 +1,39 @@
+export interface MentionTrigger {
+  open: boolean
+  query: string
+  tokenStart: number
+}
+
+const CLOSED: MentionTrigger = { open: false, query: "", tokenStart: -1 }
+
+export function shouldShowMentionPicker(value: string, caret: number): MentionTrigger {
+  if (caret <= 0) return CLOSED
+  const upToCaret = value.slice(0, caret)
+
+  let atIndex = -1
+  for (let i = upToCaret.length - 1; i >= 0; i--) {
+    const ch = upToCaret[i]
+    if (ch === "@") { atIndex = i; break }
+    if (ch === " " || ch === "\n" || ch === "\t") return CLOSED
+  }
+  if (atIndex === -1) return CLOSED
+
+  const before = atIndex === 0 ? "" : upToCaret[atIndex - 1]
+  if (before !== "" && before !== " " && before !== "\n" && before !== "\t") return CLOSED
+
+  return { open: true, query: upToCaret.slice(atIndex + 1), tokenStart: atIndex }
+}
+
+export function applyMentionToInput(args: {
+  value: string
+  caret: number
+  tokenStart: number
+  pickedPath: string
+}): { value: string; caret: number } {
+  const before = args.value.slice(0, args.tokenStart)
+  const after = args.value.slice(args.caret)
+  const replacement = `@${args.pickedPath}`
+  const nextValue = `${before}${replacement}${after}`
+  const nextCaret = before.length + replacement.length
+  return { value: nextValue, caret: nextCaret }
+}

--- a/src/client/lib/parseTranscript.test.ts
+++ b/src/client/lib/parseTranscript.test.ts
@@ -113,6 +113,29 @@ describe("processTranscriptMessages", () => {
     expect(messages[0].attachments?.[0]?.relativePath).toBe("./.kanna/uploads/spec.pdf")
   })
 
+  test("auto_continue_prompt entries hydrate with scheduleId", () => {
+    const output = processTranscriptMessages([{
+      _id: "m1",
+      createdAt: 1,
+      kind: "auto_continue_prompt",
+      scheduleId: "s1",
+    }])
+    expect(output[0]?.kind).toBe("auto_continue_prompt")
+    expect((output[0] as { scheduleId: string }).scheduleId).toBe("s1")
+  })
+
+  test("user_prompt carries autoContinue metadata", () => {
+    const output = processTranscriptMessages([{
+      _id: "m1",
+      createdAt: 1,
+      kind: "user_prompt",
+      content: "continue",
+      autoContinue: { scheduleId: "s1" },
+    }])
+    expect(output[0]?.kind).toBe("user_prompt")
+    expect((output[0] as { autoContinue?: { scheduleId: string } }).autoContinue?.scheduleId).toBe("s1")
+  })
+
   test("preserves context window update entries", () => {
     const messages = processTranscriptMessages([
       entry({

--- a/src/client/lib/parseTranscript.ts
+++ b/src/client/lib/parseTranscript.ts
@@ -52,6 +52,7 @@ export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedT
           content: entry.content,
           attachments: entry.attachments ?? [],
           steered: entry.steered,
+          autoContinue: entry.autoContinue,
         })
         break
       case "system_init":
@@ -151,6 +152,13 @@ export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedT
         messages.push({
           ...createBaseMessage(entry),
           kind: "interrupted",
+        })
+        break
+      case "auto_continue_prompt":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "auto_continue_prompt",
+          scheduleId: entry.scheduleId,
         })
         break
       default:

--- a/src/client/lib/slash-commands.test.ts
+++ b/src/client/lib/slash-commands.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { shouldShowPicker, filterCommands } from "./slash-commands"
+import type { SlashCommand } from "../../shared/types"
+
+describe("shouldShowPicker", () => {
+  test("opens when value starts with / and caret inside token", () => {
+    expect(shouldShowPicker("/rev", 4)).toEqual({ open: true, query: "rev" })
+  })
+
+  test("opens on bare slash with caret after it", () => {
+    expect(shouldShowPicker("/", 1)).toEqual({ open: true, query: "" })
+  })
+
+  test("closes after space", () => {
+    expect(shouldShowPicker("/review ", 8)).toEqual({ open: false, query: "" })
+  })
+
+  test("closes after newline", () => {
+    expect(shouldShowPicker("/review\n", 8)).toEqual({ open: false, query: "" })
+  })
+
+  test("closes when caret before slash", () => {
+    expect(shouldShowPicker("/rev", 0)).toEqual({ open: false, query: "" })
+  })
+
+  test("closes when first char not slash", () => {
+    expect(shouldShowPicker("hi /rev", 7)).toEqual({ open: false, query: "" })
+  })
+
+  test("closes for empty value", () => {
+    expect(shouldShowPicker("", 0)).toEqual({ open: false, query: "" })
+  })
+
+  test("closes when caret beyond first token", () => {
+    expect(shouldShowPicker("/review arg", 11)).toEqual({ open: false, query: "" })
+  })
+})
+
+describe("filterCommands", () => {
+  const all: SlashCommand[] = [
+    { name: "review", description: "r", argumentHint: "" },
+    { name: "reset", description: "s", argumentHint: "" },
+    { name: "init", description: "i", argumentHint: "" },
+  ]
+
+  test("empty query returns all sorted alphabetical", () => {
+    expect(filterCommands(all, "").map((c) => c.name)).toEqual(["init", "reset", "review"])
+  })
+
+  test("prefix matches rank before substring", () => {
+    const list: SlashCommand[] = [
+      { name: "unreview", description: "", argumentHint: "" },
+      { name: "review", description: "", argumentHint: "" },
+    ]
+    expect(filterCommands(list, "rev").map((c) => c.name)).toEqual(["review", "unreview"])
+  })
+
+  test("case-insensitive", () => {
+    expect(filterCommands(all, "REV").map((c) => c.name)).toEqual(["review"])
+  })
+
+  test("no matches returns empty array", () => {
+    expect(filterCommands(all, "xyz")).toEqual([])
+  })
+
+  test("same-tier alphabetical tiebreak", () => {
+    const list: SlashCommand[] = [
+      { name: "revz", description: "", argumentHint: "" },
+      { name: "revb", description: "", argumentHint: "" },
+      { name: "reva", description: "", argumentHint: "" },
+    ]
+    expect(filterCommands(list, "rev").map((c) => c.name)).toEqual(["reva", "revb", "revz"])
+  })
+
+  test("does not match on description or argumentHint", () => {
+    const list: SlashCommand[] = [
+      { name: "help", description: "review this", argumentHint: "<pr>" },
+    ]
+    expect(filterCommands(list, "review")).toEqual([])
+  })
+})

--- a/src/client/lib/slash-commands.test.ts
+++ b/src/client/lib/slash-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { shouldShowPicker, filterCommands } from "./slash-commands"
+import { applyCommandToInput, shouldShowPicker, filterCommands } from "./slash-commands"
 import type { SlashCommand } from "../../shared/types"
 
 describe("shouldShowPicker", () => {
@@ -77,5 +77,44 @@ describe("filterCommands", () => {
       { name: "help", description: "review this", argumentHint: "<pr>" },
     ]
     expect(filterCommands(list, "review")).toEqual([])
+  })
+})
+
+describe("applyCommandToInput", () => {
+  test("replaces the /token at caret with /name and trailing space when argumentHint present", () => {
+    const result = applyCommandToInput({
+      value: "/rev",
+      caret: 4,
+      command: { name: "review", description: "", argumentHint: "<pr>" },
+    })
+    expect(result).toEqual({ value: "/review ", caret: 8 })
+  })
+
+  test("omits trailing space when argumentHint is empty", () => {
+    const result = applyCommandToInput({
+      value: "/hel",
+      caret: 4,
+      command: { name: "help", description: "", argumentHint: "" },
+    })
+    expect(result).toEqual({ value: "/help", caret: 5 })
+  })
+
+  test("leaves input unchanged if caret is not inside a slash token", () => {
+    const result = applyCommandToInput({
+      value: "hello",
+      caret: 5,
+      command: { name: "review", description: "", argumentHint: "" },
+    })
+    expect(result).toEqual({ value: "hello", caret: 5 })
+  })
+
+  test("preserves content after caret", () => {
+    const result = applyCommandToInput({
+      value: "/rev rest",
+      caret: 4,
+      command: { name: "review", description: "", argumentHint: "" },
+    })
+    // This input is "/rev" + " rest"; caret at 4 means we replace "/rev"
+    expect(result).toEqual({ value: "/review rest", caret: 7 })
   })
 })

--- a/src/client/lib/slash-commands.ts
+++ b/src/client/lib/slash-commands.ts
@@ -1,0 +1,29 @@
+import type { SlashCommand } from "../../shared/types"
+
+const SLASH_TOKEN_PATTERN = /^\/(\S*)$/
+
+export function shouldShowPicker(
+  value: string,
+  caret: number,
+): { open: boolean; query: string } {
+  if (caret <= 0) return { open: false, query: "" }
+  const upToCaret = value.slice(0, caret)
+  const match = SLASH_TOKEN_PATTERN.exec(upToCaret)
+  if (!match) return { open: false, query: "" }
+  return { open: true, query: match[1] ?? "" }
+}
+
+export function filterCommands(list: SlashCommand[], query: string): SlashCommand[] {
+  const byName = (a: SlashCommand, b: SlashCommand) => a.name.localeCompare(b.name)
+  if (query === "") return [...list].sort(byName)
+
+  const q = query.toLowerCase()
+  const prefix: SlashCommand[] = []
+  const substring: SlashCommand[] = []
+  for (const cmd of list) {
+    const name = cmd.name.toLowerCase()
+    if (name.startsWith(q)) prefix.push(cmd)
+    else if (name.includes(q)) substring.push(cmd)
+  }
+  return [...prefix.sort(byName), ...substring.sort(byName)]
+}

--- a/src/client/lib/slash-commands.ts
+++ b/src/client/lib/slash-commands.ts
@@ -2,6 +2,24 @@ import type { SlashCommand } from "../../shared/types"
 
 const SLASH_TOKEN_PATTERN = /^\/(\S*)$/
 
+export function applyCommandToInput(args: {
+  value: string
+  caret: number
+  command: SlashCommand
+}): { value: string; caret: number } {
+  const { command, value, caret } = args
+  const upToCaret = value.slice(0, caret)
+  const afterCaret = value.slice(caret)
+  const match = /^\/(\S*)$/.exec(upToCaret)
+  if (!match) return { value, caret }
+  const tokenLength = match[0].length
+  const before = upToCaret.slice(0, upToCaret.length - tokenLength)
+  const replacement = command.argumentHint ? `/${command.name} ` : `/${command.name}`
+  const nextValue = `${before}${replacement}${afterCaret}`
+  const nextCaret = before.length + replacement.length
+  return { value: nextValue, caret: nextCaret }
+}
+
 export function shouldShowPicker(
   value: string,
   caret: number,

--- a/src/client/stores/preferences.test.ts
+++ b/src/client/stores/preferences.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { usePreferencesStore } from "./preferences"
+
+describe("usePreferencesStore", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ autoResumeOnRateLimit: false })
+  })
+
+  test("autoResumeOnRateLimit defaults to false", () => {
+    expect(usePreferencesStore.getState().autoResumeOnRateLimit).toBe(false)
+  })
+
+  test("setAutoResumeOnRateLimit updates state", () => {
+    usePreferencesStore.getState().setAutoResumeOnRateLimit(true)
+    expect(usePreferencesStore.getState().autoResumeOnRateLimit).toBe(true)
+  })
+})

--- a/src/client/stores/preferences.ts
+++ b/src/client/stores/preferences.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+interface PreferencesState {
+  autoResumeOnRateLimit: boolean
+  setAutoResumeOnRateLimit: (value: boolean) => void
+}
+
+interface PersistedPreferencesState {
+  autoResumeOnRateLimit?: boolean
+}
+
+function migratePreferencesState(
+  persistedState: Partial<PersistedPreferencesState> | undefined,
+): Pick<PreferencesState, "autoResumeOnRateLimit"> {
+  return {
+    autoResumeOnRateLimit: Boolean(persistedState?.autoResumeOnRateLimit),
+  }
+}
+
+export const usePreferencesStore = create<PreferencesState>()(
+  persist(
+    (set) => ({
+      autoResumeOnRateLimit: false,
+      setAutoResumeOnRateLimit: (value) => set({ autoResumeOnRateLimit: value }),
+    }),
+    {
+      name: "kanna-preferences",
+      version: 1,
+      migrate: (persistedState) => migratePreferencesState(
+        persistedState as Partial<PersistedPreferencesState> | undefined,
+      ),
+    },
+  ),
+)

--- a/src/client/stores/slashCommandsStore.test.ts
+++ b/src/client/stores/slashCommandsStore.test.ts
@@ -3,7 +3,7 @@ import { useSlashCommandsStore } from "./slashCommandsStore"
 
 describe("slashCommandsStore", () => {
   beforeEach(() => {
-    useSlashCommandsStore.setState({ byChatId: {} })
+    useSlashCommandsStore.setState({ byChatId: {}, loadingByChatId: {} })
   })
 
   test("setForChat stores list", () => {
@@ -23,14 +23,32 @@ describe("slashCommandsStore", () => {
     ])
   })
 
-  test("clear removes list", () => {
+  test("clear removes list and loading state", () => {
     useSlashCommandsStore.getState().setForChat("c1", [{ name: "x", description: "", argumentHint: "" }])
+    useSlashCommandsStore.getState().setLoadingForChat("c1", true)
     useSlashCommandsStore.getState().clear("c1")
     expect(useSlashCommandsStore.getState().byChatId["c1"]).toBeUndefined()
+    expect(useSlashCommandsStore.getState().loadingByChatId["c1"]).toBeUndefined()
   })
 
   test("clear on unknown chat is a no-op", () => {
     useSlashCommandsStore.getState().clear("nope")
     expect(useSlashCommandsStore.getState().byChatId).toEqual({})
+    expect(useSlashCommandsStore.getState().loadingByChatId).toEqual({})
+  })
+
+  test("setLoadingForChat toggles loading flag", () => {
+    useSlashCommandsStore.getState().setLoadingForChat("c1", true)
+    expect(useSlashCommandsStore.getState().loadingByChatId["c1"]).toBe(true)
+    useSlashCommandsStore.getState().setLoadingForChat("c1", false)
+    expect(useSlashCommandsStore.getState().loadingByChatId["c1"]).toBe(false)
+  })
+
+  test("setLoadingForChat is a no-op when value unchanged", () => {
+    useSlashCommandsStore.getState().setLoadingForChat("c1", true)
+    const before = useSlashCommandsStore.getState().loadingByChatId
+    useSlashCommandsStore.getState().setLoadingForChat("c1", true)
+    const after = useSlashCommandsStore.getState().loadingByChatId
+    expect(after).toBe(before)
   })
 })

--- a/src/client/stores/slashCommandsStore.test.ts
+++ b/src/client/stores/slashCommandsStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { useSlashCommandsStore } from "./slashCommandsStore"
+
+describe("slashCommandsStore", () => {
+  beforeEach(() => {
+    useSlashCommandsStore.setState({ byChatId: {} })
+  })
+
+  test("setForChat stores list", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ])
+    expect(useSlashCommandsStore.getState().byChatId["c1"]).toEqual([
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ])
+  })
+
+  test("setForChat replaces existing list", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [{ name: "a", description: "", argumentHint: "" }])
+    useSlashCommandsStore.getState().setForChat("c1", [{ name: "b", description: "", argumentHint: "" }])
+    expect(useSlashCommandsStore.getState().byChatId["c1"]).toEqual([
+      { name: "b", description: "", argumentHint: "" },
+    ])
+  })
+
+  test("clear removes list", () => {
+    useSlashCommandsStore.getState().setForChat("c1", [{ name: "x", description: "", argumentHint: "" }])
+    useSlashCommandsStore.getState().clear("c1")
+    expect(useSlashCommandsStore.getState().byChatId["c1"]).toBeUndefined()
+  })
+
+  test("clear on unknown chat is a no-op", () => {
+    useSlashCommandsStore.getState().clear("nope")
+    expect(useSlashCommandsStore.getState().byChatId).toEqual({})
+  })
+})

--- a/src/client/stores/slashCommandsStore.ts
+++ b/src/client/stores/slashCommandsStore.ts
@@ -3,18 +3,30 @@ import type { SlashCommand } from "../../shared/types"
 
 interface SlashCommandsState {
   byChatId: Record<string, SlashCommand[]>
+  loadingByChatId: Record<string, boolean>
   setForChat: (chatId: string, commands: SlashCommand[]) => void
+  setLoadingForChat: (chatId: string, loading: boolean) => void
   clear: (chatId: string) => void
 }
 
 export const useSlashCommandsStore = create<SlashCommandsState>()((set) => ({
   byChatId: {},
+  loadingByChatId: {},
   setForChat: (chatId, commands) =>
     set((state) => ({ byChatId: { ...state.byChatId, [chatId]: commands } })),
+  setLoadingForChat: (chatId, loading) =>
+    set((state) => {
+      const current = state.loadingByChatId[chatId] ?? false
+      if (current === loading) return state
+      return { loadingByChatId: { ...state.loadingByChatId, [chatId]: loading } }
+    }),
   clear: (chatId) =>
     set((state) => {
-      if (!(chatId in state.byChatId)) return state
-      const { [chatId]: _removed, ...rest } = state.byChatId
-      return { byChatId: rest }
+      const hadCommands = chatId in state.byChatId
+      const hadLoading = chatId in state.loadingByChatId
+      if (!hadCommands && !hadLoading) return state
+      const { [chatId]: _c, ...byChatId } = state.byChatId
+      const { [chatId]: _l, ...loadingByChatId } = state.loadingByChatId
+      return { byChatId, loadingByChatId }
     }),
 }))

--- a/src/client/stores/slashCommandsStore.ts
+++ b/src/client/stores/slashCommandsStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand"
+import type { SlashCommand } from "../../shared/types"
+
+interface SlashCommandsState {
+  byChatId: Record<string, SlashCommand[]>
+  setForChat: (chatId: string, commands: SlashCommand[]) => void
+  clear: (chatId: string) => void
+}
+
+export const useSlashCommandsStore = create<SlashCommandsState>()((set) => ({
+  byChatId: {},
+  setForChat: (chatId, commands) =>
+    set((state) => ({ byChatId: { ...state.byChatId, [chatId]: commands } })),
+  clear: (chatId) =>
+    set((state) => {
+      if (!(chatId in state.byChatId)) return state
+      const { [chatId]: _removed, ...rest } = state.byChatId
+      return { byChatId: rest }
+    }),
+}))

--- a/src/index.css
+++ b/src/index.css
@@ -33,94 +33,96 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 222 47% 11%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 210 20% 97%;
-    --muted-foreground: 215 16% 47%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
+    --background: oklch(99.5% 0.003 13);
+    --foreground: oklch(16% 0.01 13);
+    --card: oklch(99.5% 0.003 13);
+    --card-foreground: oklch(16% 0.01 13);
+    --popover: oklch(99.5% 0.003 13);
+    --popover-foreground: oklch(16% 0.01 13);
+    --primary: oklch(20% 0.012 13);
+    --primary-foreground: oklch(98% 0.005 13);
+    --secondary: oklch(96% 0.005 13);
+    --secondary-foreground: oklch(18% 0.01 13);
+    --muted: oklch(97% 0.005 13);
+    --muted-foreground: oklch(55% 0.013 13);
+    --accent: oklch(96% 0.005 13);
+    --accent-foreground: oklch(18% 0.01 13);
     --destructive: var(--logo);
-    --destructive-foreground: 0 0% 98%;
-    --border: 214 20% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
+    --destructive-foreground: oklch(98% 0.005 13);
+    --border: oklch(91% 0.008 13);
+    --input: oklch(91% 0.008 13);
+    --ring: oklch(18% 0.01 13);
     --radius: 0.5rem;
-    --muted-icon: 240 2% 79%;
-    --chart-1: 24.6 95% 53.1%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 221 83% 53%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --muted-icon: oklch(82% 0.008 13);
     --logo: oklch(71.2% 0.194 13.428);
+    --success: oklch(68% 0.15 155);
+    --success-foreground: oklch(99% 0.005 155);
+    --warning: oklch(76% 0.14 78);
+    --warning-foreground: oklch(25% 0.03 78);
+    --info: oklch(66% 0.13 235);
+    --info-foreground: oklch(99% 0.005 235);
   }
 
   .dark {
-    --background: 223 4% 13%;
-    --foreground: 0 0% 98%;
-    --card: 231 4% 16%;
-    --card-foreground: 0 0% 98%;
-    --popover: 223 4% 13%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 2% 10%;
-    --secondary: 240 2% 19%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 223 4% 18.5%;
-    --muted-foreground: 240 2.5% 64.9%;
-    --accent: 240 2% 19%;
-    --accent-foreground: 0 0% 98%;
+    --background: oklch(20% 0.01 13);
+    --foreground: oklch(98% 0.003 13);
+    --card: oklch(23% 0.01 13);
+    --card-foreground: oklch(98% 0.003 13);
+    --popover: oklch(20% 0.01 13);
+    --popover-foreground: oklch(98% 0.003 13);
+    --primary: oklch(98% 0.003 13);
+    --primary-foreground: oklch(18% 0.01 13);
+    --secondary: oklch(26% 0.01 13);
+    --secondary-foreground: oklch(98% 0.003 13);
+    --muted: oklch(25% 0.01 13);
+    --muted-foreground: oklch(70% 0.012 13);
+    --accent: oklch(26% 0.01 13);
+    --accent-foreground: oklch(98% 0.003 13);
     --destructive: var(--logo);
     --destructive-foreground: var(--background);
-    --border: 220 2.5% 23.5%;
-    --input: 240 4% 19%;
-    --ring: 240 4.9% 83.9%;
-    --muted-icon: 240 5% 48%;
-    --color-slate-50: oklch(98.5% 0.001 247.839);
-    --color-slate-100: oklch(96.7% 0.0013 264.542);
-    --color-slate-200: oklch(92.8% 0.0026 264.531);
-    --color-slate-300: oklch(87.2% 0.004 258.338);
-    --color-slate-400: oklch(70.7% 0.01 261.325);
-    --color-slate-500: oklch(55.1% 0.012 264.364);
-    --color-slate-600: oklch(44.6% 0.013 256.802);
-    --color-slate-700: oklch(37.3% 0.015 259.733);
-    --color-slate-800: oklch(27.8% 0.0145 256.848);
-    --color-slate-900: oklch(21% 0.015 264.665);
-    --color-slate-950: oklch(13% 0.012 261.692);
+    --border: oklch(29% 0.008 13);
+    --input: oklch(26% 0.01 13);
+    --ring: oklch(85% 0.008 13);
+    --muted-icon: oklch(55% 0.01 13);
     --logo: oklch(71.2% 0.194 13.428);
+    --success: oklch(72% 0.14 155);
+    --success-foreground: oklch(15% 0.02 155);
+    --warning: oklch(80% 0.13 78);
+    --warning-foreground: oklch(20% 0.03 78);
+    --info: oklch(72% 0.12 235);
+    --info-foreground: oklch(15% 0.02 235);
   }
 }
 
 @theme {
   --breakpoint-3xl: 125rem;
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
   --color-destructive: var(--destructive);
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
-  --color-muted-icon: hsl(var(--muted-icon));
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-muted-icon: var(--muted-icon);
   --color-logo: var(--logo);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
@@ -141,7 +143,7 @@
   body {
     background-color: var(--color-background);
     color: var(--color-foreground);
-    font-family: "Body", sans-serif;
+    font-family: "Body", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     /* font-weight: ; */
     margin: 0;
     min-height: 100dvh;
@@ -173,19 +175,9 @@
     appearance: textfield;
   }
 
-  /* Cursor pointer on all buttons, no focus/active styling */
   button {
     cursor: pointer;
     touch-action: manipulation;
-  }
-
-  button:focus,
-  button:focus-visible,
-  button:active {
-    outline: none !important;
-    box-shadow: none !important;
-    --tw-ring-shadow: none !important;
-    --tw-ring-offset-shadow: none !important;
   }
 
   /* Disable pull-to-refresh */
@@ -218,8 +210,8 @@
   .prose blockquote {
     margin: 1em 0;
     padding-left: 1em;
-    border-left: 2px solid hsl(var(--border));
-    color: hsl(var(--muted-foreground));
+    border-left: 1px solid var(--border);
+    color: var(--muted-foreground);
   }
 
   .prose blockquote > * {
@@ -249,19 +241,19 @@
   }
 
   .prose code {
-    /* background-color: hsl(var(--card)); */
+    /* background-color: var(--card); */
     padding: 0.125em 0.25em;
     border-radius: 0.25em;
     font-size: 0.875em;
   }
 
   .prose pre {
-    background-color: hsl(var(--muted));
+    background-color: var(--muted);
     padding: 0.75em 1em;
     border-radius: 0.375em;
     overflow-x: auto;
     margin: 0.75em 0;
-    border: 1px solid hsl(var(--border));
+    border: 1px solid var(--border);
   }
 
   .prose pre code {
@@ -291,11 +283,11 @@
   }
 
   diffs-container {
-    --diffs-bg: hsl(var(--background)) !important;
-    --diffs-light-bg: hsl(var(--background)) !important;
-    --diffs-dark-bg: hsl(var(--background)) !important;
+    --diffs-bg: var(--background) !important;
+    --diffs-light-bg: var(--background) !important;
+    --diffs-dark-bg: var(--background) !important;
     --diffs-gap-block: 0px !important;
-    --diffs-bg-separator: hsl(var(--background)) !important;
+    --diffs-bg-separator: var(--background) !important;
     --diffs-font-size: 11px;
   }
 
@@ -305,9 +297,9 @@
 
   [data-terminal-visual] {
     transition:
-      opacity var(--terminal-toggle-duration, 350ms) cubic-bezier(0.4, 0, 0.2, 1),
-      filter var(--terminal-toggle-duration, 350ms) cubic-bezier(0.4, 0, 0.2, 1);
-    will-change: opacity, filter;
+      opacity var(--terminal-toggle-duration, 280ms) cubic-bezier(0.22, 1, 0.36, 1),
+      transform var(--terminal-toggle-duration, 280ms) cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: opacity, transform;
   }
 
   [data-terminal-visual][data-terminal-animated="false"] {
@@ -316,19 +308,19 @@
 
   [data-terminal-visual][data-terminal-open="false"] {
     opacity: 0;
-    filter: blur(5px);
+    transform: translateY(4px);
   }
 
   [data-terminal-visual][data-terminal-open="true"] {
     opacity: 1;
-    filter: blur(0);
+    transform: translateY(0);
   }
 
   [data-right-sidebar-visual] {
     transition:
-      opacity var(--terminal-toggle-duration, 350ms) cubic-bezier(0.4, 0, 0.2, 1),
-      filter var(--terminal-toggle-duration, 350ms) cubic-bezier(0.4, 0, 0.2, 1);
-    will-change: opacity, filter;
+      opacity var(--terminal-toggle-duration, 280ms) cubic-bezier(0.22, 1, 0.36, 1),
+      transform var(--terminal-toggle-duration, 280ms) cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: opacity, transform;
   }
 
   [data-right-sidebar-visual][data-right-sidebar-animated="false"] {
@@ -337,18 +329,18 @@
 
   [data-right-sidebar-visual][data-right-sidebar-open="false"] {
     opacity: 0;
-    filter: blur(5px);
+    transform: translateX(4px);
   }
 
   [data-right-sidebar-visual][data-right-sidebar-open="true"] {
     opacity: 1;
-    filter: blur(0);
+    transform: translateX(0);
   }
 
   /* Custom scrollbar styling */
   * {
     scrollbar-width: thin;
-    scrollbar-color: hsl(var(--border)) transparent;
+    scrollbar-color: var(--border) transparent;
   }
 
   *::-webkit-scrollbar {
@@ -361,14 +353,14 @@
   }
 
   *::-webkit-scrollbar-thumb {
-    background-color: hsl(var(--border));
+    background-color: var(--border);
     border-radius: 4px;
     border: 2px solid transparent;
     background-clip: padding-box;
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    background-color: hsl(var(--muted-foreground) / 0.3);
+    background-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
   }
 
   /* Hide scrollbar utility */
@@ -461,7 +453,7 @@
   }
 
   .kanna-empty-state-flower {
-    animation: kanna-empty-state-flower-in 0.399s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
+    animation: kanna-empty-state-flower-in 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
     transform-origin: center;
   }
 
@@ -493,15 +485,15 @@
 }
 
 @theme inline {
-  --animate-shiny-text: shiny-text 1.33s linear infinite;
+  --animate-shiny-pulse: shiny-pulse 1.6s ease-in-out infinite;
 
-  @keyframes shiny-text {
-    0% {
-      background-position: calc(-100% - var(--shiny-width)) 0;
+  @keyframes shiny-pulse {
+    0%, 100% {
+      opacity: 0.55;
     }
 
-    100% {
-      background-position: calc(100% + var(--shiny-width)) 0;
+    50% {
+      opacity: 1;
     }
   }
 }

--- a/src/server/__fixtures__/claude-session-malformed.jsonl
+++ b/src/server/__fixtures__/claude-session-malformed.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","uuid":"u1","sessionId":"sess-bad","cwd":"/tmp/x","timestamp":"2026-04-20T10:00:00.000Z","message":{"role":"user","content":"ok"}}
+not valid json at all
+{"type":"assistant","uuid":"a1","sessionId":"sess-bad","timestamp":"2026-04-20T10:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"still works"}]}}

--- a/src/server/__fixtures__/claude-session-valid.jsonl
+++ b/src/server/__fixtures__/claude-session-valid.jsonl
@@ -1,0 +1,6 @@
+{"type":"user","uuid":"u1","sessionId":"sess-abc","cwd":"/tmp/kanna-test-proj","timestamp":"2026-04-20T10:00:00.000Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:01.000Z","message":{"role":"assistant","id":"msg-1","content":[{"type":"text","text":"hi back"}]}}
+{"type":"user","uuid":"u2","parentUuid":"a1","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:02.000Z","message":{"role":"user","content":"run ls"}}
+{"type":"assistant","uuid":"a2","parentUuid":"u2","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:03.000Z","message":{"role":"assistant","id":"msg-2","content":[{"type":"tool_use","id":"tu-1","name":"Bash","input":{"command":"ls","description":"list files"}}]}}
+{"type":"user","uuid":"u3","parentUuid":"a2","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:04.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-1","content":"file1\nfile2"}]}}
+{"type":"assistant","uuid":"a3","parentUuid":"u3","sessionId":"sess-abc","timestamp":"2026-04-20T10:00:05.000Z","message":{"role":"assistant","id":"msg-3","content":[{"type":"text","text":"done"}]}}

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -8,7 +8,7 @@ import {
   normalizeClaudeUsageSnapshot,
 } from "./agent"
 import type { HarnessTurn } from "./harness-types"
-import type { ChatAttachment, TranscriptEntry } from "../shared/types"
+import type { ChatAttachment, SlashCommand, TranscriptEntry } from "../shared/types"
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry: T): TranscriptEntry {
   return {
@@ -1333,6 +1333,57 @@ describe("AgentCoordinator claude integration", () => {
     events.close()
   })
 
+  test("loads supported commands when a fresh Claude session starts", async () => {
+    const events = new AsyncEventQueue<any>()
+    const commandsFromSDK: SlashCommand[] = [
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+      { name: "help", description: "Show help", argumentHint: "" },
+    ]
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        getSupportedCommands: async () => commandsFromSDK,
+        sendPrompt: async () => {
+          events.push({
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "done",
+            }),
+          })
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "hello",
+      model: "claude-opus-4-1",
+    })
+    await waitFor(() => store.turnFinishedCount === 1)
+    await waitFor(() => store.commandsLoaded.length === 1)
+
+    expect(store.commandsLoaded[0].chatId).toBe("chat-1")
+    expect(store.commandsLoaded[0].commands).toEqual(commandsFromSDK)
+
+    events.close()
+  })
+
   test("Claude final results clear running state without using draining mode", async () => {
     const events = new AsyncEventQueue<any>()
 
@@ -1475,6 +1526,10 @@ function createFakeStore() {
     turnFinishedCount: 0,
     messages: [] as TranscriptEntry[],
     queuedMessages: [] as any[],
+    commandsLoaded: [] as Array<{ chatId: string; commands: SlashCommand[] }>,
+    async recordSessionCommandsLoaded(chatId: string, commands: SlashCommand[]) {
+      this.commandsLoaded.push({ chatId, commands })
+    },
     requireChat(chatId: string) {
       expect(chatId).toBe("chat-1")
       return chat

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -205,6 +205,22 @@ describe("attachment prompt helpers", () => {
 
     expect(hint).toContain("&quot;report&quot; &lt;draft&gt;.txt")
   })
+
+  test("renders kind=\"mention\" attachments", () => {
+    const hint = buildAttachmentHintText([{
+      id: "m1",
+      kind: "mention",
+      displayName: "src/agent.ts",
+      absolutePath: "/tmp/project/src/agent.ts",
+      relativePath: "./src/agent.ts",
+      contentUrl: "",
+      mimeType: "",
+      size: 0,
+    }])
+    expect(hint).toContain("kind=\"mention\"")
+    expect(hint).toContain("path=\"/tmp/project/src/agent.ts\"")
+    expect(hint).toContain("project_path=\"./src/agent.ts\"")
+  })
 })
 
 describe("AgentCoordinator codex integration", () => {

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1524,6 +1524,142 @@ describe("AgentCoordinator claude integration", () => {
   })
 })
 
+describe("AgentCoordinator.ensureSlashCommandsLoaded", () => {
+  test("starts an ephemeral Claude session to load commands for a chat without a turn", async () => {
+    const store = createFakeStore()
+    const stateChanges: Array<string | undefined> = []
+    const commands: SlashCommand[] = [
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+    ]
+    let startCount = 0
+    let closeCount = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: (chatId) => { stateChanges.push(chatId) },
+      startClaudeSession: async () => {
+        startCount += 1
+        return {
+          provider: "claude",
+          stream: new AsyncEventQueue<any>(),
+          getAccountInfo: async () => null,
+          interrupt: async () => {},
+          close: () => { closeCount += 1 },
+          setModel: async () => {},
+          setPermissionMode: async () => {},
+          getSupportedCommands: async () => commands,
+          sendPrompt: async () => {},
+        }
+      },
+    })
+
+    await coordinator.ensureSlashCommandsLoaded("chat-1")
+
+    expect(startCount).toBe(1)
+    expect(closeCount).toBe(1)
+    expect(store.commandsLoaded).toHaveLength(1)
+    expect(store.commandsLoaded[0].commands).toEqual(commands)
+    expect(stateChanges).toContain("chat-1")
+  })
+
+  test("skips when commands already loaded for the chat", async () => {
+    const store = createFakeStore()
+    store.chat.slashCommands = [
+      { name: "help", description: "", argumentHint: "" },
+    ]
+    let startCount = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => {
+        startCount += 1
+        return {
+          provider: "claude",
+          stream: new AsyncEventQueue<any>(),
+          getAccountInfo: async () => null,
+          interrupt: async () => {},
+          close: () => {},
+          setModel: async () => {},
+          setPermissionMode: async () => {},
+          getSupportedCommands: async () => [],
+          sendPrompt: async () => {},
+        }
+      },
+    })
+
+    await coordinator.ensureSlashCommandsLoaded("chat-1")
+
+    expect(startCount).toBe(0)
+    expect(store.commandsLoaded).toHaveLength(0)
+  })
+
+  test("skips chats whose provider is codex", async () => {
+    const store = createFakeStore()
+    store.chat.provider = "codex"
+    let startCount = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => {
+        startCount += 1
+        return {
+          provider: "claude",
+          stream: new AsyncEventQueue<any>(),
+          getAccountInfo: async () => null,
+          interrupt: async () => {},
+          close: () => {},
+          setModel: async () => {},
+          setPermissionMode: async () => {},
+          getSupportedCommands: async () => [],
+          sendPrompt: async () => {},
+        }
+      },
+    })
+
+    await coordinator.ensureSlashCommandsLoaded("chat-1")
+
+    expect(startCount).toBe(0)
+    expect(store.commandsLoaded).toHaveLength(0)
+  })
+
+  test("dedupes concurrent calls via in-flight guard", async () => {
+    const store = createFakeStore()
+    let releaseCommands: (value: SlashCommand[]) => void
+    const commandsReady = new Promise<SlashCommand[]>((resolve) => {
+      releaseCommands = resolve
+    })
+    let startCount = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => {
+        startCount += 1
+        return {
+          provider: "claude",
+          stream: new AsyncEventQueue<any>(),
+          getAccountInfo: async () => null,
+          interrupt: async () => {},
+          close: () => {},
+          setModel: async () => {},
+          setPermissionMode: async () => {},
+          getSupportedCommands: () => commandsReady,
+          sendPrompt: async () => {},
+        }
+      },
+    })
+
+    const p1 = coordinator.ensureSlashCommandsLoaded("chat-1")
+    const p2 = coordinator.ensureSlashCommandsLoaded("chat-1")
+
+    await new Promise((r) => setTimeout(r, 20))
+    releaseCommands!([{ name: "plan", description: "", argumentHint: "" }])
+
+    await Promise.all([p1, p2])
+
+    expect(startCount).toBe(1)
+    expect(store.commandsLoaded).toHaveLength(1)
+  })
+})
+
 function createFakeStore() {
   const chat = {
     id: "chat-1",
@@ -1532,6 +1668,7 @@ function createFakeStore() {
     provider: null as "claude" | "codex" | null,
     planMode: false,
     sessionToken: null as string | null,
+    slashCommands: undefined as SlashCommand[] | undefined,
   }
   const project = {
     id: "project-1",
@@ -1545,9 +1682,14 @@ function createFakeStore() {
     commandsLoaded: [] as Array<{ chatId: string; commands: SlashCommand[] }>,
     async recordSessionCommandsLoaded(chatId: string, commands: SlashCommand[]) {
       this.commandsLoaded.push({ chatId, commands })
+      chat.slashCommands = commands
     },
     requireChat(chatId: string) {
       expect(chatId).toBe("chat-1")
+      return chat
+    },
+    getChat(chatId: string) {
+      if (chatId !== "chat-1") return null
       return chat
     },
     getProject(projectId: string) {

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1779,6 +1779,7 @@ function createFakeStore() {
         model: message.model,
         modelOptions: message.modelOptions,
         planMode: message.planMode,
+        autoContinue: message.autoContinue,
       }
       this.queuedMessages.push(queuedMessage)
       return queuedMessage
@@ -1898,5 +1899,113 @@ describe("AgentCoordinator rate-limit detection (manual mode)", () => {
       expect(acEvents[0].source).toBe("auto_setting")
     }
     expect(store.turnFailures.some((f) => f.reason === "rate_limit")).toBe(true)
+  })
+})
+
+describe("AgentCoordinator auto-continue firing", () => {
+  test("firing enqueues a 'continue' user message carrying autoContinue metadata", async () => {
+    const store = createFakeStore()
+    const limitErr = makeLimitError()
+    const events = new AsyncEventQueue<any>()
+
+    // FakeClock lets us manually advance time to trigger armed schedules.
+    class FakeClock {
+      private currentTime = 0
+      private readonly timers = new Map<number, { fn: () => void; fireAt: number }>()
+      private nextId = 1
+
+      now() { return this.currentTime }
+
+      setTimeout(fn: () => void, delayMs: number): number {
+        const id = this.nextId++
+        this.timers.set(id, { fn, fireAt: this.currentTime + delayMs })
+        return id
+      }
+
+      clearTimeout(id: number) { this.timers.delete(id) }
+
+      advance(ms: number) {
+        this.currentTime += ms
+        for (const [id, timer] of [...this.timers.entries()]) {
+          if (timer.fireAt <= this.currentTime) {
+            this.timers.delete(id)
+            timer.fn()
+          }
+        }
+      }
+    }
+
+    const clock = new FakeClock()
+
+    let coordinator!: AgentCoordinator
+    const { ScheduleManager: SM } = await import("./auto-continue/schedule-manager")
+    const scheduleManager = new SM({
+      clock,
+      fire: async (chatId, scheduleId) => {
+        await coordinator.fireAutoContinue(chatId, scheduleId)
+      },
+    })
+
+    coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      getAutoResumePreference: () => true,
+      scheduleManager,
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        getSupportedCommands: async () => [],
+        sendPrompt: async () => {
+          events.throw(limitErr)
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "hello",
+      model: "claude-opus-4-5",
+      autoResumeOnRateLimit: true,
+    })
+
+    // Wait for auto_continue_accepted to be stored (Task 12 already handles this).
+    await waitFor(() => store.getAutoContinueEvents("chat-1").length >= 1 && store.turnFailedCount >= 1)
+
+    const acceptedEvent = store.getAutoContinueEvents("chat-1")[0]
+    expect(acceptedEvent.kind).toBe("auto_continue_accepted")
+
+    // The limit error header sets resetAt = new Date(5_000).toISOString() → 5000 ms from epoch.
+    // Advancing the clock past that fires the schedule.
+    clock.advance(10_000)
+
+    // Wait for the fired event AND the "continue" user_prompt to both appear.
+    await waitFor(
+      () =>
+        store.getAutoContinueEvents("chat-1").some((e) => e.kind === "auto_continue_fired") &&
+        store.messages.some((m) => m.kind === "user_prompt" && m.content === "continue")
+    )
+
+    const acEvents = store.getAutoContinueEvents("chat-1")
+    const firedEvent = acEvents.find((e) => e.kind === "auto_continue_fired")
+    expect(firedEvent).toBeDefined()
+    if (firedEvent?.kind === "auto_continue_fired") {
+      expect(firedEvent.scheduleId).toBe(acceptedEvent.scheduleId)
+    }
+
+    // Exactly one "continue" user_prompt with autoContinue metadata.
+    const userPrompts = store.messages.filter(
+      (m) => m.kind === "user_prompt" && m.content === "continue"
+    )
+    expect(userPrompts).toHaveLength(1)
+    if (userPrompts[0].kind === "user_prompt") {
+      expect(userPrompts[0].autoContinue?.scheduleId).toBe(acceptedEvent.scheduleId)
+    }
   })
 })

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./agent"
 import type { HarnessTurn } from "./harness-types"
 import type { ChatAttachment, SlashCommand, TranscriptEntry } from "../shared/types"
+import type { AutoContinueEvent } from "./auto-continue/events"
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry: T): TranscriptEntry {
   return {
@@ -30,36 +31,50 @@ async function waitFor(condition: () => boolean, timeoutMs = 2000) {
 
 class AsyncEventQueue<T> implements AsyncIterable<T> {
   private readonly values: T[] = []
-  private readonly waiters: Array<(result: IteratorResult<T>) => void> = []
+  private readonly waiters: Array<{ resolve: (result: IteratorResult<T>) => void; reject: (error: unknown) => void }> = []
   private closed = false
+  private pendingError: unknown = null
 
   push(value: T) {
     const waiter = this.waiters.shift()
     if (waiter) {
-      waiter({ done: false, value })
+      waiter.resolve({ done: false, value })
       return
     }
     this.values.push(value)
   }
 
+  throw(error: unknown) {
+    this.pendingError = error
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter.reject(error)
+    }
+  }
+
   close() {
     this.closed = true
     while (this.waiters.length > 0) {
-      this.waiters.shift()?.({ done: true, value: undefined as never })
+      this.waiters.shift()?.resolve({ done: true, value: undefined as never })
     }
   }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
     return {
       next: async () => {
+        if (this.pendingError !== null) {
+          const err = this.pendingError
+          this.pendingError = null
+          throw err
+        }
         if (this.values.length > 0) {
           return { done: false, value: this.values.shift() as T }
         }
         if (this.closed) {
           return { done: true, value: undefined as never }
         }
-        return await new Promise<IteratorResult<T>>((resolve) => {
-          this.waiters.push(resolve)
+        return await new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waiters.push({ resolve, reject })
         })
       },
     }
@@ -1731,10 +1746,23 @@ function createFakeStore() {
     async recordTurnFinished() {
       this.turnFinishedCount += 1
     },
-    async recordTurnFailed() {
-      throw new Error("Did not expect turn failure")
+    turnFailedCount: 0,
+    turnFailures: [] as Array<{ chatId: string; reason: string }>,
+    async recordTurnFailed(chatId: string, reason: string) {
+      this.turnFailedCount += 1
+      this.turnFailures.push({ chatId, reason })
     },
     async recordTurnCancelled() {},
+    autoContinueEvents: [] as AutoContinueEvent[],
+    async appendAutoContinueEvent(event: AutoContinueEvent) {
+      this.autoContinueEvents.push(event)
+    },
+    getAutoContinueEvents(chatId: string) {
+      return this.autoContinueEvents.filter((e) => e.chatId === chatId)
+    },
+    listAutoContinueChats() {
+      return [...new Set(this.autoContinueEvents.map((e) => e.chatId))]
+    },
     async setSessionToken(_chatId: string, sessionToken: string | null) {
       chat.sessionToken = sessionToken
     },
@@ -1766,3 +1794,109 @@ function createFakeStore() {
     },
   }
 }
+
+function makeLimitError() {
+  const err = new Error(
+    JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error" },
+    })
+  ) as Error & { status?: number; headers?: Record<string, string> }
+  err.status = 429
+  err.headers = {
+    "anthropic-ratelimit-unified-reset": new Date(5_000).toISOString(),
+    "x-anthropic-timezone": "Asia/Saigon",
+  }
+  return err
+}
+
+describe("AgentCoordinator rate-limit detection (manual mode)", () => {
+  test("emits auto_continue_proposed when Claude throws a rate-limit error and autoResumeOnRateLimit is false", async () => {
+    const store = createFakeStore()
+    const limitErr = makeLimitError()
+    const events = new AsyncEventQueue<any>()
+
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      getAutoResumePreference: () => false,
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        getSupportedCommands: async () => [],
+        sendPrompt: async () => {
+          // Throw after sendPrompt is called — activeTurns is already set by this point
+          events.throw(limitErr)
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "hello",
+      model: "claude-opus-4-5",
+      autoResumeOnRateLimit: false,
+    })
+
+    await waitFor(() => store.getAutoContinueEvents("chat-1").length >= 1 && store.turnFailedCount >= 1)
+
+    const acEvents = store.getAutoContinueEvents("chat-1")
+    expect(acEvents).toHaveLength(1)
+    expect(acEvents[0].kind).toBe("auto_continue_proposed")
+    if (acEvents[0].kind === "auto_continue_proposed") {
+      expect(acEvents[0].tz).toBe("Asia/Saigon")
+    }
+    expect(store.turnFailures.some((f) => f.reason === "rate_limit")).toBe(true)
+  })
+
+  test("auto-resume on: emits auto_continue_accepted directly with source=auto_setting", async () => {
+    const store = createFakeStore()
+    const limitErr = makeLimitError()
+    const events = new AsyncEventQueue<any>()
+
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      getAutoResumePreference: () => true,
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        getSupportedCommands: async () => [],
+        sendPrompt: async () => {
+          events.throw(limitErr)
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "hello",
+      model: "claude-opus-4-5",
+      autoResumeOnRateLimit: true,
+    })
+
+    await waitFor(() => store.getAutoContinueEvents("chat-1").length >= 1 && store.turnFailedCount >= 1)
+
+    const acEvents = store.getAutoContinueEvents("chat-1")
+    expect(acEvents).toHaveLength(1)
+    expect(acEvents[0].kind).toBe("auto_continue_accepted")
+    if (acEvents[0].kind === "auto_continue_accepted") {
+      expect(acEvents[0].source).toBe("auto_setting")
+    }
+    expect(store.turnFailures.some((f) => f.reason === "rate_limit")).toBe(true)
+  })
+})

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1341,9 +1341,14 @@ describe("AgentCoordinator claude integration", () => {
     ]
 
     const store = createFakeStore()
+    const stateChanges: Array<string | undefined> = []
+    let releaseCommands: (value: SlashCommand[]) => void
+    const commandsReady = new Promise<SlashCommand[]>((resolve) => {
+      releaseCommands = resolve
+    })
     const coordinator = new AgentCoordinator({
       store: store as never,
-      onStateChange: () => {},
+      onStateChange: (chatId) => { stateChanges.push(chatId) },
       startClaudeSession: async () => ({
         provider: "claude",
         stream: events,
@@ -1352,7 +1357,7 @@ describe("AgentCoordinator claude integration", () => {
         close: () => {},
         setModel: async () => {},
         setPermissionMode: async () => {},
-        getSupportedCommands: async () => commandsFromSDK,
+        getSupportedCommands: () => commandsReady,
         sendPrompt: async () => {
           events.push({
             type: "transcript" as const,
@@ -1376,10 +1381,21 @@ describe("AgentCoordinator claude integration", () => {
       model: "claude-opus-4-1",
     })
     await waitFor(() => store.turnFinishedCount === 1)
+    // Let any pending coordinator state emits flush before we capture the
+    // baseline so the post-release growth strictly reflects the commands-
+    // loaded emit.
+    await new Promise((r) => setTimeout(r, 50))
+
+    const stateChangesBeforeLoad = stateChanges.length
+    releaseCommands!(commandsFromSDK)
+
     await waitFor(() => store.commandsLoaded.length === 1)
 
     expect(store.commandsLoaded[0].chatId).toBe("chat-1")
     expect(store.commandsLoaded[0].commands).toEqual(commandsFromSDK)
+    // Coordinator must nudge subscribers after persisting commands so freshly
+    // loaded slash commands reach the client.
+    await waitFor(() => stateChanges.length > stateChangesBeforeLoad)
 
     events.close()
   })

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -2012,6 +2012,8 @@ describe("AgentCoordinator auto-continue firing", () => {
 
 // ── AgentCoordinator: acceptAutoContinue / rescheduleAutoContinue / cancelAutoContinue / listLiveSchedules ──
 
+// Minimal coordinator factory for Task 14 auto-continue tests; intentionally omits
+// codexManager and generateTitle — do not use for tests that need provider flows.
 function makeCoordinatorWithStore(extraStoreFields: Partial<ReturnType<typeof createFakeStore>> = {}) {
   const store = { ...createFakeStore(), ...extraStoreFields }
   const coordinator = new AgentCoordinator({

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1273,6 +1273,7 @@ describe("AgentCoordinator claude integration", () => {
           close: () => {},
           setModel: async () => {},
           setPermissionMode: async () => {},
+          getSupportedCommands: async () => [],
           sendPrompt: async (content: string) => {
             prompts.push(content)
             if (prompts.length === 1) {
@@ -1347,6 +1348,7 @@ describe("AgentCoordinator claude integration", () => {
         close: () => {},
         setModel: async () => {},
         setPermissionMode: async () => {},
+        getSupportedCommands: async () => [],
         sendPrompt: async () => {
           events.push({
             type: "transcript" as const,
@@ -1414,6 +1416,7 @@ describe("AgentCoordinator claude integration", () => {
         close: () => {},
         setModel: async () => {},
         setPermissionMode: async () => {},
+        getSupportedCommands: async () => [],
         sendPrompt: async (content: string) => {
           prompts.push(content)
         },

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -2009,3 +2009,268 @@ describe("AgentCoordinator auto-continue firing", () => {
     }
   })
 })
+
+// ── AgentCoordinator: acceptAutoContinue / rescheduleAutoContinue / cancelAutoContinue / listLiveSchedules ──
+
+function makeCoordinatorWithStore(extraStoreFields: Partial<ReturnType<typeof createFakeStore>> = {}) {
+  const store = { ...createFakeStore(), ...extraStoreFields }
+  const coordinator = new AgentCoordinator({
+    store: store as never,
+    onStateChange: () => {},
+    getAutoResumePreference: () => false,
+    startClaudeSession: async () => { throw new Error("not needed") },
+  })
+  return { store, coordinator }
+}
+
+describe("AgentCoordinator.acceptAutoContinue", () => {
+  test("happy path: appends auto_continue_accepted with source 'user' for a proposed schedule", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    // Seed a proposed event
+    const scheduleId = "sched-1"
+    const proposedEvent: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    }
+    store.autoContinueEvents.push(proposedEvent)
+
+    const future = Date.now() + 60_000
+    await coordinator.acceptAutoContinue("chat-1", scheduleId, future)
+
+    const appended = store.autoContinueEvents.filter((e) => e.kind === "auto_continue_accepted")
+    expect(appended).toHaveLength(1)
+    expect(appended[0]!.kind).toBe("auto_continue_accepted")
+    if (appended[0]!.kind === "auto_continue_accepted") {
+      expect(appended[0]!.source).toBe("user")
+      expect(appended[0]!.scheduledAt).toBe(future)
+    }
+  })
+
+  test("guard: rejects when schedule state is not 'proposed'", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-cancel"
+    // Seed a proposed + cancelled event so state = "cancelled"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_cancelled",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      reason: "user",
+    })
+
+    await expect(
+      coordinator.acceptAutoContinue("chat-1", scheduleId, Date.now() + 60_000)
+    ).rejects.toThrow("Schedule not pending")
+  })
+
+  test("guard: rejects when scheduledAt is in the past (time guard)", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-past"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+
+    await expect(
+      coordinator.acceptAutoContinue("chat-1", scheduleId, Date.now() - 1)
+    ).rejects.toThrow("scheduledAt must be in the future")
+  })
+})
+
+describe("AgentCoordinator.rescheduleAutoContinue", () => {
+  test("happy path: appends auto_continue_rescheduled for a scheduled schedule", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-sched"
+    // Seed proposed + accepted = state "scheduled"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      scheduledAt: Date.now() + 30_000,
+      tz: "UTC",
+      source: "user",
+      resetAt: Date.now() + 10_000,
+      detectedAt: Date.now(),
+    })
+
+    const newTime = Date.now() + 120_000
+    await coordinator.rescheduleAutoContinue("chat-1", scheduleId, newTime)
+
+    const appended = store.autoContinueEvents.filter((e) => e.kind === "auto_continue_rescheduled")
+    expect(appended).toHaveLength(1)
+    if (appended[0]!.kind === "auto_continue_rescheduled") {
+      expect(appended[0]!.scheduledAt).toBe(newTime)
+    }
+  })
+
+  test("guard: rejects when schedule state is not 'scheduled'", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-prop"
+    // Proposed only = state "proposed"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+
+    await expect(
+      coordinator.rescheduleAutoContinue("chat-1", scheduleId, Date.now() + 60_000)
+    ).rejects.toThrow("Schedule not active")
+  })
+
+  test("guard: rejects when scheduledAt is in the past (time guard)", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-ts"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      scheduledAt: Date.now() + 30_000,
+      tz: "UTC",
+      source: "user",
+      resetAt: Date.now() + 10_000,
+      detectedAt: Date.now(),
+    })
+
+    await expect(
+      coordinator.rescheduleAutoContinue("chat-1", scheduleId, Date.now() - 1)
+    ).rejects.toThrow("scheduledAt must be in the future")
+  })
+})
+
+describe("AgentCoordinator.cancelAutoContinue", () => {
+  test("happy path: appends auto_continue_cancelled with given reason for a live schedule", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-live"
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      detectedAt: Date.now(),
+      resetAt: Date.now() + 10_000,
+      tz: "UTC",
+      turnId: "turn-1",
+    })
+
+    await coordinator.cancelAutoContinue("chat-1", scheduleId, "user")
+
+    const appended = store.autoContinueEvents.filter((e) => e.kind === "auto_continue_cancelled")
+    expect(appended).toHaveLength(1)
+    if (appended[0]!.kind === "auto_continue_cancelled") {
+      expect(appended[0]!.reason).toBe("user")
+    }
+  })
+
+  test("guard: silently no-ops when schedule state is outside proposed|scheduled (does not throw, no event appended)", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    const scheduleId = "sched-fired"
+    // Seed a fired schedule
+    store.autoContinueEvents.push({
+      v: 3,
+      kind: "auto_continue_fired",
+      timestamp: Date.now(),
+      chatId: "chat-1",
+      scheduleId,
+      firedAt: Date.now(),
+    })
+
+    // Should not throw
+    await coordinator.cancelAutoContinue("chat-1", scheduleId, "user")
+
+    // No cancelled event appended
+    const cancelled = store.autoContinueEvents.filter((e) => e.kind === "auto_continue_cancelled")
+    expect(cancelled).toHaveLength(0)
+  })
+})
+
+describe("AgentCoordinator.listLiveSchedules", () => {
+  test("returns scheduleIds for proposed and scheduled states only", async () => {
+    const { store, coordinator } = makeCoordinatorWithStore()
+    // proposed
+    store.autoContinueEvents.push({
+      v: 3, kind: "auto_continue_proposed", timestamp: Date.now(),
+      chatId: "chat-1", scheduleId: "sched-proposed",
+      detectedAt: Date.now(), resetAt: Date.now() + 10_000, tz: "UTC", turnId: "t1",
+    })
+    // scheduled
+    store.autoContinueEvents.push({
+      v: 3, kind: "auto_continue_proposed", timestamp: Date.now(),
+      chatId: "chat-1", scheduleId: "sched-scheduled",
+      detectedAt: Date.now(), resetAt: Date.now() + 10_000, tz: "UTC", turnId: "t2",
+    })
+    store.autoContinueEvents.push({
+      v: 3, kind: "auto_continue_accepted", timestamp: Date.now(),
+      chatId: "chat-1", scheduleId: "sched-scheduled",
+      scheduledAt: Date.now() + 30_000, tz: "UTC", source: "user",
+      resetAt: Date.now() + 10_000, detectedAt: Date.now(),
+    })
+    // fired (should not appear)
+    store.autoContinueEvents.push({
+      v: 3, kind: "auto_continue_fired", timestamp: Date.now(),
+      chatId: "chat-1", scheduleId: "sched-fired", firedAt: Date.now(),
+    })
+
+    const live = coordinator.listLiveSchedules("chat-1")
+    expect(live.sort()).toEqual(["sched-proposed", "sched-scheduled"].sort())
+  })
+})

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -10,6 +10,8 @@ import {
 import type { HarnessTurn } from "./harness-types"
 import type { ChatAttachment, SlashCommand, TranscriptEntry } from "../shared/types"
 import type { AutoContinueEvent } from "./auto-continue/events"
+import { AsyncEventQueue } from "./test-helpers/async-event-queue"
+import { waitFor } from "./test-helpers/wait-for"
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry: T): TranscriptEntry {
   return {
@@ -17,68 +19,6 @@ function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry
     createdAt: Date.now(),
     ...entry,
   } as TranscriptEntry
-}
-
-async function waitFor(condition: () => boolean, timeoutMs = 2000) {
-  const start = Date.now()
-  while (!condition()) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error("Timed out waiting for condition")
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
-}
-
-class AsyncEventQueue<T> implements AsyncIterable<T> {
-  private readonly values: T[] = []
-  private readonly waiters: Array<{ resolve: (result: IteratorResult<T>) => void; reject: (error: unknown) => void }> = []
-  private closed = false
-  private pendingError: unknown = null
-
-  push(value: T) {
-    const waiter = this.waiters.shift()
-    if (waiter) {
-      waiter.resolve({ done: false, value })
-      return
-    }
-    this.values.push(value)
-  }
-
-  throw(error: unknown) {
-    this.pendingError = error
-    const waiter = this.waiters.shift()
-    if (waiter) {
-      waiter.reject(error)
-    }
-  }
-
-  close() {
-    this.closed = true
-    while (this.waiters.length > 0) {
-      this.waiters.shift()?.resolve({ done: true, value: undefined as never })
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: async () => {
-        if (this.pendingError !== null) {
-          const err = this.pendingError
-          this.pendingError = null
-          throw err
-        }
-        if (this.values.length > 0) {
-          return { done: false, value: this.values.shift() as T }
-        }
-        if (this.closed) {
-          return { done: true, value: undefined as never }
-        }
-        return await new Promise<IteratorResult<T>>((resolve, reject) => {
-          this.waiters.push({ resolve, reject })
-        })
-      },
-    }
-  }
 }
 
 describe("normalizeClaudeStreamMessage", () => {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1087,6 +1087,15 @@ export class AgentCoordinator {
       }
       this.claudeSessions.set(args.chatId, session)
       void this.runClaudeSession(session)
+      void (async () => {
+        try {
+          const commands = await started.getSupportedCommands()
+          await this.store.recordSessionCommandsLoaded(args.chatId, commands)
+          this.emitStateChange(args.chatId)
+        } catch (error) {
+          console.warn("[kanna/agent] failed to load slash commands", error)
+        }
+      })()
     } else {
       if (session.model !== args.model) {
         await session.session.setModel(args.model)

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -715,6 +715,10 @@ export class AgentCoordinator {
     return new Set(this.drainingStreams.keys())
   }
 
+  getSlashCommandsLoadingChatIds(): Set<string> {
+    return new Set(this.slashCommandsInFlight)
+  }
+
   private emitStateChange(chatId?: string, options?: { immediate?: boolean }) {
     this.onStateChange(chatId, options)
   }
@@ -750,6 +754,7 @@ export class AgentCoordinator {
     if (!project) return
 
     this.slashCommandsInFlight.add(chatId)
+    this.emitStateChange(chatId)
     try {
       let commands: SlashCommand[]
       const existing = this.claudeSessions.get(chatId)
@@ -778,6 +783,7 @@ export class AgentCoordinator {
       console.warn("[kanna/agent] ensureSlashCommandsLoaded failed", error)
     } finally {
       this.slashCommandsInFlight.delete(chatId)
+      this.emitStateChange(chatId)
     }
   }
 

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -683,6 +683,7 @@ export class AgentCoordinator {
   readonly activeTurns = new Map<string, ActiveTurn>()
   readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
   readonly claudeSessions = new Map<string, ClaudeSessionState>()
+  private readonly slashCommandsInFlight = new Set<string>()
 
   constructor(args: AgentCoordinatorArgs) {
     this.store = args.store
@@ -736,6 +737,48 @@ export class AgentCoordinator {
     draining.turn.close()
     this.drainingStreams.delete(chatId)
     this.emitStateChange(chatId)
+  }
+
+  async ensureSlashCommandsLoaded(chatId: string): Promise<void> {
+    const chat = this.store.getChat(chatId)
+    if (!chat) return
+    if (chat.provider === "codex") return
+    if (chat.slashCommands && chat.slashCommands.length > 0) return
+    if (this.slashCommandsInFlight.has(chatId)) return
+
+    const project = this.store.getProject(chat.projectId)
+    if (!project) return
+
+    this.slashCommandsInFlight.add(chatId)
+    try {
+      let commands: SlashCommand[]
+      const existing = this.claudeSessions.get(chatId)
+      if (existing) {
+        commands = await existing.session.getSupportedCommands()
+      } else {
+        const defaultModel = normalizeServerModel("claude")
+        const defaultOptions = normalizeClaudeModelOptions(defaultModel)
+        const ephemeral = await this.startClaudeSessionFn({
+          localPath: project.localPath,
+          model: resolveClaudeApiModelId(defaultModel, defaultOptions.contextWindow),
+          effort: defaultOptions.reasoningEffort,
+          planMode: chat.planMode ?? false,
+          sessionToken: chat.sessionToken ?? null,
+          onToolRequest: async () => null,
+        })
+        try {
+          commands = await ephemeral.getSupportedCommands()
+        } finally {
+          ephemeral.close()
+        }
+      }
+      await this.store.recordSessionCommandsLoaded(chatId, commands)
+      this.emitStateChange(chatId)
+    } catch (error) {
+      console.warn("[kanna/agent] ensureSlashCommandsLoaded failed", error)
+    } finally {
+      this.slashCommandsInFlight.delete(chatId)
+    }
   }
 
   async closeChat(chatId: string) {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -811,6 +811,7 @@ export class AgentCoordinator {
       claudeSession.session.close()
       this.claudeSessions.delete(chatId)
     }
+    this.autoResumeByChat.delete(chatId)
     this.emitStateChange(chatId)
   }
 
@@ -1353,7 +1354,7 @@ export class AgentCoordinator {
     } catch (error) {
       const active = this.activeTurns.get(session.chatId)
       if (active && !active.cancelRequested) {
-        const handled = await this.handleLimitError(session.chatId, this.claudeLimitDetector, error, "")
+        const handled = await this.handleLimitError(session.chatId, this.claudeLimitDetector, error, active.clientTraceId ?? "")
         if (!handled) {
           const message = error instanceof Error ? error.message : String(error)
           await this.store.appendMessage(
@@ -1449,7 +1450,7 @@ export class AgentCoordinator {
       }
     } catch (error) {
       if (!active.cancelRequested) {
-        const handled = await this.handleLimitError(active.chatId, this.codexLimitDetector, error, "")
+        const handled = await this.handleLimitError(active.chatId, this.codexLimitDetector, error, active.clientTraceId ?? "")
         if (!handled) {
           const message = error instanceof Error ? error.message : String(error)
           await this.store.appendMessage(

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -147,6 +147,7 @@ interface SendMessageOptions {
   modelOptions?: ModelOptions
   effort?: string
   planMode?: boolean
+  autoContinue?: { scheduleId: string }
 }
 
 function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
@@ -850,6 +851,7 @@ export class AgentCoordinator {
       model: options?.model,
       modelOptions: options?.modelOptions,
       planMode: options?.planMode,
+      autoContinue: options?.autoContinue,
     })
     this.emitStateChange(chatId)
     return queued
@@ -871,6 +873,7 @@ export class AgentCoordinator {
       planMode: settings.planMode,
       appendUserPrompt: true,
       steered: options?.steered,
+      autoContinue: queuedMessage.autoContinue,
     })
   }
 
@@ -895,6 +898,7 @@ export class AgentCoordinator {
     planMode: boolean
     appendUserPrompt: boolean
     steered?: boolean
+    autoContinue?: { scheduleId: string }
     profile?: SendToStartingProfile | null
   }) {
     logSendToStartingProfile(args.profile, "start_turn.begin", {
@@ -948,7 +952,7 @@ export class AgentCoordinator {
 
     if (args.appendUserPrompt) {
       const userPromptEntry = timestamped(
-        { kind: "user_prompt", content: args.content, attachments: args.attachments, steered: args.steered },
+        { kind: "user_prompt", content: args.content, attachments: args.attachments, steered: args.steered, autoContinue: args.autoContinue },
         Date.now()
       )
       await this.store.appendMessage(args.chatId, userPromptEntry)
@@ -1588,6 +1592,38 @@ export class AgentCoordinator {
     } as Omit<TranscriptEntry, "_id" | "createdAt">))
 
     return true
+  }
+
+  async fireAutoContinue(chatId: string, scheduleId: string) {
+    const now = Date.now()
+    const fired: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_fired",
+      timestamp: now,
+      chatId,
+      scheduleId,
+      firedAt: now,
+    }
+    await this.store.appendAutoContinueEvent(fired)
+
+    try {
+      await this.enqueueMessage(chatId, "continue", [], { autoContinue: { scheduleId } })
+      await this.maybeStartNextQueuedMessage(chatId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await this.store.appendMessage(
+        chatId,
+        timestamped({
+          kind: "result",
+          subtype: "error",
+          isError: true,
+          durationMs: 0,
+          result: `Auto-continue failed: ${message}`,
+        })
+      )
+    }
+
+    this.emitStateChange(chatId)
   }
 
   async cancel(chatId: string, options?: { hideInterrupted?: boolean }) {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1604,9 +1604,8 @@ export class AgentCoordinator {
       scheduleId,
       firedAt: now,
     }
-    await this.store.appendAutoContinueEvent(fired)
-
     try {
+      await this.store.appendAutoContinueEvent(fired)
       await this.enqueueMessage(chatId, "continue", [], { autoContinue: { scheduleId } })
       await this.maybeStartNextQueuedMessage(chatId)
     } catch (error) {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -8,6 +8,7 @@ import type {
   PendingToolSnapshot,
   KannaStatus,
   QueuedChatMessage,
+  SlashCommand,
   TranscriptEntry,
 } from "../shared/types"
 import { normalizeToolCall } from "../shared/tools"
@@ -79,6 +80,7 @@ interface ClaudeSessionHandle {
   sendPrompt: (content: string) => Promise<void>
   setModel: (model: string) => Promise<void>
   setPermissionMode: (planMode: boolean) => Promise<void>
+  getSupportedCommands: () => Promise<SlashCommand[]>
 }
 
 interface ClaudeSessionState {
@@ -655,6 +657,19 @@ async function startClaudeSession(args: {
     },
     setPermissionMode: async (planMode: boolean) => {
       await q.setPermissionMode(planMode ? "plan" : "acceptEdits")
+    },
+    getSupportedCommands: async () => {
+      try {
+        const commands = await q.supportedCommands()
+        return commands.map((c) => ({
+          name: c.name,
+          description: c.description,
+          argumentHint: c.argumentHint,
+        }))
+      } catch (error) {
+        console.warn("[kanna/claude] supportedCommands failed", error)
+        return []
+      }
     },
     close: () => {
       promptQueue.close()

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1625,6 +1625,77 @@ export class AgentCoordinator {
     this.emitStateChange(chatId)
   }
 
+  async acceptAutoContinue(chatId: string, scheduleId: string, scheduledAt: number): Promise<void> {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const projection = deriveChatSchedules(events, chatId)
+    const schedule = projection.schedules[scheduleId]
+    if (!schedule) throw new Error("Schedule not found")
+    if (schedule.state !== "proposed") throw new Error("Schedule not pending")
+    if (scheduledAt <= Date.now()) throw new Error("scheduledAt must be in the future")
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      scheduledAt,
+      tz: schedule.tz,
+      source: "user",
+      resetAt: schedule.resetAt,
+      detectedAt: schedule.detectedAt,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  async rescheduleAutoContinue(chatId: string, scheduleId: string, scheduledAt: number): Promise<void> {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const schedule = deriveChatSchedules(events, chatId).schedules[scheduleId]
+    if (!schedule || schedule.state !== "scheduled") throw new Error("Schedule not active")
+    if (scheduledAt <= Date.now()) throw new Error("scheduledAt must be in the future")
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_rescheduled",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      scheduledAt,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  async cancelAutoContinue(chatId: string, scheduleId: string, reason: "user" | "chat_deleted"): Promise<void> {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const schedule = deriveChatSchedules(events, chatId).schedules[scheduleId]
+    if (!schedule) return
+    if (schedule.state !== "proposed" && schedule.state !== "scheduled") return
+
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_cancelled",
+      timestamp: Date.now(),
+      chatId,
+      scheduleId,
+      reason,
+    }
+    await this.store.appendAutoContinueEvent(event)
+    this.scheduleManager?.onEvent(event)
+    this.emitStateChange(chatId)
+  }
+
+  listLiveSchedules(chatId: string): string[] {
+    const events = this.store.getAutoContinueEvents(chatId)
+    const projection = deriveChatSchedules(events, chatId)
+    return Object.values(projection.schedules)
+      .filter((s) => s.state === "proposed" || s.state === "scheduled")
+      .map((s) => s.scheduleId)
+  }
+
   async cancel(chatId: string, options?: { hideInterrupted?: boolean }) {
     // Also clean up any draining stream for this chat.
     const draining = this.drainingStreams.get(chatId)

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1595,6 +1595,9 @@ export class AgentCoordinator {
   }
 
   async fireAutoContinue(chatId: string, scheduleId: string) {
+    // Chat may have been deleted between accept and fire — skip silently.
+    if (!this.store.getChat(chatId)) return
+
     const now = Date.now()
     const fired: AutoContinueEvent = {
       v: 3,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -660,12 +660,7 @@ async function startClaudeSession(args: {
     },
     getSupportedCommands: async () => {
       try {
-        const commands = await q.supportedCommands()
-        return commands.map((c) => ({
-          name: c.name,
-          description: c.description,
-          argumentHint: c.argumentHint,
-        }))
+        return await q.supportedCommands()
       } catch (error) {
         console.warn("[kanna/claude] supportedCommands failed", error)
         return []

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -26,6 +26,10 @@ import {
 } from "./provider-catalog"
 import { resolveClaudeApiModelId } from "../shared/types"
 import { fallbackTitleFromMessage } from "./generate-title"
+import type { AutoContinueEvent } from "./auto-continue/events"
+import { ClaudeLimitDetector, CodexLimitDetector, type LimitDetector } from "./auto-continue/limit-detector"
+import type { ScheduleManager } from "./auto-continue/schedule-manager"
+import { deriveChatSchedules } from "./auto-continue/read-model"
 
 const CLAUDE_TOOLSET = [
   "Skill",
@@ -110,6 +114,10 @@ interface AgentCoordinatorArgs {
     sessionToken: string | null
     onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
   }) => Promise<ClaudeSessionHandle>
+  claudeLimitDetector?: LimitDetector
+  codexLimitDetector?: LimitDetector
+  scheduleManager?: ScheduleManager
+  getAutoResumePreference?: () => boolean
 }
 
 interface SendToStartingProfile {
@@ -684,6 +692,11 @@ export class AgentCoordinator {
   readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
   readonly claudeSessions = new Map<string, ClaudeSessionState>()
   private readonly slashCommandsInFlight = new Set<string>()
+  private readonly claudeLimitDetector: LimitDetector
+  private readonly codexLimitDetector: LimitDetector
+  private readonly scheduleManager: ScheduleManager | null
+  private readonly getAutoResumePreference: () => boolean
+  private readonly autoResumeByChat = new Map<string, boolean>()
 
   constructor(args: AgentCoordinatorArgs) {
     this.store = args.store
@@ -691,6 +704,10 @@ export class AgentCoordinator {
     this.codexManager = args.codexManager ?? new CodexAppServerManager()
     this.generateTitle = args.generateTitle ?? generateTitleForChatDetailed
     this.startClaudeSessionFn = args.startClaudeSession ?? startClaudeSession
+    this.claudeLimitDetector = args.claudeLimitDetector ?? new ClaudeLimitDetector()
+    this.codexLimitDetector = args.codexLimitDetector ?? new CodexLimitDetector()
+    this.scheduleManager = args.scheduleManager ?? null
+    this.getAutoResumePreference = args.getAutoResumePreference ?? (() => false)
   }
 
   setBackgroundErrorReporter(report: ((message: string) => void) | null) {
@@ -1190,6 +1207,10 @@ export class AgentCoordinator {
       })
     }
 
+    if (typeof command.autoResumeOnRateLimit === "boolean" && chatId) {
+      this.autoResumeByChat.set(chatId, command.autoResumeOnRateLimit)
+    }
+
     const chat = this.store.requireChat(chatId)
     if (this.activeTurns.has(chatId)) {
       const queuedMessage = await this.enqueueMessage(chatId, command.content, command.attachments ?? [], {
@@ -1227,6 +1248,9 @@ export class AgentCoordinator {
   }
 
   async enqueue(command: Extract<ClientCommand, { type: "message.enqueue" }>) {
+    if (typeof command.autoResumeOnRateLimit === "boolean") {
+      this.autoResumeByChat.set(command.chatId, command.autoResumeOnRateLimit)
+    }
     const queuedMessage = await this.enqueueMessage(command.chatId, command.content, command.attachments ?? [], {
       provider: command.provider,
       model: command.model,
@@ -1329,18 +1353,23 @@ export class AgentCoordinator {
     } catch (error) {
       const active = this.activeTurns.get(session.chatId)
       if (active && !active.cancelRequested) {
-        const message = error instanceof Error ? error.message : String(error)
-        await this.store.appendMessage(
-          session.chatId,
-          timestamped({
-            kind: "result",
-            subtype: "error",
-            isError: true,
-            durationMs: 0,
-            result: message,
-          })
-        )
-        await this.store.recordTurnFailed(session.chatId, message)
+        const handled = await this.handleLimitError(session.chatId, this.claudeLimitDetector, error, "")
+        if (!handled) {
+          const message = error instanceof Error ? error.message : String(error)
+          await this.store.appendMessage(
+            session.chatId,
+            timestamped({
+              kind: "result",
+              subtype: "error",
+              isError: true,
+              durationMs: 0,
+              result: message,
+            })
+          )
+          await this.store.recordTurnFailed(session.chatId, message)
+        } else {
+          await this.store.recordTurnFailed(session.chatId, "rate_limit")
+        }
       }
     } finally {
       this.claudeSessions.delete(session.chatId)
@@ -1420,18 +1449,23 @@ export class AgentCoordinator {
       }
     } catch (error) {
       if (!active.cancelRequested) {
-        const message = error instanceof Error ? error.message : String(error)
-        await this.store.appendMessage(
-          active.chatId,
-          timestamped({
-            kind: "result",
-            subtype: "error",
-            isError: true,
-            durationMs: 0,
-            result: message,
-          })
-        )
-        await this.store.recordTurnFailed(active.chatId, message)
+        const handled = await this.handleLimitError(active.chatId, this.codexLimitDetector, error, "")
+        if (!handled) {
+          const message = error instanceof Error ? error.message : String(error)
+          await this.store.appendMessage(
+            active.chatId,
+            timestamped({
+              kind: "result",
+              subtype: "error",
+              isError: true,
+              durationMs: 0,
+              result: message,
+            })
+          )
+          await this.store.recordTurnFailed(active.chatId, message)
+        } else {
+          await this.store.recordTurnFailed(active.chatId, "rate_limit")
+        }
       }
     } finally {
       if (active.cancelRequested && !active.cancelRecorded) {
@@ -1496,6 +1530,63 @@ export class AgentCoordinator {
         }
       }
     }
+  }
+
+  private resolveAutoResumeFor(chatId: string): boolean {
+    const cached = this.autoResumeByChat.get(chatId)
+    if (typeof cached === "boolean") return cached
+    return this.getAutoResumePreference()
+  }
+
+  private async handleLimitError(chatId: string, detector: LimitDetector, error: unknown, turnId: string): Promise<boolean> {
+    const detection = detector.detect(chatId, error)
+    if (!detection) return false
+
+    const state = this.store.getAutoContinueEvents(chatId)
+    const live = deriveChatSchedules(state, chatId).liveScheduleId
+    if (live !== null) return true
+
+    const autoResume = this.resolveAutoResumeFor(chatId)
+    const now = Date.now()
+    const scheduleId = crypto.randomUUID()
+
+    if (autoResume) {
+      const event: AutoContinueEvent = {
+        v: 3,
+        kind: "auto_continue_accepted",
+        timestamp: now,
+        chatId,
+        scheduleId,
+        scheduledAt: detection.resetAt,
+        tz: detection.tz,
+        source: "auto_setting",
+        resetAt: detection.resetAt,
+        detectedAt: now,
+      }
+      await this.store.appendAutoContinueEvent(event)
+      this.scheduleManager?.onEvent(event)
+    } else {
+      const event: AutoContinueEvent = {
+        v: 3,
+        kind: "auto_continue_proposed",
+        timestamp: now,
+        chatId,
+        scheduleId,
+        detectedAt: now,
+        resetAt: detection.resetAt,
+        tz: detection.tz,
+        turnId,
+      }
+      await this.store.appendAutoContinueEvent(event)
+      this.scheduleManager?.onEvent(event)
+    }
+
+    await this.store.appendMessage(chatId, timestamped({
+      kind: "auto_continue_prompt",
+      scheduleId,
+    } as Omit<TranscriptEntry, "_id" | "createdAt">))
+
+    return true
   }
 
   async cancel(chatId: string, options?: { hideInterrupted?: boolean }) {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1694,6 +1694,7 @@ export class AgentCoordinator {
     return Object.values(projection.schedules)
       .filter((s) => s.state === "proposed" || s.state === "scheduled")
       .map((s) => s.scheduleId)
+      .sort()
   }
 
   async cancel(chatId: string, options?: { hideInterrupted?: boolean }) {

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -11,10 +11,15 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-async function startPasswordServer() {
+async function startPasswordServer(options: { trustProxy?: boolean; port?: number } = {}) {
   const projectDir = await mkdtemp(path.join(tmpdir(), "kanna-auth-test-"))
   tempDirs.push(projectDir)
-  const server = await startKannaServer({ port: 4320, strictPort: true, password: "secret" })
+  const server = await startKannaServer({
+    port: options.port ?? 4320,
+    strictPort: true,
+    password: "secret",
+    trustProxy: options.trustProxy ?? false,
+  })
   const project = await server.store.openProject(projectDir, "Project")
   return { server, projectDir, project }
 }
@@ -164,6 +169,92 @@ describe("password auth", () => {
       })
       expect(contentResponse.status).toBe(200)
       expect(await contentResponse.text()).toBe("hello from upload")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("ignores forwarded headers when trustProxy is off", async () => {
+    const { server } = await startPasswordServer({ port: 54321 })
+
+    try {
+      const response = await fetch(`http://localhost:${server.port}/`, {
+        redirect: "manual",
+        headers: {
+          Accept: "text/html",
+          "X-Forwarded-Host": "evil.test",
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(response.status).toBe(302)
+      expect(response.headers.get("location")).toBe(`http://localhost:${server.port}/auth/login?next=%2F`)
+
+      const loginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.test",
+          "X-Forwarded-Host": "evil.test",
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(loginResponse.status).toBe(403)
+
+      const goodLoginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `http://localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(goodLoginResponse.status).toBe(200)
+      const cookieHeader = goodLoginResponse.headers.get("set-cookie") ?? ""
+      expect(cookieHeader).not.toContain("Secure")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("honors forwarded headers when trustProxy is on", async () => {
+    const { server } = await startPasswordServer({ port: 54322, trustProxy: true })
+
+    try {
+      const redirect = await fetch(`http://localhost:${server.port}/`, {
+        redirect: "manual",
+        headers: {
+          Accept: "text/html",
+          "X-Forwarded-Host": `localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(redirect.status).toBe(302)
+      expect(redirect.headers.get("location")).toBe(`https://localhost:${server.port}/auth/login?next=%2F`)
+
+      const loginResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `https://localhost:${server.port}`,
+          "X-Forwarded-Host": `localhost:${server.port}`,
+          "X-Forwarded-Proto": "https",
+        },
+      })
+      expect(loginResponse.status).toBe(200)
+      expect(loginResponse.headers.get("set-cookie") ?? "").toContain("Secure")
+
+      const evilResponse = await fetch(`http://localhost:${server.port}/auth/login`, {
+        method: "POST",
+        body: JSON.stringify({ password: "secret", next: "/" }),
+        headers: {
+          "Content-Type": "application/json",
+          Origin: `http://localhost:${server.port}`,
+        },
+      })
+      expect(evilResponse.status).toBe(200)
     } finally {
       await server.stop()
     }

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -53,21 +53,23 @@ function forwardedProto(req: Request): string | null {
   return null
 }
 
-function effectiveOrigin(req: Request): string {
+function effectiveOrigin(req: Request, trustProxy: boolean): string {
   const url = new URL(req.url)
+  if (!trustProxy) return url.origin
   const proto = forwardedProto(req)
-  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? url.host
   const scheme = proto ?? url.protocol.replace(":", "")
-  return `${scheme}://${host}`
+  return `${scheme}://${url.host}`
 }
 
-function shouldUseSecureCookie(req: Request) {
-  const proto = forwardedProto(req)
-  if (proto) return proto === "https"
+function shouldUseSecureCookie(req: Request, trustProxy: boolean) {
+  if (trustProxy) {
+    const proto = forwardedProto(req)
+    if (proto) return proto === "https"
+  }
   return new URL(req.url).protocol === "https:"
 }
 
-function buildCookie(name: string, value: string, req: Request, extras: string[] = []) {
+function buildCookie(name: string, value: string, req: Request, trustProxy: boolean, extras: string[] = []) {
   const parts = [
     `${name}=${encodeURIComponent(value)}`,
     "Path=/",
@@ -75,7 +77,7 @@ function buildCookie(name: string, value: string, req: Request, extras: string[]
     "SameSite=Strict",
   ]
 
-  if (shouldUseSecureCookie(req)) {
+  if (shouldUseSecureCookie(req, trustProxy)) {
     parts.push("Secure")
   }
 
@@ -117,9 +119,22 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;")
 }
 
-export function createAuthManager(password: string): AuthManager {
+export interface AuthManagerOptions {
+  /**
+   * When true, the auth layer trusts X-Forwarded-Proto to decide whether the
+   * public origin is https. The hostname always comes from the Host header
+   * (never X-Forwarded-Host) because X-Forwarded-Host is passed through by
+   * some tunnels unmodified and would otherwise allow open redirects.
+   * Enable only when the server is reachable solely through a trusted reverse
+   * proxy such as cloudflared.
+   */
+  trustProxy?: boolean
+}
+
+export function createAuthManager(password: string, options: AuthManagerOptions = {}): AuthManager {
   const sessions = new Set<string>()
   const expectedPassword = Buffer.from(password)
+  const trustProxy = options.trustProxy ?? false
 
   function getSessionToken(req: Request) {
     return parseCookies(req.headers.get("cookie")).get(SESSION_COOKIE_NAME) ?? null
@@ -134,13 +149,14 @@ export function createAuthManager(password: string): AuthManager {
     const origin = req.headers.get("origin")
     if (!origin) return true
     if (origin === new URL(req.url).origin) return true
-    return origin === effectiveOrigin(req)
+    if (!trustProxy) return false
+    return origin === effectiveOrigin(req, trustProxy)
   }
 
   function createSessionCookie(req: Request) {
     const sessionToken = randomBytes(32).toString("base64url")
     sessions.add(sessionToken)
-    return buildCookie(SESSION_COOKIE_NAME, sessionToken, req)
+    return buildCookie(SESSION_COOKIE_NAME, sessionToken, req, trustProxy)
   }
 
   function clearSessionCookie(req: Request) {
@@ -148,7 +164,7 @@ export function createAuthManager(password: string): AuthManager {
     if (sessionToken) {
       sessions.delete(sessionToken)
     }
-    return buildCookie(SESSION_COOKIE_NAME, "", req, ["Max-Age=0"])
+    return buildCookie(SESSION_COOKIE_NAME, "", req, trustProxy, ["Max-Age=0"])
   }
 
   function verifyPassword(candidate: string) {
@@ -169,7 +185,7 @@ export function createAuthManager(password: string): AuthManager {
   function unauthorizedResponse(req: Request) {
     if (req.method === "GET" && requestWantsHtml(req)) {
       const url = new URL(req.url)
-      const loginUrl = new URL("/auth/login", effectiveOrigin(req))
+      const loginUrl = new URL("/auth/login", effectiveOrigin(req, trustProxy))
       loginUrl.searchParams.set("next", sanitizeNextPath(`${url.pathname}${url.search}`))
       return Response.redirect(loginUrl, 302)
     }
@@ -180,7 +196,7 @@ export function createAuthManager(password: string): AuthManager {
   function renderLoginPage(req: Request) {
     if (isAuthenticated(req)) {
       const currentUrl = new URL(req.url)
-      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), effectiveOrigin(req)), 302)
+      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), effectiveOrigin(req, trustProxy)), 302)
     }
 
     const currentUrl = new URL(req.url)
@@ -281,7 +297,7 @@ export function createAuthManager(password: string): AuthManager {
         return Response.json({ error: "Invalid password" }, { status: 401 })
       }
 
-      const redirectUrl = new URL("/auth/login", effectiveOrigin(req))
+      const redirectUrl = new URL("/auth/login", effectiveOrigin(req, trustProxy))
       redirectUrl.searchParams.set("error", "1")
       redirectUrl.searchParams.set("next", sanitizeNextPath(nextPath || fallbackNextPath))
       return Response.redirect(redirectUrl, 302)
@@ -289,7 +305,7 @@ export function createAuthManager(password: string): AuthManager {
 
     const response = wantsJson
       ? Response.json({ ok: true, nextPath: sanitizeNextPath(nextPath || fallbackNextPath) })
-      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), effectiveOrigin(req)), 302)
+      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), effectiveOrigin(req, trustProxy)), 302)
 
     response.headers.set("Set-Cookie", createSessionCookie(req))
     return response

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -47,7 +47,23 @@ function sanitizeNextPath(nextPath: string | null | undefined) {
   return nextPath
 }
 
+function forwardedProto(req: Request): string | null {
+  const xfp = req.headers.get("x-forwarded-proto")
+  if (xfp) return xfp.split(",")[0].trim().toLowerCase()
+  return null
+}
+
+function effectiveOrigin(req: Request): string {
+  const url = new URL(req.url)
+  const proto = forwardedProto(req)
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? url.host
+  const scheme = proto ?? url.protocol.replace(":", "")
+  return `${scheme}://${host}`
+}
+
 function shouldUseSecureCookie(req: Request) {
+  const proto = forwardedProto(req)
+  if (proto) return proto === "https"
   return new URL(req.url).protocol === "https:"
 }
 
@@ -117,7 +133,8 @@ export function createAuthManager(password: string): AuthManager {
   function validateOrigin(req: Request) {
     const origin = req.headers.get("origin")
     if (!origin) return true
-    return origin === new URL(req.url).origin
+    if (origin === new URL(req.url).origin) return true
+    return origin === effectiveOrigin(req)
   }
 
   function createSessionCookie(req: Request) {
@@ -152,7 +169,7 @@ export function createAuthManager(password: string): AuthManager {
   function unauthorizedResponse(req: Request) {
     if (req.method === "GET" && requestWantsHtml(req)) {
       const url = new URL(req.url)
-      const loginUrl = new URL("/auth/login", req.url)
+      const loginUrl = new URL("/auth/login", effectiveOrigin(req))
       loginUrl.searchParams.set("next", sanitizeNextPath(`${url.pathname}${url.search}`))
       return Response.redirect(loginUrl, 302)
     }
@@ -163,7 +180,7 @@ export function createAuthManager(password: string): AuthManager {
   function renderLoginPage(req: Request) {
     if (isAuthenticated(req)) {
       const currentUrl = new URL(req.url)
-      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), req.url), 302)
+      return Response.redirect(new URL(sanitizeNextPath(currentUrl.searchParams.get("next")), effectiveOrigin(req)), 302)
     }
 
     const currentUrl = new URL(req.url)
@@ -264,7 +281,7 @@ export function createAuthManager(password: string): AuthManager {
         return Response.json({ error: "Invalid password" }, { status: 401 })
       }
 
-      const redirectUrl = new URL("/auth/login", req.url)
+      const redirectUrl = new URL("/auth/login", effectiveOrigin(req))
       redirectUrl.searchParams.set("error", "1")
       redirectUrl.searchParams.set("next", sanitizeNextPath(nextPath || fallbackNextPath))
       return Response.redirect(redirectUrl, 302)
@@ -272,7 +289,7 @@ export function createAuthManager(password: string): AuthManager {
 
     const response = wantsJson
       ? Response.json({ ok: true, nextPath: sanitizeNextPath(nextPath || fallbackNextPath) })
-      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), req.url), 302)
+      : Response.redirect(new URL(sanitizeNextPath(nextPath || fallbackNextPath), effectiveOrigin(req)), 302)
 
     response.headers.set("Set-Cookie", createSessionCookie(req))
     return response

--- a/src/server/auto-continue/e2e.test.ts
+++ b/src/server/auto-continue/e2e.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { AgentCoordinator } from "../agent"
 import { EventStore } from "../event-store"
+import { AsyncEventQueue } from "../test-helpers/async-event-queue"
+import { waitFor } from "../test-helpers/wait-for"
 import type { AutoContinueEvent } from "./events"
 import { ClaudeLimitDetector, CodexLimitDetector } from "./limit-detector"
 import { ScheduleManager, type Clock } from "./schedule-manager"
@@ -47,78 +49,8 @@ class FakeClock implements Clock {
 }
 
 // ---------------------------------------------------------------------------
-// AsyncEventQueue — replicates the queue helper from agent.test.ts
-// ---------------------------------------------------------------------------
-
-class AsyncEventQueue<T> implements AsyncIterable<T> {
-  private readonly values: T[] = []
-  private readonly waiters: Array<{
-    resolve: (result: IteratorResult<T>) => void
-    reject: (error: unknown) => void
-  }> = []
-  private closed = false
-  private pendingError: unknown = null
-
-  push(value: T): void {
-    const waiter = this.waiters.shift()
-    if (waiter) {
-      waiter.resolve({ done: false, value })
-      return
-    }
-    this.values.push(value)
-  }
-
-  throw(error: unknown): void {
-    this.pendingError = error
-    const waiter = this.waiters.shift()
-    if (waiter) {
-      waiter.reject(error)
-    }
-  }
-
-  close(): void {
-    this.closed = true
-    while (this.waiters.length > 0) {
-      this.waiters.shift()?.resolve({ done: true, value: undefined as never })
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: async () => {
-        if (this.pendingError !== null) {
-          const err = this.pendingError
-          this.pendingError = null
-          throw err
-        }
-        if (this.values.length > 0) {
-          return { done: false, value: this.values.shift() as T }
-        }
-        if (this.closed) {
-          return { done: true, value: undefined as never }
-        }
-        return await new Promise<IteratorResult<T>>((resolve, reject) => {
-          this.waiters.push({ resolve, reject })
-        })
-      },
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Polls until `condition()` returns true or `timeoutMs` elapses. */
-async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<void> {
-  const start = Date.now()
-  while (!condition()) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error("Timed out waiting for condition")
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
-}
 
 /** Build a rate-limit error that ClaudeLimitDetector recognises.
  *
@@ -145,6 +77,7 @@ function makeRateLimitError(resetAt: number): Error & { status: number; headers:
 describe("auto-continue end-to-end", () => {
   test("rate limit → proposed → accept → timer fires → auto_continue_fired + 'continue' user_prompt", async () => {
     const dir = await mkdtemp(join(tmpdir(), "kanna-ac-e2e-"))
+    let scheduleManager: ScheduleManager | undefined
     try {
       // --- Set up real EventStore ---
       const store = new EventStore(dir)
@@ -157,14 +90,14 @@ describe("auto-continue end-to-end", () => {
       // acceptAutoContinue checks `scheduledAt > Date.now()` using real Date.now().
       // ScheduleManager.arm computes `delay = scheduledAt - clock.now()`.
       // By starting the fake clock at Date.now(), both quantities agree and
-      // a small delta (e.g. 200ms) works for both the guard and the advance.
+      // a 10s delta is large enough to survive slow CI runners.
       const clockStart = Date.now()
       const clock = new FakeClock(clockStart)
-      const resetAtMs = clockStart + 200 // rate-limit resets 200ms "from now"
+      const resetAtMs = clockStart + 10_000 // rate-limit resets 10s "from now"
 
       // --- ScheduleManager + coordinator (forward-reference pattern) ---
       let coordinator!: AgentCoordinator
-      const scheduleManager = new ScheduleManager({
+      scheduleManager = new ScheduleManager({
         clock,
         fire: async (cid, sid) => {
           await coordinator.fireAutoContinue(cid, sid)
@@ -224,7 +157,7 @@ describe("auto-continue end-to-end", () => {
       // ----------------------------------------------------------------
       // Step 2: Client accepts — scheduleManager arms the timer.
       // ----------------------------------------------------------------
-      const scheduledAt = clock.now() + 200 // in the future per both real and fake clock
+      const scheduledAt = clock.now() + 10_000 // in the future per both real and fake clock
       await coordinator.acceptAutoContinue(chatId, scheduleId, scheduledAt)
 
       const acEventsAfterAccept = store.getAutoContinueEvents(chatId)
@@ -240,10 +173,7 @@ describe("auto-continue end-to-end", () => {
       // The ScheduleManager callback calls coordinator.fireAutoContinue
       // which is async; we need to drain the microtask queue after advance.
       // ----------------------------------------------------------------
-      clock.advance(300)
-      // Drain the microtask/promise chain kicked off by the async fire callback.
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      await new Promise((resolve) => setTimeout(resolve, 0))
+      clock.advance(10_100)
 
       // ----------------------------------------------------------------
       // Step 4: Assert auto_continue_fired event.
@@ -278,6 +208,7 @@ describe("auto-continue end-to-end", () => {
         throw new Error("Expected user_prompt entry")
       }
     } finally {
+      scheduleManager?.shutdown()
       await rm(dir, { recursive: true, force: true })
     }
   })

--- a/src/server/auto-continue/e2e.test.ts
+++ b/src/server/auto-continue/e2e.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AgentCoordinator } from "../agent"
+import { EventStore } from "../event-store"
+import type { AutoContinueEvent } from "./events"
+import { ClaudeLimitDetector, CodexLimitDetector } from "./limit-detector"
+import { ScheduleManager, type Clock } from "./schedule-manager"
+
+// ---------------------------------------------------------------------------
+// FakeClock — controllable wall-clock for ScheduleManager
+// ---------------------------------------------------------------------------
+
+class FakeClock implements Clock {
+  private currentTime: number
+  private readonly timers = new Map<number, { fn: () => void; fireAt: number }>()
+  private nextId = 1
+
+  constructor(startAt: number) {
+    this.currentTime = startAt
+  }
+
+  now(): number {
+    return this.currentTime
+  }
+
+  setTimeout(fn: () => void, delayMs: number): number {
+    const id = this.nextId++
+    this.timers.set(id, { fn, fireAt: this.currentTime + delayMs })
+    return id
+  }
+
+  clearTimeout(id: number): void {
+    this.timers.delete(id)
+  }
+
+  advance(ms: number): void {
+    this.currentTime += ms
+    for (const [id, timer] of [...this.timers.entries()]) {
+      if (timer.fireAt <= this.currentTime) {
+        this.timers.delete(id)
+        timer.fn()
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AsyncEventQueue — replicates the queue helper from agent.test.ts
+// ---------------------------------------------------------------------------
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+  private readonly values: T[] = []
+  private readonly waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void
+    reject: (error: unknown) => void
+  }> = []
+  private closed = false
+  private pendingError: unknown = null
+
+  push(value: T): void {
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter.resolve({ done: false, value })
+      return
+    }
+    this.values.push(value)
+  }
+
+  throw(error: unknown): void {
+    this.pendingError = error
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter.reject(error)
+    }
+  }
+
+  close(): void {
+    this.closed = true
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.resolve({ done: true, value: undefined as never })
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async () => {
+        if (this.pendingError !== null) {
+          const err = this.pendingError
+          this.pendingError = null
+          throw err
+        }
+        if (this.values.length > 0) {
+          return { done: false, value: this.values.shift() as T }
+        }
+        if (this.closed) {
+          return { done: true, value: undefined as never }
+        }
+        return await new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waiters.push({ resolve, reject })
+        })
+      },
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Polls until `condition()` returns true or `timeoutMs` elapses. */
+async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition")
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+/** Build a rate-limit error that ClaudeLimitDetector recognises.
+ *
+ *  The `anthropic-ratelimit-unified-reset` header is set to
+ *  `new Date(resetAt).toISOString()` so the detector returns exactly
+ *  `resetAt` as the reset timestamp.
+ */
+function makeRateLimitError(resetAt: number): Error & { status: number; headers: Record<string, string> } {
+  const err = new Error(
+    JSON.stringify({ type: "error", error: { type: "rate_limit_error" } })
+  ) as Error & { status: number; headers: Record<string, string> }
+  err.status = 429
+  err.headers = {
+    "anthropic-ratelimit-unified-reset": new Date(resetAt).toISOString(),
+    "x-anthropic-timezone": "Asia/Saigon",
+  }
+  return err
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end test
+// ---------------------------------------------------------------------------
+
+describe("auto-continue end-to-end", () => {
+  test("rate limit → proposed → accept → timer fires → auto_continue_fired + 'continue' user_prompt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kanna-ac-e2e-"))
+    try {
+      // --- Set up real EventStore ---
+      const store = new EventStore(dir)
+      await store.initialize()
+      const project = await store.openProject("/tmp/e2e-proj")
+      const chat = await store.createChat(project.id)
+      const chatId = chat.id
+
+      // --- FakeClock anchored to real wall-clock so scheduledAt guard passes ---
+      // acceptAutoContinue checks `scheduledAt > Date.now()` using real Date.now().
+      // ScheduleManager.arm computes `delay = scheduledAt - clock.now()`.
+      // By starting the fake clock at Date.now(), both quantities agree and
+      // a small delta (e.g. 200ms) works for both the guard and the advance.
+      const clockStart = Date.now()
+      const clock = new FakeClock(clockStart)
+      const resetAtMs = clockStart + 200 // rate-limit resets 200ms "from now"
+
+      // --- ScheduleManager + coordinator (forward-reference pattern) ---
+      let coordinator!: AgentCoordinator
+      const scheduleManager = new ScheduleManager({
+        clock,
+        fire: async (cid, sid) => {
+          await coordinator.fireAutoContinue(cid, sid)
+        },
+      })
+
+      // Async event queue so we can throw a rate-limit error on demand.
+      const events = new AsyncEventQueue<never>()
+
+      coordinator = new AgentCoordinator({
+        store,
+        onStateChange: () => {},
+        claudeLimitDetector: new ClaudeLimitDetector(),
+        codexLimitDetector: new CodexLimitDetector(),
+        scheduleManager,
+        // manual mode: do NOT auto-resume so we exercise the proposed → accept path
+        getAutoResumePreference: () => false,
+        startClaudeSession: async () => ({
+          provider: "claude" as const,
+          stream: events,
+          getAccountInfo: async () => null,
+          interrupt: async () => {},
+          close: () => {},
+          setModel: async () => {},
+          setPermissionMode: async () => {},
+          getSupportedCommands: async () => [],
+          sendPrompt: async () => {
+            // Throw a rate-limit error; this is caught by runClaudeSession
+            // which routes it through handleLimitError → ClaudeLimitDetector.
+            events.throw(makeRateLimitError(resetAtMs))
+          },
+        }),
+      })
+
+      // ----------------------------------------------------------------
+      // Step 1: Send a message; session throws a rate-limit error.
+      // ----------------------------------------------------------------
+      await coordinator.send({
+        type: "chat.send",
+        chatId,
+        content: "hello",
+        model: "claude-opus-4-5",
+        provider: "claude",
+        autoResumeOnRateLimit: false,
+      })
+
+      // Wait for the proposed event to be persisted.
+      await waitFor(() => store.getAutoContinueEvents(chatId).length >= 1)
+
+      const acEventsAfterPropose = store.getAutoContinueEvents(chatId)
+      expect(acEventsAfterPropose).toHaveLength(1)
+      expect(acEventsAfterPropose[0].kind).toBe("auto_continue_proposed")
+      const proposed = acEventsAfterPropose[0] as Extract<AutoContinueEvent, { kind: "auto_continue_proposed" }>
+      expect(proposed.tz).toBe("Asia/Saigon")
+      const { scheduleId } = proposed
+
+      // ----------------------------------------------------------------
+      // Step 2: Client accepts — scheduleManager arms the timer.
+      // ----------------------------------------------------------------
+      const scheduledAt = clock.now() + 200 // in the future per both real and fake clock
+      await coordinator.acceptAutoContinue(chatId, scheduleId, scheduledAt)
+
+      const acEventsAfterAccept = store.getAutoContinueEvents(chatId)
+      expect(acEventsAfterAccept).toHaveLength(2)
+      const accepted = acEventsAfterAccept[1] as Extract<AutoContinueEvent, { kind: "auto_continue_accepted" }>
+      expect(accepted.kind).toBe("auto_continue_accepted")
+      expect(accepted.scheduleId).toBe(scheduleId)
+      expect(accepted.source).toBe("user")
+      expect(accepted.scheduledAt).toBe(scheduledAt)
+
+      // ----------------------------------------------------------------
+      // Step 3: Advance the fake clock past scheduledAt — timer fires.
+      // The ScheduleManager callback calls coordinator.fireAutoContinue
+      // which is async; we need to drain the microtask queue after advance.
+      // ----------------------------------------------------------------
+      clock.advance(300)
+      // Drain the microtask/promise chain kicked off by the async fire callback.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      // ----------------------------------------------------------------
+      // Step 4: Assert auto_continue_fired event.
+      // ----------------------------------------------------------------
+      await waitFor(() =>
+        store.getAutoContinueEvents(chatId).some((e) => e.kind === "auto_continue_fired")
+      )
+
+      const acEventsAfterFire = store.getAutoContinueEvents(chatId)
+      const firedEvent = acEventsAfterFire.find(
+        (e) => e.kind === "auto_continue_fired"
+      ) as Extract<AutoContinueEvent, { kind: "auto_continue_fired" }> | undefined
+      expect(firedEvent).toBeDefined()
+      expect(firedEvent!.scheduleId).toBe(scheduleId)
+
+      // ----------------------------------------------------------------
+      // Step 5: Assert "continue" user_prompt with autoContinue metadata.
+      // ----------------------------------------------------------------
+      await waitFor(() =>
+        store.getMessages(chatId).some((m) => m.kind === "user_prompt" && m.content === "continue")
+      )
+
+      const messages = store.getMessages(chatId)
+      const continuePrompts = messages.filter(
+        (m) => m.kind === "user_prompt" && m.content === "continue"
+      )
+      expect(continuePrompts).toHaveLength(1)
+      const continuePrompt = continuePrompts[0]
+      if (continuePrompt?.kind === "user_prompt") {
+        expect(continuePrompt.autoContinue?.scheduleId).toBe(scheduleId)
+      } else {
+        throw new Error("Expected user_prompt entry")
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/auto-continue/events.test.ts
+++ b/src/server/auto-continue/events.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import type { AutoContinueEvent } from "./events"
+
+describe("AutoContinueEvent", () => {
+  test("covers the five lifecycle kinds", () => {
+    const kinds: AutoContinueEvent["kind"][] = [
+      "auto_continue_proposed",
+      "auto_continue_accepted",
+      "auto_continue_rescheduled",
+      "auto_continue_cancelled",
+      "auto_continue_fired",
+    ]
+    expect(kinds.length).toBe(5)
+  })
+
+  test("proposed event carries reset + tz metadata", () => {
+    const event: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: "c1",
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    }
+    expect(event.tz).toBe("Asia/Saigon")
+  })
+})

--- a/src/server/auto-continue/events.ts
+++ b/src/server/auto-continue/events.ts
@@ -1,0 +1,48 @@
+export type AutoContinueEvent =
+  | {
+      v: 3
+      kind: "auto_continue_proposed"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      detectedAt: number
+      resetAt: number
+      tz: string
+      turnId: string
+    }
+  | {
+      v: 3
+      kind: "auto_continue_accepted"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      scheduledAt: number
+      tz: string
+      source: "user" | "auto_setting"
+      resetAt: number
+      detectedAt: number
+    }
+  | {
+      v: 3
+      kind: "auto_continue_rescheduled"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      scheduledAt: number
+    }
+  | {
+      v: 3
+      kind: "auto_continue_cancelled"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      reason: "user" | "chat_deleted"
+    }
+  | {
+      v: 3
+      kind: "auto_continue_fired"
+      timestamp: number
+      chatId: string
+      scheduleId: string
+      firedAt: number
+    }

--- a/src/server/auto-continue/limit-detector.test.ts
+++ b/src/server/auto-continue/limit-detector.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { ClaudeLimitDetector } from "./limit-detector"
+
+const detector = new ClaudeLimitDetector()
+
+function anthropicError(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  const error = new Error(JSON.stringify(body)) as Error & { status?: number; headers?: Record<string, string> }
+  error.status = 429
+  error.headers = headers
+  return error
+}
+
+describe("ClaudeLimitDetector", () => {
+  test("returns null for non-rate-limit errors", () => {
+    const err = new Error("Something unrelated went wrong")
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+
+  test("detects rate limit with ISO reset timestamp in headers", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = anthropicError(
+      { type: "error", error: { type: "rate_limit_error", message: "You've hit your limit · resets 12am (Asia/Saigon)" } },
+      { "anthropic-ratelimit-unified-reset": resetIso, "x-anthropic-timezone": "Asia/Saigon" }
+    )
+    const detection = detector.detect("c1", err)
+    expect(detection).not.toBeNull()
+    expect(detection!.chatId).toBe("c1")
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("falls back to tz=system when no timezone header is present", () => {
+    const resetIso = "2026-04-23T05:00:00Z"
+    const err = anthropicError(
+      { type: "error", error: { type: "rate_limit_error" } },
+      { "anthropic-ratelimit-unified-reset": resetIso }
+    )
+    const detection = detector.detect("c1", err)
+    expect(detection!.tz).toBe("system")
+  })
+
+  test("returns null when the payload is rate-limit but no reset timestamp can be parsed", () => {
+    const err = anthropicError({ type: "error", error: { type: "rate_limit_error" } })
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+
+  test("parses resetAt from the message body when headers are absent", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = new Error(JSON.stringify({
+      type: "error",
+      error: {
+        type: "rate_limit_error",
+        resets_at: resetIso,
+        timezone: "Asia/Saigon",
+      },
+    }))
+    const detection = detector.detect("c1", err)
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("does not match on status-only errors (400, 500, etc.)", () => {
+    const err = anthropicError({ type: "error", error: { type: "overloaded_error" } })
+    expect(detector.detect("c1", err)).toBeNull()
+  })
+})

--- a/src/server/auto-continue/limit-detector.test.ts
+++ b/src/server/auto-continue/limit-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { ClaudeLimitDetector } from "./limit-detector"
+import { ClaudeLimitDetector, CodexLimitDetector } from "./limit-detector"
 
 const detector = new ClaudeLimitDetector()
 
@@ -62,5 +62,42 @@ describe("ClaudeLimitDetector", () => {
   test("does not match on status-only errors (400, 500, etc.)", () => {
     const err = anthropicError({ type: "error", error: { type: "overloaded_error" } })
     expect(detector.detect("c1", err)).toBeNull()
+  })
+})
+
+const codex = new CodexLimitDetector()
+
+describe("CodexLimitDetector", () => {
+  test("returns null for non-rate-limit JSON-RPC errors", () => {
+    const err = { code: -32601, message: "Method not found" }
+    expect(codex.detect("c1", err)).toBeNull()
+  })
+
+  test("detects rate limit from error.data.code with epoch-ms reset", () => {
+    const err = {
+      code: -32001,
+      message: "Rate limited",
+      data: { code: "rate_limit", resets_at_ms: 2_000_000, timezone: "Asia/Saigon" },
+    }
+    const detection = codex.detect("c1", err)
+    expect(detection!.resetAt).toBe(2_000_000)
+    expect(detection!.tz).toBe("Asia/Saigon")
+  })
+
+  test("detects rate limit with ISO resets_at", () => {
+    const resetIso = "2026-04-23T00:00:00+07:00"
+    const err = {
+      code: -32001,
+      message: "Rate limited",
+      data: { code: "rate_limit", resets_at: resetIso },
+    }
+    const detection = codex.detect("c1", err)
+    expect(detection!.resetAt).toBe(new Date(resetIso).getTime())
+    expect(detection!.tz).toBe("system")
+  })
+
+  test("returns null when no reset timestamp can be parsed", () => {
+    const err = { code: -32001, data: { code: "rate_limit" } }
+    expect(codex.detect("c1", err)).toBeNull()
   })
 })

--- a/src/server/auto-continue/limit-detector.ts
+++ b/src/server/auto-continue/limit-detector.ts
@@ -64,3 +64,30 @@ export class ClaudeLimitDetector implements LimitDetector {
     return { chatId, resetAt, tz, raw: error }
   }
 }
+
+interface JsonRpcErrorLike {
+  code?: number
+  message?: string
+  data?: Record<string, unknown>
+}
+
+export class CodexLimitDetector implements LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null {
+    if (!error || typeof error !== "object") return null
+    const rpc = error as JsonRpcErrorLike
+    const data = rpc.data && typeof rpc.data === "object" ? rpc.data : null
+    const isRateLimit = data?.code === "rate_limit" || rpc.code === -32001
+    if (!isRateLimit) return null
+
+    let resetAt: number | null = null
+    if (typeof data?.resets_at_ms === "number" && Number.isFinite(data.resets_at_ms)) {
+      resetAt = data.resets_at_ms
+    } else {
+      resetAt = parseIsoMillis(data?.resets_at)
+    }
+    if (resetAt === null) return null
+
+    const tz = typeof data?.timezone === "string" ? (data.timezone as string) : "system"
+    return { chatId, resetAt, tz, raw: error }
+  }
+}

--- a/src/server/auto-continue/limit-detector.ts
+++ b/src/server/auto-continue/limit-detector.ts
@@ -1,0 +1,66 @@
+export interface LimitDetection {
+  chatId: string
+  resetAt: number
+  tz: string
+  raw: unknown
+}
+
+export interface LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null
+}
+
+interface ErrorLike {
+  message?: string
+  status?: number
+  headers?: Record<string, string>
+}
+
+function extractHeaders(error: unknown): Record<string, string> {
+  if (error && typeof error === "object" && "headers" in error) {
+    const headers = (error as ErrorLike).headers
+    if (headers && typeof headers === "object") return headers
+  }
+  return {}
+}
+
+function parseBody(error: unknown): Record<string, unknown> | null {
+  if (!error || typeof error !== "object") return null
+  const message = (error as ErrorLike).message
+  if (!message) return null
+  try {
+    const parsed = JSON.parse(message)
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function parseIsoMillis(value: unknown): number | null {
+  if (typeof value !== "string" || !value) return null
+  const millis = new Date(value).getTime()
+  return Number.isFinite(millis) ? millis : null
+}
+
+export class ClaudeLimitDetector implements LimitDetector {
+  detect(chatId: string, error: unknown): LimitDetection | null {
+    const body = parseBody(error)
+    const inner = body && typeof body.error === "object" && body.error !== null
+      ? (body.error as Record<string, unknown>)
+      : null
+    const isRateLimit = inner?.type === "rate_limit_error"
+      || (error as ErrorLike | null)?.status === 429 && inner?.type === "rate_limit_error"
+    if (!isRateLimit) return null
+
+    const headers = extractHeaders(error)
+    const resetAt = parseIsoMillis(headers["anthropic-ratelimit-unified-reset"])
+      ?? parseIsoMillis(inner?.resets_at)
+      ?? parseIsoMillis(inner?.reset_at)
+    if (resetAt === null) return null
+
+    const tz = headers["x-anthropic-timezone"]
+      ?? (typeof inner?.timezone === "string" ? (inner.timezone as string) : null)
+      ?? "system"
+
+    return { chatId, resetAt, tz, raw: error }
+  }
+}

--- a/src/server/auto-continue/read-model.test.ts
+++ b/src/server/auto-continue/read-model.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import { deriveChatSchedules } from "./read-model"
+import type { AutoContinueEvent } from "./events"
+
+function proposed(chatId: string, scheduleId: string, at = 1_000): AutoContinueEvent {
+  return {
+    v: 3,
+    kind: "auto_continue_proposed",
+    timestamp: at,
+    chatId,
+    scheduleId,
+    detectedAt: at,
+    resetAt: at + 10_000,
+    tz: "Asia/Saigon",
+    turnId: "turn-1",
+  }
+}
+
+function accepted(chatId: string, scheduleId: string, at = 2_000, source: "user" | "auto_setting" = "user"): AutoContinueEvent {
+  return {
+    v: 3,
+    kind: "auto_continue_accepted",
+    timestamp: at,
+    chatId,
+    scheduleId,
+    scheduledAt: at + 10_000,
+    tz: "Asia/Saigon",
+    source,
+    resetAt: at + 10_000,
+    detectedAt: at,
+  }
+}
+
+describe("deriveChatSchedules", () => {
+  test("empty event list returns empty map + null live", () => {
+    const result = deriveChatSchedules([])
+    expect(result.schedules).toEqual({})
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("proposed event yields state=proposed with liveScheduleId set", () => {
+    const result = deriveChatSchedules([proposed("c1", "s1")])
+    expect(result.schedules["s1"].state).toBe("proposed")
+    expect(result.schedules["s1"].scheduledAt).toBeNull()
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("accept after propose promotes to scheduled", () => {
+    const result = deriveChatSchedules([proposed("c1", "s1"), accepted("c1", "s1")])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].scheduledAt).toBe(12_000)
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("accept with source=auto_setting without prior proposed still produces scheduled", () => {
+    const result = deriveChatSchedules([accepted("c1", "s1", 1_500, "auto_setting")])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].resetAt).toBe(11_500)
+    expect(result.liveScheduleId).toBe("s1")
+  })
+
+  test("cancelled schedule is terminal and not live", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_cancelled", timestamp: 3_000, chatId: "c1", scheduleId: "s1", reason: "user" },
+    ])
+    expect(result.schedules["s1"].state).toBe("cancelled")
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("fired schedule is terminal and retains scheduledAt", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_fired", timestamp: 12_000, chatId: "c1", scheduleId: "s1", firedAt: 12_000 },
+    ])
+    expect(result.schedules["s1"].state).toBe("fired")
+    expect(result.schedules["s1"].scheduledAt).toBe(12_000)
+    expect(result.liveScheduleId).toBeNull()
+  })
+
+  test("live schedule tracks most recent non-terminal", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1", 1_000),
+      { v: 3, kind: "auto_continue_cancelled", timestamp: 1_100, chatId: "c1", scheduleId: "s1", reason: "user" },
+      proposed("c1", "s2", 2_000),
+    ])
+    expect(result.schedules["s1"].state).toBe("cancelled")
+    expect(result.schedules["s2"].state).toBe("proposed")
+    expect(result.liveScheduleId).toBe("s2")
+  })
+
+  test("reschedule updates scheduledAt without changing state", () => {
+    const result = deriveChatSchedules([
+      proposed("c1", "s1"),
+      accepted("c1", "s1"),
+      { v: 3, kind: "auto_continue_rescheduled", timestamp: 2_500, chatId: "c1", scheduleId: "s1", scheduledAt: 20_000 },
+    ])
+    expect(result.schedules["s1"].state).toBe("scheduled")
+    expect(result.schedules["s1"].scheduledAt).toBe(20_000)
+  })
+
+  test("events for different chats produce independent results", () => {
+    const events = [proposed("c1", "s1"), proposed("c2", "s2")]
+    expect(deriveChatSchedules(events, "c1").liveScheduleId).toBe("s1")
+    expect(deriveChatSchedules(events, "c2").liveScheduleId).toBe("s2")
+  })
+})

--- a/src/server/auto-continue/read-model.ts
+++ b/src/server/auto-continue/read-model.ts
@@ -1,0 +1,92 @@
+import type { AutoContinueSchedule } from "../../shared/types"
+import type { AutoContinueEvent } from "./events"
+
+export interface ChatSchedulesProjection {
+  schedules: Record<string, AutoContinueSchedule>
+  liveScheduleId: string | null
+}
+
+const EMPTY: ChatSchedulesProjection = { schedules: {}, liveScheduleId: null }
+
+export function deriveChatSchedules(
+  events: readonly AutoContinueEvent[],
+  chatId?: string
+): ChatSchedulesProjection {
+  const schedules: Record<string, AutoContinueSchedule> = {}
+  for (const event of events) {
+    if (chatId && event.chatId !== chatId) continue
+    applyOne(schedules, event)
+  }
+
+  let liveScheduleId: string | null = null
+  let liveOrder = -1
+  let order = 0
+  for (const event of events) {
+    order += 1
+    if (chatId && event.chatId !== chatId) continue
+    const schedule = schedules[event.scheduleId]
+    if (!schedule) continue
+    if (schedule.state !== "proposed" && schedule.state !== "scheduled") continue
+    if (order > liveOrder) {
+      liveOrder = order
+      liveScheduleId = schedule.scheduleId
+    }
+  }
+
+  return schedules === EMPTY.schedules && liveScheduleId === null
+    ? EMPTY
+    : { schedules, liveScheduleId }
+}
+
+function applyOne(schedules: Record<string, AutoContinueSchedule>, event: AutoContinueEvent): void {
+  switch (event.kind) {
+    case "auto_continue_proposed":
+      schedules[event.scheduleId] = {
+        scheduleId: event.scheduleId,
+        state: "proposed",
+        scheduledAt: null,
+        tz: event.tz,
+        resetAt: event.resetAt,
+        detectedAt: event.detectedAt,
+      }
+      return
+    case "auto_continue_accepted":
+      schedules[event.scheduleId] = {
+        scheduleId: event.scheduleId,
+        state: "scheduled",
+        scheduledAt: event.scheduledAt,
+        tz: event.tz,
+        resetAt: event.resetAt,
+        detectedAt: event.detectedAt,
+      }
+      return
+    case "auto_continue_rescheduled": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) return
+      schedules[event.scheduleId] = { ...existing, scheduledAt: event.scheduledAt }
+      return
+    }
+    case "auto_continue_cancelled": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) return
+      schedules[event.scheduleId] = { ...existing, state: "cancelled" }
+      return
+    }
+    case "auto_continue_fired": {
+      const existing = schedules[event.scheduleId]
+      if (!existing) {
+        schedules[event.scheduleId] = {
+          scheduleId: event.scheduleId,
+          state: "fired",
+          scheduledAt: event.firedAt,
+          tz: "system",
+          resetAt: event.firedAt,
+          detectedAt: event.firedAt,
+        }
+        return
+      }
+      schedules[event.scheduleId] = { ...existing, state: "fired", scheduledAt: event.firedAt }
+      return
+    }
+  }
+}

--- a/src/server/auto-continue/schedule-manager.test.ts
+++ b/src/server/auto-continue/schedule-manager.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test"
+import { ScheduleManager, type Clock } from "./schedule-manager"
+import type { AutoContinueEvent } from "./events"
+
+class FakeClock implements Clock {
+  private current = 0
+  private scheduled: Array<{ fireAt: number; fn: () => void; id: number }> = []
+  private nextId = 1
+
+  now() {
+    return this.current
+  }
+
+  setTimeout(fn: () => void, delayMs: number): number {
+    const id = this.nextId
+    this.nextId += 1
+    this.scheduled.push({ fireAt: this.current + Math.max(0, delayMs), fn, id })
+    return id
+  }
+
+  clearTimeout(id: number): void {
+    this.scheduled = this.scheduled.filter((entry) => entry.id !== id)
+  }
+
+  advance(ms: number) {
+    this.current += ms
+    const due = this.scheduled.filter((entry) => entry.fireAt <= this.current)
+    this.scheduled = this.scheduled.filter((entry) => entry.fireAt > this.current)
+    for (const { fn } of due) fn()
+  }
+
+  pending() {
+    return this.scheduled.length
+  }
+}
+
+function event(kind: AutoContinueEvent["kind"], overrides: Partial<AutoContinueEvent> = {}): AutoContinueEvent {
+  const base = { v: 3 as const, timestamp: 0, chatId: "c1", scheduleId: "s1" }
+  switch (kind) {
+    case "auto_continue_proposed":
+      return { ...base, kind, detectedAt: 0, resetAt: 1_000, tz: "UTC", turnId: "t1", ...overrides } as AutoContinueEvent
+    case "auto_continue_accepted":
+      return { ...base, kind, scheduledAt: 1_000, tz: "UTC", source: "user", resetAt: 1_000, detectedAt: 0, ...overrides } as AutoContinueEvent
+    case "auto_continue_rescheduled":
+      return { ...base, kind, scheduledAt: 2_000, ...overrides } as AutoContinueEvent
+    case "auto_continue_cancelled":
+      return { ...base, kind, reason: "user", ...overrides } as AutoContinueEvent
+    case "auto_continue_fired":
+      return { ...base, kind, firedAt: 1_000, ...overrides } as AutoContinueEvent
+  }
+}
+
+describe("ScheduleManager", () => {
+  test("proposed event does not arm a timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (chatId, scheduleId) => { fired.push(`${chatId}:${scheduleId}`) },
+    })
+    manager.onEvent(event("auto_continue_proposed"))
+    expect(clock.pending()).toBe(0)
+    expect(fired).toEqual([])
+  })
+
+  test("accepted event arms a timer that fires at scheduledAt", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (chatId, scheduleId) => { fired.push(`${chatId}:${scheduleId}`) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    expect(clock.pending()).toBe(1)
+    clock.advance(1_000)
+    expect(fired).toEqual(["c1:s1"])
+  })
+
+  test("rescheduled replaces the pending timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    manager.onEvent(event("auto_continue_rescheduled", { scheduledAt: 3_000 }))
+    clock.advance(1_000)
+    expect(fired).toEqual([])
+    clock.advance(2_000)
+    expect(fired).toEqual(["s1"])
+  })
+
+  test("cancelled clears the pending timer", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    manager.onEvent(event("auto_continue_cancelled"))
+    clock.advance(1_000)
+    expect(fired).toEqual([])
+  })
+
+  test("rehydrate arms future schedules and fires past-due ones", async () => {
+    const clock = new FakeClock()
+    clock.advance(5_000)
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.rehydrate([
+      event("auto_continue_accepted", { scheduleId: "past", scheduledAt: 1_000 }),
+      event("auto_continue_accepted", { scheduleId: "future", scheduledAt: 10_000 }),
+    ])
+    await Promise.resolve()
+    expect(fired).toEqual(["past"])
+    expect(clock.pending()).toBe(1)
+    clock.advance(5_000)
+    expect(fired).toEqual(["past", "future"])
+  })
+
+  test("rehydrate skips terminal states", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.rehydrate([
+      event("auto_continue_accepted", { scheduleId: "done", scheduledAt: 1_000 }),
+      event("auto_continue_fired", { scheduleId: "done" }),
+      event("auto_continue_accepted", { scheduleId: "cancelled", scheduledAt: 1_000 }),
+      event("auto_continue_cancelled", { scheduleId: "cancelled" }),
+    ])
+    clock.advance(10_000)
+    expect(fired).toEqual([])
+  })
+
+  test("firing a timer does not double-fire on subsequent events", () => {
+    const clock = new FakeClock()
+    const fired: string[] = []
+    const manager = new ScheduleManager({
+      clock,
+      fire: async (_, id) => { fired.push(id) },
+    })
+    manager.onEvent(event("auto_continue_accepted", { scheduledAt: 1_000 }))
+    clock.advance(1_000)
+    manager.onEvent(event("auto_continue_fired"))
+    expect(fired).toEqual(["s1"])
+  })
+})

--- a/src/server/auto-continue/schedule-manager.ts
+++ b/src/server/auto-continue/schedule-manager.ts
@@ -63,6 +63,11 @@ export class ScheduleManager {
       case "auto_continue_fired":
         this.clear(event.scheduleId)
         return
+      default: {
+        const _exhaustive: never = event
+        void _exhaustive
+        return
+      }
     }
   }
 
@@ -81,6 +86,8 @@ export class ScheduleManager {
       }
     }
 
+    // Past-due schedules fire out-of-band via microtask rather than clock.setTimeout.
+    // This keeps clock.pending() reflecting only genuinely future timers.
     if (delay <= 0) {
       void Promise.resolve().then(run)
       return

--- a/src/server/auto-continue/schedule-manager.ts
+++ b/src/server/auto-continue/schedule-manager.ts
@@ -1,0 +1,109 @@
+import type { AutoContinueEvent } from "./events"
+import { deriveChatSchedules } from "./read-model"
+
+export interface Clock {
+  now(): number
+  setTimeout(fn: () => void, delayMs: number): number
+  clearTimeout(id: number): void
+}
+
+export const realClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (fn, delayMs) => setTimeout(fn, delayMs) as unknown as number,
+  clearTimeout: (id) => clearTimeout(id as unknown as NodeJS.Timeout),
+}
+
+export interface ScheduleManagerArgs {
+  clock?: Clock
+  fire: (chatId: string, scheduleId: string) => Promise<void>
+  onError?: (error: unknown) => void
+}
+
+export class ScheduleManager {
+  private readonly clock: Clock
+  private readonly fireFn: ScheduleManagerArgs["fire"]
+  private readonly onError: (error: unknown) => void
+  private readonly timers = new Map<string, number>()
+  private readonly pendingByScheduleId = new Map<string, { chatId: string; scheduledAt: number }>()
+
+  constructor(args: ScheduleManagerArgs) {
+    this.clock = args.clock ?? realClock
+    this.fireFn = args.fire
+    this.onError = args.onError ?? ((error) => console.error("[kanna/schedule-manager]", error))
+  }
+
+  rehydrate(events: readonly AutoContinueEvent[]) {
+    const byChat = new Map<string, AutoContinueEvent[]>()
+    for (const event of events) {
+      const list = byChat.get(event.chatId) ?? []
+      list.push(event)
+      byChat.set(event.chatId, list)
+    }
+    for (const [chatId, chatEvents] of byChat.entries()) {
+      const projection = deriveChatSchedules(chatEvents, chatId)
+      for (const schedule of Object.values(projection.schedules)) {
+        if (schedule.state !== "scheduled") continue
+        if (schedule.scheduledAt === null) continue
+        this.arm(chatId, schedule.scheduleId, schedule.scheduledAt)
+      }
+    }
+  }
+
+  onEvent(event: AutoContinueEvent) {
+    switch (event.kind) {
+      case "auto_continue_proposed":
+        return
+      case "auto_continue_accepted":
+        this.arm(event.chatId, event.scheduleId, event.scheduledAt)
+        return
+      case "auto_continue_rescheduled":
+        this.arm(event.chatId, event.scheduleId, event.scheduledAt)
+        return
+      case "auto_continue_cancelled":
+      case "auto_continue_fired":
+        this.clear(event.scheduleId)
+        return
+    }
+  }
+
+  private arm(chatId: string, scheduleId: string, scheduledAt: number) {
+    this.clear(scheduleId)
+    this.pendingByScheduleId.set(scheduleId, { chatId, scheduledAt })
+    const delay = scheduledAt - this.clock.now()
+
+    const run = async () => {
+      this.timers.delete(scheduleId)
+      this.pendingByScheduleId.delete(scheduleId)
+      try {
+        await this.fireFn(chatId, scheduleId)
+      } catch (error) {
+        this.onError(error)
+      }
+    }
+
+    if (delay <= 0) {
+      void Promise.resolve().then(run)
+      return
+    }
+
+    const timerId = this.clock.setTimeout(() => { void run() }, delay)
+    this.timers.set(scheduleId, timerId)
+  }
+
+  private clear(scheduleId: string) {
+    const timerId = this.timers.get(scheduleId)
+    if (timerId !== undefined) {
+      this.clock.clearTimeout(timerId)
+      this.timers.delete(scheduleId)
+    }
+    this.pendingByScheduleId.delete(scheduleId)
+  }
+
+  shutdown() {
+    for (const timerId of this.timers.values()) {
+      this.clock.clearTimeout(timerId)
+    }
+    this.timers.clear()
+    this.pendingByScheduleId.clear()
+  }
+}

--- a/src/server/claude-session-importer.test.ts
+++ b/src/server/claude-session-importer.test.ts
@@ -140,4 +140,75 @@ describe("importClaudeSessions", () => {
       ctx.cleanup()
     }
   })
+
+  test("re-import with unchanged file is skipped (hash match)", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-hash-1")
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+
+      const first = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(first.imported).toBe(1)
+
+      const second = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(second.imported).toBe(0)
+      expect(second.updated).toBe(0)
+      expect(second.skipped).toBe(1)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+
+  test("re-import after JSONL grows appends new messages and counts as updated", async () => {
+    const ctx = fresh()
+    try {
+      const folderName = ctx.realProj.replace(/\//g, "-")
+      const projDir = path.join(ctx.homeDir, ".claude", "projects", folderName)
+      mkdirSync(projDir, { recursive: true })
+      const jsonlPath = path.join(projDir, "sess-grow.jsonl")
+
+      const line1 = JSON.stringify({
+        type: "user", uuid: "u1", sessionId: "sess-grow", cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:00.000Z",
+        message: { role: "user", content: "first" },
+      })
+      const line2 = JSON.stringify({
+        type: "assistant", uuid: "a1", sessionId: "sess-grow", cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:01.000Z",
+        message: { role: "assistant", id: "m1", content: [{ type: "text", text: "hello" }] },
+      })
+      writeFileSync(jsonlPath, `${line1}\n${line2}\n`, "utf8")
+
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+
+      const first = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(first.imported).toBe(1)
+      const chats = [...store.state.chatsById.values()].filter((c) => !c.deletedAt)
+      expect(chats.length).toBe(1)
+      expect(store.getMessages(chats[0].id).length).toBe(2)
+
+      // append a new turn
+      const line3 = JSON.stringify({
+        type: "user", uuid: "u2", sessionId: "sess-grow", cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:02.000Z",
+        message: { role: "user", content: "second" },
+      })
+      const line4 = JSON.stringify({
+        type: "assistant", uuid: "a2", sessionId: "sess-grow", cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:03.000Z",
+        message: { role: "assistant", id: "m2", content: [{ type: "text", text: "world" }] },
+      })
+      writeFileSync(jsonlPath, `${line1}\n${line2}\n${line3}\n${line4}\n`, "utf8")
+
+      const second = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(second.imported).toBe(0)
+      expect(second.updated).toBe(1)
+      expect(second.skipped).toBe(0)
+      expect(store.getMessages(chats[0].id).length).toBe(4)
+    } finally {
+      ctx.cleanup()
+    }
+  })
 })

--- a/src/server/claude-session-importer.test.ts
+++ b/src/server/claude-session-importer.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EventStore } from "./event-store"
+import { importClaudeSessions } from "./claude-session-importer"
+
+function fresh() {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kanna-data-"))
+  const homeDir = mkdtempSync(path.join(tmpdir(), "kanna-home-"))
+  const realProj = mkdtempSync(path.join(tmpdir(), "kanna-proj-"))
+  return {
+    dataDir,
+    homeDir,
+    realProj,
+    cleanup: () => {
+      rmSync(dataDir, { recursive: true, force: true })
+      rmSync(homeDir, { recursive: true, force: true })
+      rmSync(realProj, { recursive: true, force: true })
+    },
+  }
+}
+
+function seedSession(homeDir: string, realProj: string, sessionId: string) {
+  const folderName = realProj.replace(/\//g, "-")
+  const projDir = path.join(homeDir, ".claude", "projects", folderName)
+  mkdirSync(projDir, { recursive: true })
+  const line1 = JSON.stringify({
+    type: "user",
+    uuid: "u1",
+    sessionId,
+    cwd: realProj,
+    timestamp: "2026-04-20T10:00:00.000Z",
+    message: { role: "user", content: "hi" },
+  })
+  const line2 = JSON.stringify({
+    type: "assistant",
+    uuid: "a1",
+    sessionId,
+    cwd: realProj,
+    timestamp: "2026-04-20T10:00:01.000Z",
+    message: { role: "assistant", id: "m1", content: [{ type: "text", text: "hello" }] },
+  })
+  writeFileSync(path.join(projDir, `${sessionId}.jsonl`), `${line1}\n${line2}\n`, "utf8")
+}
+
+describe("importClaudeSessions", () => {
+  test("imports a session, creating project + chat + messages", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-aaa")
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+
+      const result = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(result.failed).toBe(0)
+
+      const chats = [...store.state.chatsById.values()].filter((c) => !c.deletedAt)
+      expect(chats.length).toBe(1)
+      expect(chats[0].sessionToken).toBe("sess-aaa")
+      expect(chats[0].provider).toBe("claude")
+      expect(store.getMessages(chats[0].id).length).toBe(2)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+
+  test("re-import is a no-op (dedup by sessionToken)", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-bbb")
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+
+      await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      const second = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+
+      expect(second.imported).toBe(0)
+      expect(second.skipped).toBe(1)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+
+  test("skips session whose cwd no longer exists", async () => {
+    const ctx = fresh()
+    try {
+      seedSession(ctx.homeDir, ctx.realProj, "sess-ccc")
+      rmSync(ctx.realProj, { recursive: true, force: true })
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+
+      const result = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(result.imported).toBe(0)
+      expect(result.failed).toBe(1)
+    } finally {
+      ctx.cleanup()
+    }
+  })
+})

--- a/src/server/claude-session-importer.test.ts
+++ b/src/server/claude-session-importer.test.ts
@@ -100,4 +100,44 @@ describe("importClaudeSessions", () => {
       ctx.cleanup()
     }
   })
+
+  test("derives title from array-form user text", async () => {
+    const ctx = fresh()
+    try {
+      const folderName = ctx.realProj.replace(/\//g, "-")
+      const projDir = path.join(ctx.homeDir, ".claude", "projects", folderName)
+      mkdirSync(projDir, { recursive: true })
+      const line = JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId: "sess-array",
+        cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:00.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "analyse this repo" }],
+        },
+      })
+      const line2 = JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        sessionId: "sess-array",
+        cwd: ctx.realProj,
+        timestamp: "2026-04-20T10:00:01.000Z",
+        message: { role: "assistant", id: "m1", content: [{ type: "text", text: "sure" }] },
+      })
+      writeFileSync(path.join(projDir, "sess-array.jsonl"), `${line}\n${line2}\n`, "utf8")
+
+      const store = new EventStore(ctx.dataDir)
+      await store.initialize()
+      const result = await importClaudeSessions({ store, homeDir: ctx.homeDir })
+      expect(result.imported).toBe(1)
+
+      const chats = [...store.state.chatsById.values()].filter((c) => !c.deletedAt)
+      expect(chats.length).toBe(1)
+      expect(chats[0].title).toBe("analyse this repo")
+    } finally {
+      ctx.cleanup()
+    }
+  })
 })

--- a/src/server/claude-session-importer.ts
+++ b/src/server/claude-session-importer.ts
@@ -1,14 +1,16 @@
 import { statSync } from "node:fs"
 import { homedir } from "node:os"
 import type { EventStore } from "./event-store"
+import type { ChatRecord } from "./events"
 import { mapClaudeRecordsToEntries } from "./claude-session-mapper"
 import { scanClaudeSessions } from "./claude-session-scanner"
 import type { ParsedClaudeSession } from "./claude-session-types"
 
 export interface ImportClaudeSessionsResult {
-  imported: number
-  skipped: number
-  failed: number
+  imported: number    // brand new sessions
+  updated: number     // existing sessions whose hash changed; new messages appended
+  skipped: number     // unchanged (hash match) or empty-entry sessions
+  failed: number      // cwd missing or store error
   newProjects: number
 }
 
@@ -54,6 +56,50 @@ function deriveTitle(session: ParsedClaudeSession): string {
   return "Imported session"
 }
 
+/**
+ * Extract the source record uuid from an entry _id.
+ * Mapper format: `${uuid}-user`, `${uuid}-text-<n>`, `${uuid}-tool_call-<n>`,
+ * `${uuid}-tool_result-<n>`. We match known trailing suffixes so that UUID v4
+ * values (which contain dashes) are not split incorrectly.
+ */
+function extractUuidFromEntryId(entryId: string): string | null {
+  const match = entryId.match(/^(.+)-(?:user|text-\d+|tool_call-\d+|tool_result-\d+)$/)
+  return match ? match[1] : null
+}
+
+/**
+ * Collect the set of record uuids already stored for a chat.
+ * Entries with a random uuid prefix (records that had no uuid) will always
+ * be absent from any record.uuid lookup — assumed acceptable since real Claude
+ * sessions always include uuid.
+ */
+function collectExistingUuids(store: EventStore, chatId: string): Set<string> {
+  const seen = new Set<string>()
+  for (const entry of store.getMessages(chatId)) {
+    const uuid = extractUuidFromEntryId(entry._id)
+    if (uuid) seen.add(uuid)
+  }
+  return seen
+}
+
+async function applyDelta(
+  store: EventStore,
+  chatId: string,
+  session: ParsedClaudeSession,
+): Promise<number> {
+  const seen = collectExistingUuids(store, chatId)
+  const newRecords = session.records.filter(
+    (record) => !record.uuid || !seen.has(record.uuid),
+  )
+  if (newRecords.length === 0) return 0
+
+  const entries = mapClaudeRecordsToEntries(newRecords)
+  for (const entry of entries) {
+    await store.appendMessage(chatId, entry)
+  }
+  return entries.length
+}
+
 export async function importClaudeSessions(
   args: ImportClaudeSessionsArgs,
 ): Promise<ImportClaudeSessionsResult> {
@@ -61,25 +107,48 @@ export async function importClaudeSessions(
   const sessions = scanClaudeSessions(homeDir)
 
   let imported = 0
+  let updated = 0
   let skipped = 0
   let failed = 0
   let newProjects = 0
-
-  const existingSessionTokens = new Set<string>()
-  for (const chat of store.state.chatsById.values()) {
-    if (chat.deletedAt) continue
-    if (chat.sessionToken) existingSessionTokens.add(chat.sessionToken)
-  }
 
   let scanned = 0
   for (const session of sessions) {
     scanned += 1
     if (onProgress) onProgress({ scanned, imported })
 
-    if (existingSessionTokens.has(session.sessionId)) {
-      skipped += 1
+    // Check if a chat already exists for this sessionId
+    let existingChat: ChatRecord | undefined
+    for (const chat of store.state.chatsById.values()) {
+      if (!chat.deletedAt && chat.sessionToken === session.sessionId) {
+        existingChat = chat
+        break
+      }
+    }
+
+    if (existingChat) {
+      // Hash match → nothing new to do
+      if (existingChat.sourceHash === session.sourceHash) {
+        skipped += 1
+        continue
+      }
+      // Hash changed → append only new records
+      try {
+        const appended = await applyDelta(store, existingChat.id, session)
+        if (appended > 0) {
+          updated += 1
+        } else {
+          skipped += 1
+        }
+        await store.setSourceHash(existingChat.id, session.sourceHash)
+      } catch (error) {
+        console.error("[kanna/import] failed to update session", session.filePath, error)
+        failed += 1
+      }
       continue
     }
+
+    // No existing chat — new import path
     if (!cwdExists(session.cwd)) {
       failed += 1
       continue
@@ -105,7 +174,7 @@ export async function importClaudeSessions(
       }
 
       await store.setSessionToken(chat.id, session.sessionId)
-      existingSessionTokens.add(session.sessionId)
+      await store.setSourceHash(chat.id, session.sourceHash)
       imported += 1
       if (onProgress) onProgress({ scanned, imported })
     } catch (error) {
@@ -114,5 +183,5 @@ export async function importClaudeSessions(
     }
   }
 
-  return { imported, skipped, failed, newProjects }
+  return { imported, updated, skipped, failed, newProjects }
 }

--- a/src/server/claude-session-importer.ts
+++ b/src/server/claude-session-importer.ts
@@ -1,0 +1,103 @@
+import { statSync } from "node:fs"
+import { homedir } from "node:os"
+import type { EventStore } from "./event-store"
+import { mapClaudeRecordsToEntries } from "./claude-session-mapper"
+import { scanClaudeSessions } from "./claude-session-scanner"
+import type { ParsedClaudeSession } from "./claude-session-types"
+
+export interface ImportClaudeSessionsResult {
+  imported: number
+  skipped: number
+  failed: number
+  newProjects: number
+}
+
+export interface ImportClaudeSessionsArgs {
+  store: EventStore
+  homeDir?: string
+  onProgress?: (update: { scanned: number; imported: number }) => void
+}
+
+function cwdExists(cwd: string): boolean {
+  if (!cwd) return false
+  try {
+    return statSync(cwd).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function deriveTitle(session: ParsedClaudeSession): string {
+  for (const record of session.records) {
+    if (record.type !== "user") continue
+    const content = (record as { message?: { content?: unknown } }).message?.content
+    if (typeof content === "string") {
+      const trimmed = content.trim()
+      if (trimmed) return trimmed.slice(0, 60)
+    }
+  }
+  return "Imported session"
+}
+
+export async function importClaudeSessions(
+  args: ImportClaudeSessionsArgs,
+): Promise<ImportClaudeSessionsResult> {
+  const { store, homeDir = homedir(), onProgress } = args
+  const sessions = scanClaudeSessions(homeDir)
+
+  let imported = 0
+  let skipped = 0
+  let failed = 0
+  let newProjects = 0
+
+  const existingSessionTokens = new Set<string>()
+  for (const chat of store.state.chatsById.values()) {
+    if (chat.deletedAt) continue
+    if (chat.sessionToken) existingSessionTokens.add(chat.sessionToken)
+  }
+
+  let scanned = 0
+  for (const session of sessions) {
+    scanned += 1
+    if (onProgress) onProgress({ scanned, imported })
+
+    if (existingSessionTokens.has(session.sessionId)) {
+      skipped += 1
+      continue
+    }
+    if (!cwdExists(session.cwd)) {
+      failed += 1
+      continue
+    }
+
+    const entries = mapClaudeRecordsToEntries(session.records)
+    if (entries.length === 0) {
+      skipped += 1
+      continue
+    }
+
+    try {
+      const projectBefore = store.state.projectIdsByPath.get(session.cwd)
+      const project = await store.openProject(session.cwd)
+      if (!projectBefore) newProjects += 1
+
+      const chat = await store.createChat(project.id)
+      await store.setChatProvider(chat.id, "claude")
+      await store.renameChat(chat.id, deriveTitle(session))
+
+      for (const entry of entries) {
+        await store.appendMessage(chat.id, entry)
+      }
+
+      await store.setSessionToken(chat.id, session.sessionId)
+      existingSessionTokens.add(session.sessionId)
+      imported += 1
+      if (onProgress) onProgress({ scanned, imported })
+    } catch (error) {
+      console.error("[kanna/import] failed to import session", session.filePath, error)
+      failed += 1
+    }
+  }
+
+  return { imported, skipped, failed, newProjects }
+}

--- a/src/server/claude-session-importer.ts
+++ b/src/server/claude-session-importer.ts
@@ -27,14 +27,29 @@ function cwdExists(cwd: string): boolean {
   }
 }
 
+function extractUserText(content: unknown): string | null {
+  if (typeof content === "string") {
+    const trimmed = content.trim()
+    return trimmed ? trimmed : null
+  }
+  if (!Array.isArray(content)) return null
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue
+    const blockRec = block as { type?: unknown; text?: unknown }
+    if (blockRec.type === "text" && typeof blockRec.text === "string") {
+      const trimmed = blockRec.text.trim()
+      if (trimmed) return trimmed
+    }
+  }
+  return null
+}
+
 function deriveTitle(session: ParsedClaudeSession): string {
   for (const record of session.records) {
     if (record.type !== "user") continue
     const content = (record as { message?: { content?: unknown } }).message?.content
-    if (typeof content === "string") {
-      const trimmed = content.trim()
-      if (trimmed) return trimmed.slice(0, 60)
-    }
+    const text = extractUserText(content)
+    if (text) return text.slice(0, 60)
   }
   return "Imported session"
 }

--- a/src/server/claude-session-mapper.test.ts
+++ b/src/server/claude-session-mapper.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { mapClaudeRecordsToEntries } from "./claude-session-mapper"
+import type { ClaudeSessionRecord } from "./claude-session-types"
+
+describe("mapClaudeRecordsToEntries", () => {
+  const baseTs = "2026-04-20T10:00:00.000Z"
+
+  test("user message → user_prompt entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      { type: "user", uuid: "u1", timestamp: baseTs, message: { role: "user", content: "hello" } },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("user_prompt")
+    if (entries[0].kind === "user_prompt") {
+      expect(entries[0].content).toBe("hello")
+    }
+  })
+
+  test("assistant text → assistant_text entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        timestamp: baseTs,
+        message: { role: "assistant", id: "m1", content: [{ type: "text", text: "hi" }] },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("assistant_text")
+    if (entries[0].kind === "assistant_text") {
+      expect(entries[0].text).toBe("hi")
+    }
+  })
+
+  test("assistant tool_use → tool_call entry with normalized Bash tool", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "assistant",
+        uuid: "a2",
+        timestamp: baseTs,
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu-1", name: "Bash", input: { command: "ls" } }],
+        },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("tool_call")
+    if (entries[0].kind === "tool_call") {
+      expect(entries[0].tool.toolKind).toBe("bash")
+      expect(entries[0].tool.toolId).toBe("tu-1")
+    }
+  })
+
+  test("user tool_result → tool_result entry", () => {
+    const records: ClaudeSessionRecord[] = [
+      {
+        type: "user",
+        uuid: "u1",
+        timestamp: baseTs,
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu-1", content: "file1\nfile2" }],
+        },
+      },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe("tool_result")
+    if (entries[0].kind === "tool_result") {
+      expect(entries[0].toolId).toBe("tu-1")
+      expect(entries[0].content).toBe("file1\nfile2")
+    }
+  })
+
+  test("skips summary and system records", () => {
+    const records: ClaudeSessionRecord[] = [
+      { type: "summary", summary: "x" },
+      { type: "system", content: "y" },
+      { type: "user", uuid: "u1", timestamp: baseTs, message: { role: "user", content: "hi" } },
+    ]
+    const entries = mapClaudeRecordsToEntries(records)
+    expect(entries.length).toBe(1)
+  })
+})

--- a/src/server/claude-session-mapper.ts
+++ b/src/server/claude-session-mapper.ts
@@ -1,0 +1,106 @@
+import { normalizeToolCall } from "../shared/tools"
+import type {
+  AssistantTextEntry,
+  ToolCallEntry,
+  ToolResultEntry,
+  TranscriptEntry,
+  UserPromptEntry,
+} from "../shared/types"
+import type {
+  ClaudeSessionAssistantRecord,
+  ClaudeSessionRecord,
+  ClaudeSessionUserRecord,
+} from "./claude-session-types"
+
+function toMillis(value: string | undefined): number {
+  if (!value) return Date.now()
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : Date.now()
+}
+
+function makeId(uuid: string | undefined, suffix: string): string {
+  if (uuid) return `${uuid}-${suffix}`
+  return `${crypto.randomUUID()}-${suffix}`
+}
+
+function mapUserRecord(record: ClaudeSessionUserRecord): TranscriptEntry[] {
+  const createdAt = toMillis(record.timestamp)
+  const content = record.message.content
+
+  if (typeof content === "string") {
+    const entry: UserPromptEntry = {
+      _id: makeId(record.uuid, "user"),
+      kind: "user_prompt",
+      createdAt,
+      content,
+    }
+    return [entry]
+  }
+
+  const entries: TranscriptEntry[] = []
+  for (let i = 0; i < content.length; i += 1) {
+    const block = content[i]
+    if (block.type === "tool_result") {
+      const resultEntry: ToolResultEntry = {
+        _id: makeId(record.uuid, `tool_result-${i}`),
+        kind: "tool_result",
+        createdAt,
+        toolId: block.tool_use_id,
+        content: typeof block.content === "string" ? block.content : block.content ?? null,
+        isError: block.is_error === true,
+      }
+      entries.push(resultEntry)
+    }
+  }
+  return entries
+}
+
+function mapAssistantRecord(record: ClaudeSessionAssistantRecord): TranscriptEntry[] {
+  const createdAt = toMillis(record.timestamp)
+  const messageId = record.message.id
+
+  const entries: TranscriptEntry[] = []
+  for (let i = 0; i < record.message.content.length; i += 1) {
+    const block = record.message.content[i]
+    if (block.type === "text") {
+      const entry: AssistantTextEntry = {
+        _id: makeId(record.uuid, `text-${i}`),
+        messageId,
+        kind: "assistant_text",
+        createdAt,
+        text: block.text,
+      }
+      entries.push(entry)
+      continue
+    }
+    if (block.type === "tool_use") {
+      const tool = normalizeToolCall({
+        toolName: block.name,
+        toolId: block.id,
+        input: block.input ?? {},
+      })
+      const entry: ToolCallEntry = {
+        _id: makeId(record.uuid, `tool_call-${i}`),
+        messageId,
+        kind: "tool_call",
+        createdAt,
+        tool,
+      }
+      entries.push(entry)
+    }
+  }
+  return entries
+}
+
+export function mapClaudeRecordsToEntries(records: ClaudeSessionRecord[]): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = []
+  for (const record of records) {
+    if (record.type === "user") {
+      entries.push(...mapUserRecord(record as ClaudeSessionUserRecord))
+    } else if (record.type === "assistant") {
+      entries.push(...mapAssistantRecord(record as ClaudeSessionAssistantRecord))
+    }
+    // summary / system / other: skipped
+  }
+  return entries
+}

--- a/src/server/claude-session-parser.test.ts
+++ b/src/server/claude-session-parser.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseClaudeSessionFile } from "./claude-session-parser"
+
+const FIXTURE_DIR = path.join(__dirname, "__fixtures__")
+
+describe("parseClaudeSessionFile", () => {
+  test("parses valid session with user, assistant, tool_use, tool_result", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-valid.jsonl"))
+    expect(parsed).not.toBeNull()
+    if (!parsed) return
+    expect(parsed.sessionId).toBe("sess-abc")
+    expect(parsed.cwd).toBe("/tmp/kanna-test-proj")
+    expect(parsed.records.length).toBe(6)
+    expect(parsed.firstTimestamp).toBeGreaterThan(0)
+    expect(parsed.lastTimestamp).toBeGreaterThanOrEqual(parsed.firstTimestamp)
+  })
+})

--- a/src/server/claude-session-parser.test.ts
+++ b/src/server/claude-session-parser.test.ts
@@ -14,6 +14,8 @@ describe("parseClaudeSessionFile", () => {
     expect(parsed.records.length).toBe(6)
     expect(parsed.firstTimestamp).toBeGreaterThan(0)
     expect(parsed.lastTimestamp).toBeGreaterThanOrEqual(parsed.firstTimestamp)
+    expect(typeof parsed.sourceHash).toBe("string")
+    expect(parsed.sourceHash.length).toBe(32)  // md5 hex = 32 chars
   })
 
   test("skips malformed lines, keeps valid ones", () => {

--- a/src/server/claude-session-parser.test.ts
+++ b/src/server/claude-session-parser.test.ts
@@ -15,4 +15,22 @@ describe("parseClaudeSessionFile", () => {
     expect(parsed.firstTimestamp).toBeGreaterThan(0)
     expect(parsed.lastTimestamp).toBeGreaterThanOrEqual(parsed.firstTimestamp)
   })
+
+  test("skips malformed lines, keeps valid ones", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-malformed.jsonl"))
+    expect(parsed).not.toBeNull()
+    if (!parsed) return
+    expect(parsed.records.length).toBe(2)
+    expect(parsed.sessionId).toBe("sess-bad")
+  })
+
+  test("returns null for empty file", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "claude-session-empty.jsonl"))
+    expect(parsed).toBeNull()
+  })
+
+  test("returns null for missing file", () => {
+    const parsed = parseClaudeSessionFile(path.join(FIXTURE_DIR, "does-not-exist.jsonl"))
+    expect(parsed).toBeNull()
+  })
 })

--- a/src/server/claude-session-parser.ts
+++ b/src/server/claude-session-parser.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { readFileSync, statSync } from "node:fs"
 import type { ClaudeSessionRecord, ParsedClaudeSession } from "./claude-session-types"
 
@@ -19,6 +20,7 @@ export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | 
   } catch {
     return null
   }
+  const sourceHash = createHash("md5").update(raw).digest("hex")
 
   const records: ClaudeSessionRecord[] = []
   let sessionId: string | null = null
@@ -60,5 +62,6 @@ export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | 
     firstTimestamp: Number.isFinite(first) ? first : mtime,
     lastTimestamp: Number.isFinite(last) ? last : mtime,
     records,
+    sourceHash,
   }
 }

--- a/src/server/claude-session-parser.ts
+++ b/src/server/claude-session-parser.ts
@@ -1,0 +1,59 @@
+import { readFileSync, statSync } from "node:fs"
+import type { ClaudeSessionRecord, ParsedClaudeSession } from "./claude-session-types"
+
+function tryParse(line: string): ClaudeSessionRecord | null {
+  try {
+    const parsed = JSON.parse(line)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+    if (typeof (parsed as ClaudeSessionRecord).type !== "string") return null
+    return parsed as ClaudeSessionRecord
+  } catch {
+    return null
+  }
+}
+
+export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | null {
+  let raw: string
+  try {
+    raw = readFileSync(filePath, "utf8")
+  } catch {
+    return null
+  }
+
+  const records: ClaudeSessionRecord[] = []
+  let sessionId: string | null = null
+  let cwd: string | null = null
+  let first = Number.POSITIVE_INFINITY
+  let last = 0
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const record = tryParse(trimmed)
+    if (!record) continue
+
+    if (!sessionId && typeof record.sessionId === "string") sessionId = record.sessionId
+    if (!cwd && typeof record.cwd === "string") cwd = record.cwd
+
+    const ts = typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN
+    if (!Number.isNaN(ts)) {
+      if (ts < first) first = ts
+      if (ts > last) last = ts
+    }
+
+    records.push(record)
+  }
+
+  if (!sessionId) return null
+  if (records.length === 0) return null
+
+  const mtime = statSync(filePath).mtimeMs
+  return {
+    sessionId,
+    filePath,
+    cwd: cwd ?? "",
+    firstTimestamp: Number.isFinite(first) ? first : mtime,
+    lastTimestamp: last > 0 ? last : mtime,
+    records,
+  }
+}

--- a/src/server/claude-session-parser.ts
+++ b/src/server/claude-session-parser.ts
@@ -24,7 +24,7 @@ export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | 
   let sessionId: string | null = null
   let cwd: string | null = null
   let first = Number.POSITIVE_INFINITY
-  let last = 0
+  let last = Number.NEGATIVE_INFINITY
 
   for (const line of raw.split("\n")) {
     const trimmed = line.trim()
@@ -47,13 +47,18 @@ export function parseClaudeSessionFile(filePath: string): ParsedClaudeSession | 
   if (!sessionId) return null
   if (records.length === 0) return null
 
-  const mtime = statSync(filePath).mtimeMs
+  let mtime: number
+  try {
+    mtime = statSync(filePath).mtimeMs
+  } catch {
+    mtime = Date.now()
+  }
   return {
     sessionId,
     filePath,
     cwd: cwd ?? "",
     firstTimestamp: Number.isFinite(first) ? first : mtime,
-    lastTimestamp: last > 0 ? last : mtime,
+    lastTimestamp: Number.isFinite(last) ? last : mtime,
     records,
   }
 }

--- a/src/server/claude-session-scanner.test.ts
+++ b/src/server/claude-session-scanner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { scanClaudeSessions } from "./claude-session-scanner"
+
+function makeTempClaudeHome(): { home: string; cleanup: () => void } {
+  const home = mkdtempSync(path.join(tmpdir(), "kanna-claude-home-"))
+  return { home, cleanup: () => rmSync(home, { recursive: true, force: true }) }
+}
+
+describe("scanClaudeSessions", () => {
+  test("returns empty list when ~/.claude/projects missing", () => {
+    const { home, cleanup } = makeTempClaudeHome()
+    try {
+      expect(scanClaudeSessions(home)).toEqual([])
+    } finally {
+      cleanup()
+    }
+  })
+
+  test("discovers session files inside project folders", () => {
+    const { home, cleanup } = makeTempClaudeHome()
+    try {
+      const realProj = mkdtempSync(path.join(tmpdir(), "kanna-proj-"))
+      const folderName = realProj.replace(/\//g, "-")
+      const projDir = path.join(home, ".claude", "projects", folderName)
+      mkdirSync(projDir, { recursive: true })
+      const sessionPath = path.join(projDir, "sess-abc.jsonl")
+      const line = JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId: "sess-abc",
+        cwd: realProj,
+        timestamp: "2026-04-20T10:00:00.000Z",
+        message: { role: "user", content: "hi" },
+      })
+      writeFileSync(sessionPath, `${line}\n`, "utf8")
+
+      const sessions = scanClaudeSessions(home)
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].sessionId).toBe("sess-abc")
+      expect(sessions[0].filePath).toBe(sessionPath)
+      rmSync(realProj, { recursive: true, force: true })
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/src/server/claude-session-scanner.ts
+++ b/src/server/claude-session-scanner.ts
@@ -1,0 +1,24 @@
+import { existsSync, readdirSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+import type { ParsedClaudeSession } from "./claude-session-types"
+import { parseClaudeSessionFile } from "./claude-session-parser"
+
+export function scanClaudeSessions(homeDir: string = homedir()): ParsedClaudeSession[] {
+  const projectsDir = path.join(homeDir, ".claude", "projects")
+  if (!existsSync(projectsDir)) return []
+
+  const sessions: ParsedClaudeSession[] = []
+  for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const projDir = path.join(projectsDir, entry.name)
+
+    for (const file of readdirSync(projDir, { withFileTypes: true })) {
+      if (!file.isFile() || !file.name.endsWith(".jsonl")) continue
+      const parsed = parseClaudeSessionFile(path.join(projDir, file.name))
+      if (parsed) sessions.push(parsed)
+    }
+  }
+
+  return sessions
+}

--- a/src/server/claude-session-types.ts
+++ b/src/server/claude-session-types.ts
@@ -57,4 +57,5 @@ export interface ParsedClaudeSession {
   firstTimestamp: number
   lastTimestamp: number
   records: ClaudeSessionRecord[]
+  sourceHash: string
 }

--- a/src/server/claude-session-types.ts
+++ b/src/server/claude-session-types.ts
@@ -1,0 +1,60 @@
+// src/server/claude-session-types.ts
+
+export interface ClaudeSessionRecordBase {
+  type: string
+  uuid?: string
+  parentUuid?: string | null
+  sessionId?: string
+  timestamp?: string
+  cwd?: string
+  version?: string
+}
+
+export interface ClaudeSessionUserRecord extends ClaudeSessionRecordBase {
+  type: "user"
+  message: {
+    role: "user"
+    content: string | Array<
+      | { type: "text"; text: string }
+      | { type: "tool_result"; tool_use_id: string; content?: unknown; is_error?: boolean }
+    >
+  }
+}
+
+export interface ClaudeSessionAssistantRecord extends ClaudeSessionRecordBase {
+  type: "assistant"
+  message: {
+    role: "assistant"
+    id?: string
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+    >
+  }
+}
+
+export interface ClaudeSessionSummaryRecord extends ClaudeSessionRecordBase {
+  type: "summary"
+  summary?: string
+}
+
+export interface ClaudeSessionSystemRecord extends ClaudeSessionRecordBase {
+  type: "system"
+  content?: string
+}
+
+export type ClaudeSessionRecord =
+  | ClaudeSessionUserRecord
+  | ClaudeSessionAssistantRecord
+  | ClaudeSessionSummaryRecord
+  | ClaudeSessionSystemRecord
+  | ClaudeSessionRecordBase
+
+export interface ParsedClaudeSession {
+  sessionId: string
+  filePath: string
+  cwd: string
+  firstTimestamp: number
+  lastTimestamp: number
+  records: ClaudeSessionRecord[]
+}

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -252,7 +252,7 @@ describe("compareVersions", () => {
 
 describe("classifyInstallVersionFailure", () => {
   test("maps version propagation failures to a user-facing retry message", () => {
-    expect(classifyInstallVersionFailure('error: No version matching "0.13.3" found for specifier "kanna-code"')).toEqual({
+    expect(classifyInstallVersionFailure('error: No version matching "0.13.3" found for specifier "@cuongtranba/kanna"')).toEqual({
       ok: false,
       errorCode: "version_not_live_yet",
       userTitle: "Update not live yet",
@@ -280,7 +280,7 @@ describe("runCli", () => {
     const result = await runCli(["--port", "4000", "--no-open"], deps)
 
     expect(result.kind).toBe("started")
-    expect(calls.fetchLatestVersion).toEqual(["kanna-code"])
+    expect(calls.fetchLatestVersion).toEqual(["@cuongtranba/kanna"])
     expect(calls.installVersion).toEqual([])
     expect(calls.startServer).toHaveLength(1)
     expect(calls.startServer[0]).toMatchObject({
@@ -474,7 +474,7 @@ describe("runCli", () => {
     const result = await runCli(["--port", "4000", "--no-open"], deps)
 
     expect(result).toEqual({ kind: "restarting", reason: "startup_update" })
-    expect(calls.installVersion).toEqual([{ packageName: "kanna-code", version: "0.4.0" }])
+    expect(calls.installVersion).toEqual([{ packageName: "@cuongtranba/kanna", version: "0.4.0" }])
     expect(calls.startServer).toEqual([])
   })
 
@@ -498,7 +498,7 @@ describe("runCli", () => {
     const result = await runCli(["--no-open"], deps)
 
     expect(result.kind).toBe("started")
-    expect(calls.installVersion).toEqual([{ packageName: "kanna-code", version: "0.4.0" }])
+    expect(calls.installVersion).toEqual([{ packageName: "@cuongtranba/kanna", version: "0.4.0" }])
     expect(calls.warn).toContain("[kanna] update failed, continuing current version")
   })
 

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -49,6 +49,7 @@ export interface CliRuntimeDeps {
   startServer: (options: CliOptions & {
     update: CliUpdateOptions
     onMigrationProgress?: (message: string) => void
+    trustProxy?: boolean
   }) => Promise<{ port: number; stop: () => Promise<void> }>
   fetchLatestVersion: (packageName: string) => Promise<string>
   installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
@@ -268,6 +269,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   const { port, stop } = await deps.startServer({
     ...parsedArgs.options,
+    trustProxy: isShareEnabled(parsedArgs.options.share),
     onMigrationProgress: deps.log,
     update: {
       version: deps.version,

--- a/src/server/diff-store.test.ts
+++ b/src/server/diff-store.test.ts
@@ -25,7 +25,7 @@ async function run(command: string[], cwd: string) {
 
 async function createRepo() {
   const root = await mkdtemp(path.join(tmpdir(), "kanna-diff-store-"))
-  await run(["git", "init"], root)
+  await run(["git", "init", "-b", "main"], root)
   await run(["git", "config", "user.email", "kanna@example.com"], root)
   await run(["git", "config", "user.name", "Kanna"], root)
   return root
@@ -33,7 +33,7 @@ async function createRepo() {
 
 async function createBareRemote() {
   const root = await mkdtemp(path.join(tmpdir(), "kanna-diff-remote-"))
-  await run(["git", "init", "--bare"], root)
+  await run(["git", "init", "--bare", "-b", "main"], root)
   return root
 }
 

--- a/src/server/diff-store.ts
+++ b/src/server/diff-store.ts
@@ -121,15 +121,6 @@ type SelectedBranch =
       remoteRef?: string
     }
 
-async function fileExists(filePath: string) {
-  try {
-    await stat(filePath)
-    return true
-  } catch {
-    return false
-  }
-}
-
 async function runGit(args: string[], cwd: string) {
   const process = Bun.spawn(["git", "-C", cwd, ...args], {
     stdout: "pipe",

--- a/src/server/diff-store.ts
+++ b/src/server/diff-store.ts
@@ -495,22 +495,52 @@ async function getMergeCommitCount(repoRoot: string, sourceRef: string) {
 }
 
 async function predictMergeConflicts(repoRoot: string, sourceRef: string) {
-  const result = await runGit(["merge-tree", "--write-tree", "--messages", "HEAD", sourceRef], repoRoot)
-  const output = `${result.stdout}\n${result.stderr}`.trim()
+  // Try the newer `git merge-tree --write-tree` form (requires Git 2.38+).
+  const newResult = await runGit(["merge-tree", "--write-tree", "--messages", "HEAD", sourceRef], repoRoot)
 
-  if (result.exitCode === 0) {
-    return { hasConflicts: false }
+  // Exit code 129 means the --write-tree flag is not supported (Git < 2.38).
+  // Fall back to the legacy three-argument form.
+  if (newResult.exitCode !== 129) {
+    const output = `${newResult.stdout}\n${newResult.stderr}`.trim()
+
+    if (newResult.exitCode === 0) {
+      return { hasConflicts: false }
+    }
+
+    const normalizedOutput = output.toLowerCase()
+    if (newResult.exitCode === 1 || normalizedOutput.includes("conflict")) {
+      return {
+        hasConflicts: true,
+        detail: output || "Git reported merge conflicts for this branch pair.",
+      }
+    }
+
+    throw new Error(output || "Failed to analyze merge conflicts")
   }
 
-  const normalizedOutput = output.toLowerCase()
-  if (result.exitCode === 1 || normalizedOutput.includes("conflict")) {
+  // Legacy fallback: `git merge-tree <base> HEAD <source>` (Git < 2.38).
+  const baseResult = await runGit(["merge-base", "HEAD", sourceRef], repoRoot)
+  if (baseResult.exitCode !== 0) {
+    throw new Error(baseResult.stderr.trim() || "Failed to find merge base")
+  }
+  const baseTree = baseResult.stdout.trim()
+
+  const legacyResult = await runGit(["merge-tree", baseTree, "HEAD", sourceRef], repoRoot)
+  const legacyOutput = `${legacyResult.stdout}\n${legacyResult.stderr}`.trim()
+
+  if (legacyResult.exitCode !== 0) {
+    throw new Error(legacyOutput || "Failed to analyze merge conflicts")
+  }
+
+  // In the legacy form, conflict markers (<<<<<<) appear in the output when there are conflicts.
+  if (legacyOutput.includes("<<<<<<<") || legacyOutput.toLowerCase().includes("conflict")) {
     return {
       hasConflicts: true,
-      detail: output || "Git reported merge conflicts for this branch pair.",
+      detail: legacyOutput || "Git reported merge conflicts for this branch pair.",
     }
   }
 
-  throw new Error(output || "Failed to analyze merge conflicts")
+  return { hasConflicts: false }
 }
 
 export function extractGitHubRepoSlug(remoteUrl: string | null | undefined) {

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -479,4 +479,22 @@ describe("recordSessionCommandsLoaded", () => {
       { name: "b", description: "", argumentHint: "" },
     ])
   })
+
+  test("skips redundant writes when commands are unchanged", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    const turnsLogPath = join(dataDir, "turns.jsonl")
+
+    const commands = [{ name: "review", description: "Review", argumentHint: "<pr>" }]
+    await store.recordSessionCommandsLoaded(chat.id, commands)
+    const afterFirst = (await readFile(turnsLogPath, "utf8")).trim().split("\n").length
+
+    await store.recordSessionCommandsLoaded(chat.id, [...commands.map((c) => ({ ...c }))])
+    const afterSecond = (await readFile(turnsLogPath, "utf8")).trim().split("\n").length
+
+    expect(afterSecond).toBe(afterFirst)
+  })
 })

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -69,6 +69,7 @@ describe("EventStore", () => {
         provider: null,
         planMode: false,
         sessionToken: null,
+        sourceHash: null,
         lastTurnOutcome: null,
       }],
       messages: [{
@@ -330,9 +331,11 @@ describe("EventStore", () => {
         title: "Chat",
         createdAt: 1,
         updatedAt: 5,
+        unread: false,
         provider: null,
         planMode: false,
         sessionToken: null,
+        sourceHash: null,
         lastTurnOutcome: null,
       }],
     }

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -497,4 +497,24 @@ describe("recordSessionCommandsLoaded", () => {
 
     expect(afterSecond).toBe(afterFirst)
   })
+
+  test("compaction + reload preserves slashCommands on chat records", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+
+    const commands = [
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+      { name: "help", description: "Show help", argumentHint: "" },
+    ]
+    await store.recordSessionCommandsLoaded(chat.id, commands)
+    await store.compact()
+
+    const reloaded = new EventStore(dataDir)
+    await reloaded.initialize()
+
+    expect(reloaded.getChat(chat.id)?.slashCommands).toEqual(commands)
+  })
 })

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -443,3 +443,40 @@ describe("EventStore", () => {
     expect(store.getChat(chat.id)?.id).toBe(chat.id)
   })
 })
+
+describe("recordSessionCommandsLoaded", () => {
+  test("stores latest commands on chat record", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+
+    await store.recordSessionCommandsLoaded(chat.id, [
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+    ])
+
+    expect(store.getChat(chat.id)?.slashCommands).toEqual([
+      { name: "review", description: "Review PR", argumentHint: "<pr>" },
+    ])
+  })
+
+  test("replaces commands on subsequent load", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+
+    await store.recordSessionCommandsLoaded(chat.id, [
+      { name: "a", description: "", argumentHint: "" },
+    ])
+    await store.recordSessionCommandsLoaded(chat.id, [
+      { name: "b", description: "", argumentHint: "" },
+    ])
+
+    expect(store.getChat(chat.id)?.slashCommands).toEqual([
+      { name: "b", description: "", argumentHint: "" },
+    ])
+  })
+})

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import type { TranscriptEntry } from "../shared/types"
 import type { SnapshotFile } from "./events"
+import type { AutoContinueEvent } from "./auto-continue/events"
 import { EventStore } from "./event-store"
 
 const originalRuntimeProfile = process.env.KANNA_RUNTIME_PROFILE
@@ -50,7 +51,7 @@ describe("EventStore", () => {
     const chatId = "chat-1"
 
     const snapshot: SnapshotFile = {
-      v: 2,
+      v: 3,
       generatedAt: 10,
       projects: [{
         id: "project-1",
@@ -82,7 +83,7 @@ describe("EventStore", () => {
 
     await writeFile(snapshotPath, JSON.stringify(snapshot, null, 2), "utf8")
     await writeFile(messagesLogPath, `${JSON.stringify({
-      v: 2,
+      v: 3,
       type: "message_appended",
       timestamp: 101,
       chatId,
@@ -279,7 +280,7 @@ describe("EventStore", () => {
 
     await writeFile(chatsLogPath, [
       JSON.stringify({
-        v: 2,
+        v: 3,
         type: "chat_created",
         timestamp,
         chatId,
@@ -287,7 +288,7 @@ describe("EventStore", () => {
         title: "Chat",
       }),
       JSON.stringify({
-        v: 2,
+        v: 3,
         type: "chat_read_state_set",
         timestamp,
         chatId,
@@ -297,7 +298,7 @@ describe("EventStore", () => {
     ].join("\n"), "utf8")
     await writeFile(turnsLogPath, [
       JSON.stringify({
-        v: 2,
+        v: 3,
         type: "turn_finished",
         timestamp,
         chatId,
@@ -315,8 +316,8 @@ describe("EventStore", () => {
     const dataDir = await createTempDataDir()
     const snapshotPath = join(dataDir, "snapshot.json")
 
-    const snapshot = {
-      v: 2,
+    const snapshot: SnapshotFile = {
+      v: 3,
       generatedAt: 10,
       projects: [{
         id: "project-1",
@@ -516,5 +517,73 @@ describe("recordSessionCommandsLoaded", () => {
     await reloaded.initialize()
 
     expect(reloaded.getChat(chat.id)?.slashCommands).toEqual(commands)
+  })
+})
+
+describe("EventStore auto-continue schedules", () => {
+  test("appends and replays AutoContinueEvent sequence", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/p1")
+    const chat = await store.createChat(project.id)
+
+    const proposed: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: chat.id,
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    }
+    const accepted: AutoContinueEvent = {
+      v: 3,
+      kind: "auto_continue_accepted",
+      timestamp: 1_100,
+      chatId: chat.id,
+      scheduleId: "s1",
+      scheduledAt: 2_000,
+      tz: "Asia/Saigon",
+      source: "user",
+      resetAt: 2_000,
+      detectedAt: 1_000,
+    }
+    await store.appendAutoContinueEvent(proposed)
+    await store.appendAutoContinueEvent(accepted)
+
+    const rehydrated = new EventStore(dataDir)
+    await rehydrated.initialize()
+    const events = rehydrated.getAutoContinueEvents(chat.id)
+    expect(events).toHaveLength(2)
+    expect(events[0].kind).toBe("auto_continue_proposed")
+    expect(events[1].kind).toBe("auto_continue_accepted")
+  })
+
+  test("snapshot compaction retains auto-continue events", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject("/tmp/p1")
+    const chat = await store.createChat(project.id)
+
+    await store.appendAutoContinueEvent({
+      v: 3,
+      kind: "auto_continue_proposed",
+      timestamp: 1_000,
+      chatId: chat.id,
+      scheduleId: "s1",
+      detectedAt: 1_000,
+      resetAt: 2_000,
+      tz: "Asia/Saigon",
+      turnId: "t1",
+    })
+    await store.compact()
+
+    const rehydrated = new EventStore(dataDir)
+    await rehydrated.initialize()
+    expect(rehydrated.getAutoContinueEvents(chat.id)).toHaveLength(1)
   })
 })

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -76,6 +76,8 @@ function getReplayEventPriority(event: StoreEvent) {
       return 5
     case "session_token_set":
       return 6
+    case "session_commands_loaded":
+      return 6
     case "turn_cancelled":
       return 7
     case "turn_finished":
@@ -87,8 +89,6 @@ function getReplayEventPriority(event: StoreEvent) {
       return 9
     case "chat_deleted":
       return 10
-    case "session_commands_loaded":
-      return 6 // same priority as session_token_set; both are independent turn-metadata events
   }
 }
 
@@ -106,6 +106,18 @@ function decodeCursor(cursor: string) {
   }
 
   throw new Error("Invalid history cursor")
+}
+
+function slashCommandsEqual(a: SlashCommand[], b: SlashCommand[]) {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i += 1) {
+    const ai = a[i]
+    const bi = b[i]
+    if (ai.name !== bi.name || ai.description !== bi.description || ai.argumentHint !== bi.argumentHint) {
+      return false
+    }
+  }
+  return true
 }
 
 function getHistorySnapshot(page: TranscriptPageResult, recentLimit: number): ChatHistorySnapshot {
@@ -830,17 +842,21 @@ export class EventStore {
   }
 
   async recordSessionCommandsLoaded(chatId: string, commands: SlashCommand[]) {
-    this.requireChat(chatId)
+    const chat = this.requireChat(chatId)
+    const normalized = commands.map((c) => ({
+      name: c.name,
+      description: c.description,
+      argumentHint: c.argumentHint,
+    }))
+    if (chat.slashCommands && slashCommandsEqual(chat.slashCommands, normalized)) {
+      return
+    }
     const event: TurnEvent = {
       v: STORE_VERSION,
       type: "session_commands_loaded",
       timestamp: Date.now(),
       chatId,
-      commands: commands.map((c) => ({
-        name: c.name,
-        description: c.description,
-        argumentHint: c.argumentHint,
-      })),
+      commands: normalized,
     }
     await this.append(this.turnsLogPath, event)
   }

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -83,6 +83,8 @@ function getReplayEventPriority(event: StoreEvent) {
       return 8
     case "chat_read_state_set":
       return 9
+    case "chat_source_hash_set":
+      return 9
     case "chat_deleted":
       return 10
   }
@@ -340,6 +342,7 @@ export class EventStore {
           provider: null,
           planMode: false,
           sessionToken: null,
+          sourceHash: null,
           hasMessages: false,
           lastTurnOutcome: null,
         }
@@ -379,6 +382,13 @@ export class EventStore {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.unread = event.unread
+        chat.updatedAt = event.timestamp
+        break
+      }
+      case "chat_source_hash_set": {
+        const chat = this.state.chatsById.get(event.chatId)
+        if (!chat) break
+        chat.sourceHash = event.sourceHash
         chat.updatedAt = event.timestamp
         break
       }
@@ -808,6 +818,19 @@ export class EventStore {
       sessionToken,
     }
     await this.append(this.turnsLogPath, event)
+  }
+
+  async setSourceHash(chatId: string, sourceHash: string | null) {
+    const chat = this.requireChat(chatId)
+    if (chat.sourceHash === sourceHash) return
+    const event: ChatEvent = {
+      v: STORE_VERSION,
+      type: "chat_source_hash_set",
+      timestamp: Date.now(),
+      chatId,
+      sourceHash,
+    }
+    await this.append(this.chatsLogPath, event)
   }
 
   getProject(projectId: string) {

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -87,6 +87,9 @@ function getReplayEventPriority(event: StoreEvent) {
       return 9
     case "chat_deleted":
       return 10
+    // TODO(Task 3): assign final priority once reducer is implemented
+    case "session_commands_loaded":
+      return 6
   }
 }
 

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -336,7 +336,7 @@ export class EventStore {
   }
 
   private applyEvent(event: StoreEvent) {
-    if ("kind" in event && event.kind.startsWith("auto_continue_")) {
+    if ("kind" in event) {
       this.applyAutoContinueEvent(event)
       return
     }
@@ -1129,12 +1129,7 @@ export class EventStore {
   }
 
   async appendAutoContinueEvent(event: AutoContinueEvent) {
-    const payload = `${JSON.stringify(event)}\n`
-    this.writeChain = this.writeChain.then(async () => {
-      await appendFile(this.schedulesLogPath, payload, "utf8")
-      this.applyAutoContinueEvent(event)
-    })
-    return this.writeChain
+    return this.append(this.schedulesLogPath, event)
   }
 
   getAutoContinueEvents(chatId: string): AutoContinueEvent[] {

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -783,6 +783,7 @@ export class EventStore {
       model: message.model,
       modelOptions: message.modelOptions,
       planMode: message.planMode,
+      autoContinue: message.autoContinue,
     }
     const event: QueuedMessageEvent = {
       v: STORE_VERSION,

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -465,6 +465,7 @@ export class EventStore {
         chat.updatedAt = event.timestamp
         break
       }
+      // TODO(Task 3): handle session_commands_loaded (update chat.slashCommands)
     }
   }
 

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import { getDataDir, LOG_PREFIX } from "../shared/branding"
 import type { AgentProvider, ChatHistoryPage, ChatHistorySnapshot, QueuedChatMessage, SlashCommand, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
+import type { AutoContinueEvent } from "./auto-continue/events"
 import {
   type ChatEvent,
   type ProjectEvent,
@@ -56,7 +57,8 @@ interface ParsedReplayEvent {
 }
 
 function getReplayEventPriority(event: StoreEvent) {
-  switch (event.type) {
+  const discriminator = "type" in event ? event.type : event.kind
+  switch (discriminator) {
     case "project_opened":
     case "project_removed":
     case "sidebar_project_order_set":
@@ -75,7 +77,6 @@ function getReplayEventPriority(event: StoreEvent) {
     case "turn_started":
       return 5
     case "session_token_set":
-      return 6
     case "session_commands_loaded":
       return 6
     case "turn_cancelled":
@@ -84,11 +85,16 @@ function getReplayEventPriority(event: StoreEvent) {
     case "turn_failed":
       return 8
     case "chat_read_state_set":
-      return 9
     case "chat_source_hash_set":
       return 9
     case "chat_deleted":
       return 10
+    case "auto_continue_proposed":
+    case "auto_continue_accepted":
+    case "auto_continue_rescheduled":
+    case "auto_continue_cancelled":
+    case "auto_continue_fired":
+      return 11
   }
 }
 
@@ -139,6 +145,7 @@ export class EventStore {
   private readonly messagesLogPath: string
   private readonly queuedMessagesLogPath: string
   private readonly turnsLogPath: string
+  private readonly schedulesLogPath: string
   private readonly transcriptsDir: string
   private legacyMessagesByChatId = new Map<string, TranscriptEntry[]>()
   private snapshotHasLegacyMessages = false
@@ -152,6 +159,7 @@ export class EventStore {
     this.messagesLogPath = path.join(this.dataDir, "messages.jsonl")
     this.queuedMessagesLogPath = path.join(this.dataDir, "queued-messages.jsonl")
     this.turnsLogPath = path.join(this.dataDir, "turns.jsonl")
+    this.schedulesLogPath = path.join(this.dataDir, "schedules.jsonl")
     this.transcriptsDir = path.join(this.dataDir, "transcripts")
   }
 
@@ -163,6 +171,7 @@ export class EventStore {
     await this.ensureFile(this.messagesLogPath)
     await this.ensureFile(this.queuedMessagesLogPath)
     await this.ensureFile(this.turnsLogPath)
+    await this.ensureFile(this.schedulesLogPath)
     await this.loadSnapshot()
     await this.replayLogs()
     if (!(await this.hasLegacyTranscriptData()) && await this.shouldCompact()) {
@@ -189,6 +198,7 @@ export class EventStore {
       Bun.write(this.messagesLogPath, ""),
       Bun.write(this.queuedMessagesLogPath, ""),
       Bun.write(this.turnsLogPath, ""),
+      Bun.write(this.schedulesLogPath, ""),
     ])
   }
 
@@ -230,6 +240,11 @@ export class EventStore {
           this.legacyMessagesByChatId.set(messageSet.chatId, cloneTranscriptEntries(messageSet.entries))
         }
       }
+      if (parsed.autoContinueEvents?.length) {
+        for (const entry of parsed.autoContinueEvents) {
+          this.state.autoContinueEventsByChatId.set(entry.chatId, [...entry.events])
+        }
+      }
     } catch (error) {
       console.warn(`${LOG_PREFIX} Failed to load snapshot, resetting local history:`, error)
       await this.clearStorage()
@@ -242,6 +257,7 @@ export class EventStore {
     this.state.chatsById.clear()
     this.state.queuedMessagesByChatId.clear()
     this.state.sidebarProjectOrder = []
+    this.state.autoContinueEventsByChatId.clear()
     this.cachedTranscript = null
   }
 
@@ -258,6 +274,7 @@ export class EventStore {
       ...await this.loadReplayEvents(this.messagesLogPath, 2),
       ...await this.loadReplayEvents(this.queuedMessagesLogPath, 3),
       ...await this.loadReplayEvents(this.turnsLogPath, 4),
+      ...await this.loadReplayEvents(this.schedulesLogPath, 5),
     ]
     if (this.storageReset) return
 
@@ -319,39 +336,44 @@ export class EventStore {
   }
 
   private applyEvent(event: StoreEvent) {
-    switch (event.type) {
+    if ("kind" in event && event.kind.startsWith("auto_continue_")) {
+      this.applyAutoContinueEvent(event)
+      return
+    }
+    const e = event as Exclude<StoreEvent, AutoContinueEvent>
+    switch (e.type) {
       case "project_opened": {
-        const localPath = resolveLocalPath(event.localPath)
+        const localPath = resolveLocalPath(e.localPath)
         const project = {
-          id: event.projectId,
+          id: e.projectId,
           localPath,
-          title: event.title,
-          createdAt: event.timestamp,
-          updatedAt: event.timestamp,
+          title: e.title,
+          createdAt: e.timestamp,
+          updatedAt: e.timestamp,
         }
         this.state.projectsById.set(project.id, project)
         this.state.projectIdsByPath.set(localPath, project.id)
         break
       }
       case "project_removed": {
-        const project = this.state.projectsById.get(event.projectId)
+        const project = this.state.projectsById.get(e.projectId)
         if (!project) break
-        project.deletedAt = event.timestamp
-        project.updatedAt = event.timestamp
+        project.deletedAt = e.timestamp
+        project.updatedAt = e.timestamp
         this.state.projectIdsByPath.delete(project.localPath)
         break
       }
       case "sidebar_project_order_set": {
-        this.state.sidebarProjectOrder = [...event.projectIds]
+        this.state.sidebarProjectOrder = [...e.projectIds]
         break
       }
       case "chat_created": {
       const chat = {
-          id: event.chatId,
-          projectId: event.projectId,
-          title: event.title,
-          createdAt: event.timestamp,
-          updatedAt: event.timestamp,
+          id: e.chatId,
+          projectId: e.projectId,
+          title: e.title,
+          createdAt: e.timestamp,
+          updatedAt: e.timestamp,
           unread: false,
           provider: null,
           planMode: false,
@@ -364,126 +386,132 @@ export class EventStore {
         break
       }
       case "chat_renamed": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.title = event.title
-        chat.updatedAt = event.timestamp
+        chat.title = e.title
+        chat.updatedAt = e.timestamp
         break
       }
       case "chat_deleted": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.deletedAt = event.timestamp
-        chat.updatedAt = event.timestamp
-        this.state.queuedMessagesByChatId.delete(event.chatId)
+        chat.deletedAt = e.timestamp
+        chat.updatedAt = e.timestamp
+        this.state.queuedMessagesByChatId.delete(e.chatId)
         break
       }
       case "chat_provider_set": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.provider = event.provider
-        chat.updatedAt = event.timestamp
+        chat.provider = e.provider
+        chat.updatedAt = e.timestamp
         break
       }
       case "chat_plan_mode_set": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.planMode = event.planMode
-        chat.updatedAt = event.timestamp
+        chat.planMode = e.planMode
+        chat.updatedAt = e.timestamp
         break
       }
       case "chat_read_state_set": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.unread = event.unread
-        chat.updatedAt = event.timestamp
+        chat.unread = e.unread
+        chat.updatedAt = e.timestamp
         break
       }
       case "chat_source_hash_set": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.sourceHash = event.sourceHash
-        chat.updatedAt = event.timestamp
+        chat.sourceHash = e.sourceHash
+        chat.updatedAt = e.timestamp
         break
       }
       case "message_appended": {
-        this.applyMessageMetadata(event.chatId, event.entry)
-        const existing = this.legacyMessagesByChatId.get(event.chatId) ?? []
-        existing.push({ ...event.entry })
-        this.legacyMessagesByChatId.set(event.chatId, existing)
+        this.applyMessageMetadata(e.chatId, e.entry)
+        const existing = this.legacyMessagesByChatId.get(e.chatId) ?? []
+        existing.push({ ...e.entry })
+        this.legacyMessagesByChatId.set(e.chatId, existing)
         break
       }
       case "queued_message_enqueued": {
-        const existing = this.state.queuedMessagesByChatId.get(event.chatId) ?? []
+        const existing = this.state.queuedMessagesByChatId.get(e.chatId) ?? []
         existing.push({
-          ...event.message,
-          attachments: [...event.message.attachments],
+          ...e.message,
+          attachments: [...e.message.attachments],
         })
-        this.state.queuedMessagesByChatId.set(event.chatId, existing)
-        const chat = this.state.chatsById.get(event.chatId)
+        this.state.queuedMessagesByChatId.set(e.chatId, existing)
+        const chat = this.state.chatsById.get(e.chatId)
         if (chat) {
-          chat.updatedAt = event.timestamp
+          chat.updatedAt = e.timestamp
         }
         break
       }
       case "queued_message_removed": {
-        const existing = this.state.queuedMessagesByChatId.get(event.chatId) ?? []
-        const next = existing.filter((entry) => entry.id !== event.queuedMessageId)
+        const existing = this.state.queuedMessagesByChatId.get(e.chatId) ?? []
+        const next = existing.filter((entry) => entry.id !== e.queuedMessageId)
         if (next.length > 0) {
-          this.state.queuedMessagesByChatId.set(event.chatId, next)
+          this.state.queuedMessagesByChatId.set(e.chatId, next)
         } else {
-          this.state.queuedMessagesByChatId.delete(event.chatId)
+          this.state.queuedMessagesByChatId.delete(e.chatId)
         }
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (chat) {
-          chat.updatedAt = event.timestamp
+          chat.updatedAt = e.timestamp
         }
         break
       }
       case "turn_started": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.updatedAt = event.timestamp
+        chat.updatedAt = e.timestamp
         break
       }
       case "turn_finished": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.updatedAt = event.timestamp
+        chat.updatedAt = e.timestamp
         chat.unread = true
         chat.lastTurnOutcome = "success"
         break
       }
       case "turn_failed": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.updatedAt = event.timestamp
+        chat.updatedAt = e.timestamp
         chat.unread = true
         chat.lastTurnOutcome = "failed"
         break
       }
       case "turn_cancelled": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.updatedAt = event.timestamp
+        chat.updatedAt = e.timestamp
         chat.lastTurnOutcome = "cancelled"
         break
       }
       case "session_token_set": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.sessionToken = event.sessionToken
-        chat.updatedAt = event.timestamp
+        chat.sessionToken = e.sessionToken
+        chat.updatedAt = e.timestamp
         break
       }
       case "session_commands_loaded": {
-        const chat = this.state.chatsById.get(event.chatId)
+        const chat = this.state.chatsById.get(e.chatId)
         if (!chat) break
-        chat.slashCommands = event.commands.map((c) => ({ ...c }))
-        chat.updatedAt = event.timestamp
+        chat.slashCommands = e.commands.map((c) => ({ ...c }))
+        chat.updatedAt = e.timestamp
         break
       }
     }
+  }
+
+  private applyAutoContinueEvent(event: AutoContinueEvent) {
+    const existing = this.state.autoContinueEventsByChatId.get(event.chatId) ?? []
+    existing.push(event)
+    this.state.autoContinueEventsByChatId.set(event.chatId, existing)
   }
 
   private applyMessageMetadata(chatId: string, entry: TranscriptEntry) {
@@ -1037,6 +1065,10 @@ export class EventStore {
             attachments: [...entry.attachments],
           })),
         })),
+      autoContinueEvents: [...this.state.autoContinueEventsByChatId.entries()].map(([chatId, events]) => ({
+        chatId,
+        events: [...events],
+      })),
     }
   }
 
@@ -1049,6 +1081,7 @@ export class EventStore {
       Bun.write(this.messagesLogPath, ""),
       Bun.write(this.queuedMessagesLogPath, ""),
       Bun.write(this.turnsLogPath, ""),
+      Bun.write(this.schedulesLogPath, ""),
     ])
   }
 
@@ -1090,7 +1123,26 @@ export class EventStore {
       Bun.file(this.messagesLogPath).size,
       Bun.file(this.queuedMessagesLogPath).size,
       Bun.file(this.turnsLogPath).size,
+      Bun.file(this.schedulesLogPath).size,
     ])
     return sizes.reduce((total, size) => total + size, 0) >= COMPACTION_THRESHOLD_BYTES
+  }
+
+  async appendAutoContinueEvent(event: AutoContinueEvent) {
+    const payload = `${JSON.stringify(event)}\n`
+    this.writeChain = this.writeChain.then(async () => {
+      await appendFile(this.schedulesLogPath, payload, "utf8")
+      this.applyAutoContinueEvent(event)
+    })
+    return this.writeChain
+  }
+
+  getAutoContinueEvents(chatId: string): AutoContinueEvent[] {
+    const list = this.state.autoContinueEventsByChatId.get(chatId)
+    return list ? [...list] : []
+  }
+
+  listAutoContinueChats(): string[] {
+    return [...this.state.autoContinueEventsByChatId.keys()]
   }
 }

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync as readFileSyncImmediate } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
 import { getDataDir, LOG_PREFIX } from "../shared/branding"
-import type { AgentProvider, ChatHistoryPage, ChatHistorySnapshot, QueuedChatMessage, TranscriptEntry } from "../shared/types"
+import type { AgentProvider, ChatHistoryPage, ChatHistorySnapshot, QueuedChatMessage, SlashCommand, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
 import {
   type ChatEvent,
@@ -87,9 +87,8 @@ function getReplayEventPriority(event: StoreEvent) {
       return 9
     case "chat_deleted":
       return 10
-    // TODO(Task 3): assign final priority once reducer is implemented
     case "session_commands_loaded":
-      return 6
+      return 6 // same priority as session_token_set; both are independent turn-metadata events
   }
 }
 
@@ -465,7 +464,13 @@ export class EventStore {
         chat.updatedAt = event.timestamp
         break
       }
-      // TODO(Task 3): handle session_commands_loaded (update chat.slashCommands)
+      case "session_commands_loaded": {
+        const chat = this.state.chatsById.get(event.chatId)
+        if (!chat) break
+        chat.slashCommands = event.commands.map((c) => ({ ...c }))
+        chat.updatedAt = event.timestamp
+        break
+      }
     }
   }
 
@@ -820,6 +825,22 @@ export class EventStore {
       timestamp: Date.now(),
       chatId,
       sessionToken,
+    }
+    await this.append(this.turnsLogPath, event)
+  }
+
+  async recordSessionCommandsLoaded(chatId: string, commands: SlashCommand[]) {
+    this.requireChat(chatId)
+    const event: TurnEvent = {
+      v: STORE_VERSION,
+      type: "session_commands_loaded",
+      timestamp: Date.now(),
+      chatId,
+      commands: commands.map((c) => ({
+        name: c.name,
+        description: c.description,
+        argumentHint: c.argumentHint,
+      })),
     }
     await this.append(this.turnsLogPath, event)
   }

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,4 +1,4 @@
-import type { AgentProvider, ProjectSummary, QueuedChatMessage, TranscriptEntry } from "../shared/types"
+import type { AgentProvider, ProjectSummary, QueuedChatMessage, SlashCommand, TranscriptEntry } from "../shared/types"
 
 export interface ProjectRecord extends ProjectSummary {
   deletedAt?: number
@@ -19,6 +19,7 @@ export interface ChatRecord {
   hasMessages?: boolean
   lastMessageAt?: number
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
+  slashCommands?: SlashCommand[]
 }
 
 export interface StoreState {
@@ -165,6 +166,13 @@ export type TurnEvent =
       timestamp: number
       chatId: string
       sessionToken: string | null
+    }
+  | {
+      v: 2
+      type: "session_commands_loaded"
+      timestamp: number
+      chatId: string
+      commands: Array<{ name: string; description: string; argumentHint: string }>
     }
 
 export type StoreEvent = ProjectEvent | ChatEvent | MessageEvent | QueuedMessageEvent | TurnEvent

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -15,6 +15,7 @@ export interface ChatRecord {
   provider: AgentProvider | null
   planMode: boolean
   sessionToken: string | null
+  sourceHash: string | null
   hasMessages?: boolean
   lastMessageAt?: number
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
@@ -99,6 +100,13 @@ export type ChatEvent =
       timestamp: number
       chatId: string
       unread: boolean
+    }
+  | {
+      v: 2
+      type: "chat_source_hash_set"
+      timestamp: number
+      chatId: string
+      sourceHash: string | null
     }
 
 export type MessageEvent = {

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,4 +1,5 @@
 import type { AgentProvider, ProjectSummary, QueuedChatMessage, SlashCommand, TranscriptEntry } from "../shared/types"
+import type { AutoContinueEvent } from "./auto-continue/events"
 
 export interface ProjectRecord extends ProjectSummary {
   deletedAt?: number
@@ -28,32 +29,34 @@ export interface StoreState {
   chatsById: Map<string, ChatRecord>
   queuedMessagesByChatId: Map<string, QueuedChatMessage[]>
   sidebarProjectOrder: string[]
+  autoContinueEventsByChatId: Map<string, AutoContinueEvent[]>
 }
 
 export interface SnapshotFile {
-  v: 2
+  v: 3
   generatedAt: number
   projects: ProjectRecord[]
   chats: ChatRecord[]
   sidebarProjectOrder?: string[]
   queuedMessages?: Array<{ chatId: string; entries: QueuedChatMessage[] }>
   messages?: Array<{ chatId: string; entries: TranscriptEntry[] }>
+  autoContinueEvents?: Array<{ chatId: string; events: AutoContinueEvent[] }>
 }
 
 export type ProjectEvent = {
-  v: 2
+  v: 3
   type: "project_opened"
   timestamp: number
   projectId: string
   localPath: string
   title: string
 } | {
-  v: 2
+  v: 3
   type: "project_removed"
   timestamp: number
   projectId: string
 } | {
-  v: 2
+  v: 3
   type: "sidebar_project_order_set"
   timestamp: number
   projectIds: string[]
@@ -61,7 +64,7 @@ export type ProjectEvent = {
 
 export type ChatEvent =
   | {
-      v: 2
+      v: 3
       type: "chat_created"
       timestamp: number
       chatId: string
@@ -69,41 +72,41 @@ export type ChatEvent =
       title: string
     }
   | {
-      v: 2
+      v: 3
       type: "chat_renamed"
       timestamp: number
       chatId: string
       title: string
     }
   | {
-      v: 2
+      v: 3
       type: "chat_deleted"
       timestamp: number
       chatId: string
     }
   | {
-      v: 2
+      v: 3
       type: "chat_provider_set"
       timestamp: number
       chatId: string
       provider: AgentProvider
     }
   | {
-      v: 2
+      v: 3
       type: "chat_plan_mode_set"
       timestamp: number
       chatId: string
       planMode: boolean
     }
   | {
-      v: 2
+      v: 3
       type: "chat_read_state_set"
       timestamp: number
       chatId: string
       unread: boolean
     }
   | {
-      v: 2
+      v: 3
       type: "chat_source_hash_set"
       timestamp: number
       chatId: string
@@ -111,7 +114,7 @@ export type ChatEvent =
     }
 
 export type MessageEvent = {
-  v: 2
+  v: 3
   type: "message_appended"
   timestamp: number
   chatId: string
@@ -120,14 +123,14 @@ export type MessageEvent = {
 
 export type QueuedMessageEvent =
   | {
-      v: 2
+      v: 3
       type: "queued_message_enqueued"
       timestamp: number
       chatId: string
       message: QueuedChatMessage
     }
   | {
-      v: 2
+      v: 3
       type: "queued_message_removed"
       timestamp: number
       chatId: string
@@ -136,46 +139,46 @@ export type QueuedMessageEvent =
 
 export type TurnEvent =
   | {
-      v: 2
+      v: 3
       type: "turn_started"
       timestamp: number
       chatId: string
     }
   | {
-      v: 2
+      v: 3
       type: "turn_finished"
       timestamp: number
       chatId: string
     }
   | {
-      v: 2
+      v: 3
       type: "turn_failed"
       timestamp: number
       chatId: string
       error: string
     }
   | {
-      v: 2
+      v: 3
       type: "turn_cancelled"
       timestamp: number
       chatId: string
     }
   | {
-      v: 2
+      v: 3
       type: "session_token_set"
       timestamp: number
       chatId: string
       sessionToken: string | null
     }
   | {
-      v: 2
+      v: 3
       type: "session_commands_loaded"
       timestamp: number
       chatId: string
       commands: Array<{ name: string; description: string; argumentHint: string }>
     }
 
-export type StoreEvent = ProjectEvent | ChatEvent | MessageEvent | QueuedMessageEvent | TurnEvent
+export type StoreEvent = ProjectEvent | ChatEvent | MessageEvent | QueuedMessageEvent | TurnEvent | AutoContinueEvent
 
 export function createEmptyState(): StoreState {
   return {
@@ -184,6 +187,7 @@ export function createEmptyState(): StoreState {
     chatsById: new Map(),
     queuedMessagesByChatId: new Map(),
     sidebarProjectOrder: [],
+    autoContinueEventsByChatId: new Map(),
   }
 }
 

--- a/src/server/paths-route.test.ts
+++ b/src/server/paths-route.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { startKannaServer } from "./server"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+async function startServer(port: number) {
+  const projectDir = await mkdtemp(path.join(tmpdir(), "kanna-paths-route-"))
+  tempDirs.push(projectDir)
+  const server = await startKannaServer({ port, strictPort: true })
+  return { server, projectDir }
+}
+
+describe("GET /api/projects/:id/paths", () => {
+  test("returns 404 for unknown project", async () => {
+    const { server } = await startServer(4330)
+    try {
+      const response = await fetch(`http://localhost:${server.port}/api/projects/does-not-exist/paths`)
+      expect(response.status).toBe(404)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("returns top-level entries for empty query", async () => {
+    const { server, projectDir } = await startServer(4331)
+    try {
+      await mkdir(path.join(projectDir, "src"))
+      await writeFile(path.join(projectDir, "README.md"), "")
+
+      const project = await server.store.openProject(projectDir, "t")
+      const response = await fetch(`http://localhost:${server.port}/api/projects/${project.id}/paths`)
+      expect(response.status).toBe(200)
+      const payload = await response.json() as { paths: Array<{ path: string; kind: string }> }
+      const names = payload.paths.map((p) => p.path)
+      expect(names).toContain("README.md")
+      expect(names).toContain("src/")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("respects ?query= and ?limit=", async () => {
+    const { server, projectDir } = await startServer(4332)
+    try {
+      for (let i = 0; i < 5; i++) await writeFile(path.join(projectDir, `file-${i}.txt`), "")
+
+      const project = await server.store.openProject(projectDir, "t")
+      const response = await fetch(
+        `http://localhost:${server.port}/api/projects/${project.id}/paths?query=file&limit=2`,
+      )
+      const payload = await response.json() as { paths: Array<{ path: string }> }
+      expect(payload.paths.length).toBe(2)
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/src/server/project-paths.test.ts
+++ b/src/server/project-paths.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { $ } from "bun"
+import { clearProjectPathCache, listProjectPaths } from "./project-paths"
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  clearProjectPathCache()
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe("listProjectPaths", () => {
+  test("empty query returns top-level entries with dirs suffixed", async () => {
+    const root = await makeTempDir("kanna-paths-empty-")
+    await writeFile(path.join(root, "a.txt"), "a")
+    await mkdir(path.join(root, "src"))
+    await writeFile(path.join(root, "src", "b.ts"), "b")
+
+    const paths = await listProjectPaths({ projectId: "p1", localPath: root, query: "" })
+    const names = paths.map((p) => p.path).sort()
+    expect(names).toEqual(["a.txt", "src/"])
+    expect(paths.find((p) => p.path === "src/")?.kind).toBe("dir")
+    expect(paths.find((p) => p.path === "a.txt")?.kind).toBe("file")
+  })
+
+  test("git repo: returns tracked files + derived dirs", async () => {
+    const root = await makeTempDir("kanna-paths-git-")
+    await $`git init -q`.cwd(root)
+    await $`git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init`.cwd(root)
+    await mkdir(path.join(root, "src"))
+    await writeFile(path.join(root, "src", "agent.ts"), "x")
+    await writeFile(path.join(root, "README.md"), "r")
+    await $`git add .`.cwd(root)
+    await $`git -c user.email=t@t -c user.name=t commit -q -m add`.cwd(root)
+
+    const paths = await listProjectPaths({ projectId: "p2", localPath: root, query: "agent" })
+    const names = paths.map((p) => p.path)
+    expect(names).toContain("src/agent.ts")
+  })
+
+  test("git repo: respects .gitignore for untracked files", async () => {
+    const root = await makeTempDir("kanna-paths-ignore-")
+    await $`git init -q`.cwd(root)
+    await writeFile(path.join(root, ".gitignore"), "node_modules\n")
+    await mkdir(path.join(root, "node_modules"))
+    await writeFile(path.join(root, "node_modules", "junk.js"), "x")
+    await writeFile(path.join(root, "app.ts"), "x")
+
+    const paths = await listProjectPaths({ projectId: "p3", localPath: root, query: "junk" })
+    expect(paths.map((p) => p.path)).not.toContain("node_modules/junk.js")
+  })
+
+  test("fuzzy ranking: prefix matches before substring matches", async () => {
+    const root = await makeTempDir("kanna-paths-rank-")
+    await writeFile(path.join(root, "review.ts"), "")
+    await writeFile(path.join(root, "unreview.ts"), "")
+
+    const paths = await listProjectPaths({ projectId: "p4", localPath: root, query: "rev" })
+    expect(paths.map((p) => p.path)).toEqual(["review.ts", "unreview.ts"])
+  })
+
+  test("respects limit", async () => {
+    const root = await makeTempDir("kanna-paths-limit-")
+    for (let i = 0; i < 10; i++) {
+      await writeFile(path.join(root, `file-${i}.txt`), "")
+    }
+
+    const paths = await listProjectPaths({ projectId: "p5", localPath: root, query: "file", limit: 3 })
+    expect(paths.length).toBe(3)
+  })
+
+  test("cache returns from memory on repeat call", async () => {
+    const root = await makeTempDir("kanna-paths-cache-")
+    await writeFile(path.join(root, "a.txt"), "")
+
+    const first = await listProjectPaths({ projectId: "p6", localPath: root, query: "a" })
+    await writeFile(path.join(root, "b.txt"), "") // added after first call
+    const second = await listProjectPaths({ projectId: "p6", localPath: root, query: "b" })
+
+    expect(first.map((p) => p.path)).toContain("a.txt")
+    expect(second.map((p) => p.path)).not.toContain("b.txt")
+  })
+})

--- a/src/server/project-paths.ts
+++ b/src/server/project-paths.ts
@@ -1,0 +1,191 @@
+import path from "node:path"
+import { readdir } from "node:fs/promises"
+import { existsSync, statSync, type Dirent } from "node:fs"
+import { spawn } from "bun"
+
+export interface ProjectPath {
+  path: string
+  kind: "file" | "dir"
+}
+
+interface CacheEntry {
+  files: string[]
+  dirs: string[]
+  gitIndexMtime: number | null
+  builtAt: number
+}
+
+const CACHE = new Map<string, CacheEntry>()
+const CACHE_TTL_MS = 5 * 60 * 1000
+const MAX_WALK_ENTRIES = 10_000
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+const DEFAULT_WALK_EXCLUDES = new Set([
+  ".git", "node_modules", ".next", "dist", "build", ".svn", ".hg", ".jj", ".sl",
+])
+
+export function clearProjectPathCache(projectId?: string) {
+  if (projectId) CACHE.delete(projectId)
+  else CACHE.clear()
+}
+
+export async function listProjectPaths(args: {
+  projectId: string
+  localPath: string
+  query: string
+  limit?: number
+}): Promise<ProjectPath[]> {
+  const limit = Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+  const query = args.query ?? ""
+
+  if (query === "") {
+    return listTopLevelEntries(args.localPath, limit)
+  }
+
+  const entry = await getOrBuildCache(args.projectId, args.localPath)
+  return fuzzyRank(entry, query, limit)
+}
+
+async function listTopLevelEntries(localPath: string, limit: number): Promise<ProjectPath[]> {
+  try {
+    const entries = await readdir(localPath, { withFileTypes: true })
+    const result: ProjectPath[] = []
+    for (const e of entries) {
+      if (DEFAULT_WALK_EXCLUDES.has(e.name)) continue
+      if (e.name.startsWith(".")) continue
+      result.push(e.isDirectory()
+        ? { path: `${e.name}/`, kind: "dir" }
+        : { path: e.name, kind: "file" })
+    }
+    result.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1
+      return a.path.localeCompare(b.path)
+    })
+    return result.slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+async function getOrBuildCache(projectId: string, localPath: string): Promise<CacheEntry> {
+  const existing = CACHE.get(projectId)
+  const gitIndexMtime = getGitIndexMtime(localPath)
+  const now = Date.now()
+
+  if (existing) {
+    const gitChanged = gitIndexMtime !== null && gitIndexMtime !== existing.gitIndexMtime
+    const expired = now - existing.builtAt > CACHE_TTL_MS
+    if (!gitChanged && !expired) return existing
+  }
+
+  const built = await buildCacheEntry(localPath)
+  const next: CacheEntry = { ...built, gitIndexMtime, builtAt: now }
+  CACHE.set(projectId, next)
+  return next
+}
+
+function getGitIndexMtime(localPath: string): number | null {
+  const indexPath = path.join(localPath, ".git", "index")
+  try {
+    return statSync(indexPath).mtimeMs
+  } catch {
+    return null
+  }
+}
+
+async function buildCacheEntry(localPath: string): Promise<Pick<CacheEntry, "files" | "dirs">> {
+  const gitFiles = await listGitFiles(localPath)
+  const files = gitFiles ?? await walkDirectory(localPath)
+  const dirs = deriveDirectories(files)
+  return { files, dirs }
+}
+
+async function listGitFiles(localPath: string): Promise<string[] | null> {
+  if (!existsSync(path.join(localPath, ".git"))) return null
+
+  const tracked = await runGit(localPath, ["-c", "core.quotepath=false", "ls-files"])
+  if (tracked === null) return null
+
+  const untracked = await runGit(localPath, [
+    "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard",
+  ])
+
+  const all = new Set<string>()
+  for (const line of tracked) all.add(line)
+  for (const line of untracked ?? []) all.add(line)
+  return [...all].filter((p) => p.length > 0).map((p) => p.replaceAll("\\", "/"))
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string[] | null> {
+  try {
+    const proc = spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+    const stdout = await new Response(proc.stdout).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return null
+    return stdout.split("\n").filter(Boolean)
+  } catch {
+    return null
+  }
+}
+
+async function walkDirectory(root: string): Promise<string[]> {
+  const out: string[] = []
+  const queue: string[] = [""]
+  while (queue.length > 0 && out.length < MAX_WALK_ENTRIES) {
+    const rel = queue.shift()!
+    const abs = path.join(root, rel)
+    let entries: Dirent<string>[]
+    try {
+      entries = await readdir(abs, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (DEFAULT_WALK_EXCLUDES.has(e.name)) continue
+      const nextRel = rel === "" ? e.name : `${rel}/${e.name}`
+      if (e.isDirectory()) {
+        queue.push(nextRel)
+      } else if (e.isFile()) {
+        out.push(nextRel)
+        if (out.length >= MAX_WALK_ENTRIES) break
+      }
+    }
+  }
+  return out
+}
+
+function deriveDirectories(files: string[]): string[] {
+  const dirs = new Set<string>()
+  for (const f of files) {
+    let idx = f.lastIndexOf("/")
+    while (idx > 0) {
+      dirs.add(f.slice(0, idx))
+      idx = f.lastIndexOf("/", idx - 1)
+    }
+  }
+  return [...dirs]
+}
+
+function fuzzyRank(entry: CacheEntry, query: string, limit: number): ProjectPath[] {
+  const q = query.toLowerCase()
+  const prefix: ProjectPath[] = []
+  const substring: ProjectPath[] = []
+
+  for (const f of entry.files) {
+    const hay = f.toLowerCase()
+    if (hay.startsWith(q)) prefix.push({ path: f, kind: "file" })
+    else if (hay.includes(q)) substring.push({ path: f, kind: "file" })
+  }
+  for (const d of entry.dirs) {
+    const hay = d.toLowerCase()
+    const withSlash = `${d}/`
+    if (hay.startsWith(q)) prefix.push({ path: withSlash, kind: "dir" })
+    else if (hay.includes(q)) substring.push({ path: withSlash, kind: "dir" })
+  }
+
+  const byPath = (a: ProjectPath, b: ProjectPath) => a.path.localeCompare(b.path)
+  prefix.sort(byPath)
+  substring.sort(byPath)
+  return [...prefix, ...substring].slice(0, limit)
+}

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -23,6 +23,7 @@ describe("read models", () => {
       provider: "codex",
       planMode: false,
       sessionToken: "thread-1",
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -54,6 +55,7 @@ describe("read models", () => {
       provider: "claude",
       planMode: true,
       sessionToken: "session-1",
+      sourceHash: null,
       lastTurnOutcome: null,
     })
     state.queuedMessagesByChatId.set("chat-1", [{
@@ -111,6 +113,7 @@ describe("read models", () => {
       provider: "codex",
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastMessageAt: 100,
       lastTurnOutcome: null,
     })
@@ -154,6 +157,7 @@ describe("read models", () => {
       provider: "claude",
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastMessageAt: 100,
       lastTurnOutcome: null,
     })
@@ -167,6 +171,7 @@ describe("read models", () => {
       provider: "claude",
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastMessageAt: 200,
       lastTurnOutcome: null,
     })
@@ -225,6 +230,7 @@ describe("read models", () => {
       provider: "claude",
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastMessageAt: 1_000_000 - 60 * 60 * 1_000,
       lastTurnOutcome: null,
     })
@@ -238,6 +244,7 @@ describe("read models", () => {
       provider: "claude",
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastMessageAt: 1_000_000 - 26 * 60 * 60 * 1_000,
       lastTurnOutcome: null,
     })

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
 import { createEmptyState } from "./events"
+import type { SlashCommand } from "../shared/types"
 
 describe("read models", () => {
   test("include provider data in sidebar rows", () => {
@@ -254,5 +255,51 @@ describe("read models", () => {
     expect(sidebar.projectGroups[0]?.previewChats.map((chat) => chat.chatId)).toEqual(["chat-1"])
     expect(sidebar.projectGroups[0]?.olderChats.map((chat) => chat.chatId)).toEqual(["chat-2"])
     expect(sidebar.projectGroups[0]?.defaultCollapsed).toBe(false)
+  })
+
+  test("passes slash commands from ChatRecord through to ChatSnapshot", () => {
+    const slashCommands: SlashCommand[] = [
+      { name: "review", description: "r", argumentHint: "<pr>" },
+    ]
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      unread: false,
+      provider: "claude",
+      planMode: false,
+      sessionToken: null,
+      sourceHash: null,
+      lastTurnOutcome: null,
+      slashCommands,
+    })
+
+    const snapshot = deriveChatSnapshot(
+      state,
+      new Map(),
+      new Set(),
+      "chat-1",
+      () => ({
+        messages: [],
+        history: {
+          hasOlder: false,
+          olderCursor: null,
+          recentLimit: 200,
+        },
+      })
+    )
+
+    expect(snapshot?.slashCommands).toEqual(slashCommands)
   })
 })

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -73,6 +73,7 @@ describe("read models", () => {
       state,
       new Map(),
       new Set(),
+      new Set(),
       "chat-1",
       () => ({
         messages: [],
@@ -288,6 +289,7 @@ describe("read models", () => {
     const snapshot = deriveChatSnapshot(
       state,
       new Map(),
+      new Set(),
       new Set(),
       "chat-1",
       () => ({

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -305,3 +305,53 @@ describe("read models", () => {
     expect(snapshot?.slashCommands).toEqual(slashCommands)
   })
 })
+
+describe("deriveChatSnapshot schedules", () => {
+  test("empty schedules produces empty map and null live id", () => {
+    const state = createEmptyState()
+    state.projectsById.set("p1", {
+      id: "p1", localPath: "/tmp/p", title: "P", createdAt: 0, updatedAt: 0,
+    })
+    state.chatsById.set("c1", {
+      id: "c1", projectId: "p1", title: "Chat", createdAt: 0, updatedAt: 0,
+      unread: false, provider: null, planMode: false, sessionToken: null, sourceHash: null, lastTurnOutcome: null,
+    })
+
+    const snapshot = deriveChatSnapshot(
+      state,
+      new Map(),
+      new Set(),
+      new Set(),
+      "c1",
+      () => ({ messages: [], history: { hasOlder: false, olderCursor: null, recentLimit: 0 } }),
+    )
+    expect(snapshot!.schedules).toEqual({})
+    expect(snapshot!.liveScheduleId).toBeNull()
+  })
+
+  test("proposed event projects to schedules + liveScheduleId", () => {
+    const state = createEmptyState()
+    state.projectsById.set("p1", {
+      id: "p1", localPath: "/tmp/p", title: "P", createdAt: 0, updatedAt: 0,
+    })
+    state.chatsById.set("c1", {
+      id: "c1", projectId: "p1", title: "Chat", createdAt: 0, updatedAt: 0,
+      unread: false, provider: null, planMode: false, sessionToken: null, sourceHash: null, lastTurnOutcome: null,
+    })
+    state.autoContinueEventsByChatId.set("c1", [{
+      v: 3, kind: "auto_continue_proposed", timestamp: 1, chatId: "c1", scheduleId: "s1",
+      detectedAt: 1, resetAt: 2_000, tz: "Asia/Saigon", turnId: "t1",
+    }])
+
+    const snapshot = deriveChatSnapshot(
+      state,
+      new Map(),
+      new Set(),
+      new Set(),
+      "c1",
+      () => ({ messages: [], history: { hasOlder: false, olderCursor: null, recentLimit: 0 } }),
+    )
+    expect(snapshot!.schedules["s1"].state).toBe("proposed")
+    expect(snapshot!.liveScheduleId).toBe("s1")
+  })
+})

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -10,6 +10,7 @@ import type {
 import type { ChatRecord, StoreState } from "./events"
 import { resolveLocalPath } from "./paths"
 import { SERVER_PROVIDERS } from "./provider-catalog"
+import { deriveChatSchedules } from "./auto-continue/read-model"
 
 const SIDEBAR_RECENT_WINDOW_MS = 24 * 60 * 60 * 1_000
 const SIDEBAR_RECENT_PREVIEW_LIMIT = 10
@@ -175,6 +176,8 @@ export function deriveChatSnapshot(
   }
 
   const transcript = getMessages(chat.id)
+  const autoContinueEvents = state.autoContinueEventsByChatId.get(chat.id) ?? []
+  const { schedules, liveScheduleId } = deriveChatSchedules(autoContinueEvents, chat.id)
 
   return {
     runtime,
@@ -187,5 +190,7 @@ export function deriveChatSnapshot(
     availableProviders: [...SERVER_PROVIDERS],
     slashCommands: (chat.slashCommands ?? []).map((c) => ({ ...c })),
     slashCommandsLoading: slashCommandsLoadingChatIds.has(chat.id),
+    schedules,
+    liveScheduleId,
   }
 }

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -184,6 +184,6 @@ export function deriveChatSnapshot(
     messages: transcript.messages,
     history: transcript.history,
     availableProviders: [...SERVER_PROVIDERS],
-    slashCommands: [],
+    slashCommands: (chat.slashCommands ?? []).map((c) => ({ ...c })),
   }
 }

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -153,6 +153,7 @@ export function deriveChatSnapshot(
   state: StoreState,
   activeStatuses: Map<string, KannaStatus>,
   drainingChatIds: Set<string>,
+  slashCommandsLoadingChatIds: Set<string>,
   chatId: string,
   getMessages: (chatId: string) => Pick<ChatSnapshot, "messages" | "history">
 ): ChatSnapshot | null {
@@ -185,5 +186,6 @@ export function deriveChatSnapshot(
     history: transcript.history,
     availableProviders: [...SERVER_PROVIDERS],
     slashCommands: (chat.slashCommands ?? []).map((c) => ({ ...c })),
+    slashCommandsLoading: slashCommandsLoadingChatIds.has(chat.id),
   }
 }

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -184,5 +184,6 @@ export function deriveChatSnapshot(
     messages: transcript.messages,
     history: transcript.history,
     availableProviders: [...SERVER_PROVIDERS],
+    slashCommands: [],
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -60,6 +60,14 @@ export interface StartKannaServerOptions {
   host?: string
   password?: string | null
   strictPort?: boolean
+  /**
+   * When true, the auth layer trusts X-Forwarded-Proto / X-Forwarded-Host
+   * headers for CSRF origin checks, redirect URLs, and the Secure cookie flag.
+   * Only enable when the server is reachable solely through a trusted reverse
+   * proxy such as cloudflared — otherwise these headers are client-controlled
+   * and allow CSRF bypass / open redirects.
+   */
+  trustProxy?: boolean
   onMigrationProgress?: (message: string) => void
   update?: {
     version: string
@@ -72,7 +80,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const port = options.port ?? 3210
   const hostname = options.host ?? "127.0.0.1"
   const strictPort = options.strictPort ?? false
-  const auth = options.password ? createAuthManager(options.password) : null
+  const auth = options.password ? createAuthManager(options.password, { trustProxy: options.trustProxy ?? false }) : null
   const store = new EventStore()
   const diffStore = new DiffStore(store.dataDir)
   const machineDisplayName = getMachineDisplayName()

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,6 +16,7 @@ import type { UpdateInstallAttemptResult } from "./cli-runtime"
 import { createWsRouter, type ClientState } from "./ws-router"
 import { deleteProjectUpload, inferAttachmentContentType, inferProjectFileContentType, persistProjectUpload } from "./uploads"
 import { getProjectUploadDir } from "./paths"
+import { listProjectPaths } from "./project-paths"
 
 const MAX_UPLOAD_FILES = 50
 const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024
@@ -228,6 +229,11 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
           const projectFileContentResponse = await handleProjectFileContent(req, url, store)
           if (projectFileContentResponse) {
             return projectFileContentResponse
+          }
+
+          const projectPathsResponse = await handleProjectPaths(req, url, store)
+          if (projectPathsResponse) {
+            return projectPathsResponse
           }
 
           return serveStatic(distDir, url.pathname)
@@ -444,6 +450,34 @@ async function handleProjectUploadDelete(req: Request, url: URL, store: EventSto
   })
 
   return Response.json({ ok: deleted })
+}
+
+async function handleProjectPaths(req: Request, url: URL, store: EventStore) {
+  if (req.method !== "GET") return null
+  const match = url.pathname.match(/^\/api\/projects\/([^/]+)\/paths$/)
+  if (!match) return null
+
+  const project = store.getProject(match[1])
+  if (!project) {
+    return Response.json({ error: "Project not found" }, { status: 404 })
+  }
+
+  const query = url.searchParams.get("query") ?? ""
+  const limitRaw = url.searchParams.get("limit")
+  const limit = limitRaw !== null ? Number.parseInt(limitRaw, 10) : undefined
+
+  try {
+    const paths = await listProjectPaths({
+      projectId: project.id,
+      localPath: project.localPath,
+      query,
+      limit: Number.isFinite(limit) ? limit : undefined,
+    })
+    return Response.json({ paths })
+  } catch (error) {
+    console.error("[paths] list failed:", error)
+    return Response.json({ error: "Failed to list paths" }, { status: 500 })
+  }
 }
 
 async function serveStatic(distDir: string, pathname: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,6 +13,7 @@ import { getMachineDisplayName } from "./machine-name"
 import { TerminalManager } from "./terminal-manager"
 import { UpdateManager } from "./update-manager"
 import type { UpdateInstallAttemptResult } from "./cli-runtime"
+import { createUpdateStrategy } from "./update-strategy"
 import { createWsRouter, type ClientState } from "./ws-router"
 import { deleteProjectUpload, inferAttachmentContentType, inferProjectFileContentType, persistProjectUpload } from "./uploads"
 import { getProjectUploadDir } from "./paths"
@@ -102,14 +103,26 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const terminals = new TerminalManager()
   const keybindings = new KeybindingsManager()
   await keybindings.initialize()
-  const updateManager = options.update
-    ? new UpdateManager({
+  const updateManager: UpdateManager | null = (() => {
+    if (!options.update) return null
+    let manager: UpdateManager | null = null
+    const strategy = createUpdateStrategy({
+      reloaderEnv: process.env.KANNA_RELOADER,
       currentVersion: options.update.version,
       fetchLatestVersion: options.update.fetchLatestVersion,
       installVersion: options.update.installVersion,
+      latestVersionHint: () => manager?.getSnapshot().latestVersion ?? null,
+      repoDir: process.env.KANNA_REPO_DIR,
+      pm2ProcessName: process.env.KANNA_PM2_PROCESS_NAME,
+    })
+    manager = new UpdateManager({
+      currentVersion: options.update.version,
+      checker: strategy.checker,
+      reloader: strategy.reloader,
       devMode: getRuntimeProfile() === "dev",
     })
-    : null
+    return manager
+  })()
   const agent = new AgentCoordinator({
     store,
     onStateChange: (chatId?: string, options?: { immediate?: boolean }) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -287,6 +287,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   }
 
   const shutdown = async () => {
+    scheduleManager.shutdown()
     clearInterval(staleEmptyChatPruneInterval)
     for (const chatId of [...agent.activeTurns.keys()]) {
       await agent.cancel(chatId)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -145,9 +145,6 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
       router.scheduleBroadcast()
     },
   })
-  scheduleManager.rehydrate(
-    store.listAutoContinueChats().flatMap((chatId) => store.getAutoContinueEvents(chatId))
-  )
   router = createWsRouter({
     store,
     diffStore,
@@ -164,6 +161,9 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     machineDisplayName,
     updateManager,
   })
+  scheduleManager.rehydrate(
+    store.listAutoContinueChats().flatMap((chatId) => store.getAutoContinueEvents(chatId))
+  )
   const staleEmptyChatPruneInterval = setInterval(() => {
     void router.pruneStaleEmptyChats()
       .then(() => router.broadcastSnapshots())

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,6 +18,7 @@ import { createWsRouter, type ClientState } from "./ws-router"
 import { deleteProjectUpload, inferAttachmentContentType, inferProjectFileContentType, persistProjectUpload } from "./uploads"
 import { getProjectUploadDir } from "./paths"
 import { listProjectPaths } from "./project-paths"
+import { ScheduleManager } from "./auto-continue/schedule-manager"
 
 const MAX_UPLOAD_FILES = 50
 const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024
@@ -123,8 +124,15 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     })
     return manager
   })()
-  const agent = new AgentCoordinator({
+  let agent!: AgentCoordinator
+  const scheduleManager = new ScheduleManager({
+    fire: async (chatId, scheduleId) => {
+      await agent.fireAutoContinue(chatId, scheduleId)
+    },
+  })
+  agent = new AgentCoordinator({
     store,
+    scheduleManager,
     onStateChange: (chatId?: string, options?: { immediate?: boolean }) => {
       if (chatId) {
         if (options?.immediate) {
@@ -137,6 +145,9 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
       router.scheduleBroadcast()
     },
   })
+  scheduleManager.rehydrate(
+    store.listAutoContinueChats().flatMap((chatId) => store.getAutoContinueEvents(chatId))
+  )
   router = createWsRouter({
     store,
     diffStore,

--- a/src/server/terminal-manager.test.ts
+++ b/src/server/terminal-manager.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
-import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { TerminalManager } from "./terminal-manager"
@@ -23,6 +23,9 @@ beforeAll(async () => {
   tempProjectPath = await mkdtemp(path.join(os.tmpdir(), "kanna-terminal-manager-"))
   tempHomePath = await mkdtemp(path.join(os.tmpdir(), "kanna-terminal-home-"))
   await mkdir(path.join(tempHomePath, ".config"), { recursive: true })
+  // Create a minimal .zshrc to prevent the zsh-newuser-install interactive dialog
+  // from running on first login (which would intercept test input).
+  await writeFile(path.join(tempHomePath, ".zshrc"), "# minimal test config\n", "utf8")
   process.env.HOME = tempHomePath
   process.env.ZDOTDIR = tempHomePath
   process.env.HISTFILE = path.join(tempHomePath, ".zsh_history")
@@ -85,7 +88,9 @@ async function createSession(terminalId: string) {
   })
 
   manager.write(terminalId, "printf '__KANNA_READY__\\n'\r")
-  await waitFor(() => output.includes("__KANNA_READY__"), SHELL_START_TIMEOUT_MS)
+  // Wait for the actual command output (the bare string on its own line: __KANNA_READY__\r\n)
+  // rather than the terminal echo of the input (which also contains __KANNA_READY__ inside quotes).
+  await waitFor(() => output.includes("__KANNA_READY__\r\n"), SHELL_START_TIMEOUT_MS)
 
   return {
     manager,

--- a/src/server/test-helpers/async-event-queue.ts
+++ b/src/server/test-helpers/async-event-queue.ts
@@ -1,0 +1,52 @@
+/** Async iterable queue used in tests to feed events into a session stream. */
+export class AsyncEventQueue<T> implements AsyncIterable<T> {
+  private readonly values: T[] = []
+  private readonly waiters: Array<{ resolve: (result: IteratorResult<T>) => void; reject: (error: unknown) => void }> = []
+  private closed = false
+  private pendingError: unknown = null
+
+  push(value: T): void {
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter.resolve({ done: false, value })
+      return
+    }
+    this.values.push(value)
+  }
+
+  throw(error: unknown): void {
+    this.pendingError = error
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter.reject(error)
+    }
+  }
+
+  close(): void {
+    this.closed = true
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.resolve({ done: true, value: undefined as never })
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async () => {
+        if (this.pendingError !== null) {
+          const err = this.pendingError
+          this.pendingError = null
+          throw err
+        }
+        if (this.values.length > 0) {
+          return { done: false, value: this.values.shift() as T }
+        }
+        if (this.closed) {
+          return { done: true, value: undefined as never }
+        }
+        return await new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waiters.push({ resolve, reject })
+        })
+      },
+    }
+  }
+}

--- a/src/server/test-helpers/wait-for.ts
+++ b/src/server/test-helpers/wait-for.ts
@@ -1,0 +1,14 @@
+/** Polls until `condition()` returns true or `timeoutMs` elapses. */
+export async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+  label = "condition",
+): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for ${label}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}

--- a/src/server/update-manager.test.ts
+++ b/src/server/update-manager.test.ts
@@ -1,21 +1,34 @@
 import { describe, expect, test } from "bun:test"
 import { UpdateManager } from "./update-manager"
+import { UpdateInstallError, type UpdateChecker, type UpdateReloader } from "./update-strategy"
+
+class FakeChecker implements UpdateChecker {
+  calls = 0
+  constructor(private results: Array<{ latestVersion: string; updateAvailable: boolean }>) {}
+  async check() {
+    const result = this.results[Math.min(this.calls, this.results.length - 1)]
+    this.calls += 1
+    return result
+  }
+}
+
+class FakeReloader implements UpdateReloader {
+  calls = 0
+  constructor(private onReload: () => Promise<void> = async () => {}) {}
+  async reload() {
+    this.calls += 1
+    await this.onReload()
+  }
+}
 
 describe("UpdateManager", () => {
   test("detects available updates", async () => {
     const manager = new UpdateManager({
       currentVersion: "0.12.0",
-      fetchLatestVersion: async () => "0.13.0",
-      installVersion: () => ({
-        ok: true,
-        errorCode: null,
-        userTitle: null,
-        userMessage: null,
-      }),
+      checker: new FakeChecker([{ latestVersion: "0.13.0", updateAvailable: true }]),
+      reloader: new FakeReloader(),
     })
-
     const snapshot = await manager.checkForUpdates({ force: true })
-
     expect(snapshot.status).toBe("available")
     expect(snapshot.updateAvailable).toBe(true)
     expect(snapshot.latestVersion).toBe("0.13.0")
@@ -24,46 +37,36 @@ describe("UpdateManager", () => {
   })
 
   test("bypasses cache when force is true", async () => {
-    let calls = 0
+    const checker = new FakeChecker([
+      { latestVersion: "0.12.1", updateAvailable: true },
+      { latestVersion: "0.13.0", updateAvailable: true },
+    ])
     const manager = new UpdateManager({
       currentVersion: "0.12.0",
-      fetchLatestVersion: async () => {
-        calls += 1
-        return calls === 1 ? "0.12.1" : "0.13.0"
-      },
-      installVersion: () => ({
-        ok: true,
-        errorCode: null,
-        userTitle: null,
-        userMessage: null,
-      }),
+      checker,
+      reloader: new FakeReloader(),
     })
-
     await manager.checkForUpdates()
     await manager.checkForUpdates({ force: true })
-
-    expect(calls).toBe(2)
+    expect(checker.calls).toBe(2)
     expect(manager.getSnapshot().latestVersion).toBe("0.13.0")
   })
 
-  test("surfaces install failures without clearing the running version", async () => {
-    let installedVersion: string | null = null
+  test("surfaces reloader failures without clearing the running version", async () => {
+    const reloader = new FakeReloader(async () => {
+      throw new UpdateInstallError(
+        "This update is still propagating. Try again in a few minutes.",
+        "version_not_live_yet",
+        "Update not live yet",
+      )
+    })
     const manager = new UpdateManager({
       currentVersion: "0.12.0",
-      fetchLatestVersion: async () => "0.13.0",
-      installVersion: (_packageName, version) => {
-        installedVersion = version
-        return {
-          ok: false,
-          errorCode: "version_not_live_yet",
-          userTitle: "Update not live yet",
-          userMessage: "This update is still propagating. Try again in a few minutes.",
-        }
-      },
+      checker: new FakeChecker([{ latestVersion: "0.13.0", updateAvailable: true }]),
+      reloader,
     })
-
+    await manager.checkForUpdates({ force: true })
     const result = await manager.installUpdate()
-
     expect(result).toEqual({
       ok: false,
       action: "restart",
@@ -71,31 +74,46 @@ describe("UpdateManager", () => {
       userTitle: "Update not live yet",
       userMessage: "This update is still propagating. Try again in a few minutes.",
     })
-    expect(installedVersion === "0.13.0").toBe(true)
+    expect(reloader.calls).toBe(1)
     expect(manager.getSnapshot().status).toBe("error")
     expect(manager.getSnapshot().currentVersion).toBe("0.12.0")
+  })
+
+  test("falls back to generic errorCode/userTitle when reloader throws a plain Error", async () => {
+    const reloader = new FakeReloader(async () => {
+      throw new Error("random failure")
+    })
+    const manager = new UpdateManager({
+      currentVersion: "0.12.0",
+      checker: new FakeChecker([{ latestVersion: "0.13.0", updateAvailable: true }]),
+      reloader,
+    })
+    await manager.checkForUpdates({ force: true })
+    const result = await manager.installUpdate()
+    expect(result).toEqual({
+      ok: false,
+      action: "restart",
+      errorCode: "install_failed",
+      userTitle: "Update failed",
+      userMessage: "random failure",
+    })
+    expect(manager.getSnapshot().status).toBe("error")
+    expect(manager.getSnapshot().error).toBe("random failure")
   })
 
   test("always exposes an available reload action in dev mode", async () => {
     const manager = new UpdateManager({
       currentVersion: "0.12.0",
-      fetchLatestVersion: async () => "9.9.9",
-      installVersion: () => ({
-        ok: true,
-        errorCode: null,
-        userTitle: null,
-        userMessage: null,
-      }),
+      checker: new FakeChecker([{ latestVersion: "9.9.9", updateAvailable: true }]),
+      reloader: new FakeReloader(),
       devMode: true,
     })
-
     expect(manager.getSnapshot()).toMatchObject({
       status: "available",
       updateAvailable: true,
       installAction: "restart",
       reloadRequestedAt: null,
     })
-
     const result = await manager.installUpdate()
     expect(result).toEqual({
       ok: true,

--- a/src/server/update-manager.ts
+++ b/src/server/update-manager.ts
@@ -61,6 +61,42 @@ export class UpdateManager {
     }
   }
 
+  async forceReload(): Promise<UpdateInstallResult> {
+    if (this.deps.devMode) {
+      this.setSnapshot({ ...this.snapshot, status: "restart_pending", reloadRequestedAt: Date.now(), error: null })
+      return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+    }
+
+    if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") {
+      return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+    }
+
+    this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })
+
+    try {
+      await this.deps.reloader.reload()
+    } catch (error) {
+      const installError = error instanceof UpdateInstallError ? error : null
+      const message = error instanceof Error ? error.message : String(error)
+      this.setSnapshot({ ...this.snapshot, status: "error", error: message, reloadRequestedAt: null })
+      return {
+        ok: false,
+        action: "restart",
+        errorCode: installError?.errorCode ?? "install_failed",
+        userTitle: installError?.userTitle ?? "Re-deploy failed",
+        userMessage: installError?.message ?? message,
+      }
+    }
+
+    this.setSnapshot({
+      ...this.snapshot,
+      status: "restart_pending",
+      error: null,
+      reloadRequestedAt: Date.now(),
+    })
+    return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
+  }
+
   async installUpdate(): Promise<UpdateInstallResult> {
     if (this.deps.devMode) {
       this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })

--- a/src/server/update-manager.ts
+++ b/src/server/update-manager.ts
@@ -1,13 +1,12 @@
 import type { UpdateInstallResult, UpdateSnapshot } from "../shared/types"
-import { PACKAGE_NAME } from "../shared/branding"
-import { compareVersions, type UpdateInstallAttemptResult } from "./cli-runtime"
+import { UpdateInstallError, type UpdateChecker, type UpdateReloader } from "./update-strategy"
 
 const UPDATE_CACHE_TTL_MS = 5 * 60 * 1000
 
 export interface UpdateManagerDeps {
   currentVersion: string
-  fetchLatestVersion: (packageName: string) => Promise<string>
-  installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
+  checker: UpdateChecker
+  reloader: UpdateReloader
   devMode?: boolean
 }
 
@@ -44,50 +43,27 @@ export class UpdateManager {
   }
 
   async checkForUpdates(options: { force?: boolean } = {}) {
-    if (this.deps.devMode) {
-      return this.snapshot
-    }
-
-    if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") {
-      return this.snapshot
-    }
-
-    if (this.checkPromise) {
-      return this.checkPromise
-    }
-
+    if (this.deps.devMode) return this.snapshot
+    if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") return this.snapshot
+    if (this.checkPromise) return this.checkPromise
     if (!options.force && this.snapshot.lastCheckedAt && Date.now() - this.snapshot.lastCheckedAt < UPDATE_CACHE_TTL_MS) {
       return this.snapshot
     }
 
-    this.setSnapshot({
-      ...this.snapshot,
-      status: "checking",
-      error: null,
-      reloadRequestedAt: null,
-    })
+    this.setSnapshot({ ...this.snapshot, status: "checking", error: null, reloadRequestedAt: null })
 
     const checkPromise = this.runCheck()
     this.checkPromise = checkPromise
-
     try {
       return await checkPromise
     } finally {
-      if (this.checkPromise === checkPromise) {
-        this.checkPromise = null
-      }
+      if (this.checkPromise === checkPromise) this.checkPromise = null
     }
   }
 
   async installUpdate(): Promise<UpdateInstallResult> {
     if (this.deps.devMode) {
-      this.setSnapshot({
-        ...this.snapshot,
-        status: "updating",
-        error: null,
-        reloadRequestedAt: null,
-      })
-
+      this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })
       this.setSnapshot({
         ...this.snapshot,
         status: "restart_pending",
@@ -95,14 +71,7 @@ export class UpdateManager {
         error: null,
         reloadRequestedAt: Date.now(),
       })
-
-      return {
-        ok: true,
-        action: "restart",
-        errorCode: null,
-        userTitle: null,
-        userMessage: null,
-      }
+      return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
     }
 
     if (this.snapshot.status === "updating" || this.snapshot.status === "restart_pending") {
@@ -115,26 +84,20 @@ export class UpdateManager {
       }
     }
 
-    if (this.installPromise) {
-      return this.installPromise
-    }
+    if (this.installPromise) return this.installPromise
 
     const installPromise = this.runInstall()
     this.installPromise = installPromise
-
     try {
       return await installPromise
     } finally {
-      if (this.installPromise === installPromise) {
-        this.installPromise = null
-      }
+      if (this.installPromise === installPromise) this.installPromise = null
     }
   }
 
   private async runCheck() {
     try {
-      const latestVersion = await this.deps.fetchLatestVersion(PACKAGE_NAME)
-      const updateAvailable = compareVersions(this.snapshot.currentVersion, latestVersion) < 0
+      const { latestVersion, updateAvailable } = await this.deps.checker.check()
       const nextSnapshot: UpdateSnapshot = {
         ...this.snapshot,
         latestVersion,
@@ -163,54 +126,29 @@ export class UpdateManager {
     if (!this.snapshot.updateAvailable) {
       const snapshot = await this.checkForUpdates({ force: true })
       if (!snapshot.updateAvailable) {
-        return {
-          ok: false,
-          action: "restart",
-          errorCode: null,
-          userTitle: null,
-          userMessage: null,
-        }
+        return { ok: false, action: "restart", errorCode: null, userTitle: null, userMessage: null }
       }
     }
 
-    this.setSnapshot({
-      ...this.snapshot,
-      status: "updating",
-      error: null,
-      reloadRequestedAt: null,
-    })
+    this.setSnapshot({ ...this.snapshot, status: "updating", error: null, reloadRequestedAt: null })
 
-    const targetVersion = this.snapshot.latestVersion
-    if (!targetVersion) {
+    try {
+      await this.deps.reloader.reload()
+    } catch (error) {
+      const installError = error instanceof UpdateInstallError ? error : null
+      const message = error instanceof Error ? error.message : String(error)
       this.setSnapshot({
         ...this.snapshot,
         status: "error",
-        error: "Unable to determine which version to install.",
+        error: message,
         reloadRequestedAt: null,
       })
       return {
         ok: false,
         action: "restart",
-        errorCode: "install_failed",
-        userTitle: "Update failed",
-        userMessage: "Kanna could not determine which version to install.",
-      }
-    }
-
-    const installed = this.deps.installVersion(PACKAGE_NAME, targetVersion)
-    if (!installed.ok) {
-      this.setSnapshot({
-        ...this.snapshot,
-        status: "error",
-        error: installed.userMessage ?? "Unable to install the latest version.",
-        reloadRequestedAt: null,
-      })
-      return {
-        ok: false,
-        action: "restart",
-        errorCode: installed.errorCode,
-        userTitle: installed.userTitle,
-        userMessage: installed.userMessage,
+        errorCode: installError?.errorCode ?? "install_failed",
+        userTitle: installError?.userTitle ?? "Update failed",
+        userMessage: installError?.message ?? message,
       }
     }
 
@@ -222,19 +160,11 @@ export class UpdateManager {
       error: null,
       reloadRequestedAt: Date.now(),
     })
-    return {
-      ok: true,
-      action: "restart",
-      errorCode: null,
-      userTitle: null,
-      userMessage: null,
-    }
+    return { ok: true, action: "restart", errorCode: null, userTitle: null, userMessage: null }
   }
 
   private setSnapshot(snapshot: UpdateSnapshot) {
     this.snapshot = snapshot
-    for (const listener of this.listeners) {
-      listener(snapshot)
-    }
+    for (const listener of this.listeners) listener(snapshot)
   }
 }

--- a/src/server/update-strategy.test.ts
+++ b/src/server/update-strategy.test.ts
@@ -40,7 +40,7 @@ describe("SupervisorExitReloader", () => {
       },
     })
     await reloader.reload()
-    expect(calls).toEqual([{ packageName: "kanna-code", version: "0.13.0" }])
+    expect(calls).toEqual([{ packageName: "@cuongtranba/kanna", version: "0.13.0" }])
   })
 
   test("throws UpdateInstallError with structured fields when install fails", async () => {

--- a/src/server/update-strategy.test.ts
+++ b/src/server/update-strategy.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test"
+import { NpmChecker, SupervisorExitReloader, UpdateInstallError, createUpdateStrategy, GitChecker, Pm2Reloader } from "./update-strategy"
+
+describe("NpmChecker", () => {
+  test("reports update available when latest is newer", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => "0.13.0",
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "0.13.0", updateAvailable: true })
+  })
+
+  test("reports no update when versions match", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.13.0",
+      fetchLatestVersion: async () => "0.13.0",
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "0.13.0", updateAvailable: false })
+  })
+
+  test("propagates fetch errors", async () => {
+    const checker = new NpmChecker({
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => { throw new Error("registry down") },
+    })
+    await expect(checker.check()).rejects.toThrow("registry down")
+  })
+})
+
+describe("SupervisorExitReloader", () => {
+  test("installs target version when invoked", async () => {
+    const calls: Array<{ packageName: string; version: string }> = []
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => "0.13.0",
+      installVersion: (packageName, version) => {
+        calls.push({ packageName, version })
+        return { ok: true, errorCode: null, userTitle: null, userMessage: null }
+      },
+    })
+    await reloader.reload()
+    expect(calls).toEqual([{ packageName: "kanna-code", version: "0.13.0" }])
+  })
+
+  test("throws UpdateInstallError with structured fields when install fails", async () => {
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => "0.13.0",
+      installVersion: () => ({
+        ok: false,
+        errorCode: "version_not_live_yet",
+        userTitle: "Update not live yet",
+        userMessage: "This update is still propagating. Try again in a few minutes.",
+      }),
+    })
+    await expect(reloader.reload()).rejects.toBeInstanceOf(UpdateInstallError)
+    await expect(reloader.reload()).rejects.toMatchObject({
+      message: "This update is still propagating. Try again in a few minutes.",
+      errorCode: "version_not_live_yet",
+      userTitle: "Update not live yet",
+    })
+  })
+
+  test("throws when target version cannot be resolved", async () => {
+    const reloader = new SupervisorExitReloader({
+      targetVersion: () => null,
+      installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+    })
+    await expect(reloader.reload()).rejects.toThrow(/target version/i)
+  })
+})
+
+describe("GitChecker", () => {
+  const makeRunGit = (responses: Record<string, string>) => async (args: string[]) => {
+    const key = args.join(" ")
+    if (!(key in responses)) throw new Error(`unexpected git call: ${key}`)
+    return responses[key]
+  }
+
+  test("reports update when HEAD differs from upstream", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: makeRunGit({
+        "fetch origin main": "",
+        "rev-parse HEAD": "abc123def456\n",
+        "rev-parse origin/main": "deadbeef99887\n",
+      }),
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "deadbee", updateAvailable: true })
+  })
+
+  test("reports no update when HEAD matches upstream", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: makeRunGit({
+        "fetch origin main": "",
+        "rev-parse HEAD": "abc123def456\n",
+        "rev-parse origin/main": "abc123def456\n",
+      }),
+    })
+    const result = await checker.check()
+    expect(result).toEqual({ latestVersion: "abc123d", updateAvailable: false })
+  })
+
+  test("propagates git fetch errors", async () => {
+    const checker = new GitChecker({
+      repoDir: "/tmp/repo",
+      branch: "main",
+      runGit: async () => { throw new Error("fetch failed: network") },
+    })
+    await expect(checker.check()).rejects.toThrow(/fetch failed/)
+  })
+})
+
+describe("createUpdateStrategy", () => {
+  const baseDeps = {
+    currentVersion: "0.12.0",
+    fetchLatestVersion: async () => "0.13.0",
+    installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+    latestVersionHint: () => "0.13.0",
+  } as const
+
+  test("defaults to npm + supervisor-exit when env unset", () => {
+    const strategy = createUpdateStrategy({ reloaderEnv: undefined, ...baseDeps })
+    expect(strategy.checker).toBeInstanceOf(NpmChecker)
+    expect(strategy.reloader).toBeInstanceOf(SupervisorExitReloader)
+  })
+
+  test("uses npm + supervisor-exit when env=supervisor", () => {
+    const strategy = createUpdateStrategy({ reloaderEnv: "supervisor", ...baseDeps })
+    expect(strategy.checker).toBeInstanceOf(NpmChecker)
+    expect(strategy.reloader).toBeInstanceOf(SupervisorExitReloader)
+  })
+
+  test("throws on unknown reloader value", () => {
+    expect(() => createUpdateStrategy({ reloaderEnv: "bogus", ...baseDeps })).toThrow(/unknown.*reloader/i)
+  })
+})
+
+describe("Pm2Reloader", () => {
+  function makeReloader(overrides: {
+    lockfileChanged?: boolean
+    commandErrors?: Record<string, string>
+    reloadError?: Error | null
+  } = {}) {
+    const calls: string[] = []
+    const reloader = new Pm2Reloader({
+      repoDir: "/tmp/repo",
+      processName: "kanna",
+      runCommand: async (command, args) => {
+        const line = [command, ...args].join(" ")
+        calls.push(line)
+        if (overrides.commandErrors?.[line]) {
+          throw new Error(overrides.commandErrors[line])
+        }
+      },
+      lockfileChanged: async () => overrides.lockfileChanged ?? false,
+      triggerPm2Reload: async () => {
+        calls.push("pm2.reload kanna")
+        if (overrides.reloadError) throw overrides.reloadError
+      },
+    })
+    return { reloader, calls }
+  }
+
+  test("runs git pull, build, then pm2 reload when lockfile unchanged", async () => {
+    const { reloader, calls } = makeReloader({ lockfileChanged: false })
+    await reloader.reload()
+    expect(calls).toEqual([
+      "git pull --ff-only",
+      "bun run build",
+      "pm2.reload kanna",
+    ])
+  })
+
+  test("inserts bun install when lockfile changed", async () => {
+    const { reloader, calls } = makeReloader({ lockfileChanged: true })
+    await reloader.reload()
+    expect(calls).toEqual([
+      "git pull --ff-only",
+      "bun install",
+      "bun run build",
+      "pm2.reload kanna",
+    ])
+  })
+
+  test("aborts before reload when git pull fails", async () => {
+    const { reloader, calls } = makeReloader({
+      commandErrors: { "git pull --ff-only": "merge conflict in src/foo.ts" },
+    })
+    await expect(reloader.reload()).rejects.toThrow(/git pull failed/i)
+    expect(calls).toEqual(["git pull --ff-only"])
+  })
+
+  test("aborts before reload when build fails", async () => {
+    const { reloader, calls } = makeReloader({
+      commandErrors: { "bun run build": "tsc error TS2345" },
+    })
+    await expect(reloader.reload()).rejects.toThrow(/bun run build failed/i)
+    expect(calls).toEqual(["git pull --ff-only", "bun run build"])
+  })
+
+  test("surfaces pm2 reload failures", async () => {
+    const { reloader } = makeReloader({ reloadError: new Error("pm2 daemon not running") })
+    await expect(reloader.reload()).rejects.toThrow(/pm2 reload failed/i)
+  })
+})
+
+describe("createUpdateStrategy pm2 branch", () => {
+  test("returns GitChecker + Pm2Reloader for KANNA_RELOADER=pm2", () => {
+    const strategy = createUpdateStrategy({
+      reloaderEnv: "pm2",
+      currentVersion: "0.12.0",
+      fetchLatestVersion: async () => "ignored",
+      installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+      latestVersionHint: () => null,
+      repoDir: "/tmp/repo",
+    })
+    expect(strategy.checker).toBeInstanceOf(GitChecker)
+    expect(strategy.reloader).toBeInstanceOf(Pm2Reloader)
+  })
+
+  test("throws when pm2 mode selected without repoDir", () => {
+    expect(() =>
+      createUpdateStrategy({
+        reloaderEnv: "pm2",
+        currentVersion: "0.12.0",
+        fetchLatestVersion: async () => "ignored",
+        installVersion: () => ({ ok: true, errorCode: null, userTitle: null, userMessage: null }),
+        latestVersionHint: () => null,
+      }),
+    ).toThrow(/KANNA_REPO_DIR/)
+  })
+})

--- a/src/server/update-strategy.ts
+++ b/src/server/update-strategy.ts
@@ -1,0 +1,241 @@
+import { compareVersions } from "./cli-runtime"
+import type { UpdateInstallAttemptResult } from "./cli-runtime"
+import { PACKAGE_NAME } from "../shared/branding"
+import type { UpdateInstallErrorCode } from "../shared/types"
+
+export interface UpdateChecker {
+  check(): Promise<{ latestVersion: string; updateAvailable: boolean }>
+}
+
+// Implemented by SupervisorExitReloader (Task 2) and Pm2Reloader (Task 8).
+export interface UpdateReloader {
+  reload(): Promise<void>
+}
+
+export interface NpmCheckerDeps {
+  currentVersion: string
+  fetchLatestVersion: (packageName: string) => Promise<string>
+}
+
+export class UpdateInstallError extends Error {
+  constructor(
+    message: string,
+    public readonly errorCode: UpdateInstallErrorCode | null,
+    public readonly userTitle: string | null,
+  ) {
+    super(message)
+    this.name = "UpdateInstallError"
+  }
+}
+
+export interface SupervisorExitReloaderDeps {
+  targetVersion: () => string | null
+  installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
+}
+
+export class SupervisorExitReloader implements UpdateReloader {
+  constructor(private deps: SupervisorExitReloaderDeps) {}
+
+  async reload() {
+    const version = this.deps.targetVersion()
+    if (!version) {
+      throw new UpdateInstallError(
+        "Unable to determine target version.",
+        "install_failed",
+        "Update failed",
+      )
+    }
+    const result = this.deps.installVersion(PACKAGE_NAME, version)
+    if (!result.ok) {
+      throw new UpdateInstallError(
+        result.userMessage ?? "Unable to install the latest version.",
+        result.errorCode,
+        result.userTitle,
+      )
+    }
+  }
+}
+
+export class NpmChecker implements UpdateChecker {
+  constructor(private deps: NpmCheckerDeps) {}
+
+  async check() {
+    const latestVersion = await this.deps.fetchLatestVersion(PACKAGE_NAME)
+    const updateAvailable = compareVersions(this.deps.currentVersion, latestVersion) < 0
+    return { latestVersion, updateAvailable }
+  }
+}
+
+export interface GitCheckerDeps {
+  repoDir: string
+  branch: string
+  runGit: (args: string[]) => Promise<string>
+}
+
+export class GitChecker implements UpdateChecker {
+  constructor(private deps: GitCheckerDeps) {}
+
+  async check() {
+    await this.deps.runGit(["fetch", "origin", this.deps.branch])
+    const headRaw = await this.deps.runGit(["rev-parse", "HEAD"])
+    const upstreamRaw = await this.deps.runGit(["rev-parse", `origin/${this.deps.branch}`])
+    const head = headRaw.trim()
+    const upstream = upstreamRaw.trim()
+    return {
+      latestVersion: upstream.slice(0, 7),
+      updateAvailable: head !== upstream,
+    }
+  }
+}
+
+export interface Pm2ReloaderDeps {
+  repoDir: string
+  processName: string
+  runCommand: (command: string, args: string[]) => Promise<void>
+  lockfileChanged: () => Promise<boolean>
+  triggerPm2Reload: (processName: string) => Promise<void>
+}
+
+export class Pm2Reloader implements UpdateReloader {
+  constructor(private deps: Pm2ReloaderDeps) {}
+
+  async reload() {
+    await this.step("git pull", ["git", "pull", "--ff-only"])
+    if (await this.deps.lockfileChanged()) {
+      await this.step("bun install", ["bun", "install"])
+    }
+    await this.step("bun run build", ["bun", "run", "build"])
+    try {
+      await this.deps.triggerPm2Reload(this.deps.processName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new UpdateInstallError(
+        `pm2 reload failed: ${message}`,
+        "install_failed",
+        "Update failed",
+      )
+    }
+  }
+
+  private async step(label: string, argv: string[]) {
+    const [command, ...args] = argv
+    try {
+      await this.deps.runCommand(command, args)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new UpdateInstallError(
+        `${label} failed: ${message}`,
+        "install_failed",
+        "Update failed",
+      )
+    }
+  }
+}
+
+export interface CreateUpdateStrategyDeps {
+  reloaderEnv: string | undefined
+  currentVersion: string
+  fetchLatestVersion: (packageName: string) => Promise<string>
+  installVersion: (packageName: string, version: string) => UpdateInstallAttemptResult
+  latestVersionHint: () => string | null
+  // Required for pm2 branch (KANNA_REPO_DIR).
+  repoDir?: string
+  // Optional pm2 process name override (KANNA_PM2_PROCESS_NAME). Defaults to "kanna".
+  pm2ProcessName?: string
+}
+
+export interface UpdateStrategy {
+  checker: UpdateChecker
+  reloader: UpdateReloader
+}
+
+export function createUpdateStrategy(deps: CreateUpdateStrategyDeps): UpdateStrategy {
+  const mode = deps.reloaderEnv ?? "supervisor"
+  if (mode === "supervisor") {
+    return {
+      checker: new NpmChecker({
+        currentVersion: deps.currentVersion,
+        fetchLatestVersion: deps.fetchLatestVersion,
+      }),
+      reloader: new SupervisorExitReloader({
+        targetVersion: deps.latestVersionHint,
+        installVersion: deps.installVersion,
+      }),
+    }
+  }
+  if (mode === "pm2") {
+    if (!deps.repoDir) {
+      throw new Error("KANNA_RELOADER=pm2 requires KANNA_REPO_DIR to be set")
+    }
+    const repoDir = deps.repoDir
+    return {
+      checker: new GitChecker({
+        repoDir,
+        branch: "main",
+        runGit: (args) => runCommandCapture("git", args, repoDir),
+      }),
+      reloader: new Pm2Reloader({
+        repoDir,
+        processName: deps.pm2ProcessName ?? "kanna",
+        runCommand: (command, args) => runCommandThrow(command, args, repoDir),
+        lockfileChanged: () => detectLockfileChange(repoDir),
+        triggerPm2Reload,
+      }),
+    }
+  }
+  throw new Error(`Unknown KANNA_RELOADER value "${mode}". Supported values: supervisor, pm2`)
+}
+
+async function runCommandCapture(command: string, args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn({ cmd: [command, ...args], cwd, stdout: "pipe", stderr: "pipe" })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode !== 0) {
+    const tail = stderr.trim().slice(-500)
+    throw new Error(tail || `${command} exited with code ${exitCode}`)
+  }
+  return stdout
+}
+
+async function runCommandThrow(command: string, args: string[], cwd: string): Promise<void> {
+  await runCommandCapture(command, args, cwd)
+}
+
+async function detectLockfileChange(repoDir: string): Promise<boolean> {
+  try {
+    const output = await runCommandCapture(
+      "git",
+      ["diff", "--name-only", "HEAD@{1}", "HEAD", "--", "bun.lock", "package.json"],
+      repoDir,
+    )
+    return output.trim().length > 0
+  } catch {
+    // No prior HEAD@{1} (fresh clone) or other git error — install to be safe
+    return true
+  }
+}
+
+async function triggerPm2Reload(processName: string): Promise<void> {
+  const pm2Module = await import("pm2")
+  const pm2 = pm2Module.default ?? pm2Module
+  await new Promise<void>((resolve, reject) => {
+    pm2.connect((connectErr) => {
+      if (connectErr) {
+        pm2.disconnect()
+        reject(connectErr instanceof Error ? connectErr : new Error(String(connectErr)))
+        return
+      }
+      pm2.reload(processName, (reloadErr) => {
+        pm2.disconnect()
+        if (reloadErr) {
+          reject(reloadErr instanceof Error ? reloadErr : new Error(String(reloadErr)))
+          return
+        }
+        resolve()
+      })
+    })
+  })
+}

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -524,6 +524,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -639,6 +640,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -725,6 +727,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -958,6 +961,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -1038,6 +1042,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -1372,6 +1377,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 
@@ -1471,6 +1477,7 @@ describe("ws-router", () => {
       provider: null,
       planMode: false,
       sessionToken: null,
+      sourceHash: null,
       lastTurnOutcome: null,
     })
 

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -1544,4 +1544,195 @@ describe("ws-router", () => {
       result: { snapshotChanged: false },
     })
   })
+
+  // ── autoContinue WS command tests ────────────────────────────────────────
+
+  function makeAutoContinueAgent(overrides: Record<string, unknown> = {}) {
+    const appendedEvents: unknown[] = []
+    return {
+      appendedEvents,
+      agent: {
+        getActiveStatuses: () => new Map(),
+        getDrainingChatIds: () => new Set(),
+        getSlashCommandsLoadingChatIds: () => new Set(),
+        ensureSlashCommandsLoaded: async () => {},
+        acceptAutoContinue: async (_chatId: string, _scheduleId: string, _scheduledAt: number) => {},
+        rescheduleAutoContinue: async (_chatId: string, _scheduleId: string, _scheduledAt: number) => {},
+        cancelAutoContinue: async (_chatId: string, _scheduleId: string, _reason: string) => {},
+        listLiveSchedules: (_chatId: string): string[] => [],
+        cancel: async () => {},
+        closeChat: async () => {},
+        ...overrides,
+      },
+    }
+  }
+
+  function makeAutoContinueStore(state: ReturnType<typeof createEmptyState>) {
+    return {
+      state,
+      deleteChat: async () => {},
+    }
+  }
+
+  test("autoContinue.accept routes to agent.acceptAutoContinue and acks", async () => {
+    const acceptCalls: Array<{ chatId: string; scheduleId: string; scheduledAt: number }> = []
+    const { agent } = makeAutoContinueAgent({
+      acceptAutoContinue: async (chatId: string, scheduleId: string, scheduledAt: number) => {
+        acceptCalls.push({ chatId, scheduleId, scheduledAt })
+      },
+    })
+
+    const router = createWsRouter({
+      store: makeAutoContinueStore(createEmptyState()) as never,
+      agent: agent as never,
+      terminals: { getSnapshot: () => null, onEvent: () => () => {} } as never,
+      keybindings: { getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT, onChange: () => () => {} } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "accept-1",
+        command: {
+          type: "autoContinue.accept",
+          chatId: "chat-1",
+          scheduleId: "sched-1",
+          scheduledAt: Date.now() + 60_000,
+        },
+      })
+    )
+
+    expect(acceptCalls).toHaveLength(1)
+    expect(acceptCalls[0]!.chatId).toBe("chat-1")
+    expect(acceptCalls[0]!.scheduleId).toBe("sched-1")
+    expect(ws.sent).toContainEqual({ v: PROTOCOL_VERSION, type: "ack", id: "accept-1" })
+  })
+
+  test("autoContinue.reschedule routes to agent.rescheduleAutoContinue and acks", async () => {
+    const rescheduleCalls: Array<{ chatId: string; scheduleId: string; scheduledAt: number }> = []
+    const { agent } = makeAutoContinueAgent({
+      rescheduleAutoContinue: async (chatId: string, scheduleId: string, scheduledAt: number) => {
+        rescheduleCalls.push({ chatId, scheduleId, scheduledAt })
+      },
+    })
+
+    const router = createWsRouter({
+      store: makeAutoContinueStore(createEmptyState()) as never,
+      agent: agent as never,
+      terminals: { getSnapshot: () => null, onEvent: () => () => {} } as never,
+      keybindings: { getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT, onChange: () => () => {} } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "reschedule-1",
+        command: {
+          type: "autoContinue.reschedule",
+          chatId: "chat-1",
+          scheduleId: "sched-1",
+          scheduledAt: Date.now() + 120_000,
+        },
+      })
+    )
+
+    expect(rescheduleCalls).toHaveLength(1)
+    expect(rescheduleCalls[0]!.chatId).toBe("chat-1")
+    expect(ws.sent).toContainEqual({ v: PROTOCOL_VERSION, type: "ack", id: "reschedule-1" })
+  })
+
+  test("autoContinue.cancel routes to agent.cancelAutoContinue and acks", async () => {
+    const cancelCalls: Array<{ chatId: string; scheduleId: string; reason: string }> = []
+    const { agent } = makeAutoContinueAgent({
+      cancelAutoContinue: async (chatId: string, scheduleId: string, reason: string) => {
+        cancelCalls.push({ chatId, scheduleId, reason })
+      },
+    })
+
+    const router = createWsRouter({
+      store: makeAutoContinueStore(createEmptyState()) as never,
+      agent: agent as never,
+      terminals: { getSnapshot: () => null, onEvent: () => () => {} } as never,
+      keybindings: { getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT, onChange: () => () => {} } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "cancel-1",
+        command: {
+          type: "autoContinue.cancel",
+          chatId: "chat-1",
+          scheduleId: "sched-1",
+        },
+      })
+    )
+
+    expect(cancelCalls).toHaveLength(1)
+    expect(cancelCalls[0]!.reason).toBe("user")
+    expect(ws.sent).toContainEqual({ v: PROTOCOL_VERSION, type: "ack", id: "cancel-1" })
+  })
+
+  test("chat.delete cancels live schedules before closing chat", async () => {
+    const cancelledScheduleIds: string[] = []
+    const callOrder: string[] = []
+
+    const { agent } = makeAutoContinueAgent({
+      listLiveSchedules: (_chatId: string) => ["sched-live"],
+      cancelAutoContinue: async (_chatId: string, scheduleId: string, _reason: string) => {
+        cancelledScheduleIds.push(scheduleId)
+        callOrder.push("cancelAutoContinue")
+      },
+      closeChat: async () => {
+        callOrder.push("closeChat")
+      },
+    })
+
+    const router = createWsRouter({
+      store: makeAutoContinueStore(createEmptyState()) as never,
+      agent: agent as never,
+      terminals: { getSnapshot: () => null, onEvent: () => () => {} } as never,
+      keybindings: { getSnapshot: () => DEFAULT_KEYBINDINGS_SNAPSHOT, onChange: () => () => {} } as never,
+      refreshDiscovery: async () => [],
+      getDiscoveredProjects: () => [],
+      machineDisplayName: "Local Machine",
+      updateManager: null,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(
+      ws as never,
+      JSON.stringify({
+        v: 1,
+        type: "command",
+        id: "delete-1",
+        command: { type: "chat.delete", chatId: "chat-1" },
+      })
+    )
+
+    expect(cancelledScheduleIds).toEqual(["sched-live"])
+    expect(callOrder.indexOf("cancelAutoContinue")).toBeLessThan(callOrder.indexOf("closeChat"))
+    expect(ws.sent).toContainEqual({ v: PROTOCOL_VERSION, type: "ack", id: "delete-1" })
+  })
 })

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -81,7 +81,7 @@ describe("ws-router", () => {
   test("acks system.ping without broadcasting snapshots", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -122,7 +122,7 @@ describe("ws-router", () => {
     const writes: Array<Pick<LlmProviderSnapshot, "provider" | "apiKey" | "model" | "baseUrl">> = []
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -213,7 +213,7 @@ describe("ws-router", () => {
   test("acks terminal.input without rebroadcasting terminal snapshots", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -257,7 +257,7 @@ describe("ws-router", () => {
   test("subscribes and unsubscribes chat topics", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -393,7 +393,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -466,7 +466,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "diff --git a/app.txt b/app.txt" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -549,7 +549,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -659,7 +659,7 @@ describe("ws-router", () => {
         }),
         getChat: () => state.chatsById.get("chat-1") ?? null,
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -874,7 +874,7 @@ describe("ws-router", () => {
           state.sidebarProjectOrder = [...projectIds]
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -975,7 +975,7 @@ describe("ws-router", () => {
           return ["chat-stale"]
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1055,7 +1055,7 @@ describe("ws-router", () => {
           return []
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1157,7 +1157,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1264,7 +1264,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1403,7 +1403,7 @@ describe("ws-router", () => {
         getRecentChatHistory: () => ({ entries: [], hasOlder: false, olderCursor: null }),
       } as never,
       diffStore: diffStore as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1500,7 +1500,7 @@ describe("ws-router", () => {
           return { snapshotChanged: false }
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -81,7 +81,7 @@ describe("ws-router", () => {
   test("acks system.ping without broadcasting snapshots", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -122,7 +122,7 @@ describe("ws-router", () => {
     const writes: Array<Pick<LlmProviderSnapshot, "provider" | "apiKey" | "model" | "baseUrl">> = []
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -213,7 +213,7 @@ describe("ws-router", () => {
   test("acks terminal.input without rebroadcasting terminal snapshots", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -257,7 +257,7 @@ describe("ws-router", () => {
   test("subscribes and unsubscribes chat topics", async () => {
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -329,6 +329,8 @@ describe("ws-router", () => {
           return new Map()
         },
         getDrainingChatIds: () => new Set(),
+        getSlashCommandsLoadingChatIds: () => new Set(),
+        ensureSlashCommandsLoaded: async () => {},
       } as never,
       terminals: {
         getSnapshot: () => null,
@@ -393,7 +395,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -466,7 +468,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "diff --git a/app.txt b/app.txt" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -549,7 +551,7 @@ describe("ws-router", () => {
         ignoreFile: async () => ({ snapshotChanged: false }),
         readPatch: async () => ({ patch: "" }),
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -659,7 +661,7 @@ describe("ws-router", () => {
         }),
         getChat: () => state.chatsById.get("chat-1") ?? null,
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -874,7 +876,7 @@ describe("ws-router", () => {
           state.sidebarProjectOrder = [...projectIds]
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -975,7 +977,7 @@ describe("ws-router", () => {
           return ["chat-stale"]
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1055,7 +1057,7 @@ describe("ws-router", () => {
           return []
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1157,7 +1159,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1264,7 +1266,7 @@ describe("ws-router", () => {
 
     const router = createWsRouter({
       store: { state: createEmptyState() } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1403,7 +1405,7 @@ describe("ws-router", () => {
         getRecentChatHistory: () => ({ entries: [], hasOlder: false, olderCursor: null }),
       } as never,
       diffStore: diffStore as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},
@@ -1500,7 +1502,7 @@ describe("ws-router", () => {
           return { snapshotChanged: false }
         },
       } as never,
-      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
+      agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set(), getSlashCommandsLoadingChatIds: () => new Set(), ensureSlashCommandsLoaded: async () => {} } as never,
       terminals: {
         getSnapshot: () => null,
         onEvent: () => () => {},

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -427,6 +427,7 @@ export function createWsRouter({
           store.state,
           agent.getActiveStatuses(),
           agent.getDrainingChatIds(),
+          agent.getSlashCommandsLoadingChatIds(),
           topic.chatId,
           (chatId) => store.getRecentChatHistory(chatId, topic.recentLimit ?? DEFAULT_CHAT_RECENT_LIMIT)
         ),

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1145,6 +1145,9 @@ export function createWsRouter({
         const snapshotSignatures = ensureSnapshotSignatures(ws)
         ws.data.subscriptions.set(parsed.id, parsed.topic)
         snapshotSignatures.delete(parsed.id)
+        if (parsed.topic.type === "chat") {
+          void agent.ensureSlashCommandsLoaded(parsed.topic.chatId)
+        }
         if (parsed.topic.type === "local-projects") {
           void refreshDiscovery().then(() => {
             if (ws.data.subscriptions.has(parsed.id)) {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -718,6 +718,19 @@ export function createWsRouter({
           })
           return
         }
+        case "update.reload": {
+          if (!updateManager) {
+            throw new Error("Update manager unavailable.")
+          }
+          const result = await updateManager.forceReload()
+          send(ws, {
+            v: PROTOCOL_VERSION,
+            type: "ack",
+            id,
+            result,
+          })
+          return
+        }
         case "settings.readKeybindings": {
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: keybindings.getSnapshot() })
           return

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -837,10 +837,31 @@ export function createWsRouter({
         }
         case "chat.delete": {
           await agent.cancel(command.chatId)
+          for (const scheduleId of agent.listLiveSchedules(command.chatId)) {
+            await agent.cancelAutoContinue(command.chatId, scheduleId, "chat_deleted")
+          }
           await agent.closeChat(command.chatId)
           await store.deleteChat(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           await broadcastFilteredSnapshots({ includeSidebar: true })
+          return
+        }
+        case "autoContinue.accept": {
+          await agent.acceptAutoContinue(command.chatId, command.scheduleId, command.scheduledAt)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "autoContinue.reschedule": {
+          await agent.rescheduleAutoContinue(command.chatId, command.scheduleId, command.scheduledAt)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "autoContinue.cancel": {
+          await agent.cancelAutoContinue(command.chatId, command.scheduleId, "user")
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
           return
         }
         case "chat.markRead": {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -14,6 +14,7 @@ import type { UpdateManager } from "./update-manager"
 import { deriveChatSnapshot, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
 import type { LlmProviderSnapshot } from "../shared/types"
 import type { LlmProviderValidationResult } from "../shared/types"
+import { importClaudeSessions } from "./claude-session-importer"
 
 const DEFAULT_CHAT_RECENT_LIMIT = 200
 
@@ -761,6 +762,15 @@ export function createWsRouter({
           const project = await store.openProject(command.localPath, command.title)
           await refreshDiscovery()
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: { projectId: project.id } })
+          break
+        }
+        case "sessions.importClaude": {
+          const result = await importClaudeSessions({ store })
+          if (result.newProjects > 0) {
+            await refreshDiscovery()
+          }
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
+          await broadcastFilteredSnapshots({ includeSidebar: true })
           break
         }
         case "project.remove": {

--- a/src/shared/branding.ts
+++ b/src/shared/branding.ts
@@ -2,7 +2,7 @@ export const APP_NAME = "Kanna"
 export const CLI_COMMAND = "kanna"
 export const DATA_ROOT_NAME = ".kanna"
 export const DEV_DATA_ROOT_NAME = ".kanna-dev"
-export const PACKAGE_NAME = "kanna-code"
+export const PACKAGE_NAME = "@cuongtranba/kanna"
 export const RUNTIME_PROFILE_ENV_VAR = "KANNA_RUNTIME_PROFILE"
 // Read version from package.json — JSON import works in both Bun and Vite
 import pkg from "../../package.json"

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -50,6 +50,7 @@ export type TerminalEvent =
 export type ClientCommand =
   | { type: "project.open"; localPath: string }
   | { type: "project.create"; localPath: string; title: string }
+  | { type: "sessions.importClaude" }
   | { type: "project.remove"; projectId: string }
   | { type: "sidebar.reorderProjectGroups"; projectIds: string[] }
   | { type: "project.readDiffPatch"; projectId: string; path: string }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -57,6 +57,7 @@ export type ClientCommand =
   | { type: "system.ping" }
   | { type: "update.check"; force?: boolean }
   | { type: "update.install" }
+  | { type: "update.reload" }
   | { type: "settings.readKeybindings" }
   | { type: "settings.writeKeybindings"; bindings: KeybindingsSnapshot["bindings"] }
   | { type: "settings.readLlmProvider" }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -100,6 +100,7 @@ export type ClientCommand =
       modelOptions?: ModelOptions
       effort?: string
       planMode?: boolean
+      autoResumeOnRateLimit?: boolean
     }
   | { type: "chat.refreshDiffs"; chatId: string }
   | { type: "chat.initGit"; chatId: string }
@@ -182,6 +183,7 @@ export type ClientCommand =
       model?: string
       modelOptions?: ModelOptions
       planMode?: boolean
+      autoResumeOnRateLimit?: boolean
     }
   | {
       type: "message.steer"

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -193,6 +193,9 @@ export type ClientCommand =
       chatId: string
       queuedMessageId: string
     }
+  | { type: "autoContinue.accept"; chatId: string; scheduleId: string; scheduledAt: number }
+  | { type: "autoContinue.reschedule"; chatId: string; scheduleId: string; scheduledAt: number }
+  | { type: "autoContinue.cancel"; chatId: string; scheduleId: string }
   | { type: "terminal.create"; projectId: string; terminalId: string; cols: number; rows: number; scrollback: number }
   | { type: "terminal.input"; terminalId: string; data: string }
   | { type: "terminal.resize"; terminalId: string; cols: number; rows: number }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -882,6 +882,7 @@ export interface ChatSnapshot {
   history: ChatHistorySnapshot
   availableProviders: ProviderCatalogEntry[]
   slashCommands: SlashCommand[]
+  slashCommandsLoading: boolean
 }
 
 export interface ChatHistoryPage {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,7 +6,7 @@ export type LlmProviderKind = "openai" | "openrouter" | "custom"
 export const DEFAULT_OPENAI_SDK_MODEL = "gpt-5.4-mini"
 export const DEFAULT_OPENROUTER_SDK_MODEL = "moonshotai/kimi-k2.5:nitro"
 
-export type AttachmentKind = "image" | "file"
+export type AttachmentKind = "image" | "file" | "mention"
 
 export interface ChatAttachment {
   id: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -869,12 +869,19 @@ export interface ChatHistorySnapshot {
   recentLimit: number
 }
 
+export interface SlashCommand {
+  name: string
+  description: string
+  argumentHint: string
+}
+
 export interface ChatSnapshot {
   runtime: ChatRuntime
   queuedMessages: QueuedChatMessage[]
   messages: TranscriptEntry[]
   history: ChatHistorySnapshot
   availableProviders: ProviderCatalogEntry[]
+  slashCommands: SlashCommand[]
 }
 
 export interface ChatHistoryPage {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,4 @@
-export const STORE_VERSION = 2 as const
+export const STORE_VERSION = 3 as const
 export const PROTOCOL_VERSION = 1 as const
 
 export type AgentProvider = "claude" | "codex"
@@ -481,6 +481,7 @@ export interface UserPromptEntry extends TranscriptEntryBase {
   content: string
   attachments?: ChatAttachment[]
   steered?: boolean
+  autoContinue?: { scheduleId: string }
 }
 
 export interface SystemInitEntry extends TranscriptEntryBase {
@@ -730,6 +731,7 @@ export type TranscriptEntry =
   | CompactSummaryEntry
   | ContextClearedEntry
   | InterruptedEntry
+  | AutoContinuePromptEntry
 
 export interface HydratedToolCallBase<TKind extends string, TInput, TResult> {
   id: string
@@ -837,7 +839,7 @@ export type HydratedToolCall =
   | HydratedUnknownToolCall
 
 export type HydratedTranscriptMessage =
-  | ({ kind: "user_prompt"; content: string; attachments?: ChatAttachment[]; steered?: boolean; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "user_prompt"; content: string; attachments?: ChatAttachment[]; steered?: boolean; autoContinue?: { scheduleId: string }; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "system_init"; model: string; tools: string[]; agents: string[]; slashCommands: string[]; mcpServers: McpServerInfo[]; provider: AgentProvider; id: string; messageId?: string; timestamp: string; hidden?: boolean; debugRaw?: string })
   | ({ kind: "account_info"; accountInfo: AccountInfo; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "assistant_text"; text: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
@@ -849,6 +851,7 @@ export type HydratedTranscriptMessage =
   | ({ kind: "context_cleared"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "interrupted"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "unknown"; json: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "auto_continue_prompt"; scheduleId: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ id: string; messageId?: string; hidden?: boolean } & HydratedToolCall)
 
 export interface ChatRuntime {
@@ -883,6 +886,8 @@ export interface ChatSnapshot {
   availableProviders: ProviderCatalogEntry[]
   slashCommands: SlashCommand[]
   slashCommandsLoading: boolean
+  schedules: Record<string, AutoContinueSchedule>
+  liveScheduleId: string | null
 }
 
 export interface ChatHistoryPage {
@@ -899,4 +904,20 @@ export interface KannaSnapshot {
 export interface PendingToolSnapshot {
   toolUseId: string
   toolKind: "ask_user_question" | "exit_plan_mode"
+}
+
+export type AutoContinueScheduleState = "proposed" | "scheduled" | "fired" | "cancelled"
+
+export interface AutoContinueSchedule {
+  scheduleId: string
+  state: AutoContinueScheduleState
+  scheduledAt: number | null
+  tz: string
+  resetAt: number
+  detectedAt: number
+}
+
+export interface AutoContinuePromptEntry extends TranscriptEntryBase {
+  kind: "auto_continue_prompt"
+  scheduleId: string
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -28,6 +28,7 @@ export interface QueuedChatMessage {
   model?: string
   modelOptions?: ModelOptions
   planMode?: boolean
+  autoContinue?: { scheduleId: string }
 }
 
 export interface InternalUserAttachmentsData {


### PR DESCRIPTION
## Summary

Detects rate-limit errors from Claude/Codex, shows a card in the transcript with the reset time, lets the user accept / edit / cancel, and fires a `"continue"` user prompt at the scheduled moment. A Settings toggle auto-accepts instead of asking.

- **Event-sourced schedules** — new `AutoContinue*` event kinds persisted via `EventStore`; pure reducer derives live state.
- **ScheduleManager** — injectable clock, timer-based fire loop, re-arms on server restart for schedules still in the future.
- **Transcript UI** — `AutoContinueCard` with four states (proposed / scheduled / fired / cancelled); "auto-sent" badge on user prompts fired by the feature.
- **End-to-end test** (`src/server/auto-continue/e2e.test.ts`) — rate-limit error → proposed → accept → FakeClock advance → fired → "continue" user_prompt with metadata.

## Test plan

- [x] `bun run check` clean (previously-failing `onForceReload` test fixtures fixed in this branch too)
- [x] `bun test` — 669/669 pass, 1502 expect() calls
- [x] E2E test asserts full pipeline with real EventStore + FakeClock
- [ ] Manual smoke: trigger synthetic rate-limit, verify proposed card → edit time → Schedule → scheduled state → Cancel → cancelled state
- [ ] Manual smoke: toggle Settings → Auto-resume on rate limit, confirm schedules directly without proposal card
- [ ] Manual smoke: restart dev server, confirm pending schedules re-arm

## Follow-ups (non-blocking, flagged in final review)

- Duplicate `auto_continue_accepted` event is silently permitted if user double-clicks before state propagates; reducer is idempotent but worth an idempotency guard.
- `autoContinueTime.parseLocal` does not handle fall-back DST duplicate hour (returns pre-transition epoch).
- `ChatSnapshot.liveScheduleId` is projected but not currently consumed client-side.