### PR TITLE
fix: move mobile upload action away from input edge

### DIFF
--- a/src/client/components/chat-ui/ChatInput.test.ts
+++ b/src/client/components/chat-ui/ChatInput.test.ts
@@ -122,7 +122,7 @@ describe("trimTrailingPastedNewlines", () => {
 })
 
 describe("ChatInput", () => {
-  test("renders the mobile attachment trigger as a native file input target", () => {
+  test("renders the mobile attachment trigger as a native file input target on the right side", () => {
     const html = renderToStaticMarkup(createElement(ChatInput, {
       onSubmit: async () => undefined,
       disabled: false,
@@ -134,6 +134,7 @@ describe("ChatInput", () => {
     expect(html).toContain('aria-label="Add attachment"')
     expect(html).toContain('type="file"')
     expect(html).toContain("absolute inset-0 cursor-pointer opacity-0")
+    expect(html.indexOf('aria-label="Add attachment"')).toBeGreaterThan(html.indexOf('placeholder="Build something..."'))
     expect(html).not.toContain('type="file" multiple="" class="hidden"')
   })
 })

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -685,11 +685,28 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
           ) : null}
 
           <div className="flex items-end max-w-[840px] mx-auto border dark:bg-card/40 backdrop-blur-lg border-border rounded-[29px] pr-1.5">
+            <Textarea
+              ref={setTextareaRefs}
+              placeholder="Build something..."
+              value={value}
+              autoFocus
+              {...{ [CHAT_INPUT_ATTRIBUTE]: "" }}
+              rows={1}
+              onChange={(event) => {
+                setValue(event.target.value)
+                if (chatId) setDraft(chatId, event.target.value)
+                autoResize()
+              }}
+              onPaste={handlePaste}
+              onKeyDown={handleKeyDown}
+              disabled={disabled}
+              className="min-w-0 flex-1 text-base p-3 md:p-4 !pr-2 md:pl-6 resize-none max-h-[200px] outline-none bg-transparent border-0 shadow-none"
+            />
             <label
               aria-label="Add attachment"
               className={cn(
                 buttonVariants({ variant: "ghost", size: "icon" }),
-                "relative md:hidden flex-shrink-0 ml-1 mb-1 h-10 w-10 rounded-full text-muted-foreground hover:text-foreground",
+                "relative md:hidden flex-shrink-0 mb-1 h-10 w-10 rounded-full text-muted-foreground hover:text-foreground",
                 disabled && "pointer-events-none opacity-50",
               )}
             >
@@ -709,23 +726,6 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 }}
               />
             </label>
-            <Textarea
-              ref={setTextareaRefs}
-              placeholder="Build something..."
-              value={value}
-              autoFocus
-              {...{ [CHAT_INPUT_ATTRIBUTE]: "" }}
-              rows={1}
-              onChange={(event) => {
-                setValue(event.target.value)
-                if (chatId) setDraft(chatId, event.target.value)
-                autoResize()
-              }}
-              onPaste={handlePaste}
-              onKeyDown={handleKeyDown}
-              disabled={disabled}
-              className="flex-1 text-base p-3 md:p-4 !pr-2 pl-0 md:pl-6 resize-none max-h-[200px] outline-none bg-transparent border-0 shadow-none"
-            />
             <Button
               type="button"
               onPointerDown={(event) => {


### PR DESCRIPTION
## Summary
- move the mobile attachment upload control to the right side of the chat composer, between the textarea and send button
- restore normal left padding on the textarea so typing and left-edge interactions do not overlap the file input target
- add a regression assertion that the native file input target renders after the textarea

## Why
On iOS, the upload control could be triggered accidentally while typing or interacting with the chat input because it sat on the left edge near the open/minimize interaction area.

## Test
- bun test src/client/components/chat-ui/ChatInput.test.ts