### PR TITLE
Add browser chat notifications

### DIFF
--- a/src/client/app/App.test.tsx
+++ b/src/client/app/App.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { getAppAuthStateFromStatus, shouldPlayChatNotificationSound, shouldRedirectToChangelog, shouldRetryAuthStatusRequest } from "./App"
-import { getBrowserWindowTitle, getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
+import { getBrowserWindowTitle, getChatNotificationEvents, getChatNotificationSnapshot, getChatSoundBurstCount, getNotificationTitleCount } from "./chatNotifications"
 import { DEFAULT_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH, clampSidebarWidth } from "./KannaSidebar"
 import { isBrowserUnfocused, shouldPlayChatSound } from "../lib/chatSounds"
 import type { AppSettingsSnapshot, SidebarChatRow } from "../../shared/types"
@@ -298,6 +298,145 @@ describe("chat sound helpers", () => {
           },
         ])],
     })).toBe(3)
+  })
+
+  test("extracts notification events with project, chat, and response text", () => {
+    const events = getChatNotificationEvents(previous, {
+      projectGroups: [createProjectGroup([
+          {
+            _id: "chat-1",
+            _creationTime: 1,
+            chatId: "chat-1",
+            title: "Unread",
+            status: "idle",
+            unread: true,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+            lastAgentMessagePreview: "Done with the change.",
+          },
+          {
+            _id: "chat-2",
+            _creationTime: 2,
+            chatId: "chat-2",
+            title: "Waiting",
+            status: "waiting_for_user",
+            unread: false,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+            lastAgentMessagePreview: "Which option should I use?",
+          },
+        ], "Project title")],
+    })
+
+    expect(events).toEqual([
+      {
+        chatId: "chat-1",
+        projectTitle: "Project title",
+        chatTitle: "Unread",
+        message: "Done with the change.",
+      },
+      {
+        chatId: "chat-2",
+        projectTitle: "Project title",
+        chatTitle: "Waiting",
+        message: "Which option should I use?",
+      },
+    ])
+  })
+
+  test("uses pending user input text for new waiting notifications", () => {
+    const events = getChatNotificationEvents(previous, {
+      projectGroups: [createProjectGroup([
+          {
+            _id: "chat-2",
+            _creationTime: 2,
+            chatId: "chat-2",
+            title: "Waiting",
+            status: "waiting_for_user",
+            unread: false,
+            localPath: "/tmp/project",
+            provider: null,
+            hasAutomation: false,
+            lastAgentMessagePreview: "Old assistant preview.",
+            pendingUserInputPreview: "Which runtime should I use?",
+          },
+        ], "Project title")],
+    })
+
+    expect(events).toEqual([
+      {
+        chatId: "chat-2",
+        projectTitle: "Project title",
+        chatTitle: "Waiting",
+        message: "Which runtime should I use?",
+      },
+    ])
+  })
+
+  test("extracts notification events when net unread count is unchanged", () => {
+    const previous = {
+      projectGroups: [createProjectGroup([
+        {
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: "Already unread",
+          status: "idle" as const,
+          unread: true,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+        {
+          _id: "chat-2",
+          _creationTime: 2,
+          chatId: "chat-2",
+          title: "Newly unread",
+          status: "idle" as const,
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+      ], "Project title")],
+    }
+    const next = {
+      projectGroups: [createProjectGroup([
+        {
+          _id: "chat-1",
+          _creationTime: 1,
+          chatId: "chat-1",
+          title: "Already unread",
+          status: "idle" as const,
+          unread: false,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+        },
+        {
+          _id: "chat-2",
+          _creationTime: 2,
+          chatId: "chat-2",
+          title: "Newly unread",
+          status: "idle" as const,
+          unread: true,
+          localPath: "/tmp/project",
+          provider: null,
+          hasAutomation: false,
+          lastAgentMessagePreview: "Fresh update.",
+        },
+      ], "Project title")],
+    }
+
+    expect(getChatSoundBurstCount(previous, next)).toBe(0)
+    expect(getChatNotificationEvents(previous, next)).toEqual([{
+      chatId: "chat-2",
+      projectTitle: "Project title",
+      chatTitle: "Newly unread",
+      message: "Fresh update.",
+    }])
   })
 
   test("does not replay for an already-waiting chat", () => {

--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -9,9 +9,10 @@ import { Input } from "../components/ui/input"
 import { TooltipProvider } from "../components/ui/tooltip"
 import { APP_NAME, SDK_CLIENT_APP } from "../../shared/branding"
 import { useChatSoundPreferencesStore } from "../stores/chatSoundPreferencesStore"
-import type { ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import type { ChatBrowserNotificationPreference, ChatSoundPreference } from "../stores/chatSoundPreferencesStore"
+import { shouldShowChatBrowserNotification, showChatBrowserNotification } from "../lib/chatBrowserNotifications"
 import { playChatNotificationSound, shouldPlayChatSound } from "../lib/chatSounds"
-import { getBrowserWindowTitle, getChatSoundBurstCount } from "./chatNotifications"
+import { getBrowserWindowTitle, getChatNotificationEvents, getChatSoundBurstCount } from "./chatNotifications"
 import { KannaSidebar } from "./KannaSidebar"
 import { BoardPage } from "./BoardPage"
 import { ChatPage } from "./ChatPage"
@@ -196,6 +197,14 @@ export function shouldPlayChatNotificationSound(
   return Boolean(appSettings) && shouldPlayChatSound(preference, doc)
 }
 
+export function shouldShowChatNotificationPopup(
+  appSettings: AppSettingsSnapshot | null,
+  preference: ChatBrowserNotificationPreference,
+  doc: Pick<Document, "visibilityState" | "hasFocus"> = document
+) {
+  return Boolean(appSettings) && shouldShowChatBrowserNotification(preference, doc)
+}
+
 function KannaLayout() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -203,6 +212,7 @@ function KannaLayout() {
   const state = useKannaState(params.chatId ?? null)
   const chatSoundPreference = useChatSoundPreferencesStore((store) => store.chatSoundPreference)
   const chatSoundId = useChatSoundPreferencesStore((store) => store.chatSoundId)
+  const chatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.chatBrowserNotificationPreference)
   const showMobileOpenButton = location.pathname === "/"
   const currentVersion = SDK_CLIENT_APP.split("/")[1] ?? "unknown"
   const previousSidebarDataRef = useRef<ReturnType<typeof useKannaState>["sidebarData"] | null>(null)
@@ -348,14 +358,27 @@ function KannaLayout() {
   }, [browserTitle])
 
   useEffect(() => {
+    const previousSidebarData = previousSidebarDataRef.current
     const burstCount = getChatSoundBurstCount(previousSidebarDataRef.current, state.sidebarData)
+    const browserNotificationEvents = getChatNotificationEvents(previousSidebarData, state.sidebarData)
     previousSidebarDataRef.current = state.sidebarData
 
-    if (burstCount <= 0) return
-    if (!shouldPlayChatNotificationSound(state.appSettings, chatSoundPreference)) return
+    if (burstCount > 0 && shouldPlayChatNotificationSound(state.appSettings, chatSoundPreference)) {
+      void playChatNotificationSound(chatSoundId, burstCount).catch(() => undefined)
+    }
 
-    void playChatNotificationSound(chatSoundId, burstCount).catch(() => undefined)
-  }, [chatSoundId, chatSoundPreference, state.appSettings, state.sidebarData])
+    if (browserNotificationEvents.length <= 0) return
+    if (!shouldShowChatNotificationPopup(state.appSettings, chatBrowserNotificationPreference)) return
+    for (const event of browserNotificationEvents) {
+      showChatBrowserNotification({
+        ...event,
+        onClick: () => {
+          window.focus()
+          navigate(`/chat/${event.chatId}`)
+        },
+      })
+    }
+  }, [chatBrowserNotificationPreference, chatSoundId, chatSoundPreference, navigate, state.appSettings, state.sidebarData])
 
   return (
     <div className="flex h-[100dvh] min-h-[100dvh] overflow-hidden">

--- a/src/client/app/SettingsPage.test.tsx
+++ b/src/client/app/SettingsPage.test.tsx
@@ -9,6 +9,7 @@ import {
   getKeybindingsSubtitle,
   loadChangelog,
   resetSettingsPageChangelogCache,
+  resolveChatBrowserNotificationPreferenceAfterPermission,
   resolveSettingsSectionId,
   setCachedChangelog,
   shouldPreviewChatSoundChange,
@@ -180,6 +181,23 @@ describe("shouldPreviewChatSoundChange", () => {
     expect(shouldPreviewChatSoundChange("always", "never")).toBe(true)
     expect(shouldPreviewChatSoundChange("never", "unfocused")).toBe(true)
     expect(shouldPreviewChatSoundChange("funk", "glass")).toBe(true)
+  })
+})
+
+describe("resolveChatBrowserNotificationPreferenceAfterPermission", () => {
+  test("keeps enabled browser notification preferences only after permission is granted", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "granted")).toBe("always")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("unfocused", "granted")).toBe("unfocused")
+  })
+
+  test("falls back to never when browser notifications cannot be used", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "denied")).toBe("never")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("unfocused", "unsupported")).toBe("never")
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("always", "default")).toBe("never")
+  })
+
+  test("keeps never without requiring browser permission", () => {
+    expect(resolveChatBrowserNotificationPreferenceAfterPermission("never", "denied")).toBe("never")
   })
 })
 

