### PR TITLE
Update browser title with project and chat context

### DIFF
--- a/src/client/app/App.test.tsx
+++ b/src/client/app/App.test.tsx
@@ -1,19 +1,20 @@
 import { describe, expect, test } from "bun:test"
 import { getAppAuthStateFromStatus, shouldPlayChatNotificationSound, shouldRedirectToChangelog, shouldRetryAuthStatusRequest } from "./App"
-import { getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
+import { getBrowserWindowTitle, getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
 import { DEFAULT_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH, clampSidebarWidth } from "./KannaSidebar"
 import { isBrowserUnfocused, shouldPlayChatSound } from "../lib/chatSounds"
 import type { AppSettingsSnapshot, SidebarChatRow } from "../../shared/types"
 
-function createProjectGroup(chats: SidebarChatRow[]) {
+function createProjectGroup(chats: SidebarChatRow[], title = "Project", archivedChats: SidebarChatRow[] = []) {
   return {
     groupKey: "project-1",
-    title: "Project",
     realTitle: "Project",
     localPath: "/tmp/project",
+    title,
     chats,
     previewChats: chats,
     olderChats: [],
+    archivedChats,
     defaultCollapsed: false,
   }
 }
@@ -93,6 +94,108 @@ describe("getNotificationTitleCount", () => {
           },
         ])],
     })).toBe(4)
