### PR TITLE
Fix Codex collaboration reasoning effort forwarding

### DIFF
--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -210,6 +210,58 @@ describe("CodexAppServerManager", () => {
     expect(threadStart?.params.serviceTier).toBe("fast")
     expect(turnStart?.params.effort).toBe("xhigh")
     expect(turnStart?.params.serviceTier).toBe("fast")
+    expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBe("xhigh")
+  })
+
+  test("keeps collaboration reasoning effort null when turn effort is omitted", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "completed", error: null } },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "Run pwd",
+      planMode: false,
+      onToolRequest: async () => ({}),
+    })
+
+    await collectStream(turn.stream)
+
+    const turnStart = process.messages.find((message: any) => message.method === "turn/start") as
+      | { method: "turn/start"; params: { collaborationMode?: { settings?: { reasoning_effort?: string | null } } } }
+      | undefined
+
     expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBeNull()
   })
 

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -880,7 +880,7 @@ export class CodexAppServerManager {
           mode: args.planMode ? "plan" : "default",
           settings: {
             model: args.model,
-            reasoning_effort: null,
+            reasoning_effort: args.effort ?? null,
             developer_instructions: null,
           },
         },


### PR DESCRIPTION
Summary

Bugfix: Codex collaboration-mode sessions were not receiving the reasoning effort selected for the active chat turn. Kanna forwarded the effort to the top-level turn, but the collaboration-mode payload always sent `reasoning_effort: null`, so collaborator or subagent work could run with Codex default effort instead of the selected effort.

What changed

- Pass `args.effort ?? null` into `collaborationMode.settings.reasoning_effort` when starting app-server turns.
- Keep the omitted-effort fallback explicit by sending `null`, not `undefined`.
- Cover both the explicit-effort and omitted-effort paths in `codex-app-server` tests.