--- a/src/client/app/SettingsPage.tsx
+++ b/src/client/app/SettingsPage.tsx
@@ -35,7 +35,11 @@ export {
   setCachedChangelog,
 } from "./settings/ChangelogSection"
 export { SkillsSection } from "./settings/SkillsSection"
-export { getKeybindingsSubtitle, shouldPreviewChatSoundChange } from "./settings/shared"
+export {
+  getKeybindingsSubtitle,
+  resolveChatBrowserNotificationPreferenceAfterPermission,
+  shouldPreviewChatSoundChange,
+} from "./settings/shared"
 
 const sidebarItems = [
   {

--- a/src/client/app/chatNotifications.ts
+++ b/src/client/app/chatNotifications.ts
@@ -50,6 +50,13 @@ interface ChatNotificationSnapshot {
   waitingChatIds: Set<string>
 }
 
+interface ChatNotificationEvent {
+  chatId: string
+  projectTitle: string
+  chatTitle: string
+  message: string
+}
+
 export function getChatNotificationSnapshot(sidebarData: SidebarData): ChatNotificationSnapshot {
   let unreadCount = 0
   const waitingChatIds = new Set<string>()
@@ -81,4 +88,41 @@ export function getChatSoundBurstCount(previous: SidebarData | null, next: Sideb
   }
 
   return unreadIncrease + newWaitingChats
+}
+
+export function getChatNotificationEvents(previous: SidebarData | null, next: SidebarData): ChatNotificationEvent[] {
+  if (!previous) return []
+
+  const previousChats = new Map<string, { unread: boolean; waiting: boolean }>()
+  for (const group of previous.projectGroups) {
+    for (const chat of group.chats) {
+      previousChats.set(chat.chatId, {
+        unread: chat.unread,
+        waiting: chat.status === "waiting_for_user",
+      })
+    }
+  }
+
+  const events: ChatNotificationEvent[] = []
+  for (const group of next.projectGroups) {
+    for (const chat of group.chats) {
+      const previousChat = previousChats.get(chat.chatId) ?? { unread: false, waiting: false }
+
+      const becameUnread = chat.unread && !previousChat.unread
+      const becameWaiting = chat.status === "waiting_for_user" && !previousChat.waiting
+      if (!becameUnread && !becameWaiting) continue
+
+      // The read model keeps this preview synced to the latest assistant text for the chat.
+      events.push({
+        chatId: chat.chatId,
+        projectTitle: group.title?.trim() || group.localPath,
+        chatTitle: chat.title.trim() || "Untitled chat",
+        message: becameWaiting
+          ? chat.pendingUserInputPreview ?? chat.lastAgentMessagePreview ?? ""
+          : chat.lastAgentMessagePreview ?? "",
+      })
+    }
+  }
+
+  return events
 }

--- a/src/client/app/settings/GeneralSection.tsx
+++ b/src/client/app/settings/GeneralSection.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "../../components/ui/select"
 import { useTheme, type ThemePreference } from "../../hooks/useTheme"
+import { requestChatBrowserNotificationPermission } from "../../lib/chatBrowserNotifications"
 import { playChatNotificationSound } from "../../lib/chatSounds"
 import {
   DEFAULT_TERMINAL_MIN_COLUMN_WIDTH,
@@ -27,11 +28,18 @@ import {
   getDefaultEditorCommandTemplate,
   useTerminalPreferencesStore,
 } from "../../stores/terminalPreferencesStore"
-import { CHAT_SOUND_OPTIONS, useChatSoundPreferencesStore, type ChatSoundId, type ChatSoundPreference } from "../../stores/chatSoundPreferencesStore"
+import {
+  CHAT_SOUND_OPTIONS,
+  useChatSoundPreferencesStore,
+  type ChatBrowserNotificationPreference,
+  type ChatSoundId,
+  type ChatSoundPreference,
+} from "../../stores/chatSoundPreferencesStore"
 import type { KannaState } from "../useKannaState"
 import {
   ENABLED_DISABLED_OPTIONS,
   handleSettingsInputKeyDown,
+  resolveChatBrowserNotificationPreferenceAfterPermission,
   SettingsErrorBanner,
   SettingsRow,
   shouldPreviewChatSoundChange,
@@ -44,6 +52,15 @@ const themeOptions = [
 ]
 
 const chatSoundPreferenceOptions: { value: ChatSoundPreference; label: string }[] = [
+  { value: "never", label: "Never" },
+  { value: "unfocused", label: "When Unfocused" },
+  { value: "always", label: "Always" },
+]
+
+const chatBrowserNotificationPreferenceOptions: Array<{
+  value: ChatBrowserNotificationPreference
+  label: string
+}> = [
   { value: "never", label: "Never" },
   { value: "unfocused", label: "When Unfocused" },
   { value: "always", label: "Always" },
@@ -71,8 +88,10 @@ export function GeneralSection({
   const setEditorCommandTemplate = useTerminalPreferencesStore((store) => store.setEditorCommandTemplate)
   const chatSoundPreference = useChatSoundPreferencesStore((store) => store.chatSoundPreference)
   const chatSoundId = useChatSoundPreferencesStore((store) => store.chatSoundId)
+  const chatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.chatBrowserNotificationPreference)
   const setChatSoundPreference = useChatSoundPreferencesStore((store) => store.setChatSoundPreference)
   const setChatSoundId = useChatSoundPreferencesStore((store) => store.setChatSoundId)
+  const setChatBrowserNotificationPreference = useChatSoundPreferencesStore((store) => store.setChatBrowserNotificationPreference)
 
   const [scrollbackDraft, setScrollbackDraft] = useState(String(scrollbackLines))
   const [minColumnWidthDraft, setMinColumnWidthDraft] = useState(String(minColumnWidth))
@@ -181,6 +200,33 @@ export function GeneralSection({
     void playChatNotificationSound(nextValue, 1).catch(() => undefined)
   }
 
+  function handleChatBrowserNotificationPreferenceChange(nextValue: ChatBrowserNotificationPreference) {
+    if (chatBrowserNotificationPreference === nextValue) {
+      return
+    }
+
+    async function savePreference(preference: ChatBrowserNotificationPreference) {
+      setChatBrowserNotificationPreference(preference)
+      await handleWriteAppSettings({ chatBrowserNotificationPreference: preference })
+    }
+
+    void (async () => {
+      try {
+        const permission = nextValue === "never"
+          ? "granted"
+          : await requestChatBrowserNotificationPermission()
+        const resolvedPreference = resolveChatBrowserNotificationPreferenceAfterPermission(nextValue, permission)
+
+        await savePreference(resolvedPreference)
+        if (nextValue !== "never" && resolvedPreference === "never") {
+          setAppSettingsError("Browser notifications are blocked or unsupported for this browser.")
+        }
+      } catch (error) {
+        setAppSettingsError(error instanceof Error ? error.message : "Unable to save chat notification settings.")
+      }
+    })()
+  }
+
   async function handleAnalyticsPreferenceChange(nextValue: "enabled" | "disabled") {
     try {
       setAppSettingsError(null)
@@ -287,6 +333,29 @@ export function GeneralSection({
             <SelectContent>
               <SelectGroup>
                 {CHAT_SOUND_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+
+        <SettingsRow
+          title="Chat Notifications"
+          description="Show browser system notifications for new chat activity"
+        >
+          <Select
+            value={chatBrowserNotificationPreference}
+            onValueChange={(value) => handleChatBrowserNotificationPreferenceChange(value as ChatBrowserNotificationPreference)}
+          >
+            <SelectTrigger className="min-w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {chatBrowserNotificationPreferenceOptions.map((option) => (
                   <SelectItem key={option.value} value={option.value}>
                     {option.label}
                   </SelectItem>

--- a/src/client/app/settings/shared.tsx
+++ b/src/client/app/settings/shared.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, ReactNode } from "react"
 import { cn } from "../../lib/utils"
+import type { ChatBrowserNotificationPreference } from "../../stores/chatSoundPreferencesStore"
 
 /** Shared row layout + tiny helpers for the settings sections. */
 
@@ -17,6 +18,14 @@ export function shouldPreviewChatSoundChange(
   nextValue: string
 ) {
   return previousValue !== nextValue
+}
+
+export function resolveChatBrowserNotificationPreferenceAfterPermission(
+  requestedPreference: ChatBrowserNotificationPreference,
+  permission: NotificationPermission | "unsupported"
+): ChatBrowserNotificationPreference {
+  if (requestedPreference === "never") return "never"
+  return permission === "granted" ? requestedPreference : "never"
 }
 
 export function handleSettingsInputKeyDown(event: KeyboardEvent<HTMLInputElement>, commit: () => void) {

--- a/src/client/app/useAppSettingsSync.ts
+++ b/src/client/app/useAppSettingsSync.ts
@@ -120,6 +120,7 @@ function syncRuntimeStoresFromAppSettings(snapshot: AppSettingsSnapshot) {
   const chatSoundPreferences = useChatSoundPreferencesStore.getState()
   chatSoundPreferences.setChatSoundPreference(snapshot.chatSoundPreference)
   chatSoundPreferences.setChatSoundId(snapshot.chatSoundId)
+  chatSoundPreferences.setChatBrowserNotificationPreference(snapshot.chatBrowserNotificationPreference)
 
   useChatPreferencesStore.getState().syncProviderDefaults(snapshot.defaultProvider, snapshot.providerDefaults)
 }

--- a/src/client/lib/chatBrowserNotifications.test.ts
+++ b/src/client/lib/chatBrowserNotifications.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  createChatBrowserNotificationPayload,
+  showChatBrowserNotification,
+  shouldShowChatBrowserNotification,
+  truncateChatBrowserNotificationMessage,
+} from "./chatBrowserNotifications"
+
+const originalNotification = globalThis.Notification
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "Notification", {
+    configurable: true,
+    writable: true,
+    value: originalNotification,
+  })
+})
+
+describe("chat browser notifications", () => {
+  test("applies browser notification preference gates", () => {
+    const focusedDoc = { visibilityState: "visible" as const, hasFocus: () => true }
+    const hiddenDoc = { visibilityState: "hidden" as const, hasFocus: () => false }
+
+    expect(shouldShowChatBrowserNotification("never", hiddenDoc)).toBe(false)
+    expect(shouldShowChatBrowserNotification("always", focusedDoc)).toBe(true)
+    expect(shouldShowChatBrowserNotification("unfocused", hiddenDoc)).toBe(true)
+    expect(shouldShowChatBrowserNotification("unfocused", focusedDoc)).toBe(false)
+  })
+
+  test("creates title from project and chat and truncates message text", () => {
+    const payload = createChatBrowserNotificationPayload({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: `First line\n\n${"A".repeat(220)}`,
+    })
+
+    expect(payload.title).toBe("Project - Chat")
+    expect(payload.body).toBe(`First line ${"A".repeat(166)}...`)
+  })
+
+  test("uses a fallback body when the response text is missing", () => {
+    expect(truncateChatBrowserNotificationMessage(" \n ")).toBe("New chat activity.")
+  })
+
+  test("constructs a browser notification when permission is granted", () => {
+    const created: Array<{ title: string; options?: NotificationOptions; onclick: ((event: Event) => void) | null; close: () => void }> = []
+    class FakeNotification {
+      static permission: NotificationPermission = "granted"
+      onclick: ((event: Event) => void) | null = null
+      close = () => {}
+
+      constructor(title: string, options?: NotificationOptions) {
+        created.push(this as never)
+        Object.assign(this, { title, options })
+      }
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+    })).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(created[0]).toMatchObject({
+      title: "Project - Chat",
+      options: { body: "Done." },
+    })
+  })
+
+  test("runs the click handler and closes the notification when clicked", () => {
+    let clicked = 0
+    let closed = 0
+    const created: Array<{ onclick: ((event: Event) => void) | null }> = []
+    class FakeNotification {
+      static permission: NotificationPermission = "granted"
+      onclick: ((event: Event) => void) | null = null
+      close = () => {
+        closed += 1
+      }
+
+      constructor() {
+        created.push(this)
+      }
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+      onClick: () => {
+        clicked += 1
+      },
+    })).toBe(true)
+
+    created[0]?.onclick?.(new Event("click"))
+
+    expect(clicked).toBe(1)
+    expect(closed).toBe(1)
+  })
+
+  test("does not construct a browser notification without permission", () => {
+    class FakeNotification {
+      static permission: NotificationPermission = "denied"
+    }
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: FakeNotification,
+    })
+
+    expect(showChatBrowserNotification({
+      projectTitle: "Project",
+      chatTitle: "Chat",
+      message: "Done.",
+    })).toBe(false)
+  })
+})

--- a/src/client/lib/chatBrowserNotifications.ts
+++ b/src/client/lib/chatBrowserNotifications.ts
@@ -1,0 +1,57 @@
+import type { ChatBrowserNotificationPreference } from "../stores/chatSoundPreferencesStore"
+import { isBrowserUnfocused } from "./chatSounds"
+
+const CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH = 180
+
+export function shouldShowChatBrowserNotification(
+  preference: ChatBrowserNotificationPreference,
+  doc: Pick<Document, "visibilityState" | "hasFocus"> = document
+) {
+  if (preference === "never") return false
+  if (preference === "always") return true
+  return isBrowserUnfocused(doc)
+}
+
+export function truncateChatBrowserNotificationMessage(message: string) {
+  const normalized = message.replace(/\s+/g, " ").trim()
+  if (!normalized) return "New chat activity."
+  if (normalized.length <= CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH) return normalized
+  return `${normalized.slice(0, CHAT_BROWSER_NOTIFICATION_MESSAGE_MAX_LENGTH - 3)}...`
+}
+
+export function createChatBrowserNotificationPayload(args: {
+  projectTitle: string
+  chatTitle: string
+  message: string
+}) {
+  return {
+    title: `${args.projectTitle} - ${args.chatTitle}`,
+    body: truncateChatBrowserNotificationMessage(args.message),
+  }
+}
+
+export async function requestChatBrowserNotificationPermission() {
+  if (typeof Notification === "undefined") return "unsupported" as const
+  if (Notification.permission === "granted") return "granted" as const
+  if (Notification.permission === "denied") return "denied" as const
+  return Notification.requestPermission()
+}
+
+export function showChatBrowserNotification(args: {
+  projectTitle: string
+  chatTitle: string
+  message: string
+  onClick?: () => void
+}) {
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") return false
+  const payload = createChatBrowserNotificationPayload(args)
+  const notification = new Notification(payload.title, { body: payload.body })
+  const onClick = args.onClick
+  if (onClick) {
+    notification.onclick = () => {
+      notification.close()
+      onClick()
+    }
+  }
+  return true
+}

--- a/src/client/stores/chatSoundPreferencesStore.test.ts
+++ b/src/client/stores/chatSoundPreferencesStore.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import {
+  DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE,
   DEFAULT_CHAT_SOUND_ID,
   DEFAULT_CHAT_SOUND_PREFERENCE,
+  normalizeChatBrowserNotificationPreference,
   normalizeChatSoundId,
   normalizeChatSoundPreference,
   useChatSoundPreferencesStore,
@@ -26,6 +28,19 @@ describe("normalizeChatSoundPreference", () => {
   })
 })
 
+describe("normalizeChatBrowserNotificationPreference", () => {
+  test("accepts supported values", () => {
+    expect(normalizeChatBrowserNotificationPreference("never")).toBe("never")
+    expect(normalizeChatBrowserNotificationPreference("unfocused")).toBe("unfocused")
+    expect(normalizeChatBrowserNotificationPreference("always")).toBe("always")
+  })
+
+  test("falls back to the default for unknown values", () => {
+    expect(normalizeChatBrowserNotificationPreference("loud")).toBe(DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE)
+    expect(normalizeChatBrowserNotificationPreference(undefined)).toBe(DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE)
+  })
+})
+
 describe("normalizeChatSoundId", () => {
   test("accepts supported values", () => {
     expect(normalizeChatSoundId("blow")).toBe("blow")
@@ -40,9 +55,10 @@ describe("normalizeChatSoundId", () => {
 })
 
 describe("chat sound preferences store", () => {
-  test("defaults to always and funk", () => {
+  test("defaults sounds to always and browser notifications to never", () => {
     expect(useChatSoundPreferencesStore.getState().chatSoundPreference).toBe("always")
     expect(useChatSoundPreferencesStore.getState().chatSoundId).toBe("funk")
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("never")
   })
 
   test("normalizes stored values through the setters", () => {
@@ -57,5 +73,11 @@ describe("chat sound preferences store", () => {
 
     useChatSoundPreferencesStore.getState().setChatSoundId("invalid" as never)
     expect(useChatSoundPreferencesStore.getState().chatSoundId).toBe("funk")
+
+    useChatSoundPreferencesStore.getState().setChatBrowserNotificationPreference("unfocused")
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("unfocused")
+
+    useChatSoundPreferencesStore.getState().setChatBrowserNotificationPreference("invalid" as never)
+    expect(useChatSoundPreferencesStore.getState().chatBrowserNotificationPreference).toBe("never")
   })
 })

--- a/src/client/stores/chatSoundPreferencesStore.ts
+++ b/src/client/stores/chatSoundPreferencesStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand"
-import type { ChatSoundId, ChatSoundPreference } from "../../shared/types"
+import type { ChatBrowserNotificationPreference, ChatSoundId, ChatSoundPreference } from "../../shared/types"
 
-export type { ChatSoundId, ChatSoundPreference }
+export type { ChatBrowserNotificationPreference, ChatSoundId, ChatSoundPreference }
 
 export const DEFAULT_CHAT_SOUND_PREFERENCE: ChatSoundPreference = "always"
 export const DEFAULT_CHAT_SOUND_ID: ChatSoundId = "funk"
+export const DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE: ChatBrowserNotificationPreference = "never"
 
 export const CHAT_SOUND_OPTIONS: Array<{ value: ChatSoundId; label: string }> = [
   { value: "blow", label: "Blow" },
@@ -29,6 +30,17 @@ export function normalizeChatSoundPreference(value?: string): ChatSoundPreferenc
   }
 }
 
+export function normalizeChatBrowserNotificationPreference(value?: string): ChatBrowserNotificationPreference {
+  switch (value) {
+    case "never":
+    case "unfocused":
+    case "always":
+      return value
+    default:
+      return DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE
+  }
+}
+
 export function normalizeChatSoundId(value?: string): ChatSoundId {
   switch (value) {
     case "blow":
@@ -49,15 +61,19 @@ export function normalizeChatSoundId(value?: string): ChatSoundId {
 export interface ChatSoundPreferencesState {
   chatSoundPreference: ChatSoundPreference
   chatSoundId: ChatSoundId
+  chatBrowserNotificationPreference: ChatBrowserNotificationPreference
   setChatSoundPreference: (value: ChatSoundPreference) => void
   setChatSoundId: (value: ChatSoundId) => void
+  setChatBrowserNotificationPreference: (value: ChatBrowserNotificationPreference) => void
 }
 
 export const useChatSoundPreferencesStore = create<ChatSoundPreferencesState>()(
   (set) => ({
     chatSoundPreference: DEFAULT_CHAT_SOUND_PREFERENCE,
     chatSoundId: DEFAULT_CHAT_SOUND_ID,
+    chatBrowserNotificationPreference: DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE,
     setChatSoundPreference: (value) => set({ chatSoundPreference: normalizeChatSoundPreference(value) }),
     setChatSoundId: (value) => set({ chatSoundId: normalizeChatSoundId(value) }),
+    setChatBrowserNotificationPreference: (value) => set({ chatBrowserNotificationPreference: normalizeChatBrowserNotificationPreference(value) }),
   })
 )

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -856,6 +856,7 @@ describe("AgentCoordinator codex integration", () => {
     })
 
     await waitFor(() => coordinator.getPendingTool("chat-1")?.toolKind === "ask_user_question")
+    expect(coordinator.getPendingToolPreviews().get("chat-1")).toBe("Provider?")
     await coordinator.cancel("chat-1")
 
     const discardedResult = store.messages.find((entry) => entry.kind === "tool_result" && entry.toolId === "question-1")

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -74,6 +74,28 @@ interface PendingToolRequest {
   resolve: (result: unknown) => void
 }
 
+function normalizePreviewText(text: string) {
+  return text.replace(/\s+/g, " ").trim()
+}
+
+function getToolRequestPreview(tool: PendingToolRequest["tool"]) {
+  if (tool.toolKind === "ask_user_question") {
+    const questions = tool.input.questions
+      .map((question) => normalizePreviewText(question.question))
+      .filter(Boolean)
+    if (questions.length > 0) return questions.join(" ")
+  }
+
+  if (tool.toolKind === "exit_plan_mode") {
+    const summary = normalizePreviewText(tool.input.summary ?? "")
+    if (summary) return summary
+    const plan = normalizePreviewText(tool.input.plan ?? "")
+    if (plan) return plan
+  }
+
+  return "Waiting for your response."
+}
+
 interface ActiveTurn {
   chatId: string
   provider: AgentProvider
@@ -730,6 +752,15 @@ export class AgentCoordinator {
     return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
   }
 
+  getPendingToolPreviews() {
+    const previews = new Map<string, string>()
+    for (const [chatId, turn] of this.activeTurns.entries()) {
+      if (!turn.pendingTool) continue
+      previews.set(chatId, getToolRequestPreview(turn.pendingTool.tool))
+    }
+    return previews
+  }
+
   getDrainingChatIds(): Set<string> {
     return new Set(this.drainingStreams.keys())
   }
@@ -945,15 +976,14 @@ export class AgentCoordinator {
         throw new Error("Chat turn ended unexpectedly")
       }
 
-      active.status = "waiting_for_user"
-      this.emitStateChange(args.chatId)
-
       return await new Promise<unknown>((resolve) => {
         active.pendingTool = {
           toolUseId: request.tool.toolId,
           tool: request.tool,
           resolve,
         }
+        active.status = "waiting_for_user"
+        this.emitStateChange(args.chatId)
       })
     }
 

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -25,6 +25,7 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
     theme: "system",
     chatSoundPreference: "always",
     chatSoundId: "funk",
+    chatBrowserNotificationPreference: "never",
     terminal: {
       scrollbackLines: 1_000,
       minColumnWidth: 450,
@@ -145,6 +146,7 @@ describe("AppSettingsManager", () => {
     const snapshot = await manager.writePatch({
       theme: "dark",
       chatSoundId: "glass",
+      chatBrowserNotificationPreference: "unfocused",
       terminal: { scrollbackLines: 2_500 },
       editor: { preset: "vscode" },
       providerDefaults: {
@@ -157,6 +159,7 @@ describe("AppSettingsManager", () => {
       analyticsUserId: string
       theme: string
       chatSoundId: string
+      chatBrowserNotificationPreference: string
       terminal: { scrollbackLines: number; minColumnWidth: number }
       editor: { preset: string; commandTemplate: string }
       providerDefaults: { codex: { modelOptions: { fastMode: boolean } } }
@@ -164,6 +167,7 @@ describe("AppSettingsManager", () => {
 
     expect(snapshot.theme).toBe("dark")
     expect(snapshot.chatSoundId).toBe("glass")
+    expect(snapshot.chatBrowserNotificationPreference).toBe("unfocused")
     expect(snapshot.terminal.scrollbackLines).toBe(2_500)
     expect(snapshot.terminal.minColumnWidth).toBe(450)
     expect(snapshot.editor.preset).toBe("vscode")
@@ -172,6 +176,7 @@ describe("AppSettingsManager", () => {
     expect(nextPayload.analyticsUserId).toBe(initialPayload.analyticsUserId)
     expect(nextPayload.theme).toBe("dark")
     expect(nextPayload.chatSoundId).toBe("glass")
+    expect(nextPayload.chatBrowserNotificationPreference).toBe("unfocused")
 
     manager.dispose()
   })

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -14,6 +14,7 @@ import {
   type AppSettingsPatch,
   type AppSettingsSnapshot,
   type AppThemePreference,
+  type ChatBrowserNotificationPreference,
   type ChatSoundId,
   type ChatSoundPreference,
   type DefaultProviderPreference,
@@ -27,6 +28,7 @@ interface AppSettingsFile {
   theme?: unknown
   chatSoundPreference?: unknown
   chatSoundId?: unknown
+  chatBrowserNotificationPreference?: unknown
   terminal?: {
     scrollbackLines?: unknown
     minColumnWidth?: unknown
@@ -64,6 +66,7 @@ const MAX_TERMINAL_MIN_COLUMN_WIDTH = 900
 const DEFAULT_EDITOR_PRESET: EditorPreset = "cursor"
 const DEFAULT_CHAT_SOUND_PREFERENCE: ChatSoundPreference = "always"
 const DEFAULT_CHAT_SOUND_ID: ChatSoundId = "funk"
+const DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE: ChatBrowserNotificationPreference = "never"
 
 function createAnalyticsUserId() {
   return `anon_${randomUUID()}`
@@ -96,6 +99,12 @@ function normalizeTheme(value: unknown): AppThemePreference {
 
 function normalizeChatSoundPreference(value: unknown): ChatSoundPreference {
   return value === "never" || value === "unfocused" || value === "always" ? value : DEFAULT_CHAT_SOUND_PREFERENCE
+}
+
+function normalizeChatBrowserNotificationPreference(value: unknown): ChatBrowserNotificationPreference {
+  return value === "never" || value === "unfocused" || value === "always"
+    ? value
+    : DEFAULT_CHAT_BROWSER_NOTIFICATION_PREFERENCE
 }
 
 function normalizeChatSoundId(value: unknown): ChatSoundId {
@@ -140,6 +149,7 @@ function toFilePayload(state: AppSettingsState) {
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    chatBrowserNotificationPreference: state.chatBrowserNotificationPreference,
     terminal: state.terminal,
     editor: state.editor,
     defaultProvider: state.defaultProvider,
@@ -155,6 +165,7 @@ function toSnapshot(state: AppSettingsState): AppSettingsSnapshot {
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    chatBrowserNotificationPreference: state.chatBrowserNotificationPreference,
     terminal: state.terminal,
     editor: state.editor,
     defaultProvider: state.defaultProvider,
@@ -205,6 +216,7 @@ function normalizeAppSettings(
     theme: normalizeTheme(source?.theme),
     chatSoundPreference: normalizeChatSoundPreference(source?.chatSoundPreference),
     chatSoundId: normalizeChatSoundId(source?.chatSoundId),
+    chatBrowserNotificationPreference: normalizeChatBrowserNotificationPreference(source?.chatBrowserNotificationPreference),
     terminal: {
       scrollbackLines: clampNumber(source?.terminal?.scrollbackLines, DEFAULT_TERMINAL_SCROLLBACK, MIN_TERMINAL_SCROLLBACK, MAX_TERMINAL_SCROLLBACK),
       minColumnWidth: clampNumber(source?.terminal?.minColumnWidth, DEFAULT_TERMINAL_MIN_COLUMN_WIDTH, MIN_TERMINAL_MIN_COLUMN_WIDTH, MAX_TERMINAL_MIN_COLUMN_WIDTH),
@@ -240,6 +252,7 @@ function toComparablePayload(source: AppSettingsFile) {
     theme: source.theme,
     chatSoundPreference: source.chatSoundPreference,
     chatSoundId: source.chatSoundId,
+    chatBrowserNotificationPreference: source.chatBrowserNotificationPreference,
     terminal: source.terminal,
     editor: source.editor,
     defaultProvider: source.defaultProvider,

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -47,6 +47,7 @@ describe("read models", () => {
       provider: "codex",
       planMode: false,
       sessionToken: "thread-1",
+      lastAgentMessagePreview: "Done with the change.",
       lastTurnOutcome: null,
     })
 
@@ -55,10 +56,55 @@ describe("read models", () => {
     expect(sidebar.projectGroups[0]?.localPath).toBe("/tmp/project")
     expect(sidebar.projectGroups[0]?.chats[0]?.provider).toBe("codex")
     expect(sidebar.projectGroups[0]?.chats[0]?.unread).toBe(true)
+    expect(sidebar.projectGroups[0]?.chats[0]?.lastAgentMessagePreview).toBe("Done with the change.")
     expect(sidebar.projectGroups[0]?.chats[0]?.canFork).toBe(true)
     expect(sidebar.projectGroups[0]?.previewChats.map((chat) => chat.chatId)).toEqual(["chat-1"])
     expect(sidebar.projectGroups[0]?.olderChats).toEqual([])
     expect(sidebar.projectGroups[0]?.defaultCollapsed).toBe(false)
+  })
+
+  test("includes pending user input previews only while chats are waiting", () => {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      unread: false,
+      provider: "codex",
+      planMode: false,
+      sessionToken: "thread-1",
+      lastTurnOutcome: null,
+    })
+
+    const sidebar = deriveSidebarData(
+      state,
+      new Map([["chat-1", "waiting_for_user"]]),
+      {
+        nowMs: 1_000_000,
+        pendingUserInputPreviews: new Map([["chat-1", "Which runtime should I use?"]]),
+      },
+    )
+    expect(sidebar.projectGroups[0]?.chats[0]?.pendingUserInputPreview).toBe("Which runtime should I use?")
+
+    const idleSidebar = deriveSidebarData(
+      state,
+      new Map([["chat-1", "idle"]]),
+      {
+        nowMs: 1_000_000,
+        pendingUserInputPreviews: new Map([["chat-1", "Which runtime should I use?"]]),
+      },
+    )
+    expect(idleSidebar.projectGroups[0]?.chats[0]?.pendingUserInputPreview).toBeUndefined()
   })
 
   test("uses sidebar-only project titles without changing local project metadata", () => {

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -82,6 +82,7 @@ export function deriveSidebarData(
     sidebarProjectOrder?: string[]
     drainingChatIds?: Set<string>
     pendingToolKinds?: Map<string, string>
+    pendingUserInputPreviews?: Map<string, string>
   }
 ): SidebarData {
   const nowMs = options?.nowMs ?? Date.now()
@@ -117,13 +118,14 @@ export function deriveSidebarData(
     return projectChats
       .sort((a, b) => getSidebarChatSortTimestamp(b) - getSidebarChatSortTimestamp(a))
       .map((chat) => {
+        const status = deriveStatus(chat, activeStatuses.get(chat.id))
         const pendingToolKind = options?.pendingToolKinds?.get(chat.id)
         return {
           _id: chat.id,
           _creationTime: chat.createdAt,
           chatId: chat.id,
           title: chat.title,
-          status: deriveStatus(chat, activeStatuses.get(chat.id)),
+          status,
           unread: chat.unread,
           ...(chat.doneAt ? { done: true } : {}),
           localPath: project.localPath,
@@ -132,6 +134,9 @@ export function deriveSidebarData(
           ...(chat.lastUserMessagePreview ? { lastUserMessagePreview: chat.lastUserMessagePreview } : {}),
           ...(chat.lastAgentMessagePreview ? { lastAgentMessagePreview: chat.lastAgentMessagePreview } : {}),
           ...(pendingToolKind ? { pendingToolKind } : {}),
+          ...(status === "waiting_for_user" && options?.pendingUserInputPreviews?.get(chat.id)
+            ? { pendingUserInputPreview: options.pendingUserInputPreviews.get(chat.id) }
+            : {}),
           hasAutomation: false,
           canFork: canForkChat(chat, activeStatuses, drainingChatIds) || undefined,
         }

--- a/src/server/ws-router.staleness.test.ts
+++ b/src/server/ws-router.staleness.test.ts
@@ -249,6 +249,7 @@ function createWorld(options?: { projectPath?: string }) {
   const agent = {
     getActiveStatuses: () => new Map(),
     getDrainingChatIds: () => new Set(),
+    getPendingToolPreviews: () => new Map(),
     getPendingTool: () => null,
     cancel: async () => {},
     closeChat: async () => {},

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -76,6 +76,7 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
   theme: "system",
   chatSoundPreference: "always",
   chatSoundId: "funk",
+  chatBrowserNotificationPreference: "never",
   terminal: {
     scrollbackLines: 1_000,
     minColumnWidth: 450,
@@ -318,7 +319,11 @@ function createTestRouter(overrides: Partial<CreateWsRouterArgs> = {}) {
   return createWsRouter({
     store: createFakeStore(),
     diffStore: createFakeDiffStore(),
-    agent: { getActiveStatuses: () => new Map(), getDrainingChatIds: () => new Set() } as never,
+    agent: {
+      getActiveStatuses: () => new Map(),
+      getDrainingChatIds: () => new Set(),
+      getPendingToolPreviews: () => new Map(),
+    } as never,
     terminals: {
       getSnapshot: () => null,
       onEvent: () => () => {},
@@ -530,6 +535,7 @@ describe("ws-router", () => {
             theme: patch.theme ?? snapshot.theme,
             chatSoundPreference: patch.chatSoundPreference ?? snapshot.chatSoundPreference,
             chatSoundId: patch.chatSoundId ?? snapshot.chatSoundId,
+            chatBrowserNotificationPreference: patch.chatBrowserNotificationPreference ?? snapshot.chatBrowserNotificationPreference,
             defaultProvider: patch.defaultProvider ?? snapshot.defaultProvider,
             terminal: { ...snapshot.terminal, ...patch.terminal },
             editor: { ...snapshot.editor, ...patch.editor },
@@ -721,6 +727,7 @@ describe("ws-router", () => {
           closeChat: async () => {},
           getActiveStatuses: () => new Map(),
           getDrainingChatIds: () => new Set(),
+          getPendingToolPreviews: () => new Map(),
         } as never,
         analytics: {
           track: (eventName: string) => {
@@ -854,6 +861,7 @@ describe("ws-router", () => {
           return new Map()
         },
         getDrainingChatIds: () => new Set(),
+        getPendingToolPreviews: () => new Map(),
       } as never,
     })
 
@@ -1376,7 +1384,8 @@ describe("ws-router", () => {
       agent: {
         getActiveStatuses: () => new Map(),
         getDrainingChatIds: () => new Set(),
-          forkChat: async (chatId: string) => {
+        getPendingToolPreviews: () => new Map(),
+        forkChat: async (chatId: string) => {
           forkChatCalls.push(chatId)
           state.chatsById.set("chat-fork-1", {
             id: "chat-fork-1",
@@ -1606,6 +1615,7 @@ describe("ws-router", () => {
     const router = createTestRouter({
       agent: {
         getActiveStatuses: () => new Map(),
+        getPendingToolPreviews: () => new Map(),
         setBackgroundErrorReporter: (reporter: ((message: string) => void) | null) => {
           reportBackgroundError = reporter
         },

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -202,6 +202,7 @@ export function createWsRouter({
       sidebarProjectOrder: store.getSidebarProjectOrder(),
       drainingChatIds: agent.getDrainingChatIds(),
       pendingToolKinds,
+      pendingUserInputPreviews: agent.getPendingToolPreviews(),
     })
 
     const sidebar = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ export type AgentProvider = "claude" | "codex" | "cursor" | "pi"
 export type LlmProviderKind = "openai" | "openrouter" | "custom"
 export type AppThemePreference = "light" | "dark" | "system"
 export type ChatSoundPreference = "never" | "unfocused" | "always"
+export type ChatBrowserNotificationPreference = ChatSoundPreference
 export type ChatSoundId = "blow" | "bottle" | "frog" | "funk" | "glass" | "ping" | "pop" | "purr" | "tink"
 export type DefaultProviderPreference = "last_used" | AgentProvider
 export type EditorPreset = "cursor" | "vscode" | "xcode" | "windsurf" | "custom"
@@ -713,6 +714,8 @@ export interface SidebarChatRow {
   lastAgentMessagePreview?: string
   /** Tool kind the chat is waiting on when status is waiting_for_user (e.g. "ask_user_question"). */
   pendingToolKind?: string
+  /** Preview of the tool request that currently needs user input. */
+  pendingUserInputPreview?: string
   hasAutomation: boolean
   canFork?: boolean
 }
@@ -783,6 +786,7 @@ export interface AppSettingsSnapshot {
   theme: AppThemePreference
   chatSoundPreference: ChatSoundPreference
   chatSoundId: ChatSoundId
+  chatBrowserNotificationPreference: ChatBrowserNotificationPreference
   terminal: {
     scrollbackLines: number
     minColumnWidth: number
@@ -805,6 +809,7 @@ export interface AppSettingsPatch {
   theme?: AppThemePreference
   chatSoundPreference?: ChatSoundPreference
   chatSoundId?: ChatSoundId
+  chatBrowserNotificationPreference?: ChatBrowserNotificationPreference
   boardAutoReturn?: boolean
   terminal?: Partial<AppSettingsSnapshot["terminal"]>
   editor?: Partial<AppSettingsSnapshot["editor"]>


### PR DESCRIPTION
Summary

Adds an opt-in browser notification setting for chat activity so users can receive system notifications alongside existing chat sound events.

What changed

- Adds a Browser Notifications setting next to Chat Sound with Never, Unfocused, and Always choices.
- Shows system notifications for newly unread chats and chats waiting for user input.
- Builds notification titles from the project and chat names, and uses a concise response or pending-question preview for the body.
- Opens the corresponding chat when the user clicks a notification.
- Persists and normalizes the new preference with the existing app settings and local preference stores.

Notes

The setting defaults to Never and only requests browser notification permission when the user enables notification delivery.