### PR TITLE
Add browser chat notifications

### DIFF
--- a/src/client/app/App.test.tsx
+++ b/src/client/app/App.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { getAppAuthStateFromStatus, shouldPlayChatNotificationSound, shouldRedirectToChangelog, shouldRetryAuthStatusRequest } from "./App"
-import { getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
+import { getChatNotificationEvents, getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
 import { DEFAULT_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH, clampSidebarWidth } from "./KannaSidebar"
 import { isBrowserUnfocused, shouldPlayChatSound } from "../lib/chatSounds"
 import type { AppSettingsSnapshot, SidebarChatRow } from "../../shared/types"
 
-function createProjectGroup(chats: SidebarChatRow[]) {
+function createProjectGroup(chats: SidebarChatRow[], title = "Project") {
   return {
     groupKey: "project-1",
-    title: "Project",
+    title,
     realTitle: "Project",
     localPath: "/tmp/project",
     chats,
@@ -174,6 +174,116 @@ describe("chat sound helpers", () => {
           },
         ])],
     })).toBe(3)
+  })
+
+  test("extracts notification events with project, chat, and response text", () => {
+    const events = getChatNotificationEvents(previous, {
+      projectGroups: [createProjectGroup([
+          {
+            _id: "chat-1",
+            _creationTime: 1,
+            chatId: "chat-1",
+            title: "Unread",
+            status: "idle",
+            unread: true,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+            lastAssistantResponsePreview: "Done with the change.",
+          },
+          {
+            _id: "chat-2",
+            _creationTime: 2,
+            chatId: "chat-2",
+            title: "Waiting",
+            status: "waiting_for_user",
+            unread: false,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+            lastAssistantResponsePreview: "Which option should I use?",
+          },
+        ], "Project title")],
+    })
+
+    expect(events).toEqual([
+      {
+        chatId: "chat-1",
+        projectTitle: "Project title",
+        chatTitle: "Unread",
+        message: "Done with the change.",
+      },
+      {
+        chatId: "chat-2",
+        projectTitle: "Project title",
+        chatTitle: "Waiting",
+        message: "Which option should I use?",
+      },
+    ])
+  })
+
+  test("extracts notification events when net unread count is unchanged", () => {
+    const previous = {
+      projectGroups: [createProjectGroup([
+        {
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: "Already unread",
+          status: "idle" as const,
+          unread: true,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+        {
+          _id: "chat-2",
+          _creationTime: 2,
+          chatId: "chat-2",
+          title: "Newly unread",
+          status: "idle" as const,
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+      ], "Project title")],
+    }
+    const next = {
+      projectGroups: [createProjectGroup([
+        {
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: "Already unread",
+          status: "idle" as const,
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+        {
+          _id: "chat-2",
+          _creationTime: 2,
+          chatId: "chat-2",
+          title: "Newly unread",
+          status: "idle" as const,
+          unread: true,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+          lastAssistantResponsePreview: "Fresh update.",
+        },
+      ], "Project title")],
+    }
+
+    expect(getChatSoundBurstCount(previous, next)).toBe(0)
+    expect(getChatNotificationEvents(previous, next)).toEqual([{
+      chatId: "chat-2",
+      projectTitle: "Project title",
+      chatTitle: "Newly unread",
+      message: "Fresh update.",
+    }])
   })
 
   test("does not replay for an already-waiting chat", () => {

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -9,9 +9,10 @@ import { Input } from "../components/ui/input"
 import { TooltipProvider } from "../components/ui/tooltip"
 import { APP_NAME, SDK_CLIENT_APP } from "../../shared/branding"
 import { useChatSoundPreferencesStore } from "../stores/chatSoundPreferencesStore"
-import type { ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import type { ChatBrowserNotificationPreference, ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import { shouldShowChatBrowserNotification, showChatBrowserNotification } from "../lib/chatBrowserNotifications"
 import { playChatNotificationSound, shouldPlayChatSound } from "../lib/chatSounds"
-import { getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
+import { getChatNotificationEvents, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
 import { KannaSidebar } from "./KannaSidebar"
 import { ChatPage } from "./ChatPage"
 import { LocalProjectsPage } from "./LocalProjectsPage"
@@ -195,6 +196,14 @@ export function shouldPlayChatNotificationSound(
   return Boolean(appSettings) && shouldPlayChatSound(preference, doc)
 }
 
+export function shouldShowChatNotificationPopup(
+  appSettings: AppSettingsSnapshot | null,
+  preference: ChatBrowserNotificationPreference,
+  doc: Pick<Document, "visibilityState" | "hasFocus"> = document
+) {
+  return Boolean(appSettings) && shouldShowChatBrowserNotification(preference, doc)
+}
+
 function KannaLayout() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -202,6 +211,7 @@ function KannaLayout() {
   const state = useKannaState(params.chatId ?? null)
   const chatSoundPreference = useChatSoundPreferencesStore((store) => store.chatSoundPreference)
   const chatSoundId = useChatSoundPreferencesStore((store) => store.chatSoundId)
+  const chatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.chatBrowserNotificationPreference)
   const showMobileOpenButton = location.pathname === "/"
   const currentVersion = SDK_CLIENT_APP.split("/")[1] ?? "unknown"
   const previousSidebarDataRef = useRef<ReturnType<typeof useKannaState>["sidebarData"] | null>(null)
@@ -346,14 +356,27 @@ function KannaLayout() {
   }, [state.sidebarData])
 
   useEffect(() => {
+    const previousSidebarData = previousSidebarDataRef.current
     const burstCount = getChatSoundBurstCount(previousSidebarDataRef.current, state.sidebarData)
+    const browserNotificationEvents = getChatNotificationEvents(previousSidebarData, state.sidebarData)
     previousSidebarDataRef.current = state.sidebarData
 
-    if (burstCount <= 0) return
-    if (!shouldPlayChatNotificationSound(state.appSettings, chatSoundPreference)) return
+    if (burstCount > 0 && shouldPlayChatNotificationSound(state.appSettings, chatSoundPreference)) {
+      void playChatNotificationSound(chatSoundId, burstCount).catch(() => undefined)
+    }
 
-    void playChatNotificationSound(chatSoundId, burstCount).catch(() => undefined)
-  }, [chatSoundId, chatSoundPreference, state.appSettings, state.sidebarData])
+    if (browserNotificationEvents.length <= 0) return
+    if (!shouldShowChatNotificationPopup(state.appSettings, chatBrowserNotificationPreference)) return
+    for (const event of browserNotificationEvents) {
+      showChatBrowserNotification({
+        ...event,
+        onClick: () => {
+          window.focus()
+          navigate(`/chat/${event.chatId}`)
+        },
+      })
+    }
+  }, [chatBrowserNotificationPreference, chatSoundId, chatSoundPreference, navigate, state.appSettings, state.sidebarData])
 
   return (
     <div className="flex h-[100dvh] min-h-[100dvh] overflow-hidden">

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -9,6 +9,7 @@ import {
   getKeybindingsSubtitle,
   loadChangelog,
   resetSettingsPageChangelogCache,
+  resolveChatBrowserNotificationPreferenceAfterPermission,
   resolveSettingsSectionId,
   setCachedChangelog,
   shouldPreviewChatSoundChange,
@@ -180,6 +181,23 @@ describe("shouldPreviewChatSoundChange", () => {
     expect(shouldPreviewChatSoundChange("always", "never")).toBe(true)
     expect(shouldPreviewChatSoundChange("never", "unfocused")).toBe(true)
     expect(shouldPreviewChatSoundChange("funk", "glass")).toBe(true)
+  })
+})
+
+describe("resolveChatBrowserNotificationPreferenceAfterPermission", () => {
+  test("keeps enabled browser notification preferences only after permission is granted", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "granted")).toBe("always")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("unfocused", "granted")).toBe("unfocused")
+  })
+
+  test("falls back to never when browser notifications cannot be used", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "denied")).toBe("never")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("unfocused", "unsupported")).toBe("never")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "default")).toBe("never")
+  })
+
+  test("keeps never without requiring browser permission", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("never", "denied")).toBe("never")
   })
 })
 

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -59,6 +59,7 @@ import {
 import { useTheme, type ThemePreference } from "../hooks/useTheme"
 import { KEYBINDING_ACTION_LABELS, formatKeybindingInput, getResolvedKeybindings, parseKeybindingInput } from "../lib/keybindings"
 import { playChatNotificationSound } from "../lib/chatSounds"
+import { requestChatBrowserNotificationPermission } from "../lib/chatBrowserNotifications"
 import { cn } from "../lib/utils"
 import {
   DEFAULT_TERMINAL_MIN_COLUMN_WIDTH,
@@ -71,7 +72,7 @@ import {
   useTerminalPreferencesStore,
 } from "../stores/terminalPreferencesStore"
 import { useChatPreferencesStore } from "../stores/chatPreferencesStore"
-import { CHAT_SOUND_OPTIONS, useChatSoundPreferencesStore, type ChatSoundId, type ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import { CHAT_SOUND_OPTIONS, useChatSoundPreferencesStore, type ChatBrowserNotificationPreference, type ChatSoundId, type ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
 import type { KannaState } from "./useKannaState"
 
 const sidebarItems = [
@@ -127,6 +128,12 @@ const chatSoundPreferenceOptions: { value: ChatSoundPreference; label: string }[
   { value: "always", label: "Always" },
 ]
 
+const chatBrowserNotificationPreferenceOptions: { value: ChatBrowserNotificationPreference; label: string }[] = [
+  { value: "never", label: "Never" },
+  { value: "unfocused", label: "When Unfocused" },
+  { value: "always", label: "Always" },
+]
+
 const analyticsOptions = [
   { value: "disabled" as const, label: "Off" },
   { value: "enabled" as const, label: "On" },
@@ -173,6 +180,14 @@ export function shouldPreviewChatSoundChange(
   nextValue: string
 ) {
   return previousValue !== nextValue
+}
+
+export function resolveChatBrowserNotificationPreferenceAfterPermission(
+  requestedPreference: ChatBrowserNotificationPreference,
+  permission: NotificationPermission | "unsupported"
+): ChatBrowserNotificationPreference {
+  if (requestedPreference === "never") return "never"
+  return permission === "granted" ? requestedPreference : "never"
 }
 
 export function resetSettingsPageChangelogCache() {
@@ -827,8 +842,10 @@ export function SettingsPage() {
   const setEditorCommandTemplate = useTerminalPreferencesStore((store) => store.setEditorCommandTemplate)
   const chatSoundPreference = useChatSoundPreferencesStore((store) => store.chatSoundPreference)
   const chatSoundId = useChatSoundPreferencesStore((store) => store.chatSoundId)
+  const chatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.chatBrowserNotificationPreference)
   const setChatSoundPreference = useChatSoundPreferencesStore((store) => store.setChatSoundPreference)
   const setChatSoundId = useChatSoundPreferencesStore((store) => store.setChatSoundId)
+  const setChatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.setChatBrowserNotificationPreference)
   const keybindings = state.keybindings
   const appSettings = state.appSettings
   const llmProvider = state.llmProvider
@@ -1060,6 +1077,33 @@ export function SettingsPage() {
       setAppSettingsError(error instanceof Error ? error.message : "Unable to save chat sound settings.")
     })
     void playChatNotificationSound(nextValue, 1).catch(() => undefined)
+  }
+
+  function handleChatBrowserNotificationPreferenceChange(nextValue: ChatBrowserNotificationPreference) {
+    if (chatBrowserNotificationPreference === nextValue) {
+      return
+    }
+
+    async function savePreference(preference: ChatBrowserNotificationPreference) {
+      setChatBrowserNotificationPreference(preference)
+      await handleWriteAppSettings({ chatBrowserNotificationPreference: preference })
+    }
+
+    void (async () => {
+      try {
+        const permission = nextValue === "never"
+          ? "granted"
+          : await requestChatBrowserNotificationPermission()
+        const resolvedPreference = resolveChatBrowserNotificationPreferenceAfterPermission(nextValue, permission)
+
+        await savePreference(resolvedPreference)
+        if (nextValue !== "never" && resolvedPreference === "never") {
+          setAppSettingsError("Browser notifications are blocked or unsupported for this browser.")
+        }
+      } catch (error) {
+        setAppSettingsError(error instanceof Error ? error.message : "Unable to save chat notification settings.")
+      }
+    })()
   }
 
   async function handleAnalyticsPreferenceChange(nextValue: "enabled" | "disabled") {
@@ -1460,6 +1504,29 @@ export function SettingsPage() {
                           <SelectContent>
                             <SelectGroup>
                               {CHAT_SOUND_OPTIONS.map((option) => (
+                                <SelectItem key={option.value} value={option.value}>
+                                  {option.label}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </SettingsRow>
+
+                      <SettingsRow
+                        title="Chat Notifications"
+                        description="Show browser system notifications for new chat activity"
+                      >
+                        <Select
+                          value={chatBrowserNotificationPreference}
+                          onValueChange={(value) => handleChatBrowserNotificationPreferenceChange(value as ChatBrowserNotificationPreference)}
+                        >
+                          <SelectTrigger className="min-w-[180px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {chatBrowserNotificationPreferenceOptions.map((option) => (
                                 <SelectItem key={option.value} value={option.value}>
                                   {option.label}
                                 </SelectItem>

--- a/src/client/app/chatNotifications.ts
+++ b/src/client/app/chatNotifications.ts
@@ -13,6 +13,13 @@ interface ChatNotificationSnapshot {
   waitingChatIds: Set<string>
 }
 
+interface ChatNotificationEvent {
+  chatId: string
+  projectTitle: string
+  chatTitle: string
+  message: string
+}
+
 export function getChatNotificationSnapshot(sidebarData: SidebarData): ChatNotificationSnapshot {
   let unreadCount = 0
   const waitingChatIds = new Set<string>()
@@ -44,4 +51,39 @@ export function getChatSoundBurstCount(previous: SidebarData | null, next: Sideb
   }
 
   return unreadIncrease + newWaitingChats
+}
+
+export function getChatNotificationEvents(previous: SidebarData | null, next: SidebarData): ChatNotificationEvent[] {
+  if (!previous) return []
+
+  const previousChats = new Map<string, { unread: boolean; waiting: boolean }>()
+  for (const group of previous.projectGroups) {
+    for (const chat of group.chats) {
+      previousChats.set(chat.chatId, {
+        unread: chat.unread,
+        waiting: chat.status === "waiting_for_user",
+      })
+    }
+  }
+
+  const events: ChatNotificationEvent[] = []
+  for (const group of next.projectGroups) {
+    for (const chat of group.chats) {
+      const previousChat = previousChats.get(chat.chatId) ?? { unread: false, waiting: false }
+
+      const becameUnread = chat.unread && !previousChat.unread
+      const becameWaiting = chat.status === "waiting_for_user" && !previousChat.waiting
+      if (!becameUnread && !becameWaiting) continue
+
+      // The read model keeps this preview synced to the latest assistant text for the chat.
+      events.push({
+        chatId: chat.chatId,
+        projectTitle: group.title?.trim() || group.localPath,
+        chatTitle: chat.title.trim() || "Untitled chat",
+        message: chat.lastAssistantResponsePreview ?? "",
+      })
+    }
+  }
+
+  return events
 }

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -296,6 +296,7 @@ function syncRuntimeStoresFromAppSettings(snapshot: AppSettingsSnapshot) {
   const chatSoundPreferences = useChatSoundPreferencesStore.getState()
   chatSoundPreferences.setChatSoundPreference(snapshot.chatSoundPreference)
   chatSoundPreferences.setChatSoundId(snapshot.chatSoundId)
+  chatSoundPreferences.setChatBrowserNotificationPreference(snapshot.chatBrowserNotificationPreference)
 
   useChatPreferencesStore.getState().syncProviderDefaults(snapshot.defaultProvider, snapshot.providerDefaults)
 }

--- a/src/client/lib/chatBrowserNotifications.test.ts
+++ b/src/client/lib/chatBrowserNotifications.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  createChatBrowserNotificationPayload,
+  showChatBrowserNotification,
+  shouldShowChatBrowserNotification,
+  truncateChatBrowserNotificationMessage,
+} from "./chatBrowserNotifications"
+
+const originalNotification = globalThis.Notification
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "Notification", {
+    configurable: true,
+    writable: true,
+    value: originalNotification,
+  })
+})
+
+describe("chat browser notifications", () => {
+  test("applies browser notification preference gates", () => {
+    const focusedDoc = { visibilityState: "visible" as const, hasFocus: () => true }
+    const hiddenDoc = { visibilityState: "hidden" as const, hasFocus: () => false }
+
+    expect(shouldShowChatBrowserNotification("never", hiddenDoc)).toBe(false)
+    expect(shouldShowChatBrowserNotification("always", focusedDoc)).toBe(true)
+    expect(shouldShowChatBrowserNotification("unfocused", hiddenDoc)).toBe(true)
+    expect(shouldShowChatBrowserNotification("unfocused", focusedDoc)).toBe(false)
+  })
+
+  test("creates title from project and chat and truncates message text", () => {
+    const payload = createChatBrowserNotificationPayload({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: `First line\n\n${"A".repeat(220)}`,
+    })
+
+    expect(payload.title).toBe("Project - Chat")
+    expect(payload.body).toBe(`First line ${"A".repeat(166)}...`)
+  })
+
+  test("uses a fallback body when the response text is missing", () => {
+    expect(truncateChatBrowserNotificationMessage(" \n ")).toBe("New chat activity.")
+  })
+
+  test("constructs a browser notification when permission is granted", () => {
+    const created: Array<{ title: string; options?: NotificationOptions; onclick: ((event: Event) => void) | null; close: () => void }> = []
+    class FakeNotification {
+      static permission: NotificationPermission = "granted"
+      onclick: ((event: Event) => void) | null = null
+      close = () => {}
+
+      constructor(title: string, options?: NotificationOptions) {
+        created.push(this as never)
+        Object.assign(this, { title, options })
+      }
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+    })).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(created[0]).toMatchObject({
+      title: "Project - Chat",
+      options: { body: "Done." },
+    })
+  })
+
+  test("runs the click handler and closes the notification when clicked", () => {
+    let clicked = 0
+    let closed = 0
+    const created: Array<{ onclick: ((event: Event) => void) | null }> = []
+    class FakeNotification {
+      static permission: NotificationPermission = "granted"
+      onclick: ((event: Event) => void) | null = null
+      close = () => {
+        closed += 1
+      }
+
+      constructor() {
+        created.push(this)
+      }
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+      onClick: () => {
+        clicked += 1
+      },
+    })).toBe(true)
+
+    created[0]?.onclick?.(new Event("click"))
+
+    expect(clicked).toBe(1)
+    expect(closed).toBe(1)
+  })
+
+  test("does not construct a browser notification without permission", () => {
+    class FakeNotification {
+      static permission: NotificationPermission = "denied"
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+    })).toBe(false)
+  })
+})