+  })
+})
+
+describe("getBrowserWindowTitle", () => {
+  test("adds the active project and chat title to the app title", () => {
+    expect(getBrowserWindowTitle({
+      appName: "Kanna",
+      activeProjectId: "project-1",
+      activeChatId: "chat-1",
+      sidebarData: {
+        projectGroups: [createProjectGroup([{
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: "Chat title",
+          status: "idle",
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        }], "Project title")],
+      },
+    })).toBe("Kanna : Project title : Chat title")
+  })
+
+  test("keeps the full project title and truncates chat titles after 80 characters", () => {
+    const longProjectTitle = "Project ".repeat(20).trim()
+    const longChatTitle = "A".repeat(81)
+
+    expect(getBrowserWindowTitle({
+      appName: "Kanna",
+      activeProjectId: "project-1",
+      activeChatId: "chat-1",
+      sidebarData: {
+        projectGroups: [createProjectGroup([{
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: longChatTitle,
+          status: "idle",
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        }], longProjectTitle)],
+      },
+    })).toBe(`Kanna : ${longProjectTitle} : ${"A".repeat(80)}...`)
+  })
+
+  test("finds archived active chats by title", () => {
+    expect(getBrowserWindowTitle({
+      appName: "Kanna",
+      activeProjectId: null,
+      activeChatId: "chat-archived",
+      sidebarData: {
+        projectGroups: [createProjectGroup([], "Project title", [{
+          _id: "chat-archived",
+          _creationTime: 1,
+          chatId: "chat-archived",
+          title: "Archived chat",
+          status: "idle",
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        }])],
+      },
+    })).toBe("Kanna : Project title : Archived chat")
+  })
+
+  test("keeps notification counts and omits the chat segment when no chat is active", () => {
+    expect(getBrowserWindowTitle({
+      appName: "Kanna",
+      activeProjectId: "project-1",
+      activeChatId: null,
+      sidebarData: {
+        projectGroups: [createProjectGroup([
+          {
+            _id: "chat-1",
+            _creationTime: 1,
+            chatId: "chat-1",
+            title: "Unread",
+            status: "idle",
+            unread: true,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+          },
+          {
+            _id: "chat-2",
+            _creationTime: 2,
+            chatId: "chat-2",
+            title: "Waiting",
+            status: "waiting_for_user",
+            unread: false,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+          },
+        ], "Project title")],
+      },
+    })).toBe("[2] Kanna : Project title")
   })
 })
 

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -11,7 +11,7 @@ import { APP_NAME, SDK_CLIENT_APP } from "../../shared/branding"
 import { useChatSoundPreferencesStore } from "../stores/chatSoundPreferencesStore"
 import type { ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
 import { playChatNotificationSound, shouldPlayChatSound } from "../lib/chatSounds"
-import { getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
+import { getBrowserWindowTitle, getChatSoundBurstCount } from "./chatNotifications"
 import { KannaSidebar } from "./KannaSidebar"
 import { ChatPage } from "./ChatPage"
 import { LocalProjectsPage } from "./LocalProjectsPage"
@@ -205,6 +205,12 @@ function KannaLayout() {
   const showMobileOpenButton = location.pathname === "/"
   const currentVersion = SDK_CLIENT_APP.split("/")[1] ?? "unknown"
   const previousSidebarDataRef = useRef<ReturnType<typeof useKannaState>["sidebarData"] | null>(null)
+  const browserTitle = useMemo(() => getBrowserWindowTitle({
+    appName: APP_NAME,
+    sidebarData: state.sidebarData,
+    activeProjectId: state.activeProjectId,
+    activeChatId: state.activeChatId,
+  }), [state.activeChatId, state.activeProjectId, state.sidebarData])
   const handleSidebarCreateChat = useCallback((projectId: string) => {
     void state.handleCreateChat(projectId)
   }, [state.handleCreateChat])
@@ -320,12 +326,12 @@ function KannaLayout() {
   }, [currentVersion, location.pathname, navigate])
 
   useLayoutEffect(() => {
-    document.title = APP_NAME
-  }, [location.key])
+    document.title = browserTitle
+  }, [browserTitle, location.key])
 
   useEffect(() => {
     function handlePageShow() {
-      document.title = APP_NAME
+      document.title = browserTitle
     }
 
     function handlePageHide() {
@@ -338,12 +344,7 @@ function KannaLayout() {
       window.removeEventListener("pageshow", handlePageShow)
       window.removeEventListener("pagehide", handlePageHide)
     }
-  }, [])
-
-  useEffect(() => {
-    const notificationCount = getNotificationTitleCount(state.sidebarData)
-    document.title = notificationCount > 0 ? `[${notificationCount}] ${APP_NAME}` : APP_NAME
-  }, [state.sidebarData])
+  }, [browserTitle])
 
   useEffect(() => {
     const burstCount = getChatSoundBurstCount(previousSidebarDataRef.current, state.sidebarData)

--- a/src/client/app/chatNotifications.ts
+++ b/src/client/app/chatNotifications.ts
@@ -1,4 +1,10 @@
-import type { SidebarData } from "../../shared/types"
+import type { SidebarChatRow, SidebarData, SidebarProjectGroup } from "../../shared/types"
+
+const BROWSER_CHAT_TITLE_MAX_LENGTH = 80
+
+function getSidebarGroupChats(group: SidebarProjectGroup): SidebarChatRow[] {
+  return [...group.chats, ...(group.archivedChats ?? [])]
+}
 
 export function getNotificationTitleCount(sidebarData: SidebarData) {
   return sidebarData.projectGroups.reduce((count, group) => (
@@ -6,6 +12,35 @@ export function getNotificationTitleCount(sidebarData: SidebarData) {
       chatCount + (chat.unread ? 1 : 0) + (chat.status === "waiting_for_user" ? 1 : 0)
     ), 0)
   ), 0)
+}
+
+export function getBrowserWindowTitle(args: {
+  appName: string
+  sidebarData: SidebarData
+  activeProjectId: string | null
+  activeChatId: string | null
+}) {
+  const notificationCount = getNotificationTitleCount(args.sidebarData)
+  const baseTitle = notificationCount > 0 ? `[${notificationCount}] ${args.appName}` : args.appName
+  const projectGroup = args.activeProjectId
+    ? args.sidebarData.projectGroups.find((group) => group.groupKey === args.activeProjectId)
+    : args.activeChatId
+      ? args.sidebarData.projectGroups.find((group) => (
+          getSidebarGroupChats(group).some((chat) => chat.chatId === args.activeChatId)
+        ))
+      : null
+  const projectTitle = projectGroup?.title?.trim()
+  if (!projectGroup || !projectTitle) return baseTitle
+
+  const chatTitle = args.activeChatId
+    ? getSidebarGroupChats(projectGroup).find((chat) => chat.chatId === args.activeChatId)?.title.trim()
+    : null
+  if (!chatTitle) return `${baseTitle} : ${projectTitle}`
+
+  const browserChatTitle = chatTitle.length > BROWSER_CHAT_TITLE_MAX_LENGTH
+    ? `${chatTitle.slice(0, BROWSER_CHAT_TITLE_MAX_LENGTH)}...`
+    : chatTitle
+  return `${baseTitle} : ${projectTitle} : ${browserChatTitle}`
 }
 
 interface ChatNotificationSnapshot {


### PR DESCRIPTION
Summary

Updates the browser tab title so it includes the active project and chat context instead of only showing the app name / notification count. This makes it easier to tell multiple Kanna tabs apart.

What changed

- Adds getBrowserWindowTitle() to derive a title from the active project, active chat, and existing notification count.
- Wires KannaLayout to keep document.title in sync across route changes and page show/hide events.
- Truncates long chat titles while preserving the project title.
- Adds focused coverage for project/chat title formatting and notification-count behavior.
