### PR TITLE
feat: add /sessionEnd slash command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+KANNA_DIR="/home/electerm/data/CorpHub/personal/Kanna"
+PROJECT_DIR="/home/electerm/data/CorpHub/personal/ProcesetAETL"
+
+cd "$KANNA_DIR"
+
+exec bun run ./src/server/cli.ts \
+    --no-open \
+    --port 10002 \
+    --remote

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -96,7 +96,7 @@ function getTranscriptMessageRenderState(
         shouldRender = message.toolKind !== "todo_write" || isLatestTodoWrite
         break
       case "result":
-        shouldRender = !hideResult && (!message.success || message.durationMs > 60000)
+        shouldRender = !hideResult && (!message.success || message.durationMs > 60000 || (message.durationMs === 0 && !!message.result))
         break
       case "context_window_updated":
         shouldRender = false

--- a/src/client/components/messages/ResultMessage.tsx
+++ b/src/client/components/messages/ResultMessage.tsx
@@ -35,6 +35,16 @@ export function ResultMessage({ message }: Props) {
     )
   }
 
+  if (message.durationMs === 0 && message.result) {
+    return (
+      <MetaRow className="px-0.5 text-xs tracking-wide">
+        <div className="w-full h-[1px] bg-border"></div>
+        <MetaLabel className="whitespace-nowrap text-[11px] tracking-widest text-muted-foreground/60 uppercase flex-shrink-0">{message.result}</MetaLabel>
+        <div className="w-full h-[1px] bg-border"></div>
+      </MetaRow>
+    )
+  }
+
   return (
     <MetaRow className={`px-0.5 text-xs tracking-wide ${message.durationMs > 60000 ? '' : 'hidden'}`}>
       <div className="w-full h-[1px] bg-border"></div>

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -96,6 +96,7 @@ interface ClaudeSessionState {
   accountInfoLoaded: boolean
   nextPromptSeq: number
   pendingPromptSeqs: number[]
+  runningPromise?: Promise<void>
 }
 
 interface AgentCoordinatorArgs {
@@ -748,6 +749,39 @@ export class AgentCoordinator {
     this.emitStateChange(chatId)
   }
 
+  async sessionEndCommand(chatId: string): Promise<void> {
+    if (this.activeTurns.has(chatId)) {
+      await this.cancel(chatId, { hideInterrupted: true })
+    }
+    await this.closeChat(chatId)
+    await this.store.appendMessage(
+      chatId,
+      timestamped({
+        kind: "result",
+        subtype: "success",
+        isError: false,
+        durationMs: 0,
+        result: "Session ended.",
+      })
+    )
+    this.emitStateChange(chatId)
+  }
+
+  // Gracefully close all Claude sessions: sends close signal (which delivers SIGTERM
+  // to Claude Code after the SDK's 5-second timer), then waits for each session's
+  // runningPromise to resolve so Claude Code has time to fire its SessionEnd hook.
+  async closeAllSessionsGracefully(timeoutMs = 25_000): Promise<void> {
+    const sessions = [...this.claudeSessions.values()]
+    if (sessions.length === 0) return
+    for (const session of sessions) {
+      session.session.close()
+    }
+    await Promise.race([
+      Promise.all(sessions.map(s => s.runningPromise ?? Promise.resolve())),
+      new Promise<void>(resolve => setTimeout(resolve, timeoutMs)),
+    ])
+  }
+
   private resolveProvider(options: SendMessageOptions, currentProvider: AgentProvider | null) {
     if (currentProvider) return currentProvider
     return options.provider ?? "claude"
@@ -1093,7 +1127,7 @@ export class AgentCoordinator {
         pendingPromptSeqs: [],
       }
       this.claudeSessions.set(args.chatId, session)
-      void this.runClaudeSession(session)
+      session.runningPromise = this.runClaudeSession(session)
     } else {
       if (session.model !== args.model) {
         await session.session.setModel(args.model)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -287,6 +287,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     for (const chatId of [...agent.activeTurns.keys()]) {
       await agent.cancel(chatId)
     }
+    await agent.closeAllSessionsGracefully()
     router.dispose()
     appSettings.dispose()
     keybindings.dispose()

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1293,6 +1293,12 @@ export function createWsRouter({
           break
         }
         case "chat.send": {
+          if (command.chatId && command.content?.trim() === "/sessionEnd") {
+            await agent.sessionEndCommand(command.chatId)
+            await broadcastChatStateImmediately(command.chatId)
+            send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result: { chatId: command.chatId } })
+            return
+          }
           const result = await agent.send(command)
           const profile = command.clientTraceId && result.chatId
             ? agent.getActiveTurnProfile(result.chatId)


### PR DESCRIPTION
Closes #71

## Summary

- Adds a `/sessionEnd` slash command that closes the active Claude Code session from within the chat
- Renders a **"Session ended."** footer divider in the transcript after the command runs (same visual style as the "Worked for X" separator)
- Calls `closeAllSessionsGracefully()` on server shutdown so in-flight sessions always get a clean SIGTERM before the process exits

## Changes

**`src/server/agent.ts`**
- `sessionEndCommand(chatId)` — cancels any in-flight turn, closes the Claude session (triggering SDK abort → SIGTERM → Claude Code fires its `SessionEnd` hook), appends a synthetic `result` entry with `durationMs: 0` as a sentinel for the notification
- `closeAllSessionsGracefully(timeoutMs)` — waits for all session promises on shutdown; `runningPromise` added to `ClaudeSessionState`

**`src/server/server.ts`**
- Calls `closeAllSessionsGracefully()` in `shutdown()` so sessions are cleanly terminated even without an explicit `/sessionEnd`

**`src/server/ws-router.ts`**
- Intercepts `/sessionEnd` in `chat.send` before the normal send path

**`src/client/app/KannaTranscript.tsx`**
- Extends the result-visibility condition: entries with `durationMs === 0` and a non-empty `result` string are always shown (sentinel for synthetic notifications; real agent results are always ≥ 1 ms)

**`src/client/components/messages/ResultMessage.tsx`**
- Renders the `durationMs === 0` case as a horizontal separator with the result text

## Test plan

- [ ] Open a chat, send a message, type `/sessionEnd` — "Session ended." footer appears in transcript
- [ ] Verify the underlying Claude Code session is closed (no orphaned processes)
- [ ] Verify `stopwaitsecs` / server shutdown closes all sessions gracefully
- [ ] Confirm no regression: normal short agent runs do not show the footer

🤖 Generated with [Claude Code](https://claude.ai/claude-code)