--- a/src/client/lib/chatBrowserNotifications.ts
+++ b/src/client/lib/chatBrowserNotifications.ts
@@ -1,0 +1,57 @@
+import type { ChatBrowserNotificationPreference } from "../stores/chatSoundPreferencesStore"
+import { isBrowserUnfocused } from "./chatSounds"
+
+const CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH = 180
+
+export function shouldShowChatBrowserNotification(
+  preference: ChatBrowserNotificationPreference,
+  doc: Pick<Document, "visibilityState" | "hasFocus"> = document
+) {
+  if (preference === "never") return false
+  if (preference === "always") return true
+  return isBrowserUnfocused(doc)
+}
+
+export function truncateChatBrowserNotificationMessage(message: string) {
+  const normalized = message.replace(/\s+/g, " ").trim()
+  if (!normalized) return "New chat activity."
+  if (normalized.length <= CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH) return normalized
+  return `${normalized.slice(0, CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH - 3)}...`
+}
+
+export function createChatBrowserNotificationPayload(args: {
+  projectTitle: string
+  chatTitle: string
+  message: string
+}) {
+  return {
+    title: `${args.projectTitle} - ${args.chatTitle}`,
+    body: truncateChatBrowserNotificationMessage(args.message),
+  }
+}
+
+export async function requestChatBrowserNotificationPermission() {
+  if (typeof Notification === "undefined") return "unsupported" as const
+  if (Notification.permission === "granted") return "granted" as const
+  if (Notification.permission === "denied") return "denied" as const
+  return Notification.requestPermission()
+}
+
+export function showChatBrowserNotification(args: {
+  projectTitle: string
+  chatTitle: string
+  message: string
+  onClick?: () => void
+}) {
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") return false
+  const payload = createChatBrowserNotificationPayload(args)
+  const notification = new Notification(payload.title, { body: payload.body })
+  const onClick = args.onClick
+  if (onClick) {
+    notification.onclick = () => {
+      notification.close()
+      onClick()
+    }
+  }
+  return true
+}

