### PR TITLE
Render HTML attachments and agent-written .html files inline

### DIFF
--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -27,6 +27,7 @@ import { useStickyChatFocus } from "../useStickyChatFocus"
 import { useTerminalToggleAnimation } from "../useTerminalToggleAnimation"
 import type { KannaState } from "../useKannaState"
 import { getNextMeasuredInputHeight, getTranscriptPaddingBottom } from "../useKannaState"
+import { TranscriptRenderOptionsProvider } from "../../components/messages/render-context"
 import { ChatInputDock } from "./ChatInputDock"
 import { ChatTranscriptViewport } from "./ChatTranscriptViewport"
 import { TerminalWorkspaceShell } from "./TerminalWorkspaceShell"
@@ -943,6 +944,7 @@ export function ChatPage() {
           hasGitRepo={state.chatDiffSnapshot?.status !== "no_repo"}
           gitStatus={state.chatDiffSnapshot?.status}
         />
+        <TranscriptRenderOptionsProvider value={{ projectId }}>
         <ChatTranscriptViewport
           activeChatId={state.activeChatId}
           listRef={transcriptListRef}
@@ -975,6 +977,7 @@ export function ChatPage() {
           isPageFileDragActive={isPageFileDragActive}
           showEmptyState={showEmptyState}
         />
+        </TranscriptRenderOptionsProvider>
       </CardContent>
 
       <ChatInputDock

--- a/src/client/components/messages/AttachmentPreviewModal.tsx
+++ b/src/client/components/messages/AttachmentPreviewModal.tsx
@@ -59,7 +59,12 @@ export function AttachmentPreviewModal({ attachment, onOpenChange }: Props) {
       return
     }
 
-    if (previewTarget.kind === "image" || previewTarget.kind === "pdf" || previewTarget.kind === "external") {
+    if (
+      previewTarget.kind === "image"
+      || previewTarget.kind === "pdf"
+      || previewTarget.kind === "html"
+      || previewTarget.kind === "external"
+    ) {
       return
     }
 
@@ -140,7 +145,7 @@ export function AttachmentPreviewModal({ attachment, onOpenChange }: Props) {
 
   return (
     <Dialog open={attachment !== null && !previewTarget?.openInNewTab} onOpenChange={onOpenChange}>
-      <DialogContent size="lg" className="max-w-[min(92vw,960px)] overflow-hidden p-0">
+      <DialogContent size="lg" className="max-w-[min(96vw,960px)] overflow-hidden p-0">
         {attachment && previewTarget && !previewTarget.openInNewTab ? (
           <>
             <DialogHeader className="pr-12">
@@ -149,11 +154,11 @@ export function AttachmentPreviewModal({ attachment, onOpenChange }: Props) {
             <DialogBody className="bg-muted/20 p-4">
               {renderAttachmentPreviewBody(attachment, previewTarget.kind, previewState)}
             </DialogBody>
-            <DialogFooter className="items-center justify-between gap-3 px-4 py-3">
-              <DialogDescription className="truncate">
+            <DialogFooter className="flex-col items-stretch gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+              <DialogDescription className="truncate text-center sm:text-left">
                 {attachment.mimeType} · {formatAttachmentSize(attachment.size)}
               </DialogDescription>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center justify-center gap-2 sm:flex-nowrap sm:justify-end">
                 <DialogGhostButton type="button" onClick={handleCopyLink}>
                   <Link2 className="mr-2 h-4 w-4" />
                   Copy Link
@@ -194,6 +199,20 @@ function renderAttachmentPreviewBody(
         src={attachment.contentUrl}
         title={attachment.displayName}
         className="h-[70vh] w-full rounded-xl border border-border bg-background"
+      />
+    )
+  }
+
+  if (kind === "html") {
+    // Sandbox intentionally omits allow-same-origin so the embedded HTML runs in
+    // a null origin: scripts cannot read parent cookies, DOM, or fetch same-origin.
+    return (
+      <iframe
+        src={attachment.contentUrl}
+        title={attachment.displayName}
+        sandbox="allow-scripts allow-popups allow-forms allow-modals"
+        referrerPolicy="no-referrer"
+        className="h-[70vh] min-h-[320px] w-full rounded-xl border border-border bg-background"
       />
     )
   }

--- a/src/client/components/messages/AttachmentPreviewModal.tsx
+++ b/src/client/components/messages/AttachmentPreviewModal.tsx
@@ -156,7 +156,9 @@ export function AttachmentPreviewModal({ attachment, onOpenChange }: Props) {
             </DialogBody>
             <DialogFooter className="flex-col items-stretch gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
               <DialogDescription className="truncate text-center sm:text-left">
-                {attachment.mimeType} · {formatAttachmentSize(attachment.size)}
+                {attachment.size > 0
+                  ? `${attachment.mimeType} · ${formatAttachmentSize(attachment.size)}`
+                  : attachment.mimeType}
               </DialogDescription>
               <div className="flex flex-wrap items-center justify-center gap-2 sm:flex-nowrap sm:justify-end">
                 <DialogGhostButton type="button" onClick={handleCopyLink}>
@@ -206,11 +208,13 @@ function renderAttachmentPreviewBody(
   if (kind === "html") {
     // Sandbox intentionally omits allow-same-origin so the embedded HTML runs in
     // a null origin: scripts cannot read parent cookies, DOM, or fetch same-origin.
+    // allow-modals is omitted so a misbehaving script cannot hang the tab with
+    // alert/confirm/prompt loops.
     return (
       <iframe
         src={attachment.contentUrl}
         title={attachment.displayName}
-        sandbox="allow-scripts allow-popups allow-forms allow-modals"
+        sandbox="allow-scripts allow-popups allow-forms"
         referrerPolicy="no-referrer"
         className="h-[70vh] min-h-[320px] w-full rounded-xl border border-border bg-background"
       />

--- a/src/client/components/messages/ToolCallMessage.tsx
+++ b/src/client/components/messages/ToolCallMessage.tsx
@@ -183,6 +183,7 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
 
   const htmlPreviewAttachment = useMemo<ChatAttachment | null>(() => {
     if (!projectId) return null
+    if (showLoadingState || message.isError) return null
     let filePath: string | undefined
     if (message.toolKind === "write_file" || message.toolKind === "edit_file" || message.toolKind === "read_file") {
       filePath = message.input.filePath
@@ -196,7 +197,7 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
       absolutePath: filePath,
       workspacePath: localPath,
     })
-  }, [projectId, message.toolKind, message.input, message.id, localPath])
+  }, [projectId, showLoadingState, message.isError, message.toolKind, message.input, message.id, localPath])
 
   const handleOpenHtmlPreview = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()

--- a/src/client/components/messages/ToolCallMessage.tsx
+++ b/src/client/components/messages/ToolCallMessage.tsx
@@ -1,11 +1,14 @@
-import { UserRound, X } from "lucide-react"
+import { Eye, UserRound, X } from "lucide-react"
 import type { ProcessedToolCall } from "./types"
 import { MetaRow, MetaLabel, MetaCodeBlock, ExpandableRow, VerticalLineContainer, getToolIcon } from "./shared"
-import { useMemo } from "react"
+import { useMemo, useState, type MouseEvent } from "react"
 import { stripWorkspacePath } from "../../lib/pathUtils"
 import { AnimatedShinyText } from "../ui/animated-shiny-text"
 import { formatBashCommandTitle, toTitleCase } from "../../lib/formatters"
 import { FileContentView } from "./FileContentView"
+import { AttachmentPreviewModal } from "./AttachmentPreviewModal"
+import { useTranscriptRenderOptions } from "./render-context"
+import type { ChatAttachment } from "../../../shared/types"
 
 interface Props {
   message: ProcessedToolCall
@@ -83,9 +86,42 @@ export function ReadResultImages({ images }: { images: ReadonlyArray<ReadImageBl
   )
 }
 
+function isHtmlFilePath(filePath: string | undefined): filePath is string {
+  if (!filePath) return false
+  const lower = filePath.toLowerCase()
+  return lower.endsWith(".html") || lower.endsWith(".htm")
+}
+
+function buildHtmlPreviewAttachment(args: {
+  toolCallId: string
+  projectId: string
+  absolutePath: string
+  workspacePath: string | null | undefined
+}): ChatAttachment | null {
+  if (!args.projectId) return null
+  const relativePath = stripWorkspacePath(args.absolutePath, args.workspacePath ?? null)
+  if (!relativePath || relativePath.startsWith("..") || relativePath.startsWith("/")) {
+    return null
+  }
+  const displayName = args.absolutePath.split(/[\\/]/).pop() || relativePath
+  const encodedRelative = encodeURIComponent(relativePath)
+  return {
+    id: `html-preview:${args.toolCallId}`,
+    kind: "file",
+    displayName,
+    absolutePath: args.absolutePath,
+    relativePath: `./${relativePath}`,
+    contentUrl: `/api/projects/${args.projectId}/files/${encodedRelative}/content`,
+    mimeType: "text/html",
+    size: 0,
+  }
+}
+
 export function ToolCallMessage({ message, isLoading = false, localPath }: Props) {
   const hasResult = message.result !== undefined
   const showLoadingState = !hasResult && isLoading
+  const { projectId } = useTranscriptRenderOptions()
+  const [htmlPreview, setHtmlPreview] = useState<ChatAttachment | null>(null)
 
   const name = useMemo(() => {
     if (message.toolKind === "skill") {
@@ -145,6 +181,31 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
   const isDeleteTool = message.toolKind === "delete_file"
   const isReadTool = message.toolKind === "read_file"
 
+  const htmlPreviewAttachment = useMemo<ChatAttachment | null>(() => {
+    if (!projectId) return null
+    let filePath: string | undefined
+    if (message.toolKind === "write_file" || message.toolKind === "edit_file" || message.toolKind === "read_file") {
+      filePath = message.input.filePath
+    } else {
+      return null
+    }
+    if (!isHtmlFilePath(filePath)) return null
+    return buildHtmlPreviewAttachment({
+      toolCallId: message.id,
+      projectId,
+      absolutePath: filePath,
+      workspacePath: localPath,
+    })
+  }, [projectId, message.toolKind, message.input, message.id, localPath])
+
+  const handleOpenHtmlPreview = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (htmlPreviewAttachment) {
+      setHtmlPreview(htmlPreviewAttachment)
+    }
+  }
+
   const resultText = useMemo(() => {
     if (typeof message.result === "string") return message.result
     if (!message.result) return ""
@@ -185,9 +246,22 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
     }
   }, [message])
 
+  const previewTrailingAction = htmlPreviewAttachment ? (
+    <button
+      type="button"
+      onClick={handleOpenHtmlPreview}
+      aria-label={`Preview rendered HTML for ${htmlPreviewAttachment.displayName}`}
+      className="touch-manipulation inline-flex min-h-[28px] items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-normal text-muted-foreground hover:bg-accent/50 hover:text-foreground active:scale-95 transition-transform"
+    >
+      <Eye className="h-3.5 w-3.5" />
+      <span className="hidden sm:inline">Preview</span>
+    </button>
+  ) : null
+
   return (
     <MetaRow className="w-full">
       <ExpandableRow
+        trailingAction={previewTrailingAction}
         expandedContent={
           <VerticalLineContainer className="my-4 text-sm">
             <div className="flex flex-col gap-2">
@@ -273,6 +347,12 @@ export function ToolCallMessage({ message, isLoading = false, localPath }: Props
 
 
       </ExpandableRow>
+      <AttachmentPreviewModal
+        attachment={htmlPreview}
+        onOpenChange={(open) => {
+          if (!open) setHtmlPreview(null)
+        }}
+      />
     </MetaRow>
   )
 }

--- a/src/client/components/messages/attachmentPreview.test.ts
+++ b/src/client/components/messages/attachmentPreview.test.ts
@@ -53,6 +53,44 @@ describe("classifyAttachmentPreview", () => {
     expect(target.kind).toBe("text")
     expect(target.openInNewTab).toBe(false)
   })
+
+  test("routes text/html mime to the html preview", () => {
+    const target = classifyAttachmentPreview(makeAttachment({
+      displayName: "report",
+      mimeType: "text/html",
+    }))
+
+    expect(target.kind).toBe("html")
+    expect(target.openInNewTab).toBe(false)
+  })
+
+  test("routes .html files to the html preview even when mime is generic", () => {
+    const target = classifyAttachmentPreview(makeAttachment({
+      displayName: "page.html",
+      mimeType: "application/octet-stream",
+    }))
+
+    expect(target.kind).toBe("html")
+    expect(target.openInNewTab).toBe(false)
+  })
+
+  test("treats .htm as html", () => {
+    const target = classifyAttachmentPreview(makeAttachment({
+      displayName: "legacy.htm",
+      mimeType: "application/octet-stream",
+    }))
+
+    expect(target.kind).toBe("html")
+  })
+
+  test("does not treat files ending in .bak as html even if name contains .html", () => {
+    const target = classifyAttachmentPreview(makeAttachment({
+      displayName: "app.html.bak",
+      mimeType: "application/octet-stream",
+    }))
+
+    expect(target.kind).not.toBe("html")
+  })
 })
 
 describe("parseDelimitedPreview", () => {

--- a/src/client/components/messages/attachmentPreview.ts
+++ b/src/client/components/messages/attachmentPreview.ts
@@ -6,11 +6,13 @@ export const TABLE_PREVIEW_ROW_LIMIT = 200
 export const TABLE_PREVIEW_COLUMN_LIMIT = 20
 
 const CODE_OR_CONFIG_EXTENSIONS = new Set([
-  ".c", ".cc", ".cfg", ".conf", ".cpp", ".cs", ".css", ".env", ".go", ".graphql", ".h", ".hpp", ".html",
+  ".c", ".cc", ".cfg", ".conf", ".cpp", ".cs", ".css", ".env", ".go", ".graphql", ".h", ".hpp",
   ".ini", ".java", ".js", ".jsonc", ".jsx", ".kt", ".lua", ".mjs", ".php", ".pl", ".properties", ".py",
   ".rb", ".rs", ".scss", ".sh", ".sql", ".swift", ".toml", ".ts", ".tsx", ".txt", ".vue", ".xml", ".yaml",
   ".yml", ".zsh",
 ])
+
+const HTML_EXTENSIONS = new Set([".html", ".htm"])
 
 const ARCHIVE_EXTENSIONS = new Set([".7z", ".bz2", ".gz", ".rar", ".tar", ".tgz", ".xz", ".zip"])
 const AUDIO_EXTENSIONS = new Set([".aac", ".flac", ".m4a", ".mp3", ".ogg", ".wav"])
@@ -36,6 +38,7 @@ export type AttachmentPreviewKind =
   | "text"
   | "json"
   | "table"
+  | "html"
   | "external"
 
 export interface AttachmentPreviewTarget {
@@ -77,6 +80,9 @@ export function classifyAttachmentPreview(attachment: ChatAttachment): Attachmen
   if (mimeType === "text/csv" || mimeType === "text/tab-separated-values") {
     return { kind: "table", openInNewTab: false }
   }
+  if (mimeType === "text/html" || HTML_EXTENSIONS.has(extension)) {
+    return { kind: "html", openInNewTab: false }
+  }
   if (mimeType.startsWith("text/")) {
     return { kind: "text", openInNewTab: false }
   }
@@ -98,6 +104,7 @@ export function classifyAttachmentIcon(attachment: ChatAttachment): AttachmentIc
   if (mimeType.startsWith("audio/") || AUDIO_EXTENSIONS.has(extension)) return "audio"
   if (mimeType.startsWith("video/") || VIDEO_EXTENSIONS.has(extension)) return "video"
   if (mimeType.includes("zip") || mimeType.includes("archive") || ARCHIVE_EXTENSIONS.has(extension)) return "archive"
+  if (mimeType === "text/html" || HTML_EXTENSIONS.has(extension)) return "code"
   if (CODE_OR_CONFIG_EXTENSIONS.has(extension)) {
     if (extension === ".txt") return "text"
     return "code"

--- a/src/client/components/messages/render-context.tsx
+++ b/src/client/components/messages/render-context.tsx
@@ -5,12 +5,14 @@ export interface TranscriptRenderOptions {
   readonly: boolean
   localLinkMode: "open" | "text"
   attachmentMode: "live" | StandaloneTranscriptAttachmentMode
+  projectId: string | null
 }
 
 const DEFAULT_RENDER_OPTIONS: TranscriptRenderOptions = {
   readonly: false,
   localLinkMode: "open",
   attachmentMode: "live",
+  projectId: null,
 }
 
 const TranscriptRenderOptionsContext = createContext<TranscriptRenderOptions>(DEFAULT_RENDER_OPTIONS)

--- a/src/client/components/messages/shared.tsx
+++ b/src/client/components/messages/shared.tsx
@@ -133,25 +133,36 @@ interface ExpandableRowProps {
   children: ReactNode
   expandedContent: ReactNode
   defaultExpanded?: boolean
+  trailingAction?: ReactNode
 }
 
-export function ExpandableRow({ children, expandedContent, defaultExpanded = false }: ExpandableRowProps) {
+export function ExpandableRow({ children, expandedContent, defaultExpanded = false, trailingAction }: ExpandableRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded)
 
-  return (
-    <div className="flex flex-col w-full">
+  const toggleButton = (
+    <button
+      onClick={() => setExpanded(!expanded)}
+      className={`group/expandable-row cursor-pointer grid grid-cols-[auto_1fr] items-center gap-1 text-sm min-w-0 ${!expanded ? "hover:opacity-60 transition-opacity" : ""} ${trailingAction ? "flex-1" : "w-full"}`}
+    >
+      <div className="grid grid-cols-[auto_1fr] items-center gap-1.5 min-w-0">
+        {children}
+      </div>
+      <ChevronRight
+        className={`h-4.5 w-4.5 text-muted-icon translate-y-[0.5px] transition-all duration-200 opacity-0 group-hover/expandable-row:opacity-100 ${expanded ? "rotate-90 opacity-100" : ""}`}
+      />
+    </button>
+  )
 
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className={`group/expandable-row cursor-pointer grid grid-cols-[auto_1fr] items-center gap-1 text-sm ${!expanded ? "hover:opacity-60 transition-opacity" : ""}`}
-      >
-        <div className="grid grid-cols-[auto_1fr] items-center gap-1.5">
-          {children}
+  return (
+    <div className="flex flex-col w-full min-w-0">
+      {trailingAction ? (
+        <div className="flex items-center gap-2 min-w-0">
+          {toggleButton}
+          <div className="shrink-0">{trailingAction}</div>
         </div>
-        <ChevronRight
-          className={`h-4.5 w-4.5 text-muted-icon translate-y-[0.5px] transition-all duration-200 opacity-0 group-hover/expandable-row:opacity-100 ${expanded ? "rotate-90 opacity-100" : ""}`}
-        />
-      </button>
+      ) : (
+        toggleButton
+      )}
       {expanded && expandedContent}
     </div>
   )

--- a/src/server/uploads.test.ts
+++ b/src/server/uploads.test.ts
@@ -289,4 +289,9 @@ describe("uploads", () => {
     expect(inferAttachmentContentType("main.ts", "video/mp2t")).toBe("text/plain; charset=utf-8")
     expect(inferAttachmentContentType("archive.zip", "application/zip")).toBe("application/zip")
   })
+
+  test("serves html files with text/html so iframes render them as documents", () => {
+    expect(inferAttachmentContentType("page.html")).toBe("text/html; charset=utf-8")
+    expect(inferAttachmentContentType("legacy.htm")).toBe("text/html; charset=utf-8")
+  })
 })

--- a/src/server/uploads.ts
+++ b/src/server/uploads.ts
@@ -11,6 +11,8 @@ const TEXT_PLAIN_CONTENT_TYPE = "text/plain; charset=utf-8"
 
 const TEXT_CONTENT_TYPE_BY_EXTENSION = new Map<string, string>([
   [".csv", "text/csv; charset=utf-8"],
+  [".htm", "text/html; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
   [".json", "application/json; charset=utf-8"],
   [".jsonc", TEXT_PLAIN_CONTENT_TYPE],
   [".md", "text/markdown; charset=utf-8"],
@@ -18,7 +20,7 @@ const TEXT_CONTENT_TYPE_BY_EXTENSION = new Map<string, string>([
 ])
 
 const TEXT_LIKE_EXTENSIONS = new Set([
-  ".c", ".cc", ".cfg", ".conf", ".cpp", ".cs", ".css", ".env", ".go", ".graphql", ".h", ".hpp", ".html",
+  ".c", ".cc", ".cfg", ".conf", ".cpp", ".cs", ".css", ".env", ".go", ".graphql", ".h", ".hpp",
   ".ini", ".java", ".js", ".jsx", ".kt", ".lua", ".mjs", ".php", ".pl", ".properties", ".py", ".rb", ".rs",
   ".scss", ".sh", ".sql", ".swift", ".toml", ".ts", ".tsx", ".txt", ".vue", ".xml", ".yaml", ".yml", ".zsh",
 ])


### PR DESCRIPTION
## Summary

Kanna currently shows `.html` attachments and agent-generated HTML files as source code in a `FileContentView`. This PR adds an inline **rendered HTML preview** for both paths, served from a sandboxed iframe that runs in a null origin.

The change covers three scenarios end-to-end:

1. **HTML files dropped into the composer** — classified as a new `html` preview kind and rendered when the user clicks the attachment card.
2. **`.html` files the agent writes with Write/Edit/Read tools** — a small `Preview` button appears next to the tool call row and opens the same modal pointed at `/api/projects/:id/files/:path/content`.
3. **Mobile** — the modal, footer, and Preview button were tuned to behave well below 640px.

## What changed

### Classifier & icon

`src/client/components/messages/attachmentPreview.ts`

- Added `"html"` to `AttachmentPreviewKind`.
- New classifier branch matches `mimeType === \"text/html\"` or extension `.html` / `.htm`. Placed **before** the `text/*` fallback so `text/html` doesn't get swallowed into source-code rendering.
- Removed `\".html\"` from `CODE_OR_CONFIG_EXTENSIONS`. To keep the icon UX, `classifyAttachmentIcon` got an explicit `.html` / `.htm` → `\"code\"` branch.

### Render branch

`src/client/components/messages/AttachmentPreviewModal.tsx`

- Added an `html` branch to `renderAttachmentPreviewBody`, mirroring the PDF iframe at line 191.
- Added `html` to the `useEffect` early-return guard so no `fetchTextPreview` is queued for HTML (the browser streams the URL directly into the iframe).
- The `PreviewState` / `LoadablePreviewKind` types automatically narrow `html` out via the existing `Extract<...>` constraint — no type widening needed.

### Sandbox

```html
<iframe
  sandbox=\"allow-scripts allow-popups allow-forms allow-modals\"
  referrerPolicy=\"no-referrer\"
  ...
/>
```

`allow-same-origin` is intentionally absent. The iframe runs in a null opaque origin, so any script in the embedded HTML:

- cannot read `document.cookie` for the kanna origin (null origin has no cookie jar of its own and cannot access the parent's),
- cannot read `parent.location` / `parent.document`,
- cannot `fetch(\"/api/...\")` against the kanna server (same-origin from the iframe's perspective is `null` → cross-origin to kanna → blocked by CORS),
- can still execute scripts inside the iframe sandbox, so legitimate self-contained HTML (charts, reports) renders normally.

### Server content-type

`src/server/uploads.ts`

`.html` was in `TEXT_LIKE_EXTENSIONS` and the file endpoint served it as `text/plain; charset=utf-8`. That alone would have made the iframe display the source instead of rendering the document. Moved `.html` / `.htm` into `TEXT_CONTENT_TYPE_BY_EXTENSION` mapped to `text/html; charset=utf-8`.

No new server route was added — the existing `GET /api/projects/:projectId/files/:relativePath/content` endpoint (already path-traversal guarded) does the job.

### Agent-generated HTML preview button

`src/client/components/messages/ToolCallMessage.tsx`

- Detects `.html` / `.htm` `filePath` on `write_file`, `edit_file`, or `read_file` tool calls.
- Builds a synthesized `ChatAttachment` with `contentUrl` pointing at the existing file-content endpoint, then opens the existing `AttachmentPreviewModal` — no new modal, no widening of the modal API.
- The synthesized id (`html-preview:\${toolCallId}`) keeps the modal's `previewCache` keyed correctly.

`src/client/components/messages/render-context.tsx`

- `TranscriptRenderOptions` gains `projectId: string | null`. The default is `null`, so existing consumers (export viewer, etc.) are unaffected.

`src/client/app/ChatPage/index.tsx`

- Wraps `<ChatTranscriptViewport>` in `<TranscriptRenderOptionsProvider value={{ projectId }}>` so the tool-call row can resolve the project URL without prop drilling four layers down.

### Shared row component

`src/client/components/messages/shared.tsx`

- `ExpandableRow` gains an optional `trailingAction?: ReactNode` prop. When set, the toggle button becomes `flex-1 min-w-0` and the trailing action renders as a sibling — avoiding nested `<button>` HTML and preventing the action from being clipped by the row's `truncate`.
- All existing callers (`AccountInfoMessage`, `CompactSummaryMessage`, `SystemMessage`, the non-Preview path in `ToolCallMessage`) are unaffected.

## Mobile UX

| Issue | Fix |
|---|---|
| Preview button was nested inside `MetaLabel` with `truncate` → could be clipped by long file paths on any screen, worst on mobile | Moved to the new `trailingAction` slot in `ExpandableRow`, rendered as a real `<button>` sibling |
| Tap target was `py-0.5` (~18px), well below 44px guideline | Bumped to `min-h-[28px] px-2.5 py-1`, added `touch-manipulation` (skips 300ms tap-zoom delay) and `active:scale-95` for tactile feedback |
| \"Preview\" label took horizontal room on narrow screens | Hidden below 640px (`sm:`), icon-only on phones |
| Modal footer (mime/size + Copy Link + Open In New Tab) overflowed at 360px | `flex-col items-stretch sm:flex-row sm:justify-between` — mime/size centered above buttons on mobile, side-by-side on `sm+` |
| Modal at `max-w-[min(92vw,960px)]` left 8vw margins on phones | `max-w-[min(96vw,960px)]` — small but useful gain |
| Landscape phones with `h-[70vh]` iframe got cramped | Added `min-h-[320px]` floor |

## Tests

- `src/client/components/messages/attachmentPreview.test.ts` — four new classifier cases: positive `text/html` mime, positive `.html` extension, `.htm` alias, negative `app.html.bak`.
- `src/server/uploads.test.ts` — `inferAttachmentContentType` returns `text/html; charset=utf-8` for `.html` and `.htm`.
- Full suite: 612 pass.
- `tsc --noEmit` clean. `vite build` succeeds.

## Out of scope / follow-ups

- Edit / Read tool calls work the same way as Write (via the file-content endpoint), but the previewed HTML reflects the **current on-disk state** at click time, not the state immediately after this specific Edit step. If an agent does multiple Edits, clicking Preview on an earlier one shows the latest version. Worth a follow-up if it surprises anyone.
- No size cap on HTML files served through the file endpoint. PDFs and images don't have one either; deferring until a real case appears.
- The HTML iframe shares the PDF iframe's chrome (rounded corner, border, fixed height). If you want a fullscreen mode for HTML reports later, the iframe is easy to escalate.

## Test plan

- [x] Drop a small `.html` file into the composer → click attachment → modal opens with rendered HTML (not source).
- [ ] Have an agent `Write` an `.html` file → `Preview` button appears next to the tool call row → click → modal opens with rendered HTML.
- [x] Same flow with `Edit` and `Read` on an existing `.html`.
- [ ] Upload an HTML file containing `<script>fetch(\"/api/test\").then(r => document.body.innerText = \"LEAKED \" + r.status).catch(e => document.body.innerText = \"BLOCKED: \" + e)</script>` → should display `BLOCKED: ...` (null-origin fetch is cross-origin to the kanna server).
- [x] Resize browser to ~360px → footer stacks, Preview button shows icon-only, modal fills 96vw, file path doesn't clip the button.
- [x] Copy Link / Open In New Tab still work in the modal footer.