### PR TITLE
Support CLAUDE_EXECUTABLE for custom Claude wrappers

### DIFF
--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1,4 +1,5 @@
 import { query, type CanUseTool, type PermissionResult, type Query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
+import { homedir } from "node:os"
 import type {
   AgentProvider,
   ChatAttachment,
@@ -628,7 +629,7 @@ async function startClaudeSession(args: {
       canUseTool,
       tools: [...CLAUDE_TOOLSET],
       settingSources: ["user", "project", "local"],
-      pathToClaudeCodeExecutable: process.env.CLAUDE_EXECUTABLE || undefined,
+      pathToClaudeCodeExecutable: process.env.CLAUDE_EXECUTABLE?.replace(/^~(?=\/|$)/, homedir()) || undefined,
       env: (() => { const { CLAUDECODE: _, ...env } = process.env; return env })(),
     },
   })

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -628,6 +628,7 @@ async function startClaudeSession(args: {
       canUseTool,
       tools: [...CLAUDE_TOOLSET],
       settingSources: ["user", "project", "local"],
+      pathToClaudeCodeExecutable: process.env.CLAUDE_EXECUTABLE || undefined,
       env: (() => { const { CLAUDECODE: _, ...env } = process.env; return env })(),
     },
   })


### PR DESCRIPTION
## Problem

The Anthropic Agent SDK's `query()` function ignores `PATH` entirely. When `pathToClaudeCodeExecutable` is not set, it resolves the binary as `../cli.js` relative to its own `sdk.mjs` — always running the SDK's bundled `cli.js` regardless of what `claude` binary comes first in your shell's `PATH`.

This means wrappers like `~/bin/claude` (e.g. to route through AWS Bedrock, Azure AI Foundry, or a corporate proxy) were silently bypassed.

## Solution

One line: pass `process.env.CLAUDE_EXECUTABLE` to `pathToClaudeCodeExecutable` in the `query()` call in `agent.ts`.

```ts
pathToClaudeCodeExecutable: process.env.CLAUDE_EXECUTABLE || undefined,
```

When unset, the SDK falls back to its default behaviour (bundled `cli.js`), so there is no regression for existing users.

## Usage

Set `CLAUDE_EXECUTABLE` to the path of your wrapper before starting kanna:

```bash
CLAUDE_EXECUTABLE=~/bin/claude kanna
```

Your wrapper receives the same arguments the SDK would normally pass to `claude`, so a minimal Bedrock/Foundry shim just needs to swap the API endpoint and credentials before exec-ing the real binary.

## Why PATH alone never worked

The SDK source (`sdk.mjs`) does:
```js
let H = W.pathToClaudeCodeExecutable;
if (!H) {
    H = path.join(path.dirname(import.meta.url), 'cli.js')
}
// then spawns: bun H ...
```

No `which`, no `PATH` lookup — just a hardcoded relative path to the bundled CLI.