--- a/src/client/stores/chatSoundPreferencesStore.test.ts
+++ b/src/client/stores/chatSoundPreferencesStore.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import {
+  DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE,
   DEFAULT_CHAT_SOUND_ID,
   DEFAULT_CHAT_SOUND_PREFERENCE,
+  normalizeChatBrowserNotificationPreference,
   normalizeChatSoundId,
   normalizeChatSoundPreference,
   useChatSoundPreferencesStore,
@@ -26,6 +28,19 @@ describe("normalizeChatSoundPreference", () => {
   })
 })
 
+describe("normalizeChatBrowserNotificationPreference", () => {
+  test("accepts supported values", () => {
+    expect(normalizeChatBrowserNotificationPreference("never")).toBe("never")
+    expect(normalizeChatBrowserNotificationPreference("unfocused")).toBe("unfocused")
+    expect(normalizeChatBrowserNotificationPreference("always")).toBe("always")
+  })
+
+  test("falls back to the default for unknown values", () => {
+    expect(normalizeChatBrowserNotificationPreference("loud")).toBe(DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE)
+    expect(normalizeChatBrowserNotificationPreference(undefined)).toBe(DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE)
+  })
+})
+
 describe("normalizeChatSoundId", () => {
   test("accepts supported values", () => {
     expect(normalizeChatSoundId("blow")).toBe("blow")
@@ -40,9 +55,10 @@ describe("normalizeChatSoundId", () => {
 })
 
 describe("chat sound preferences store", () => {
-  test("defaults to always and funk", () => {
+  test("defaults sounds to always and browser notifications to never", () => {
     expect(useChatSoundPreferencesStore.getState().chatSoundPreference).toBe("always")
     expect(useChatSoundPreferencesStore.getState().chatSoundId).toBe("funk")
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("never")
   })
 
   test("normalizes stored values through the setters", () => {
@@ -57,5 +73,11 @@ describe("chat sound preferences store", () => {
 
     useChatSoundPreferencesStore.getState().setChatSoundId("invalid" as never)
     expect(useChatSoundPreferencesStore.getState().chatSoundId).toBe("funk")
+
+    useChatSoundPreferencesStore.getState().setChatBrowserNotificationPreference("unfocused")
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("unfocused")
+
+    useChatSoundPreferencesStore.getState().setChatBrowserNotificationPreference("invalid" as never)
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("never")
   })
 })

--- a/src/client/stores/chatSoundPreferencesStore.ts
+++ b/src/client/stores/chatSoundPreferencesStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand"
-import type { ChatSoundId, ChatSoundPreference } from "../../shared/types"
+import type { ChatBrowserNotificationPreference, ChatSoundId, ChatSoundPreference } from "../../shared/types"
 
-export type { ChatSoundId, ChatSoundPreference }
+export type { ChatBrowserNotificationPreference, ChatSoundId, ChatSoundPreference }
 
 export const DEFAULT_CHAT_SOUND_PREFERENCE: ChatSoundPreference = "always"
 export const DEFAULT_CHAT_SOUND_ID: ChatSoundId = "funk"
+export const DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE: ChatBrowserNotificationPreference = "never"
 
 export const CHAT_SOUND_OPTIONS: Array<{ value: ChatSoundId; label: string }> = [
   { value: "blow", label: "Blow" },
@@ -29,6 +30,17 @@ export function normalizeChatSoundPreference(value?: string): ChatSoundPreferenc
   }
 }
 
+export function normalizeChatBrowserNotificationPreference(value?: string): ChatBrowserNotificationPreference {
+  switch (value) {
+    case "never":
+    case "unfocused":
+    case "always":
+      return value
+    default:
+      return DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE
+  }
+}
+
 export function normalizeChatSoundId(value?: string): ChatSoundId {
   switch (value) {
     case "blow":
@@ -49,15 +61,19 @@ export function normalizeChatSoundId(value?: string): ChatSoundId {
 export interface ChatSoundPreferencesState {
   chatSoundPreference: ChatSoundPreference
   chatSoundId: ChatSoundId
+  chatBrowserNotificationPreference: ChatBrowserNotificationPreference
   setChatSoundPreference: (value: ChatSoundPreference) => void
   setChatSoundId: (value: ChatSoundId) => void
+  setChatBrowserNotificationPreference: (value: ChatBrowserNotificationPreference) => void
 }
 
 export const useChatSoundPreferencesStore = create<ChatSoundPreferencesState>()(
   (set) => ({
     chatSoundPreference: DEFAULT_CHAT_SOUND_PREFERENCE,
     chatSoundId: DEFAULT_CHAT_SOUND_ID,
+    chatBrowserNotificationPreference: DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE,
     setChatSoundPreference: (value) => set({ chatSoundPreference: normalizeChatSoundPreference(value) }),
     setChatSoundId: (value) => set({ chatSoundId: normalizeChatSoundId(value) }),
+    setChatBrowserNotificationPreference: (value) => set({ chatBrowserNotificationPreference: normalizeChatBrowserNotificationPreference(value) }),
   })
 )

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -25,6 +25,7 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
     theme: "system",
     chatSoundPreference: "always",
     chatSoundId: "funk",
+    chatBrowserNotificationPreference: "never",
     terminal: {
       scrollbackLines: 1_000,
       minColumnWidth: 450,
@@ -129,6 +130,7 @@ describe("AppSettingsManager", () => {
     const snapshot = await manager.writePatch({
       theme: "dark",
       chatSoundId: "glass",
+      chatBrowserNotificationPreference: "unfocused",
       terminal: { scrollbackLines: 2_500 },
       editor: { preset: "vscode" },
       providerDefaults: {
@@ -141,6 +143,7 @@ describe("AppSettingsManager", () => {
       analyticsUserId: string
       theme: string
       chatSoundId: string
+      chatBrowserNotificationPreference: string
       terminal: { scrollbackLines: number; minColumnWidth: number }
       editor: { preset: string; commandTemplate: string }
       providerDefaults: { codex: { modelOptions: { fastMode: boolean } } }
@@ -148,6 +151,7 @@ describe("AppSettingsManager", () => {
 
     expect(snapshot.theme).toBe("dark")
     expect(snapshot.chatSoundId).toBe("glass")
+    expect(snapshot.chatBrowserNotificationPreference).toBe("unfocused")
     expect(snapshot.terminal.scrollbackLines).toBe(2_500)
     expect(snapshot.terminal.minColumnWidth).toBe(450)
     expect(snapshot.editor.preset).toBe("vscode")
@@ -156,6 +160,7 @@ describe("AppSettingsManager", () => {
     expect(nextPayload.analyticsUserId).toBe(initialPayload.analyticsUserId)
     expect(nextPayload.theme).toBe("dark")
     expect(nextPayload.chatSoundId).toBe("glass")
+    expect(nextPayload.chatBrowserNotificationPreference).toBe("unfocused")
 
     manager.dispose()
   })

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -16,6 +16,7 @@ import {
   type AppSettingsPatch,
   type AppSettingsSnapshot,
   type AppThemePreference,
+  type ChatBrowserNotificationPreference,
   type ChatProviderPreferences,
   type ChatSoundId,
   type ChatSoundPreference,
@@ -33,6 +34,7 @@ interface AppSettingsFile {
   theme?: unknown
   chatSoundPreference?: unknown
   chatSoundId?: unknown
+  chatBrowserNotificationPreference?: unknown
   terminal?: {
     scrollbackLines?: unknown
     minColumnWidth?: unknown
@@ -67,6 +69,7 @@ const MAX_TERMINAL_MIN_COLUMN_WIDTH = 900
 const DEFAULT_EDITOR_PRESET: EditorPreset = "cursor"
 const DEFAULT_CHAT_SOUND_PREFERENCE: ChatSoundPreference = "always"
 const DEFAULT_CHAT_SOUND_ID: ChatSoundId = "funk"
+const DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE: ChatBrowserNotificationPreference = "never"
 
 function formatDisplayPath(filePath: string) {
   const homePath = homedir()
@@ -123,6 +126,12 @@ function normalizeTheme(value: unknown): AppThemePreference {
 
 function normalizeChatSoundPreference(value: unknown): ChatSoundPreference {
   return value === "never" || value === "unfocused" || value === "always" ? value : DEFAULT_CHAT_SOUND_PREFERENCE
+}
+
+function normalizeChatBrowserNotificationPreference(value: unknown): ChatBrowserNotificationPreference {
+  return value === "never" || value === "unfocused" || value === "always"
+    ? value
+    : DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE
 }
 
 function normalizeChatSoundId(value: unknown): ChatSoundId {
@@ -220,6 +229,7 @@ function toFilePayload(state: AppSettingsState) {
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    chatBrowserNotificationPreference: state.chatBrowserNotificationPreference,
     terminal: state.terminal,
     editor: state.editor,
     defaultProvider: state.defaultProvider,
@@ -234,6 +244,7 @@ function toSnapshot(state: AppSettingsState): AppSettingsSnapshot {
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    chatBrowserNotificationPreference: state.chatBrowserNotificationPreference,
     terminal: state.terminal,
     editor: state.editor,
     defaultProvider: state.defaultProvider,
@@ -278,6 +289,7 @@ function normalizeAppSettings(
     theme: normalizeTheme(source?.theme),
     chatSoundPreference: normalizeChatSoundPreference(source?.chatSoundPreference),
     chatSoundId: normalizeChatSoundId(source?.chatSoundId),
+    chatBrowserNotificationPreference: normalizeChatBrowserNotificationPreference(source?.chatBrowserNotificationPreference),
     terminal: {
       scrollbackLines: clampNumber(source?.terminal?.scrollbackLines, DEFAULT_TERMINAL_SCROLLBACK, MIN_TERMINAL_SCROLLBACK, MAX_TERMINAL_SCROLLBACK),
       minColumnWidth: clampNumber(source?.terminal?.minColumnWidth, DEFAULT_TERMINAL_MIN_COLUMN_WIDTH, MIN_TERMINAL_MIN_COLUMN_WIDTH, MAX_TERMINAL_MIN_COLUMN_WIDTH),
@@ -312,6 +324,7 @@ function toComparablePayload(source: AppSettingsFile) {
     theme: source.theme,
     chatSoundPreference: source.chatSoundPreference,
     chatSoundId: source.chatSoundId,
+    chatBrowserNotificationPreference: source.chatBrowserNotificationPreference,
     terminal: source.terminal,
     editor: source.editor,
     defaultProvider: source.defaultProvider,

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -21,6 +21,7 @@ import { resolveLocalPath } from "./paths"
 const COMPACTION_THRESHOLD_BYTES = 2 * 1024 * 1024
 const STALE_EMPTY_CHAT_MAX_AGE_MS = 30 * 60 * 1000
 const SIDEBAR_PROJECT_ORDER_FILE = "sidebar-order.json"
+const LAST_ASSISTANT_RESPONSE_PREVIEW_MAX_LENGTH = 220
 
 function normalizeSidebarProjectOrder(value: unknown) {
   if (!Array.isArray(value)) {
@@ -53,6 +54,12 @@ function logSendToStartingProfile(stage: string, details?: Record<string, unknow
     stage,
     ...details,
   }))
+}
+
+function createAssistantResponsePreview(text: string) {
+  const normalized = text.replace(/\s+/g, " ").trim()
+  if (normalized.length <= LAST_ASSISTANT_RESPONSE_PREVIEW_MAX_LENGTH) return normalized
+  return `${normalized.slice(0, LAST_ASSISTANT_RESPONSE_PREVIEW_MAX_LENGTH - 3)}...`
 }
 
 interface LegacyTranscriptStats {
@@ -609,6 +616,11 @@ export class EventStore {
     chat.hasMessages = true
     if (entry.kind === "user_prompt") {
       chat.lastMessageAt = entry.createdAt
+    } else if (entry.kind === "assistant_text") {
+      const preview = createAssistantResponsePreview(entry.text)
+      if (preview) {
+        chat.lastAssistantResponsePreview = preview
+      }
     }
     chat.updatedAt = Math.max(chat.updatedAt, entry.createdAt)
   }
@@ -1225,6 +1237,33 @@ export class EventStore {
     }
   }
 
+  private recomputeTranscriptMetadata(chatId: string, entries: TranscriptEntry[]) {
+    const chat = this.state.chatsById.get(chatId)
+    if (!chat) return
+
+    let lastMessageAt: number | undefined
+    let lastAssistantResponsePreview: string | undefined
+    let latestEntryAt = 0
+    for (const entry of entries) {
+      latestEntryAt = Math.max(latestEntryAt, entry.createdAt)
+      if (entry.kind === "user_prompt") {
+        lastMessageAt = Math.max(lastMessageAt ?? 0, entry.createdAt)
+      } else if (entry.kind === "assistant_text") {
+        const preview = createAssistantResponsePreview(entry.text)
+        if (preview) {
+          lastAssistantResponsePreview = preview
+        }
+      }
+    }
+
+    chat.lastMessageAt = lastMessageAt ?? chat.lastMessageAt
+    chat.lastAssistantResponsePreview = lastAssistantResponsePreview
+    chat.hasMessages = entries.length > 0
+    if (latestEntryAt > 0) {
+      chat.updatedAt = Math.max(chat.updatedAt, latestEntryAt)
+    }
+  }
+
   async compact() {
     const snapshot = this.createSnapshot()
     await Bun.write(this.snapshotPath, JSON.stringify(snapshot, null, 2))
@@ -1256,6 +1295,7 @@ export class EventStore {
       const payload = entries.map((entry) => JSON.stringify(entry)).join("\n")
       await writeFile(tempPath, payload ? `${payload}\n` : "", "utf8")
       await rename(tempPath, transcriptPath)
+      this.recomputeTranscriptMetadata(chatId, entries)
       if (logEveryChat || (index + 1) % 25 === 0 || index === messageSets.length - 1) {
         onProgress?.(`${LOG_PREFIX} transcript migration: ${index + 1}/${messageSets.length} chats`)
       }

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -20,6 +20,7 @@ export interface ChatRecord {
   pendingForkSessionToken?: string | null
   hasMessages?: boolean
   lastMessageAt?: number
+  lastAssistantResponsePreview?: string
   lastTurnOutcome: "success" | "failed" | "cancelled" | null
 }
 

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -23,6 +23,7 @@ describe("read models", () => {
       provider: "codex",
       planMode: false,
       sessionToken: "thread-1",
+      lastAssistantResponsePreview: "Done with the change.",
       lastTurnOutcome: null,
     })
 
@@ -31,6 +32,7 @@ describe("read models", () => {
     expect(sidebar.projectGroups[0]?.localPath).toBe("/tmp/project")
     expect(sidebar.projectGroups[0]?.chats[0]?.provider).toBe("codex")
     expect(sidebar.projectGroups[0]?.chats[0]?.unread).toBe(true)
+    expect(sidebar.projectGroups[0]?.chats[0]?.lastAssistantResponsePreview).toBe("Done with the change.")
     expect(sidebar.projectGroups[0]?.chats[0]?.canFork).toBe(true)
     expect(sidebar.projectGroups[0]?.previewChats.map((chat) => chat.chatId)).toEqual(["chat-1"])
     expect(sidebar.projectGroups[0]?.olderChats).toEqual([])

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -109,6 +109,7 @@ export function deriveSidebarData(
         localPath: project.localPath,
         provider: chat.provider,
         lastMessageAt: chat.lastMessageAt,
+        lastAssistantResponsePreview: chat.lastAssistantResponsePreview,
         hasAutomation: false,
         canFork: canForkChat(chat, activeStatuses, drainingChatIds) || undefined,
       }))

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -76,6 +76,7 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
   theme: "system",
   chatSoundPreference: "always",
   chatSoundId: "funk",
+  chatBrowserNotificationPreference: "never",
   terminal: {
     scrollbackLines: 1_000,
     minColumnWidth: 450,
@@ -463,6 +464,7 @@ describe("ws-router", () => {
             theme: patch.theme ?? snapshot.theme,
             chatSoundPreference: patch.chatSoundPreference ?? snapshot.chatSoundPreference,
             chatSoundId: patch.chatSoundId ?? snapshot.chatSoundId,
+            chatBrowserNotificationPreference: patch.chatBrowserNotificationPreference ?? snapshot.chatBrowserNotificationPreference,
             defaultProvider: patch.defaultProvider ?? snapshot.defaultProvider,
             terminal: { ...snapshot.terminal, ...patch.terminal },
             editor: { ...snapshot.editor, ...patch.editor },

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -454,6 +454,7 @@ export function createWsRouter({
     theme: "system",
     chatSoundPreference: "always",
     chatSoundId: "funk",
+    chatBrowserNotificationPreference: "never",
     terminal: {
       scrollbackLines: 1_000,
       minColumnWidth: 450,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ export type AgentProvider = "claude" | "codex"
 export type LlmProviderKind = "openai" | "openrouter" | "custom"
 export type AppThemePreference = "light" | "dark" | "system"
 export type ChatSoundPreference = "never" | "unfocused" | "always"
+export type ChatBrowserNotificationPreference = ChatSoundPreference
 export type ChatSoundId = "blow" | "bottle" | "frog" | "funk" | "glass" | "ping" | "pop" | "purr" | "tink"
 export type DefaultProviderPreference = "last_used" | AgentProvider
 export type EditorPreset = "cursor" | "vscode" | "xcode" | "windsurf" | "custom"
@@ -383,6 +384,7 @@ export interface SidebarChatRow {
   localPath: string
   provider: AgentProvider | null
   lastMessageAt?: number
+  lastAssistantResponsePreview?: string
   hasAutomation: boolean
   canFork?: boolean
 }
@@ -427,6 +429,7 @@ export interface AppSettingsSnapshot {
   theme: AppThemePreference
   chatSoundPreference: ChatSoundPreference
   chatSoundId: ChatSoundId
+  chatBrowserNotificationPreference: ChatBrowserNotificationPreference
   terminal: {
     scrollbackLines: number
     minColumnWidth: number
@@ -447,6 +450,7 @@ export interface AppSettingsPatch {
   theme?: AppThemePreference
   chatSoundPreference?: ChatSoundPreference
   chatSoundId?: ChatSoundId
+  chatBrowserNotificationPreference?: ChatBrowserNotificationPreference
   terminal?: Partial<AppSettingsSnapshot["terminal"]>
   editor?: Partial<AppSettingsSnapshot["editor"]>
   defaultProvider?: DefaultProviderPreference


### PR DESCRIPTION
Summary

Adds optional browser notifications for chat activity so Kanna can alert users when relevant chats need attention while the browser is unfocused.

What changed

- Adds a browser notification preference alongside the existing chat sound preference.
- Adds app settings persistence and WebSocket wiring for the browser notification option.
- Extracts notification event data from sidebar chat transitions, including project title, chat title, and latest assistant preview.
- Shows browser notifications when the preference allows it and the browser Notification permission is granted.
- Opens the relevant chat when a browser notification is clicked.
- Adds focused tests for notification preferences, event extraction, browser notification payloads, settings persistence, and WebSocket/read-model wiring.

Notes

Browser notifications default to off. Users must enable the preference and grant browser notification permission before notifications are shown.