### PR TITLE
Add Cursor CLI (Composer 2.5) provider support

### DIFF
--- a/src/client/app/ChatPage/ChatInputDock.tsx
+++ b/src/client/app/ChatPage/ChatInputDock.tsx
@@ -2,6 +2,7 @@ import { memo, type RefObject } from "react"
 import { ChatInput, type ChatInputHandle } from "../../components/chat-ui/ChatInput"
 import type { ContextWindowSnapshot } from "../../lib/contextWindow"
 import type { KannaState } from "../useKannaState"
+import type { AgentProvider } from "../../../shared/types"
 
 interface ChatInputDockProps {
   inputRef: RefObject<HTMLDivElement | null>
@@ -14,7 +15,7 @@ interface ChatInputDockProps {
   runtimeStatus: string | null
   canCancel: boolean
   projectId: string | null
-  activeProvider: "claude" | "codex" | null
+  activeProvider: AgentProvider | null
   availableProviders: KannaState["availableProviders"]
   contextWindowSnapshot: ContextWindowSnapshot | null
   onSubmit: KannaState["handleSend"]

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -155,19 +155,30 @@ function getEffectiveComposerState(
     return composerState
   }
 
-  return activeProvider === "claude"
-    ? {
+  if (activeProvider === "claude") {
+    return {
       provider: "claude",
       model: providerDefaults.claude.model,
       modelOptions: { ...providerDefaults.claude.modelOptions },
       planMode: composerState.planMode,
     }
-    : {
-      provider: "codex",
-      model: providerDefaults.codex.model,
-      modelOptions: { ...providerDefaults.codex.modelOptions },
+  }
+
+  if (activeProvider === "cursor") {
+    return {
+      provider: "cursor",
+      model: providerDefaults.cursor.model,
+      modelOptions: { ...providerDefaults.cursor.modelOptions },
       planMode: composerState.planMode,
     }
+  }
+
+  return {
+    provider: "codex",
+    model: providerDefaults.codex.model,
+    modelOptions: { ...providerDefaults.codex.modelOptions },
+    planMode: composerState.planMode,
+  }
 }
 
 const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
@@ -521,6 +532,8 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     let modelOptions: ModelOptions
     if (providerPrefs.provider === "claude") {
       modelOptions = { claude: { ...providerPrefs.modelOptions } }
+    } else if (providerPrefs.provider === "cursor") {
+      modelOptions = { cursor: { ...providerPrefs.modelOptions } }
     } else {
       modelOptions = { codex: { ...providerPrefs.modelOptions } }
     }
@@ -796,7 +809,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                   updateComposerState(
                     (state) => state.provider === "claude"
                       ? state
-                      : { ...state, modelOptions: { ...state.modelOptions, fastMode: change.fastMode } }
+                      : ({ ...state, modelOptions: { ...state.modelOptions, fastMode: change.fastMode } } as ComposerState)
                   )
                   break
               }

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -11,6 +11,7 @@ import {
   normalizeClaudeContextWindow,
   resolveClaudeContextWindowTokens,
 } from "../../../shared/types"
+import { assertNever } from "../../../shared/assert"
 import { Button, buttonVariants } from "../ui/button"
 import { Textarea } from "../ui/textarea"
 import { ScrollArea } from "../ui/scroll-area"
@@ -155,29 +156,30 @@ function getEffectiveComposerState(
     return composerState
   }
 
-  if (activeProvider === "claude") {
-    return {
-      provider: "claude",
-      model: providerDefaults.claude.model,
-      modelOptions: { ...providerDefaults.claude.modelOptions },
-      planMode: composerState.planMode,
-    }
-  }
-
-  if (activeProvider === "cursor") {
-    return {
-      provider: "cursor",
-      model: providerDefaults.cursor.model,
-      modelOptions: { ...providerDefaults.cursor.modelOptions },
-      planMode: composerState.planMode,
-    }
-  }
-
-  return {
-    provider: "codex",
-    model: providerDefaults.codex.model,
-    modelOptions: { ...providerDefaults.codex.modelOptions },
-    planMode: composerState.planMode,
+  switch (activeProvider) {
+    case "claude":
+      return {
+        provider: "claude",
+        model: providerDefaults.claude.model,
+        modelOptions: { ...providerDefaults.claude.modelOptions },
+        planMode: composerState.planMode,
+      }
+    case "codex":
+      return {
+        provider: "codex",
+        model: providerDefaults.codex.model,
+        modelOptions: { ...providerDefaults.codex.modelOptions },
+        planMode: composerState.planMode,
+      }
+    case "cursor":
+      return {
+        provider: "cursor",
+        model: providerDefaults.cursor.model,
+        modelOptions: { ...providerDefaults.cursor.modelOptions },
+        planMode: composerState.planMode,
+      }
+    default:
+      return assertNever(activeProvider)
   }
 }
 

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -10,6 +10,7 @@ import {
   type ClaudeReasoningEffort,
   type CodexModelOptions,
   type CodexReasoningEffort,
+  type CursorModelOptions,
   type ProviderCatalogEntry,
   supportsClaudeMaxReasoningEffort,
 } from "../../../shared/types"
@@ -46,9 +47,26 @@ function OpenAIIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   )
 }
 
+function CursorIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      <path d="M12 2 3 7v10l9 5 9-5V7l-9-5Z" opacity="0.35" />
+      <path d="m12 12 9-5v10l-9 5V12Z" opacity="0.7" />
+      <path d="M3 7l9 5v10l-9-5V7Z" />
+    </svg>
+  )
+}
+
 export const PROVIDER_ICONS: Record<AgentProvider, IconComponent> = {
   claude: AnthropicIcon,
   codex: OpenAIIcon,
+  cursor: CursorIcon,
 }
 
 export function PopoverMenuItem({
@@ -145,7 +163,7 @@ interface ChatPreferenceControlsProps {
   providerLocked?: boolean
   showCodexCliRequirementHints?: boolean
   model: string
-  modelOptions: ClaudeModelOptions | CodexModelOptions
+  modelOptions: ClaudeModelOptions | CodexModelOptions | CursorModelOptions
   onProviderChange?: (provider: AgentProvider) => void
   onModelChange: (provider: AgentProvider, model: string) => void
   onModelOptionChange: (change: ModelOptionChange) => void
@@ -177,6 +195,7 @@ export function ChatPreferenceControls({
   const showPlanMode = includePlanMode && providerConfig?.supportsPlanMode && onPlanModeChange
   const claudeModelOptions = selectedProvider === "claude" ? modelOptions as ClaudeModelOptions : null
   const codexModelOptions = selectedProvider === "codex" ? modelOptions as CodexModelOptions : null
+  const cursorModelOptions = selectedProvider === "cursor" ? modelOptions as CursorModelOptions : null
   const contextWindowOptions = providerConfig.models.find((candidate) => candidate.id === model)?.contextWindowOptions ?? []
   const selectedContextWindow = claudeModelOptions?.contextWindow ?? CLAUDE_CONTEXT_WINDOW_OPTIONS[0].id
   const ContextWindowIcon = selectedContextWindow === "1m" ? SquareMenu : SquareMinus
@@ -247,47 +266,49 @@ export function ChatPreferenceControls({
         })}
       </InputPopover>
 
-      <InputPopover
-        trigger={(
-          <>
-            <Brain className="h-3.5 w-3.5" />
-            <span>{
-              selectedProvider === "claude"
-                ? CLAUDE_REASONING_OPTIONS.find((effort) => effort.id === modelOptions.reasoningEffort)?.label ?? modelOptions.reasoningEffort
-                : CODEX_REASONING_OPTIONS.find((effort) => effort.id === modelOptions.reasoningEffort)?.label ?? modelOptions.reasoningEffort
-            }</span>
-          </>
-        )}
-      >
-        {(close) => (
-          selectedProvider === "claude"
-            ? CLAUDE_REASONING_OPTIONS.map((effort) => (
-              <PopoverMenuItem
-                key={effort.id}
-                onClick={() => {
-                  onModelOptionChange({ type: "claudeReasoningEffort", effort: effort.id })
-                  close()
-                }}
-                selected={modelOptions.reasoningEffort === effort.id}
-                icon={<Brain className="h-4 w-4 text-muted-foreground" />}
-                label={effort.label}
-                disabled={effort.id === "max" && !supportsClaudeMaxReasoningEffort(model)}
-              />
-            ))
-            : CODEX_REASONING_OPTIONS.map((effort) => (
-              <PopoverMenuItem
-                key={effort.id}
-                onClick={() => {
-                  onModelOptionChange({ type: "codexReasoningEffort", effort: effort.id })
-                  close()
-                }}
-                selected={modelOptions.reasoningEffort === effort.id}
-                icon={<Brain className="h-4 w-4 text-muted-foreground" />}
-                label={effort.label}
-              />
-            ))
-        )}
-      </InputPopover>
+      {selectedProvider !== "cursor" ? (
+        <InputPopover
+          trigger={(
+            <>
+              <Brain className="h-3.5 w-3.5" />
+              <span>{
+                selectedProvider === "claude"
+                  ? CLAUDE_REASONING_OPTIONS.find((effort) => effort.id === claudeModelOptions?.reasoningEffort)?.label ?? claudeModelOptions?.reasoningEffort
+                  : CODEX_REASONING_OPTIONS.find((effort) => effort.id === codexModelOptions?.reasoningEffort)?.label ?? codexModelOptions?.reasoningEffort
+              }</span>
+            </>
+          )}
+        >
+          {(close) => (
+            selectedProvider === "claude"
+              ? CLAUDE_REASONING_OPTIONS.map((effort) => (
+                <PopoverMenuItem
+                  key={effort.id}
+                  onClick={() => {
+                    onModelOptionChange({ type: "claudeReasoningEffort", effort: effort.id })
+                    close()
+                  }}
+                  selected={claudeModelOptions?.reasoningEffort === effort.id}
+                  icon={<Brain className="h-4 w-4 text-muted-foreground" />}
+                  label={effort.label}
+                  disabled={effort.id === "max" && !supportsClaudeMaxReasoningEffort(model)}
+                />
+              ))
+              : CODEX_REASONING_OPTIONS.map((effort) => (
+                <PopoverMenuItem
+                  key={effort.id}
+                  onClick={() => {
+                    onModelOptionChange({ type: "codexReasoningEffort", effort: effort.id })
+                    close()
+                  }}
+                  selected={codexModelOptions?.reasoningEffort === effort.id}
+                  icon={<Brain className="h-4 w-4 text-muted-foreground" />}
+                  label={effort.label}
+                />
+              ))
+          )}
+        </InputPopover>
+      ) : null}
 
       {selectedProvider === "claude" && contextWindowOptions.length > 1 ? (
         <InputPopover
@@ -347,6 +368,45 @@ export function ChatPreferenceControls({
                 selected={Boolean(codexModelOptions?.fastMode)}
                 icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
                 label="Fast Mode"
+              />
+            </>
+          )}
+        </InputPopover>
+      ) : null}
+
+      {selectedProvider === "cursor" ? (
+        <InputPopover
+          trigger={(
+            <>
+              {cursorModelOptions?.fastMode
+                ? <Gauge className="h-3.5 w-3.5" />
+                : <Gauge className="h-3.5 w-3.5 -scale-x-100" />}
+              <span>{cursorModelOptions?.fastMode ? "Fast" : "Standard"}</span>
+            </>
+          )}
+          triggerClassName={cursorModelOptions?.fastMode ? "text-emerald-500 dark:text-emerald-400" : undefined}
+        >
+          {(close) => (
+            <>
+              <PopoverMenuItem
+                onClick={() => {
+                  onModelOptionChange({ type: "fastMode", fastMode: false })
+                  close()
+                }}
+                selected={!cursorModelOptions?.fastMode}
+                icon={<Gauge className="h-4 w-4 text-muted-foreground -scale-x-100" />}
+                label="Standard"
+                description="Composer 2.5"
+              />
+              <PopoverMenuItem
+                onClick={() => {
+                  onModelOptionChange({ type: "fastMode", fastMode: true })
+                  close()
+                }}
+                selected={Boolean(cursorModelOptions?.fastMode)}
+                icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
+                label="Fast"
+                description="Composer 2.5 Fast"
               />
             </>
           )}

--- a/src/client/stores/appSettingsStore.ts
+++ b/src/client/stores/appSettingsStore.ts
@@ -43,6 +43,14 @@ export function mergeAppSettingsPatch(
           ...patch.providerDefaults?.codex?.modelOptions,
         },
       },
+      cursor: {
+        ...settings.providerDefaults.cursor,
+        ...patch.providerDefaults?.cursor,
+        modelOptions: {
+          ...settings.providerDefaults.cursor.modelOptions,
+          ...patch.providerDefaults?.cursor?.modelOptions,
+        },
+      },
     },
   }
 }

--- a/src/client/stores/chatPreferencesStore.test.ts
+++ b/src/client/stores/chatPreferencesStore.test.ts
@@ -259,6 +259,34 @@ describe("chat preference store", () => {
     })
   })
 
+  test("changing the model or options of a Cursor chat keeps it on Cursor", () => {
+    const store = useChatPreferencesStore.getState()
+
+    store.setComposerState("chat-a", {
+      provider: "cursor",
+      model: "composer-2.5",
+      modelOptions: { fastMode: true },
+      planMode: false,
+    })
+
+    // Selecting the model must not silently convert the composer to Codex.
+    store.setChatComposerModel("chat-a", "composer-2.5")
+    expect(store.getComposerState("chat-a")).toEqual({
+      provider: "cursor",
+      model: "composer-2.5",
+      modelOptions: { fastMode: true },
+      planMode: false,
+    })
+
+    store.setChatComposerModelOptions("chat-a", { fastMode: false })
+    expect(store.getComposerState("chat-a")).toEqual({
+      provider: "cursor",
+      model: "composer-2.5",
+      modelOptions: { fastMode: false },
+      planMode: false,
+    })
+  })
+
   test("resetChatComposerFromProvider copies provider defaults into the target chat", () => {
     useChatPreferencesStore.setState({
       ...INITIAL_STATE,

--- a/src/client/stores/chatPreferencesStore.test.ts
+++ b/src/client/stores/chatPreferencesStore.test.ts
@@ -67,6 +67,11 @@ describe("migrateChatPreferencesState", () => {
           modelOptions: { reasoningEffort: "minimal", fastMode: true },
           planMode: false,
         },
+        cursor: {
+          model: "composer-2.5",
+          modelOptions: { fastMode: false },
+          planMode: false,
+        },
       },
       chatStates: {},
       legacyComposerState: {

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -19,6 +19,7 @@ import {
   type ProviderPreference,
   type ProviderModelOptionsByProvider,
 } from "../../shared/types"
+import { assertNever } from "../../shared/assert"
 
 export type { ChatProviderPreferences, DefaultProviderPreference, ProviderPreference }
 
@@ -110,10 +111,19 @@ export function normalizeDefaultProvider(value?: string): DefaultProviderPrefere
   return "last_used"
 }
 
+// Loose model-options shape accepted by the provider preference normalizers. Each
+// normalizer validates the fields it cares about, so options from any provider (or
+// raw persisted data) are accepted and coerced.
+type ProviderModelOptionsInput = {
+  reasoningEffort?: ClaudeModelOptions["reasoningEffort"] | CodexModelOptions["reasoningEffort"]
+  contextWindow?: ClaudeModelOptions["contextWindow"]
+  fastMode?: boolean
+}
+
 export function normalizeClaudePreference(value?: {
   model?: string
   effort?: string
-  modelOptions?: Partial<ClaudeModelOptions>
+  modelOptions?: ProviderModelOptionsInput
   planMode?: boolean
 }): ProviderPreference<ClaudeModelOptions> {
   const reasoningEffort = value?.modelOptions?.reasoningEffort
@@ -138,7 +148,7 @@ export function normalizeClaudePreference(value?: {
 export function normalizeCodexPreference(value?: {
   model?: string
   effort?: string
-  modelOptions?: Partial<CodexModelOptions>
+  modelOptions?: ProviderModelOptionsInput
   planMode?: boolean
 }): ProviderPreference<CodexModelOptions> {
   const reasoningEffort = value?.modelOptions?.reasoningEffort
@@ -160,7 +170,7 @@ export function normalizeCodexPreference(value?: {
 
 export function normalizeCursorPreference(value?: {
   model?: string
-  modelOptions?: Partial<CursorModelOptions>
+  modelOptions?: ProviderModelOptionsInput
   planMode?: boolean
 }): ProviderPreference<CursorModelOptions> {
   return {
@@ -171,6 +181,44 @@ export function normalizeCursorPreference(value?: {
         : DEFAULT_CURSOR_MODEL_OPTIONS.fastMode,
     },
     planMode: false,
+  }
+}
+
+type ProviderPreferenceInput = {
+  model?: string
+  effort?: string
+  modelOptions?: ProviderModelOptionsInput
+  planMode?: boolean
+}
+
+// Exhaustive provider dispatch: adding a provider to AgentProvider forces a new case
+// here (via assertNever) instead of silently falling through to one provider's branch.
+export function normalizeProviderPreference(
+  provider: AgentProvider,
+  value?: ProviderPreferenceInput
+): ChatProviderPreferences[AgentProvider] {
+  switch (provider) {
+    case "claude":
+      return normalizeClaudePreference(value)
+    case "codex":
+      return normalizeCodexPreference(value)
+    case "cursor":
+      return normalizeCursorPreference(value)
+    default:
+      return assertNever(provider)
+  }
+}
+
+function composerStateForProvider(provider: AgentProvider, value?: ProviderPreferenceInput): ComposerState {
+  switch (provider) {
+    case "claude":
+      return { provider, ...normalizeClaudePreference(value) }
+    case "codex":
+      return { provider, ...normalizeCodexPreference(value) }
+    case "cursor":
+      return { provider, ...normalizeCursorPreference(value) }
+    default:
+      return assertNever(provider)
   }
 }
 
@@ -267,33 +315,7 @@ function composerFromProviderDefaults(
   provider: AgentProvider,
   providerDefaults: ChatProviderPreferences
 ): ComposerState {
-  if (provider === "claude") {
-    const preference = providerDefaults.claude
-    return {
-      provider: "claude",
-      model: preference.model,
-      modelOptions: { ...preference.modelOptions },
-      planMode: preference.planMode,
-    }
-  }
-
-  if (provider === "cursor") {
-    const preference = providerDefaults.cursor
-    return {
-      provider: "cursor",
-      model: preference.model,
-      modelOptions: { ...preference.modelOptions },
-      planMode: preference.planMode,
-    }
-  }
-
-  const preference = providerDefaults.codex
-  return {
-    provider: "codex",
-    model: preference.model,
-    modelOptions: { ...preference.modelOptions },
-    planMode: preference.planMode,
-  }
+  return composerStateForProvider(provider, providerDefaults[provider])
 }
 
 function cloneComposerState(state: ComposerState): ComposerState {
@@ -494,7 +516,7 @@ interface ChatPreferencesState {
   setChatComposerModel: (chatId: string, model: string) => void
   setChatComposerModelOptions: (
     chatId: string,
-    modelOptions: Partial<ClaudeModelOptions> | Partial<CodexModelOptions>
+    modelOptions: Partial<ClaudeModelOptions> | Partial<CodexModelOptions> | Partial<CursorModelOptions>
   ) => void
   setChatComposerPlanMode: (chatId: string, planMode: boolean) => void
   resetChatComposerFromProvider: (chatId: string, provider: AgentProvider) => void
@@ -567,36 +589,20 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
         set((state) => ({
           providerDefaults: {
             ...state.providerDefaults,
-            [provider]: provider === "claude"
-              ? normalizeClaudePreference({
-                ...state.providerDefaults.claude,
-                model,
-              })
-              : normalizeCodexPreference({
-                ...state.providerDefaults.codex,
-                model,
-              }),
+            [provider]: normalizeProviderPreference(provider, { ...state.providerDefaults[provider], model }),
           },
         })),
       setProviderDefaultModelOptions: (provider, modelOptions) =>
         set((state) => ({
           providerDefaults: {
             ...state.providerDefaults,
-            [provider]: provider === "claude"
-              ? normalizeClaudePreference({
-                ...state.providerDefaults.claude,
-                modelOptions: {
-                  ...state.providerDefaults.claude.modelOptions,
-                  ...modelOptions as Partial<ClaudeModelOptions>,
-                },
-              })
-              : normalizeCodexPreference({
-                ...state.providerDefaults.codex,
-                modelOptions: {
-                  ...state.providerDefaults.codex.modelOptions,
-                  ...modelOptions as Partial<CodexModelOptions>,
-                },
-              }),
+            [provider]: normalizeProviderPreference(provider, {
+              ...state.providerDefaults[provider],
+              modelOptions: {
+                ...state.providerDefaults[provider].modelOptions,
+                ...modelOptions,
+              } as ProviderModelOptionsInput,
+            }),
           },
         })),
       setProviderDefaultPlanMode: (provider, planMode) =>
@@ -649,58 +655,16 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
       setChatComposerProvider: (chatId, provider) =>
         set((state) => withChatComposerState(state, chatId, () => composerFromProviderDefaults(provider, state.providerDefaults))),
       setChatComposerModel: (chatId, model) =>
-        set((state) => withChatComposerState(state, chatId, (composerState) => (
-          composerState.provider === "claude"
-            ? {
-              provider: "claude",
-              model: normalizeClaudePreference({
-                ...composerState,
-                model,
-              }).model,
-              modelOptions: normalizeClaudePreference({
-                ...composerState,
-                model,
-              }).modelOptions,
-              planMode: composerState.planMode,
-            }
-            : {
-              provider: "codex",
-              model,
-              modelOptions: normalizeCodexPreference({
-                ...composerState,
-                model,
-              }).modelOptions,
-              planMode: composerState.planMode,
-            }
-        ))),
+        set((state) => withChatComposerState(state, chatId, (composerState) =>
+          composerStateForProvider(composerState.provider, { ...composerState, model })
+        )),
       setChatComposerModelOptions: (chatId, modelOptions) =>
-        set((state) => withChatComposerState(state, chatId, (composerState) => (
-          composerState.provider === "claude"
-            ? {
-              provider: "claude",
-              model: composerState.model,
-              modelOptions: normalizeClaudePreference({
-                ...composerState,
-                modelOptions: {
-                  ...composerState.modelOptions,
-                  ...modelOptions as Partial<ClaudeModelOptions>,
-                },
-              }).modelOptions,
-              planMode: composerState.planMode,
-            }
-            : {
-              provider: "codex",
-              model: composerState.model,
-              modelOptions: normalizeCodexPreference({
-                ...composerState,
-                modelOptions: {
-                  ...composerState.modelOptions,
-                  ...modelOptions as Partial<CodexModelOptions>,
-                },
-              }).modelOptions,
-              planMode: composerState.planMode,
-            }
-        ))),
+        set((state) => withChatComposerState(state, chatId, (composerState) =>
+          composerStateForProvider(composerState.provider, {
+            ...composerState,
+            modelOptions: { ...composerState.modelOptions, ...modelOptions } as ProviderModelOptionsInput,
+          })
+        )),
       setChatComposerPlanMode: (chatId, planMode) =>
         set((state) => withChatComposerState(state, chatId, (composerState) => ({
           ...composerState,

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -6,6 +6,7 @@ import {
   normalizeClaudeContextWindow,
   normalizeClaudeModelId,
   normalizeCodexModelId,
+  normalizeCursorModelId,
   isClaudeReasoningEffort,
   isCodexReasoningEffort,
   supportsClaudeMaxReasoningEffort,
@@ -163,7 +164,7 @@ export function normalizeCursorPreference(value?: {
   planMode?: boolean
 }): ProviderPreference<CursorModelOptions> {
   return {
-    model: "composer-2.5",
+    model: normalizeCursorModelId(value?.model),
     modelOptions: {
       fastMode: typeof value?.modelOptions?.fastMode === "boolean"
         ? value.modelOptions.fastMode

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand"
 import {
   DEFAULT_CLAUDE_MODEL_OPTIONS,
   DEFAULT_CODEX_MODEL_OPTIONS,
+  DEFAULT_CURSOR_MODEL_OPTIONS,
   normalizeClaudeContextWindow,
   normalizeClaudeModelId,
   normalizeCodexModelId,
@@ -12,6 +13,7 @@ import {
   type ChatProviderPreferences,
   type ClaudeModelOptions,
   type CodexModelOptions,
+  type CursorModelOptions,
   type DefaultProviderPreference,
   type ProviderPreference,
   type ProviderModelOptionsByProvider,
@@ -30,6 +32,12 @@ export type ComposerState =
     provider: "codex"
     model: string
     modelOptions: CodexModelOptions
+    planMode: boolean
+  }
+  | {
+    provider: "cursor"
+    model: string
+    modelOptions: CursorModelOptions
     planMode: boolean
   }
 
@@ -84,6 +92,12 @@ type PersistedComposerState =
     modelOptions?: Partial<CodexModelOptions>
     planMode?: boolean
   }
+  | {
+    provider: "cursor"
+    model?: string
+    modelOptions?: Partial<CursorModelOptions>
+    planMode?: boolean
+  }
 
 type PersistedChatPreferencesState = Pick<
   ChatPreferencesState,
@@ -91,7 +105,7 @@ type PersistedChatPreferencesState = Pick<
 > & LegacyPersistedChatPreferencesState
 
 export function normalizeDefaultProvider(value?: string): DefaultProviderPreference {
-  if (value === "claude" || value === "codex") return value
+  if (value === "claude" || value === "codex" || value === "cursor") return value
   return "last_used"
 }
 
@@ -143,6 +157,22 @@ export function normalizeCodexPreference(value?: {
   }
 }
 
+export function normalizeCursorPreference(value?: {
+  model?: string
+  modelOptions?: Partial<CursorModelOptions>
+  planMode?: boolean
+}): ProviderPreference<CursorModelOptions> {
+  return {
+    model: "composer-2.5",
+    modelOptions: {
+      fastMode: typeof value?.modelOptions?.fastMode === "boolean"
+        ? value.modelOptions.fastMode
+        : DEFAULT_CURSOR_MODEL_OPTIONS.fastMode,
+    },
+    planMode: false,
+  }
+}
+
 function forcePersistedCodexPreference<T extends {
   model?: string
   effort?: string
@@ -189,6 +219,11 @@ export function createDefaultProviderDefaults(): ChatProviderPreferences {
       modelOptions: { ...DEFAULT_CODEX_MODEL_OPTIONS },
       planMode: false,
     },
+    cursor: {
+      model: "composer-2.5",
+      modelOptions: { ...DEFAULT_CURSOR_MODEL_OPTIONS },
+      planMode: false,
+    },
   }
 }
 
@@ -205,10 +240,16 @@ export function normalizeProviderDefaults(value?: {
     modelOptions?: Partial<CodexModelOptions>
     planMode?: boolean
   }
+  cursor?: {
+    model?: string
+    modelOptions?: Partial<CursorModelOptions>
+    planMode?: boolean
+  }
 }): ChatProviderPreferences {
   return {
     claude: normalizeClaudePreference(value?.claude),
     codex: normalizeCodexPreference(value?.codex),
+    cursor: normalizeCursorPreference(value?.cursor),
   }
 }
 
@@ -235,6 +276,16 @@ function composerFromProviderDefaults(
     }
   }
 
+  if (provider === "cursor") {
+    const preference = providerDefaults.cursor
+    return {
+      provider: "cursor",
+      model: preference.model,
+      modelOptions: { ...preference.modelOptions },
+      planMode: preference.planMode,
+    }
+  }
+
   const preference = providerDefaults.codex
   return {
     provider: "codex",
@@ -245,19 +296,28 @@ function composerFromProviderDefaults(
 }
 
 function cloneComposerState(state: ComposerState): ComposerState {
-  return state.provider === "claude"
-    ? {
+  if (state.provider === "claude") {
+    return {
       provider: "claude",
       model: state.model,
       modelOptions: { ...state.modelOptions },
       planMode: state.planMode,
     }
-    : {
-      provider: "codex",
+  }
+  if (state.provider === "cursor") {
+    return {
+      provider: "cursor",
       model: state.model,
       modelOptions: { ...state.modelOptions },
       planMode: state.planMode,
     }
+  }
+  return {
+    provider: "codex",
+    model: state.model,
+    modelOptions: { ...state.modelOptions },
+    planMode: state.planMode,
+  }
 }
 
 function sameComposerState(left: ComposerState | undefined, right: ComposerState): boolean {
@@ -272,6 +332,10 @@ function sameComposerState(left: ComposerState | undefined, right: ComposerState
   if (left.provider === "codex" && right.provider === "codex") {
     return left.modelOptions.reasoningEffort === right.modelOptions.reasoningEffort
       && left.modelOptions.fastMode === right.modelOptions.fastMode
+  }
+
+  if (left.provider === "cursor" && right.provider === "cursor") {
+    return left.modelOptions.fastMode === right.modelOptions.fastMode
   }
 
   return false
@@ -297,6 +361,16 @@ function normalizeComposerState(
     const preference = normalizeCodexPreference(value)
     return {
       provider: "codex",
+      model: preference.model,
+      modelOptions: preference.modelOptions,
+      planMode: preference.planMode,
+    }
+  }
+
+  if (value?.provider === "cursor") {
+    const preference = normalizeCursorPreference(value)
+    return {
+      provider: "cursor",
       model: preference.model,
       modelOptions: preference.modelOptions,
       planMode: preference.planMode,

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -9,14 +9,7 @@ import {
 } from "./agent"
 import type { HarnessTurn } from "./harness-types"
 import type { ChatAttachment, TranscriptEntry } from "../shared/types"
-
-function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(entry: T): TranscriptEntry {
-  return {
-    _id: crypto.randomUUID(),
-    createdAt: Date.now(),
-    ...entry,
-  } as TranscriptEntry
-}
+import { timestamped } from "./transcript"
 
 async function waitFor(condition: () => boolean, timeoutMs = 2000) {
   const start = Date.now()

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -17,15 +17,18 @@ import { EventStore } from "./event-store"
 import type { AnalyticsReporter } from "./analytics"
 import { NoopAnalyticsReporter } from "./analytics"
 import { CodexAppServerManager } from "./codex-app-server"
+import { CursorCliManager } from "./cursor-cli"
 import { type GenerateChatTitleResult, generateTitleForChatDetailed } from "./generate-title"
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
 import {
   applyClaudeSdkModels,
   type ClaudeSdkModelInfo,
   codexServiceTierFromModelOptions,
+  cursorModelIdForOptions,
   getServerProviderCatalog,
   normalizeClaudeModelOptions,
   normalizeCodexModelOptions,
+  normalizeCursorModelOptions,
   normalizeServerModel,
 } from "./provider-catalog"
 import { resolveClaudeApiModelId } from "../shared/types"
@@ -106,6 +109,7 @@ interface AgentCoordinatorArgs {
   onStateChange: (chatId?: string, options?: { immediate?: boolean }) => void
   analytics?: AnalyticsReporter
   codexManager?: CodexAppServerManager
+  cursorManager?: CursorCliManager
   generateTitle?: (messageContent: string, cwd: string) => Promise<GenerateChatTitleResult>
   startClaudeSession?: (args: {
     localPath: string
@@ -680,6 +684,7 @@ export class AgentCoordinator {
   private readonly onStateChange: (chatId?: string, options?: { immediate?: boolean }) => void
   private readonly analytics: AnalyticsReporter
   private readonly codexManager: CodexAppServerManager
+  private readonly cursorManager: CursorCliManager
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<GenerateChatTitleResult>
   private readonly startClaudeSessionFn: NonNullable<AgentCoordinatorArgs["startClaudeSession"]>
   private reportBackgroundError: ((message: string) => void) | null = null
@@ -692,6 +697,7 @@ export class AgentCoordinator {
     this.onStateChange = args.onStateChange
     this.analytics = args.analytics ?? NoopAnalyticsReporter
     this.codexManager = args.codexManager ?? new CodexAppServerManager()
+    this.cursorManager = args.cursorManager ?? new CursorCliManager()
     this.generateTitle = args.generateTitle ?? generateTitleForChatDetailed
     this.startClaudeSessionFn = args.startClaudeSession ?? startClaudeSession
   }
@@ -781,6 +787,16 @@ export class AgentCoordinator {
         effort: modelOptions.reasoningEffort,
         serviceTier: undefined,
         planMode: catalog.supportsPlanMode ? Boolean(options.planMode) : false,
+      }
+    }
+
+    if (provider === "cursor") {
+      const modelOptions = normalizeCursorModelOptions(options.modelOptions)
+      return {
+        model: cursorModelIdForOptions(normalizeServerModel(provider, options.model), modelOptions),
+        effort: undefined,
+        serviceTier: undefined,
+        planMode: false,
       }
     }
 
@@ -952,6 +968,26 @@ export class AgentCoordinator {
         forkSession: Boolean(chat.pendingForkSessionToken),
         onToolRequest,
       })
+      logSendToStartingProfile(args.profile, "start_turn.provider_boot.ready", {
+        chatId: args.chatId,
+        provider: args.provider,
+        model: args.model,
+      })
+    } else if (args.provider === "cursor") {
+      logSendToStartingProfile(args.profile, "start_turn.provider_boot.begin", {
+        chatId: args.chatId,
+        provider: args.provider,
+        model: args.model,
+      })
+      turn = await this.cursorManager.startTurn({
+        cwd: project.localPath,
+        content: buildPromptText(args.content, args.attachments),
+        model: args.model,
+        sessionToken: chat.pendingForkSessionToken ? null : chat.sessionToken,
+      })
+      if (chat.pendingForkSessionToken) {
+        await this.store.setPendingForkSessionToken(args.chatId, null)
+      }
       logSendToStartingProfile(args.profile, "start_turn.provider_boot.ready", {
         chatId: args.chatId,
         provider: args.provider,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -962,15 +962,13 @@ export class AgentCoordinator {
         provider: args.provider,
         model: args.model,
       })
+      // Cursor cannot fork (see canForkChat), so a turn always resumes its own session.
       turn = await this.cursorManager.startTurn({
         cwd: project.localPath,
         content: buildPromptText(args.content, args.attachments),
         model: args.model,
-        sessionToken: chat.pendingForkSessionToken ? null : chat.sessionToken,
+        sessionToken: chat.sessionToken,
       })
-      if (chat.pendingForkSessionToken) {
-        await this.store.setPendingForkSessionToken(args.chatId, null)
-      }
       logSendToStartingProfile(args.profile, "start_turn.provider_boot.ready", {
         chatId: args.chatId,
         provider: args.provider,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -33,6 +33,8 @@ import {
 } from "./provider-catalog"
 import { resolveClaudeApiModelId } from "../shared/types"
 import { fallbackTitleFromMessage } from "./generate-title"
+import { asNumber, asRecord } from "../shared/json"
+import { timestamped } from "./transcript"
 
 const CLAUDE_TOOLSET = [
   "Skill",
@@ -151,17 +153,6 @@ interface SendMessageOptions {
   planMode?: boolean
 }
 
-function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
-  entry: T,
-  createdAt = Date.now()
-): TranscriptEntry {
-  return {
-    _id: crypto.randomUUID(),
-    createdAt,
-    ...entry,
-  } as TranscriptEntry
-}
-
 function stringFromUnknown(value: unknown) {
   if (typeof value === "string") return value
   try {
@@ -175,14 +166,6 @@ function buildSteeredMessageContent(content: string) {
   return content.trim().length > 0
     ? `${STEERED_MESSAGE_PREFIX}\n\n${content}`
     : STEERED_MESSAGE_PREFIX
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
 
 function escapeXmlAttribute(value: string) {

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -51,6 +51,13 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
         },
         planMode: false,
       },
+      cursor: {
+        model: "composer-2.5",
+        modelOptions: {
+          fastMode: false,
+        },
+        planMode: false,
+      },
     },
     warning: null,
     filePathDisplay: filePath,

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -13,6 +13,7 @@ import {
   normalizeClaudeContextWindow,
   normalizeClaudeModelId,
   normalizeCodexModelId,
+  normalizeCursorModelId,
   supportsClaudeMaxReasoningEffort,
   type AppSettingsPatch,
   type AppSettingsSnapshot,
@@ -218,7 +219,7 @@ function normalizeCursorPreference(value?: {
   planMode?: unknown
 }): ProviderPreference<CursorModelOptions> {
   return {
-    model: "composer-2.5",
+    model: normalizeCursorModelId(typeof value?.model === "string" ? value.model : undefined),
     modelOptions: {
       fastMode: typeof value?.modelOptions?.fastMode === "boolean"
         ? value.modelOptions.fastMode

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -7,6 +7,7 @@ import { getSettingsFilePath, LOG_PREFIX } from "../shared/branding"
 import {
   DEFAULT_CLAUDE_MODEL_OPTIONS,
   DEFAULT_CODEX_MODEL_OPTIONS,
+  DEFAULT_CURSOR_MODEL_OPTIONS,
   isClaudeReasoningEffort,
   isCodexReasoningEffort,
   normalizeClaudeContextWindow,
@@ -21,6 +22,7 @@ import {
   type ChatSoundPreference,
   type ClaudeModelOptions,
   type CodexModelOptions,
+  type CursorModelOptions,
   type DefaultProviderPreference,
   type EditorPreset,
   type ProviderPreference,
@@ -45,6 +47,7 @@ interface AppSettingsFile {
   providerDefaults?: {
     claude?: Partial<ProviderPreference<Partial<ClaudeModelOptions>>> & { effort?: unknown }
     codex?: Partial<ProviderPreference<Partial<CodexModelOptions>>> & { effort?: unknown }
+    cursor?: Partial<ProviderPreference<Partial<CursorModelOptions>>>
   }
 }
 
@@ -108,6 +111,11 @@ function createDefaultProviderDefaults(): ChatProviderPreferences {
       modelOptions: { ...DEFAULT_CODEX_MODEL_OPTIONS },
       planMode: false,
     },
+    cursor: {
+      model: "composer-2.5",
+      modelOptions: { ...DEFAULT_CURSOR_MODEL_OPTIONS },
+      planMode: false,
+    },
   }
 }
 
@@ -143,7 +151,7 @@ function normalizeChatSoundId(value: unknown): ChatSoundId {
 }
 
 function normalizeDefaultProvider(value: unknown): DefaultProviderPreference {
-  return value === "claude" || value === "codex" || value === "last_used" ? value : "last_used"
+  return value === "claude" || value === "codex" || value === "cursor" || value === "last_used" ? value : "last_used"
 }
 
 function normalizeEditorPreset(value: unknown): EditorPreset {
@@ -204,11 +212,28 @@ function normalizeCodexPreference(value?: {
   }
 }
 
+function normalizeCursorPreference(value?: {
+  model?: unknown
+  modelOptions?: Partial<Record<keyof CursorModelOptions, unknown>>
+  planMode?: unknown
+}): ProviderPreference<CursorModelOptions> {
+  return {
+    model: "composer-2.5",
+    modelOptions: {
+      fastMode: typeof value?.modelOptions?.fastMode === "boolean"
+        ? value.modelOptions.fastMode
+        : DEFAULT_CURSOR_MODEL_OPTIONS.fastMode,
+    },
+    planMode: false,
+  }
+}
+
 function normalizeProviderDefaults(value: AppSettingsFile["providerDefaults"] | undefined): ChatProviderPreferences {
   const defaults = createDefaultProviderDefaults()
   return {
     claude: normalizeClaudePreference(value?.claude ?? defaults.claude),
     codex: normalizeCodexPreference(value?.codex ?? defaults.codex),
+    cursor: normalizeCursorPreference(value?.cursor ?? defaults.cursor),
   }
 }
 
@@ -346,6 +371,14 @@ function applyPatch(state: AppSettingsState, patch: AppSettingsPatch): AppSettin
         modelOptions: {
           ...state.providerDefaults.codex.modelOptions,
           ...patch.providerDefaults?.codex?.modelOptions,
+        },
+      },
+      cursor: {
+        ...state.providerDefaults.cursor,
+        ...patch.providerDefaults?.cursor,
+        modelOptions: {
+          ...state.providerDefaults.cursor.modelOptions,
+          ...patch.providerDefaults?.cursor?.modelOptions,
         },
       },
     },

--- a/src/server/async-queue.ts
+++ b/src/server/async-queue.ts
@@ -1,0 +1,45 @@
+/**
+ * A minimal push/pull async queue used to turn callback/stream-driven agent
+ * output into an `AsyncIterable`. Shared by the provider harness adapters
+ * (Codex app-server, Cursor CLI).
+ */
+export class AsyncQueue<T> implements AsyncIterable<T> {
+  private values: T[] = []
+  private resolvers: Array<(value: IteratorResult<T>) => void> = []
+  private done = false
+
+  push(value: T) {
+    if (this.done) return
+    const resolver = this.resolvers.shift()
+    if (resolver) {
+      resolver({ value, done: false })
+      return
+    }
+    this.values.push(value)
+  }
+
+  finish() {
+    if (this.done) return
+    this.done = true
+    while (this.resolvers.length > 0) {
+      const resolver = this.resolvers.shift()
+      resolver?.({ value: undefined as T, done: true })
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.values.length > 0) {
+          return Promise.resolve({ value: this.values.shift() as T, done: false })
+        }
+        if (this.done) {
+          return Promise.resolve({ value: undefined as T, done: true })
+        }
+        return new Promise<IteratorResult<T>>((resolve) => {
+          this.resolvers.push(resolve)
+        })
+      },
+    }
+  }
+}

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -12,6 +12,8 @@ import type {
 } from "../shared/types"
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
 import { AsyncQueue } from "./async-queue"
+import { asNumber, asRecord } from "../shared/json"
+import { timestamped } from "./transcript"
 import {
   type CollabAgentToolCallItem,
   type ContextCompactedNotification,
@@ -143,17 +145,6 @@ export interface GenerateStructuredArgs {
   serviceTier?: ServiceTier
 }
 
-function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
-  entry: T,
-  createdAt = Date.now()
-): TranscriptEntry {
-  return {
-    _id: randomUUID(),
-    createdAt,
-    ...entry,
-  } as TranscriptEntry
-}
-
 function codexSystemInitEntry(model: string): TranscriptEntry {
   return timestamped({
     kind: "system_init",
@@ -236,15 +227,6 @@ function contentFromMcpResult(item: McpToolCallItem): unknown {
     return { error: item.error.message }
   }
   return item.result?.structuredContent ?? item.result?.content ?? null
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null
-  return value as Record<string, unknown>
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
 
 function normalizeCodexTokenUsage(

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -11,6 +11,7 @@ import type {
   TranscriptEntry,
 } from "../shared/types"
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
+import { AsyncQueue } from "./async-queue"
 import {
   type CollabAgentToolCallItem,
   type ContextCompactedNotification,
@@ -689,47 +690,6 @@ function itemToToolResults(item: ThreadItem): TranscriptEntry[] {
       })]
     default:
       return []
-  }
-}
-
-class AsyncQueue<T> implements AsyncIterable<T> {
-  private values: T[] = []
-  private resolvers: Array<(value: IteratorResult<T>) => void> = []
-  private done = false
-
-  push(value: T) {
-    if (this.done) return
-    const resolver = this.resolvers.shift()
-    if (resolver) {
-      resolver({ value, done: false })
-      return
-    }
-    this.values.push(value)
-  }
-
-  finish() {
-    if (this.done) return
-    this.done = true
-    while (this.resolvers.length > 0) {
-      const resolver = this.resolvers.shift()
-      resolver?.({ value: undefined as T, done: true })
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: () => {
-        if (this.values.length > 0) {
-          return Promise.resolve({ value: this.values.shift() as T, done: false })
-        }
-        if (this.done) {
-          return Promise.resolve({ value: undefined as T, done: true })
-        }
-        return new Promise<IteratorResult<T>>((resolve) => {
-          this.resolvers.push(resolve)
-        })
-      },
-    }
   }
 }
 

--- a/src/server/cursor-cli.test.ts
+++ b/src/server/cursor-cli.test.ts
@@ -52,6 +52,42 @@ describe("parseCursorLine", () => {
     }
   })
 
+  test("started edit tool call maps Cursor's path/streamContent onto Write", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-3","tool_call":{"editToolCall":{"args":{"path":"/repo/calc.py","streamContent":"def add(a, b):\\n    return a + b\\n"}}},"session_id":"sess-1"}`
+    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entry.kind).toBe("tool_call")
+    if (entry.kind === "tool_call" && entry.tool.toolKind === "write_file") {
+      expect(entry.tool.input.filePath).toBe("/repo/calc.py")
+      expect(entry.tool.input.content).toContain("def add")
+    }
+  })
+
+  test("started glob/grep/updateTodos tool calls map onto Glob/Grep/TodoWrite", () => {
+    const glob = transcriptEntries(parseCursorLine(
+      `{"type":"tool_call","subtype":"started","call_id":"g-1","tool_call":{"globToolCall":{"args":{"targetDirectory":"/repo","globPattern":"**/*.py"}}},"session_id":"s"}`,
+      "composer-2.5",
+    ))[0]
+    if (glob.kind === "tool_call" && glob.tool.toolKind === "glob") {
+      expect(glob.tool.input.pattern).toBe("**/*.py")
+    }
+
+    const grep = transcriptEntries(parseCursorLine(
+      `{"type":"tool_call","subtype":"started","call_id":"g-2","tool_call":{"grepToolCall":{"args":{"pattern":"def add","path":"/repo"}}},"session_id":"s"}`,
+      "composer-2.5",
+    ))[0]
+    if (grep.kind === "tool_call" && grep.tool.toolKind === "grep") {
+      expect(grep.tool.input.pattern).toBe("def add")
+    }
+
+    const todo = transcriptEntries(parseCursorLine(
+      `{"type":"tool_call","subtype":"started","call_id":"t-1","tool_call":{"updateTodosToolCall":{"args":{"todos":[{"content":"step","status":"pending"}]}}},"session_id":"s"}`,
+      "composer-2.5",
+    ))[0]
+    if (todo.kind === "tool_call" && todo.tool.toolKind === "todo_write") {
+      expect(Array.isArray(todo.tool.input.todos)).toBe(true)
+    }
+  })
+
   test("completed tool call becomes a tool_result keyed by call id", () => {
     const line = `{"type":"tool_call","subtype":"completed","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"},"result":{"success":{"content":"hello world\\n","isEmpty":false}}}},"session_id":"sess-1"}`
     const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))

--- a/src/server/cursor-cli.test.ts
+++ b/src/server/cursor-cli.test.ts
@@ -1,127 +1,103 @@
 import { describe, expect, test } from "bun:test"
-import { normalizeCursorUsage, parseCursorLine } from "./cursor-cli"
+import { PassThrough } from "node:stream"
+import { CursorCliManager, normalizeCursorUsage, parseCursorLine, type CursorChildProcess } from "./cursor-cli"
 import type { HarnessEvent } from "./harness-types"
 
 function transcriptEntries(events: HarnessEvent[]) {
   return events.flatMap((event) => (event.type === "transcript" && event.entry ? [event.entry] : []))
 }
 
+function firstEntry(line: string, model = "composer-2.5") {
+  return transcriptEntries(parseCursorLine(line, model))[0]
+}
+
 describe("parseCursorLine", () => {
   test("init emits a session token and a cursor system_init entry", () => {
-    const line = `{"type":"system","subtype":"init","apiKeySource":"env","cwd":"/repo","session_id":"sess-1","model":"Composer 2.5 Fast","permissionMode":"default"}`
-    const events = parseCursorLine(line, "composer-2.5-fast")
-
+    const events = parseCursorLine(
+      `{"type":"system","subtype":"init","apiKeySource":"env","cwd":"/repo","session_id":"sess-1","model":"Composer 2.5 Fast"}`,
+      "composer-2.5-fast",
+    )
     expect(events[0]).toEqual({ type: "session_token", sessionToken: "sess-1" })
-    const [entry] = transcriptEntries(events)
-    expect(entry.kind).toBe("system_init")
-    if (entry.kind === "system_init") {
-      expect(entry.provider).toBe("cursor")
-      // Uses the configured model id rather than the display label from the event.
-      expect(entry.model).toBe("composer-2.5-fast")
-    }
+    // Uses the configured model id, not the display label ("Composer 2.5 Fast") from the event.
+    expect(transcriptEntries(events)[0]).toMatchObject({
+      kind: "system_init",
+      provider: "cursor",
+      model: "composer-2.5-fast",
+    })
   })
 
   test("assistant text becomes an assistant_text entry", () => {
-    const line = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I found the bug"}]},"session_id":"sess-1"}`
-    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    expect(entry.kind).toBe("assistant_text")
-    if (entry.kind === "assistant_text") {
-      expect(entry.text).toBe("I found the bug")
-    }
+    const line = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I found the bug"}]},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({ kind: "assistant_text", text: "I found the bug" })
   })
 
-  test("started shell tool call maps to a Bash tool call", () => {
-    const line = `{"type":"tool_call","subtype":"started","call_id":"c-1","tool_call":{"shellToolCall":{"args":{"command":"ls -la","description":"List files"}}},"session_id":"sess-1"}`
-    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    expect(entry.kind).toBe("tool_call")
-    if (entry.kind === "tool_call") {
-      expect(entry.tool.toolKind).toBe("bash")
-      expect(entry.tool.toolId).toBe("c-1")
-      if (entry.tool.toolKind === "bash") {
-        expect(entry.tool.input.command).toBe("ls -la")
-      }
-    }
+  test("shell tool call maps onto Bash", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-1","tool_call":{"shellToolCall":{"args":{"command":"ls -la","description":"List files"}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({
+      kind: "tool_call",
+      tool: { toolKind: "bash", toolId: "c-1", input: { command: "ls -la" } },
+    })
   })
 
-  test("started read tool call maps to a Read tool call with file path", () => {
-    const line = `{"type":"tool_call","subtype":"started","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"}}},"session_id":"sess-1"}`
-    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    expect(entry.kind).toBe("tool_call")
-    if (entry.kind === "tool_call" && entry.tool.toolKind === "read_file") {
-      expect(entry.tool.input.filePath).toBe("/repo/note.txt")
-    }
+  test("read tool call maps onto Read with the file path", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({
+      kind: "tool_call",
+      tool: { toolKind: "read_file", input: { filePath: "/repo/note.txt" } },
+    })
   })
 
-  test("started edit tool call maps Cursor's path/streamContent onto Write", () => {
-    const line = `{"type":"tool_call","subtype":"started","call_id":"c-3","tool_call":{"editToolCall":{"args":{"path":"/repo/calc.py","streamContent":"def add(a, b):\\n    return a + b\\n"}}},"session_id":"sess-1"}`
-    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    expect(entry.kind).toBe("tool_call")
-    if (entry.kind === "tool_call" && entry.tool.toolKind === "write_file") {
-      expect(entry.tool.input.filePath).toBe("/repo/calc.py")
-      expect(entry.tool.input.content).toContain("def add")
-    }
+  test("edit tool call maps Cursor's path/streamContent onto Write", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-3","tool_call":{"editToolCall":{"args":{"path":"/repo/calc.py","streamContent":"def add(a, b):\\n    return a + b\\n"}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({
+      kind: "tool_call",
+      tool: { toolKind: "write_file", input: { filePath: "/repo/calc.py", content: expect.stringContaining("def add") } },
+    })
   })
 
-  test("started glob/grep/updateTodos tool calls map onto Glob/Grep/TodoWrite", () => {
-    const glob = transcriptEntries(parseCursorLine(
-      `{"type":"tool_call","subtype":"started","call_id":"g-1","tool_call":{"globToolCall":{"args":{"targetDirectory":"/repo","globPattern":"**/*.py"}}},"session_id":"s"}`,
-      "composer-2.5",
-    ))[0]
-    if (glob.kind === "tool_call" && glob.tool.toolKind === "glob") {
-      expect(glob.tool.input.pattern).toBe("**/*.py")
-    }
+  test("glob / grep / updateTodos map onto Glob / Grep / TodoWrite", () => {
+    expect(firstEntry(`{"type":"tool_call","subtype":"started","call_id":"g-1","tool_call":{"globToolCall":{"args":{"targetDirectory":"/repo","globPattern":"**/*.py"}}},"session_id":"s"}`))
+      .toMatchObject({ kind: "tool_call", tool: { toolKind: "glob", input: { pattern: "**/*.py" } } })
 
-    const grep = transcriptEntries(parseCursorLine(
-      `{"type":"tool_call","subtype":"started","call_id":"g-2","tool_call":{"grepToolCall":{"args":{"pattern":"def add","path":"/repo"}}},"session_id":"s"}`,
-      "composer-2.5",
-    ))[0]
-    if (grep.kind === "tool_call" && grep.tool.toolKind === "grep") {
-      expect(grep.tool.input.pattern).toBe("def add")
-    }
+    expect(firstEntry(`{"type":"tool_call","subtype":"started","call_id":"g-2","tool_call":{"grepToolCall":{"args":{"pattern":"def add","path":"/repo"}}},"session_id":"s"}`))
+      .toMatchObject({ kind: "tool_call", tool: { toolKind: "grep", input: { pattern: "def add" } } })
 
-    const todo = transcriptEntries(parseCursorLine(
-      `{"type":"tool_call","subtype":"started","call_id":"t-1","tool_call":{"updateTodosToolCall":{"args":{"todos":[{"content":"step","status":"pending"}]}}},"session_id":"s"}`,
-      "composer-2.5",
-    ))[0]
-    if (todo.kind === "tool_call" && todo.tool.toolKind === "todo_write") {
-      expect(Array.isArray(todo.tool.input.todos)).toBe(true)
-    }
+    expect(firstEntry(`{"type":"tool_call","subtype":"started","call_id":"t-1","tool_call":{"updateTodosToolCall":{"args":{"todos":[{"content":"step","status":"pending"}]}}},"session_id":"s"}`))
+      .toMatchObject({ kind: "tool_call", tool: { toolKind: "todo_write", input: { todos: [{ content: "step", status: "pending" }] } } })
+  })
+
+  test("an unmapped tool falls through to unknown_tool rather than being dropped", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"u-1","tool_call":{"mysteryToolCall":{"args":{"foo":"bar"}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({ kind: "tool_call", tool: { toolKind: "unknown_tool" } })
   })
 
   test("completed tool call becomes a tool_result keyed by call id", () => {
-    const line = `{"type":"tool_call","subtype":"completed","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"},"result":{"success":{"content":"hello world\\n","isEmpty":false}}}},"session_id":"sess-1"}`
-    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    expect(entry.kind).toBe("tool_result")
-    if (entry.kind === "tool_result") {
-      expect(entry.toolId).toBe("c-2")
-      expect(entry.isError).toBe(false)
-      expect(entry.content).toEqual({ content: "hello world\n", isEmpty: false })
-    }
+    const line = `{"type":"tool_call","subtype":"completed","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"},"result":{"success":{"content":"hello world\\n","isEmpty":false}}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({
+      kind: "tool_result",
+      toolId: "c-2",
+      isError: false,
+      content: { content: "hello world\n", isEmpty: false },
+    })
   })
 
-  test("result emits a context-window update and a success result", () => {
-    const line = `{"type":"result","subtype":"success","duration_ms":15609,"is_error":false,"result":"Done","session_id":"sess-1","usage":{"inputTokens":17640,"outputTokens":138,"cacheReadTokens":27968,"cacheWriteTokens":0}}`
-    const entries = transcriptEntries(parseCursorLine(line, "composer-2.5"))
-    const kinds = entries.map((entry) => entry.kind)
-    expect(kinds).toContain("context_window_updated")
-    expect(kinds).toContain("result")
+  test("a failed tool call is flagged as an error result", () => {
+    const line = `{"type":"tool_call","subtype":"completed","call_id":"c-9","tool_call":{"shellToolCall":{"args":{"command":"nope"},"result":{"error":{"message":"boom"}}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({ kind: "tool_result", toolId: "c-9", isError: true })
+  })
 
-    const result = entries.find((entry) => entry.kind === "result")
-    if (result?.kind === "result") {
-      expect(result.isError).toBe(false)
-      expect(result.subtype).toBe("success")
-      expect(result.result).toBe("Done")
-      expect(result.durationMs).toBe(15609)
-    }
+  test("result emits a context-window update followed by a success result", () => {
+    const line = `{"type":"result","subtype":"success","duration_ms":15609,"is_error":false,"result":"Done","session_id":"s","usage":{"inputTokens":17640,"outputTokens":138,"cacheReadTokens":27968,"cacheWriteTokens":0}}`
+    const entries = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entries.map((entry) => entry.kind)).toEqual(["context_window_updated", "result"])
+    expect(entries[1]).toMatchObject({ kind: "result", isError: false, subtype: "success", result: "Done", durationMs: 15609 })
   })
 
   test("error result is surfaced as an error result entry", () => {
-    const line = `{"type":"result","subtype":"error","is_error":true,"result":"boom","session_id":"sess-1"}`
-    const result = transcriptEntries(parseCursorLine(line, "composer-2.5")).find((entry) => entry.kind === "result")
-    if (result?.kind === "result") {
-      expect(result.isError).toBe(true)
-      expect(result.subtype).toBe("error")
-    }
+    const line = `{"type":"result","subtype":"error","is_error":true,"result":"boom","session_id":"s"}`
+    const entries = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ kind: "result", isError: true, subtype: "error", result: "boom" })
   })
 
   test("prompt echo, reasoning, and malformed lines produce no entries", () => {
@@ -134,21 +110,105 @@ describe("parseCursorLine", () => {
 
 describe("normalizeCursorUsage", () => {
   test("sums direct + cache tokens into the context window snapshot", () => {
-    const usage = normalizeCursorUsage({
-      inputTokens: 17640,
+    const usage = normalizeCursorUsage({ inputTokens: 17640, outputTokens: 138, cacheReadTokens: 27968, cacheWriteTokens: 0 })
+    expect(usage).toMatchObject({
+      inputTokens: 17640 + 27968,
+      cachedInputTokens: 27968,
       outputTokens: 138,
-      cacheReadTokens: 27968,
-      cacheWriteTokens: 0,
+      usedTokens: 17640 + 27968 + 138,
     })
-    expect(usage).not.toBeNull()
-    expect(usage?.inputTokens).toBe(17640 + 27968)
-    expect(usage?.cachedInputTokens).toBe(27968)
-    expect(usage?.outputTokens).toBe(138)
-    expect(usage?.usedTokens).toBe(17640 + 27968 + 138)
   })
 
   test("returns null when there is no usage", () => {
     expect(normalizeCursorUsage(undefined)).toBeNull()
     expect(normalizeCursorUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 })).toBeNull()
+  })
+})
+
+// Exercises the injectable `spawnProcess` seam: argv/stdin/resume wiring, stdout
+// stream -> events, and the "process ended without a result" error synthesis.
+function makeFakeChild() {
+  const stdin = new PassThrough()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+  let onClose: ((code: number | null) => void) | undefined
+  const child = {
+    stdin,
+    stdout,
+    stderr,
+    kill: () => true,
+    once(event: "close" | "error", listener: (arg: never) => void) {
+      if (event === "close") onClose = listener as unknown as (code: number | null) => void
+      return child
+    },
+  } as unknown as CursorChildProcess
+  return { child, stdin, stdout, stderr, close: (code: number | null) => onClose?.(code) }
+}
+
+describe("CursorCliManager.startTurn", () => {
+  test("passes --force/--model/--resume and writes the prompt to stdin", async () => {
+    const fake = makeFakeChild()
+    let captured: { cwd: string; argv: string[] } | undefined
+    const manager = new CursorCliManager({ spawnProcess: (args) => { captured = args; return fake.child } })
+
+    const stdinText = new Promise<string>((resolve) => {
+      let data = ""
+      fake.stdin.on("data", (chunk) => { data += chunk.toString() })
+      fake.stdin.on("end", () => resolve(data))
+    })
+
+    const turn = await manager.startTurn({ cwd: "/repo", content: "fix the bug", model: "composer-2.5-fast", sessionToken: "sess-9" })
+
+    expect(turn.provider).toBe("cursor")
+    expect(captured?.cwd).toBe("/repo")
+    expect(captured?.argv).toEqual([
+      "-p", "--output-format", "stream-json", "--force", "--model", "composer-2.5-fast", "--resume", "sess-9",
+    ])
+    expect(await stdinText).toBe("fix the bug")
+  })
+
+  test("omits --resume when there is no session token", async () => {
+    const fake = makeFakeChild()
+    let captured: { cwd: string; argv: string[] } | undefined
+    const manager = new CursorCliManager({ spawnProcess: (args) => { captured = args; return fake.child } })
+    await manager.startTurn({ cwd: "/repo", content: "hi", model: "composer-2.5", sessionToken: null })
+    expect(captured?.argv).not.toContain("--resume")
+  })
+
+  test("parses stdout NDJSON into events without synthesizing an error", async () => {
+    const fake = makeFakeChild()
+    const manager = new CursorCliManager({ spawnProcess: () => fake.child })
+    const turn = await manager.startTurn({ cwd: "/repo", content: "hi", model: "composer-2.5", sessionToken: null })
+    const iter = turn.stream[Symbol.asyncIterator]()
+
+    fake.stdout.write(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi there"}]},"session_id":"s"}\n`)
+    fake.stdout.write(`{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"s"}\n`)
+
+    // The consumer awaits each event as it is pushed, so this is deterministic without timers.
+    expect((await iter.next()).value).toMatchObject({ type: "transcript", entry: { kind: "assistant_text", text: "hi there" } })
+    expect((await iter.next()).value).toMatchObject({ type: "transcript", entry: { kind: "result", isError: false } })
+
+    fake.stdout.end()
+    fake.close(0)
+    expect((await iter.next()).done).toBe(true)
+  })
+
+  test("synthesizes an error result (with stderr) when the process ends without one", async () => {
+    const fake = makeFakeChild()
+    const manager = new CursorCliManager({ spawnProcess: () => fake.child })
+    const turn = await manager.startTurn({ cwd: "/repo", content: "hi", model: "bad-model", sessionToken: null })
+    const iter = turn.stream[Symbol.asyncIterator]()
+
+    // Awaiting stderr's "end" guarantees the manager's "data" handler ran first.
+    fake.stderr.end("Cannot use this model: bad-model")
+    await new Promise<void>((resolve) => fake.stderr.once("end", resolve))
+    fake.stdout.end()
+    fake.close(1)
+
+    expect((await iter.next()).value).toMatchObject({
+      type: "transcript",
+      entry: { kind: "result", isError: true, subtype: "error", result: expect.stringContaining("Cannot use this model") },
+    })
+    expect((await iter.next()).done).toBe(true)
   })
 })

--- a/src/server/cursor-cli.test.ts
+++ b/src/server/cursor-cli.test.ts
@@ -86,6 +86,11 @@ describe("parseCursorLine", () => {
     expect(firstEntry(line)).toMatchObject({ kind: "tool_result", toolId: "c-9", isError: true })
   })
 
+  test("a completed tool with no structured result is not a false-positive error", () => {
+    const line = `{"type":"tool_call","subtype":"completed","call_id":"c-7","tool_call":{"shellToolCall":{"args":{"command":"ls"}}},"session_id":"s"}`
+    expect(firstEntry(line)).toMatchObject({ kind: "tool_result", toolId: "c-7", isError: false })
+  })
+
   test("result emits a context-window update followed by a success result", () => {
     const line = `{"type":"result","subtype":"success","duration_ms":15609,"is_error":false,"result":"Done","session_id":"s","usage":{"inputTokens":17640,"outputTokens":138,"cacheReadTokens":27968,"cacheWriteTokens":0}}`
     const entries = transcriptEntries(parseCursorLine(line, "composer-2.5"))

--- a/src/server/cursor-cli.test.ts
+++ b/src/server/cursor-cli.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeCursorUsage, parseCursorLine } from "./cursor-cli"
+import type { HarnessEvent } from "./harness-types"
+
+function transcriptEntries(events: HarnessEvent[]) {
+  return events.flatMap((event) => (event.type === "transcript" && event.entry ? [event.entry] : []))
+}
+
+describe("parseCursorLine", () => {
+  test("init emits a session token and a cursor system_init entry", () => {
+    const line = `{"type":"system","subtype":"init","apiKeySource":"env","cwd":"/repo","session_id":"sess-1","model":"Composer 2.5 Fast","permissionMode":"default"}`
+    const events = parseCursorLine(line, "composer-2.5-fast")
+
+    expect(events[0]).toEqual({ type: "session_token", sessionToken: "sess-1" })
+    const [entry] = transcriptEntries(events)
+    expect(entry.kind).toBe("system_init")
+    if (entry.kind === "system_init") {
+      expect(entry.provider).toBe("cursor")
+      // Uses the configured model id rather than the display label from the event.
+      expect(entry.model).toBe("composer-2.5-fast")
+    }
+  })
+
+  test("assistant text becomes an assistant_text entry", () => {
+    const line = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I found the bug"}]},"session_id":"sess-1"}`
+    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entry.kind).toBe("assistant_text")
+    if (entry.kind === "assistant_text") {
+      expect(entry.text).toBe("I found the bug")
+    }
+  })
+
+  test("started shell tool call maps to a Bash tool call", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-1","tool_call":{"shellToolCall":{"args":{"command":"ls -la","description":"List files"}}},"session_id":"sess-1"}`
+    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entry.kind).toBe("tool_call")
+    if (entry.kind === "tool_call") {
+      expect(entry.tool.toolKind).toBe("bash")
+      expect(entry.tool.toolId).toBe("c-1")
+      if (entry.tool.toolKind === "bash") {
+        expect(entry.tool.input.command).toBe("ls -la")
+      }
+    }
+  })
+
+  test("started read tool call maps to a Read tool call with file path", () => {
+    const line = `{"type":"tool_call","subtype":"started","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"}}},"session_id":"sess-1"}`
+    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entry.kind).toBe("tool_call")
+    if (entry.kind === "tool_call" && entry.tool.toolKind === "read_file") {
+      expect(entry.tool.input.filePath).toBe("/repo/note.txt")
+    }
+  })
+
+  test("completed tool call becomes a tool_result keyed by call id", () => {
+    const line = `{"type":"tool_call","subtype":"completed","call_id":"c-2","tool_call":{"readToolCall":{"args":{"path":"/repo/note.txt"},"result":{"success":{"content":"hello world\\n","isEmpty":false}}}},"session_id":"sess-1"}`
+    const [entry] = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    expect(entry.kind).toBe("tool_result")
+    if (entry.kind === "tool_result") {
+      expect(entry.toolId).toBe("c-2")
+      expect(entry.isError).toBe(false)
+      expect(entry.content).toEqual({ content: "hello world\n", isEmpty: false })
+    }
+  })
+
+  test("result emits a context-window update and a success result", () => {
+    const line = `{"type":"result","subtype":"success","duration_ms":15609,"is_error":false,"result":"Done","session_id":"sess-1","usage":{"inputTokens":17640,"outputTokens":138,"cacheReadTokens":27968,"cacheWriteTokens":0}}`
+    const entries = transcriptEntries(parseCursorLine(line, "composer-2.5"))
+    const kinds = entries.map((entry) => entry.kind)
+    expect(kinds).toContain("context_window_updated")
+    expect(kinds).toContain("result")
+
+    const result = entries.find((entry) => entry.kind === "result")
+    if (result?.kind === "result") {
+      expect(result.isError).toBe(false)
+      expect(result.subtype).toBe("success")
+      expect(result.result).toBe("Done")
+      expect(result.durationMs).toBe(15609)
+    }
+  })
+
+  test("error result is surfaced as an error result entry", () => {
+    const line = `{"type":"result","subtype":"error","is_error":true,"result":"boom","session_id":"sess-1"}`
+    const result = transcriptEntries(parseCursorLine(line, "composer-2.5")).find((entry) => entry.kind === "result")
+    if (result?.kind === "result") {
+      expect(result.isError).toBe(true)
+      expect(result.subtype).toBe("error")
+    }
+  })
+
+  test("prompt echo, reasoning, and malformed lines produce no entries", () => {
+    expect(parseCursorLine(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}`, "composer-2.5")).toEqual([])
+    expect(parseCursorLine(`{"type":"thinking","subtype":"delta"}`, "composer-2.5")).toEqual([])
+    expect(parseCursorLine("not json", "composer-2.5")).toEqual([])
+    expect(parseCursorLine("", "composer-2.5")).toEqual([])
+  })
+})
+
+describe("normalizeCursorUsage", () => {
+  test("sums direct + cache tokens into the context window snapshot", () => {
+    const usage = normalizeCursorUsage({
+      inputTokens: 17640,
+      outputTokens: 138,
+      cacheReadTokens: 27968,
+      cacheWriteTokens: 0,
+    })
+    expect(usage).not.toBeNull()
+    expect(usage?.inputTokens).toBe(17640 + 27968)
+    expect(usage?.cachedInputTokens).toBe(27968)
+    expect(usage?.outputTokens).toBe(138)
+    expect(usage?.usedTokens).toBe(17640 + 27968 + 138)
+  })
+
+  test("returns null when there is no usage", () => {
+    expect(normalizeCursorUsage(undefined)).toBeNull()
+    expect(normalizeCursorUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 })).toBeNull()
+  })
+})

--- a/src/server/cursor-cli.ts
+++ b/src/server/cursor-cli.ts
@@ -1,0 +1,489 @@
+import { spawn } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import { createInterface } from "node:readline"
+import type { Readable, Writable } from "node:stream"
+import type { ContextWindowUsageSnapshot, TranscriptEntry } from "../shared/types"
+import { normalizeToolCall } from "../shared/tools"
+import type { HarnessEvent, HarnessTurn } from "./harness-types"
+
+/**
+ * Adapter for the Cursor CLI (`cursor-agent` binary).
+ *
+ * Unlike Claude (SDK) and Codex (persistent JSON-RPC `app-server`), Cursor runs
+ * one headless process per turn:
+ *
+ *   cursor-agent -p --output-format stream-json --force --model <id> [--resume <session>]
+ *
+ * with the prompt written to stdin. It emits NDJSON on stdout. `--force` is required
+ * in headless mode, otherwise the process blocks on a "Workspace Trust" prompt.
+ * Auth is via the CURSOR_API_KEY environment variable (inherited from the parent).
+ *
+ * Stream event types (one JSON object per line):
+ *   - { type: "system", subtype: "init", session_id, model, cwd, apiKeySource }
+ *   - { type: "user", ... }                              (prompt echo — ignored)
+ *   - { type: "assistant", message: { content: [{ type: "text", text }] } }
+ *   - { type: "thinking", subtype: "delta"|"completed" } (reasoning — ignored)
+ *   - { type: "tool_call", subtype: "started"|"completed", call_id, tool_call: { <name>ToolCall: {...} } }
+ *   - { type: "result", subtype: "success", is_error, duration_ms, result, session_id, usage }
+ */
+
+function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
+  entry: T,
+  createdAt = Date.now()
+): TranscriptEntry {
+  return {
+    _id: randomUUID(),
+    createdAt,
+    ...entry,
+  } as TranscriptEntry
+}
+
+// Minimal child-process surface so tests can inject a fake without rebuilding ChildProcess.
+export interface CursorChildProcess {
+  readonly stdin: Writable | null
+  readonly stdout: Readable | null
+  readonly stderr: Readable | null
+  kill(signal?: NodeJS.Signals): boolean
+  once(event: "close", listener: (code: number | null) => void): unknown
+  once(event: "error", listener: (err: Error) => void): unknown
+}
+
+export type SpawnCursorAgent = (args: { cwd: string; argv: string[] }) => CursorChildProcess
+
+export interface StartCursorTurnArgs {
+  cwd: string
+  content: string
+  /** Concrete model id to spawn, e.g. "composer-2.5" or "composer-2.5-fast". */
+  model: string
+  /** Previous Cursor session id to resume, if any. */
+  sessionToken: string | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Map Cursor's token usage into Kanna's context-window snapshot. Mirrors
+ * `normalizeClaudeUsageSnapshot` in agent.ts. Cursor does not report a max
+ * context window, so `maxTokens` is left undefined.
+ */
+export function normalizeCursorUsage(value: unknown): ContextWindowUsageSnapshot | null {
+  const usage = asRecord(value)
+  if (!usage) return null
+
+  const directInputTokens = asNumber(usage.inputTokens) ?? 0
+  const cacheReadTokens = asNumber(usage.cacheReadTokens) ?? 0
+  const cacheWriteTokens = asNumber(usage.cacheWriteTokens) ?? 0
+  const outputTokens = asNumber(usage.outputTokens) ?? 0
+
+  const inputTokens = directInputTokens + cacheReadTokens + cacheWriteTokens
+  const usedTokens = inputTokens + outputTokens
+  if (usedTokens <= 0) return null
+
+  return {
+    usedTokens,
+    inputTokens,
+    ...(cacheReadTokens > 0 ? { cachedInputTokens: cacheReadTokens } : {}),
+    ...(outputTokens > 0 ? { outputTokens } : {}),
+    lastUsedTokens: usedTokens,
+    lastInputTokens: inputTokens,
+    ...(cacheReadTokens > 0 ? { lastCachedInputTokens: cacheReadTokens } : {}),
+    ...(outputTokens > 0 ? { lastOutputTokens: outputTokens } : {}),
+    compactsAutomatically: false,
+  }
+}
+
+/**
+ * Translate a Cursor tool call into the Claude-style tool name + snake_case
+ * argument keys that `normalizeToolCall` understands, so tools render natively
+ * in the UI. Unknown tools fall through to `unknown_tool`.
+ */
+function translateCursorTool(
+  rawName: string,
+  args: Record<string, unknown>
+): { toolName: string; input: Record<string, unknown> } {
+  const key = rawName.toLowerCase().replace(/[^a-z]/g, "")
+  switch (key) {
+    case "shell":
+    case "bash":
+    case "terminal":
+      return {
+        toolName: "Bash",
+        input: { command: args.command ?? args.cmd ?? "", description: args.description },
+      }
+    case "read":
+    case "readfile":
+      return {
+        toolName: "Read",
+        input: { file_path: args.path ?? args.file_path ?? args.target_file ?? "" },
+      }
+    case "write":
+    case "writefile":
+    case "createfile":
+      return {
+        toolName: "Write",
+        input: { file_path: args.path ?? args.file_path ?? "", content: args.contents ?? args.content ?? "" },
+      }
+    case "edit":
+    case "editfile":
+    case "searchreplace":
+    case "multiedit":
+      return {
+        toolName: "Edit",
+        input: {
+          file_path: args.path ?? args.file_path ?? args.target_file ?? "",
+          old_string: args.old_string ?? args.oldString ?? args.old ?? "",
+          new_string: args.new_string ?? args.newString ?? args.new ?? "",
+        },
+      }
+    case "ls":
+    case "glob":
+    case "listdir":
+    case "list":
+      return {
+        toolName: "Glob",
+        input: { pattern: args.globPattern ?? args.pattern ?? args.path ?? args.target_directory ?? "" },
+      }
+    case "grep":
+    case "ripgrep":
+    case "search":
+    case "codebasesearch":
+      return {
+        toolName: "Grep",
+        input: {
+          pattern: args.pattern ?? args.query ?? "",
+          output_mode: args.outputMode ?? args.output_mode,
+        },
+      }
+    case "web":
+    case "websearch":
+      return {
+        toolName: "WebSearch",
+        input: { query: args.query ?? args.search_term ?? "" },
+      }
+    case "todo":
+    case "todowrite":
+    case "updatetodos":
+      return {
+        toolName: "TodoWrite",
+        input: { todos: Array.isArray(args.todos) ? args.todos : [] },
+      }
+    default:
+      // Unknown tool — pass the raw name through; normalizeToolCall returns unknown_tool.
+      return { toolName: rawName, input: args }
+  }
+}
+
+/**
+ * Cursor nests tool calls under keys like "shellToolCall", "readToolCall".
+ * Returns the raw tool name, its args, and the completed result (if present).
+ */
+function extractCursorTool(toolCall: unknown): {
+  rawName: string
+  args: Record<string, unknown>
+  result?: unknown
+} {
+  const obj = asRecord(toolCall)
+  if (obj) {
+    for (const [k, v] of Object.entries(obj)) {
+      if (k.endsWith("ToolCall")) {
+        const inner = asRecord(v)
+        return {
+          rawName: k.slice(0, -"ToolCall".length),
+          args: asRecord(inner?.args) ?? {},
+          result: inner?.result,
+        }
+      }
+    }
+    // Fallback: { name, args }
+    const name = asString(obj.name)
+    if (name) {
+      return { rawName: name, args: asRecord(obj.args) ?? {}, result: obj.result }
+    }
+  }
+  return { rawName: "unknown", args: {} }
+}
+
+function extractAssistantText(message: unknown): string {
+  const content = asRecord(message)?.content
+  if (!Array.isArray(content)) return ""
+  return content
+    .filter((item): item is Record<string, unknown> => asRecord(item)?.type === "text")
+    .map((item) => asString(item.text) ?? "")
+    .join("")
+}
+
+/**
+ * Parse a single NDJSON line from `cursor-agent` into Kanna harness events.
+ * Pure and side-effect free so it can be unit tested against captured fixtures.
+ */
+export function parseCursorLine(line: string, configuredModel: string): HarnessEvent[] {
+  const trimmed = line.trim()
+  if (!trimmed) return []
+
+  let value: Record<string, unknown> | null
+  try {
+    value = asRecord(JSON.parse(trimmed))
+  } catch {
+    return []
+  }
+  if (!value) return []
+
+  const type = asString(value.type)
+  const debugRaw = trimmed
+
+  switch (type) {
+    case "system": {
+      if (asString(value.subtype) !== "init") return []
+      const events: HarnessEvent[] = []
+      const sessionId = asString(value.session_id)
+      if (sessionId) events.push({ type: "session_token", sessionToken: sessionId })
+      events.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "system_init",
+          provider: "cursor",
+          model: configuredModel,
+          tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "TodoWrite"],
+          agents: [],
+          slashCommands: [],
+          mcpServers: [],
+          debugRaw,
+        }),
+      })
+      return events
+    }
+
+    case "assistant": {
+      const text = extractAssistantText(value.message)
+      if (!text) return []
+      return [{ type: "transcript", entry: timestamped({ kind: "assistant_text", text, debugRaw }) }]
+    }
+
+    case "tool_call": {
+      const subtype = asString(value.subtype)
+      const callId = asString(value.call_id) ?? randomUUID()
+      const { rawName, args, result } = extractCursorTool(value.tool_call)
+
+      if (subtype === "started") {
+        const { toolName, input } = translateCursorTool(rawName, args)
+        return [
+          {
+            type: "transcript",
+            entry: timestamped({
+              kind: "tool_call",
+              tool: normalizeToolCall({ toolName, toolId: callId, input }),
+              debugRaw,
+            }),
+          },
+        ]
+      }
+
+      if (subtype === "completed") {
+        const resultRecord = asRecord(result)
+        const success = resultRecord && "success" in resultRecord
+        const isError = Boolean(resultRecord && ("error" in resultRecord || "failure" in resultRecord))
+        const content = resultRecord
+          ? (resultRecord.success ?? resultRecord.error ?? resultRecord.failure ?? result)
+          : result
+        return [
+          {
+            type: "transcript",
+            entry: timestamped({
+              kind: "tool_result",
+              toolId: callId,
+              content,
+              isError: isError || !success,
+              debugRaw,
+            }),
+          },
+        ]
+      }
+
+      return []
+    }
+
+    case "result": {
+      const events: HarnessEvent[] = []
+      const usage = normalizeCursorUsage(value.usage)
+      if (usage) {
+        events.push({
+          type: "transcript",
+          entry: timestamped({ kind: "context_window_updated", usage }),
+        })
+      }
+      const isError = Boolean(value.is_error)
+      events.push({
+        type: "transcript",
+        entry: timestamped({
+          kind: "result",
+          subtype: isError ? "error" : "success",
+          isError,
+          durationMs: asNumber(value.duration_ms) ?? 0,
+          result: asString(value.result) ?? "",
+          debugRaw,
+        }),
+      })
+      return events
+    }
+
+    // "user" (prompt echo), "thinking" (reasoning), and unknown types are dropped —
+    // Kanna already records the user prompt and has no reasoning transcript kind.
+    default:
+      return []
+  }
+}
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+  private values: T[] = []
+  private resolvers: Array<(value: IteratorResult<T>) => void> = []
+  private done = false
+
+  push(value: T) {
+    if (this.done) return
+    const resolver = this.resolvers.shift()
+    if (resolver) {
+      resolver({ value, done: false })
+      return
+    }
+    this.values.push(value)
+  }
+
+  finish() {
+    if (this.done) return
+    this.done = true
+    while (this.resolvers.length > 0) {
+      const resolver = this.resolvers.shift()
+      resolver?.({ value: undefined as T, done: true })
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.values.length > 0) {
+          return Promise.resolve({ value: this.values.shift() as T, done: false })
+        }
+        if (this.done) {
+          return Promise.resolve({ value: undefined as T, done: true })
+        }
+        return new Promise<IteratorResult<T>>((resolve) => {
+          this.resolvers.push(resolve)
+        })
+      },
+    }
+  }
+}
+
+export class CursorCliManager {
+  private readonly spawnProcess: SpawnCursorAgent
+
+  constructor(args: { spawnProcess?: SpawnCursorAgent } = {}) {
+    this.spawnProcess =
+      args.spawnProcess ??
+      (({ cwd, argv }) =>
+        spawn("cursor-agent", argv, {
+          cwd,
+          stdio: ["pipe", "pipe", "pipe"],
+          env: process.env,
+        }) as unknown as CursorChildProcess)
+  }
+
+  async startTurn(args: StartCursorTurnArgs): Promise<HarnessTurn> {
+    const argv = [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--force",
+      "--model",
+      args.model,
+    ]
+    if (args.sessionToken) {
+      argv.push("--resume", args.sessionToken)
+    }
+
+    const child = this.spawnProcess({ cwd: args.cwd, argv })
+    const queue = new AsyncQueue<HarnessEvent>()
+
+    let sawResult = false
+    let finished = false
+    let stderr = ""
+
+    const finalize = (code: number | null) => {
+      if (finished) return
+      finished = true
+      if (!sawResult) {
+        const detail = stderr.trim() || `cursor-agent exited with code ${code ?? "unknown"}`
+        queue.push({
+          type: "transcript",
+          entry: timestamped({
+            kind: "result",
+            subtype: "error",
+            isError: true,
+            durationMs: 0,
+            result: detail,
+          }),
+        })
+      }
+      queue.finish()
+    }
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout })
+      rl.on("line", (line) => {
+        for (const event of parseCursorLine(line, args.model)) {
+          if (event.type === "transcript" && event.entry?.kind === "result") {
+            sawResult = true
+          }
+          queue.push(event)
+        }
+      })
+    }
+
+    if (child.stderr) {
+      child.stderr.on("data", (chunk: Buffer | string) => {
+        stderr += chunk.toString()
+      })
+    }
+
+    child.once("error", (err) => {
+      stderr += `\n${err.message}`
+      finalize(null)
+    })
+    child.once("close", (code) => finalize(code))
+
+    // Send the prompt over stdin and close it so the agent starts.
+    if (child.stdin) {
+      child.stdin.end(args.content)
+    }
+
+    return {
+      provider: "cursor",
+      stream: queue,
+      interrupt: async () => {
+        try {
+          child.kill("SIGINT")
+        } catch {
+          // process already gone
+        }
+      },
+      close: () => {
+        try {
+          child.kill()
+        } catch {
+          // process already gone
+        }
+      },
+    }
+  }
+}

--- a/src/server/cursor-cli.ts
+++ b/src/server/cursor-cli.ts
@@ -2,10 +2,12 @@ import { spawn } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
-import type { ContextWindowUsageSnapshot, TranscriptEntry } from "../shared/types"
+import type { ContextWindowUsageSnapshot } from "../shared/types"
+import { asNumber, asRecord, asString } from "../shared/json"
 import { normalizeToolCall } from "../shared/tools"
 import type { HarnessEvent, HarnessTurn } from "./harness-types"
 import { AsyncQueue } from "./async-queue"
+import { timestamped } from "./transcript"
 
 /**
  * Adapter for the Cursor CLI (`cursor-agent` binary).
@@ -28,17 +30,6 @@ import { AsyncQueue } from "./async-queue"
  *   - { type: "result", subtype: "success", is_error, duration_ms, result, session_id, usage }
  */
 
-function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
-  entry: T,
-  createdAt = Date.now()
-): TranscriptEntry {
-  return {
-    _id: randomUUID(),
-    createdAt,
-    ...entry,
-  } as TranscriptEntry
-}
-
 // Minimal child-process surface so tests can inject a fake without rebuilding ChildProcess.
 export interface CursorChildProcess {
   readonly stdin: Writable | null
@@ -58,19 +49,6 @@ export interface StartCursorTurnArgs {
   model: string
   /** Previous Cursor session id to resume, if any. */
   sessionToken: string | null
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
 
 /**
@@ -113,74 +91,24 @@ function translateCursorTool(
   rawName: string,
   args: Record<string, unknown>
 ): { toolName: string; input: Record<string, unknown> } {
-  const key = rawName.toLowerCase().replace(/[^a-z]/g, "")
-  switch (key) {
+  // Tool keys and argument names are taken from observed `cursor-agent` stream
+  // output. Anything unmapped falls through to `unknown_tool`, which still renders.
+  switch (rawName.toLowerCase().replace(/[^a-z]/g, "")) {
     case "shell":
-    case "bash":
-    case "terminal":
-      return {
-        toolName: "Bash",
-        input: { command: args.command ?? args.cmd ?? "", description: args.description },
-      }
+      return { toolName: "Bash", input: { command: args.command ?? "", description: args.description } }
     case "read":
-    case "readfile":
-      return {
-        toolName: "Read",
-        input: { file_path: args.path ?? args.file_path ?? args.target_file ?? "" },
-      }
-    case "write":
-    case "writefile":
-    case "createfile":
-      return {
-        toolName: "Write",
-        input: { file_path: args.path ?? args.file_path ?? "", content: args.contents ?? args.content ?? "" },
-      }
+      return { toolName: "Read", input: { file_path: args.path ?? "" } }
     case "edit":
-    case "editfile":
-    case "searchreplace":
-    case "multiedit":
-      return {
-        toolName: "Edit",
-        input: {
-          file_path: args.path ?? args.file_path ?? args.target_file ?? "",
-          old_string: args.old_string ?? args.oldString ?? args.old ?? "",
-          new_string: args.new_string ?? args.newString ?? args.new ?? "",
-        },
-      }
-    case "ls":
+      // Cursor's edit emits the full new file content (`streamContent`) rather than
+      // an old/new diff, so it maps cleanly onto Write.
+      return { toolName: "Write", input: { file_path: args.path ?? "", content: args.streamContent ?? "" } }
     case "glob":
-    case "listdir":
-    case "list":
-      return {
-        toolName: "Glob",
-        input: { pattern: args.globPattern ?? args.pattern ?? args.path ?? args.target_directory ?? "" },
-      }
+      return { toolName: "Glob", input: { pattern: args.globPattern ?? "" } }
     case "grep":
-    case "ripgrep":
-    case "search":
-    case "codebasesearch":
-      return {
-        toolName: "Grep",
-        input: {
-          pattern: args.pattern ?? args.query ?? "",
-          output_mode: args.outputMode ?? args.output_mode,
-        },
-      }
-    case "web":
-    case "websearch":
-      return {
-        toolName: "WebSearch",
-        input: { query: args.query ?? args.search_term ?? "" },
-      }
-    case "todo":
-    case "todowrite":
+      return { toolName: "Grep", input: { pattern: args.pattern ?? "" } }
     case "updatetodos":
-      return {
-        toolName: "TodoWrite",
-        input: { todos: Array.isArray(args.todos) ? args.todos : [] },
-      }
+      return { toolName: "TodoWrite", input: { todos: Array.isArray(args.todos) ? args.todos : [] } }
     default:
-      // Unknown tool — pass the raw name through; normalizeToolCall returns unknown_tool.
       return { toolName: rawName, input: args }
   }
 }

--- a/src/server/cursor-cli.ts
+++ b/src/server/cursor-cli.ts
@@ -5,6 +5,7 @@ import type { Readable, Writable } from "node:stream"
 import type { ContextWindowUsageSnapshot, TranscriptEntry } from "../shared/types"
 import { normalizeToolCall } from "../shared/tools"
 import type { HarnessEvent, HarnessTurn } from "./harness-types"
+import { AsyncQueue } from "./async-queue"
 
 /**
  * Adapter for the Cursor CLI (`cursor-agent` binary).
@@ -341,47 +342,6 @@ export function parseCursorLine(line: string, configuredModel: string): HarnessE
     // Kanna already records the user prompt and has no reasoning transcript kind.
     default:
       return []
-  }
-}
-
-class AsyncQueue<T> implements AsyncIterable<T> {
-  private values: T[] = []
-  private resolvers: Array<(value: IteratorResult<T>) => void> = []
-  private done = false
-
-  push(value: T) {
-    if (this.done) return
-    const resolver = this.resolvers.shift()
-    if (resolver) {
-      resolver({ value, done: false })
-      return
-    }
-    this.values.push(value)
-  }
-
-  finish() {
-    if (this.done) return
-    this.done = true
-    while (this.resolvers.length > 0) {
-      const resolver = this.resolvers.shift()
-      resolver?.({ value: undefined as T, done: true })
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: () => {
-        if (this.values.length > 0) {
-          return Promise.resolve({ value: this.values.shift() as T, done: false })
-        }
-        if (this.done) {
-          return Promise.resolve({ value: undefined as T, done: true })
-        }
-        return new Promise<IteratorResult<T>>((resolve) => {
-          this.resolvers.push(resolve)
-        })
-      },
-    }
   }
 }
 

--- a/src/server/cursor-cli.ts
+++ b/src/server/cursor-cli.ts
@@ -219,12 +219,11 @@ export function parseCursorLine(line: string, configuredModel: string): HarnessE
       }
 
       if (subtype === "completed") {
+        // Only flag an error when Cursor explicitly reports one. A missing/non-object
+        // result (e.g. a bare string) is treated as success rather than a false error.
         const resultRecord = asRecord(result)
-        const success = resultRecord && "success" in resultRecord
         const isError = Boolean(resultRecord && ("error" in resultRecord || "failure" in resultRecord))
-        const content = resultRecord
-          ? (resultRecord.success ?? resultRecord.error ?? resultRecord.failure ?? result)
-          : result
+        const content = resultRecord?.success ?? resultRecord?.error ?? resultRecord?.failure ?? result
         return [
           {
             type: "transcript",
@@ -232,7 +231,7 @@ export function parseCursorLine(line: string, configuredModel: string): HarnessE
               kind: "tool_result",
               toolId: callId,
               content,
-              isError: isError || !success,
+              isError,
               debugRaw,
             }),
           },

--- a/src/server/provider-catalog.test.ts
+++ b/src/server/provider-catalog.test.ts
@@ -75,9 +75,10 @@ describe("provider catalog normalization", () => {
     expect(cursorModelIdForOptions("composer-2.5-fast", { fastMode: true })).toBe("composer-2.5-fast")
   })
 
-  test("exposes Cursor in the server provider catalog", () => {
+  test("resolves the Cursor default model through the server catalog", () => {
+    // Exercises the catalog lookup + default fallback (throws if "cursor" is unregistered).
     expect(normalizeServerModel("cursor")).toBe("composer-2.5")
-    expect(SERVER_PROVIDERS.find((provider) => provider.id === "cursor")?.label).toBe("Cursor")
+    expect(normalizeServerModel("cursor", "composer-2.5-fast")).toBe("composer-2.5")
   })
 
   test("normalizes server model ids through the shared alias catalog", () => {

--- a/src/server/provider-catalog.test.ts
+++ b/src/server/provider-catalog.test.ts
@@ -3,8 +3,10 @@ import {
   SERVER_PROVIDERS,
   applyClaudeSdkModels,
   codexServiceTierFromModelOptions,
+  cursorModelIdForOptions,
   normalizeClaudeModelOptions,
   normalizeCodexModelOptions,
+  normalizeCursorModelOptions,
   normalizeServerModel,
   resetServerProvidersForTests,
 } from "./provider-catalog"
@@ -61,6 +63,21 @@ describe("provider catalog normalization", () => {
       fastMode: true,
     })
     expect(codexServiceTierFromModelOptions(normalized)).toBe("fast")
+  })
+
+  test("normalizes Cursor model options and applies the fast model suffix", () => {
+    expect(normalizeCursorModelOptions(undefined)).toEqual({ fastMode: false })
+    expect(normalizeCursorModelOptions({ cursor: { fastMode: true } })).toEqual({ fastMode: true })
+
+    expect(cursorModelIdForOptions("composer-2.5", { fastMode: false })).toBe("composer-2.5")
+    expect(cursorModelIdForOptions("composer-2.5", { fastMode: true })).toBe("composer-2.5-fast")
+    // Idempotent if the base id already carries the suffix.
+    expect(cursorModelIdForOptions("composer-2.5-fast", { fastMode: true })).toBe("composer-2.5-fast")
+  })
+
+  test("exposes Cursor in the server provider catalog", () => {
+    expect(normalizeServerModel("cursor")).toBe("composer-2.5")
+    expect(SERVER_PROVIDERS.find((provider) => provider.id === "cursor")?.label).toBe("Cursor")
   })
 
   test("normalizes server model ids through the shared alias catalog", () => {

--- a/src/server/provider-catalog.ts
+++ b/src/server/provider-catalog.ts
@@ -2,6 +2,7 @@ import type {
   AgentProvider,
   ClaudeModelOptions,
   CodexModelOptions,
+  CursorModelOptions,
   ClaudeContextWindow,
   ModelOptions,
   ProviderCatalogEntry,
@@ -11,6 +12,7 @@ import type {
 import {
   DEFAULT_CLAUDE_MODEL_OPTIONS,
   DEFAULT_CODEX_MODEL_OPTIONS,
+  DEFAULT_CURSOR_MODEL_OPTIONS,
   PROVIDERS,
   normalizeClaudeContextWindow,
   normalizeProviderModelId,
@@ -153,4 +155,19 @@ export function normalizeCodexModelOptions(modelOptions?: ModelOptions, legacyEf
 
 export function codexServiceTierFromModelOptions(modelOptions: CodexModelOptions): ServiceTier | undefined {
   return modelOptions.fastMode ? "fast" : undefined
+}
+
+export function normalizeCursorModelOptions(modelOptions?: ModelOptions): CursorModelOptions {
+  return {
+    fastMode: typeof modelOptions?.cursor?.fastMode === "boolean"
+      ? modelOptions.cursor.fastMode
+      : DEFAULT_CURSOR_MODEL_OPTIONS.fastMode,
+  }
+}
+
+// Cursor encodes "fast" in the model id itself (composer-2.5 vs composer-2.5-fast),
+// so we apply the suffix at spawn time rather than tracking a separate service tier.
+export function cursorModelIdForOptions(baseModel: string, modelOptions: CursorModelOptions): string {
+  if (!modelOptions.fastMode) return baseModel
+  return baseModel.endsWith("-fast") ? baseModel : `${baseModel}-fast`
 }

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -397,6 +397,18 @@ describe("read models", () => {
       sessionToken: "thread-1",
       lastTurnOutcome: null,
     })
+    state.chatsById.set("chat-cursor", {
+      id: "chat-cursor",
+      projectId: "project-1",
+      title: "Cursor",
+      createdAt: 4,
+      updatedAt: 4,
+      unread: false,
+      provider: "cursor",
+      planMode: false,
+      sessionToken: "cursor-session",
+      lastTurnOutcome: null,
+    })
 
     const sidebar = deriveSidebarData(
       state,
@@ -407,5 +419,7 @@ describe("read models", () => {
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-active")?.canFork).toBeUndefined()
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-pending")?.canFork).toBe(true)
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-draining")?.canFork).toBeUndefined()
+    // Cursor has no fork primitive, so forking is disabled even with a live session.
+    expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-cursor")?.canFork).toBeUndefined()
   })
 })

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -31,6 +31,8 @@ function canForkChat(
   drainingChatIds: Set<string>,
 ) {
   if (!chat.provider) return false
+  // Cursor has no fork/branch primitive, so forking would silently start a fresh session.
+  if (chat.provider === "cursor") return false
   if (!chat.sessionToken && !chat.pendingForkSessionToken) return false
   if (activeStatuses.has(chat.id)) return false
   if (drainingChatIds.has(chat.id)) return false

--- a/src/server/transcript.ts
+++ b/src/server/transcript.ts
@@ -1,0 +1,14 @@
+import { randomUUID } from "node:crypto"
+import type { TranscriptEntry } from "../shared/types"
+
+/** Stamp a transcript entry with a generated id and creation time. */
+export function timestamped<T extends Omit<TranscriptEntry, "_id" | "createdAt">>(
+  entry: T,
+  createdAt = Date.now()
+): TranscriptEntry {
+  return {
+    _id: randomUUID(),
+    createdAt,
+    ...entry,
+  } as TranscriptEntry
+}

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -102,6 +102,13 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
       },
       planMode: false,
     },
+    cursor: {
+      model: "composer-2.5",
+      modelOptions: {
+        fastMode: false,
+      },
+      planMode: false,
+    },
   },
   warning: null,
   filePathDisplay: "~/.kanna/data/settings.json",

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -480,6 +480,13 @@ export function createWsRouter({
         },
         planMode: false,
       },
+      cursor: {
+        model: "composer-2.5",
+        modelOptions: {
+          fastMode: false,
+        },
+        planMode: false,
+      },
     },
     warning: null,
     filePathDisplay: "~/.kanna/data/settings.json",
@@ -510,6 +517,14 @@ export function createWsRouter({
         modelOptions: {
           ...snapshot.providerDefaults.codex.modelOptions,
           ...patch.providerDefaults?.codex?.modelOptions,
+        },
+      },
+      cursor: {
+        ...snapshot.providerDefaults.cursor,
+        ...patch.providerDefaults?.cursor,
+        modelOptions: {
+          ...snapshot.providerDefaults.cursor.modelOptions,
+          ...patch.providerDefaults?.cursor?.modelOptions,
         },
       },
     },

--- a/src/shared/assert.ts
+++ b/src/shared/assert.ts
@@ -1,0 +1,7 @@
+/**
+ * Exhaustiveness guard for discriminated unions. Reaching this at runtime means
+ * a case was missed; referencing `value: never` makes it a compile-time error too.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(value)}`)
+}

--- a/src/shared/json.ts
+++ b/src/shared/json.ts
@@ -1,0 +1,14 @@
+/** Small, dependency-free coercion helpers for parsing untrusted JSON values. */
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -354,6 +354,10 @@ export function normalizeCodexModelId(modelId?: string, fallbackModelId = "gpt-5
   return normalizeProviderModelId("codex", modelId, fallbackModelId)
 }
 
+export function normalizeCursorModelId(modelId?: string, fallbackModelId = "composer-2.5"): string {
+  return normalizeProviderModelId("cursor", modelId, fallbackModelId)
+}
+
 export function getProviderModelOption(provider: AgentProvider, modelId: string): ProviderModelOption | undefined {
   const normalizedModelId = normalizeProviderModelId(provider, modelId)
   return getProviderCatalog(provider).models.find((candidate) => candidate.id === normalizedModelId)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,7 +1,7 @@
 export const STORE_VERSION = 2 as const
 export const PROTOCOL_VERSION = 1 as const
 
-export type AgentProvider = "claude" | "codex"
+export type AgentProvider = "claude" | "codex" | "cursor"
 export type LlmProviderKind = "openai" | "openrouter" | "custom"
 export type AppThemePreference = "light" | "dark" | "system"
 export type ChatSoundPreference = "never" | "unfocused" | "always"
@@ -181,9 +181,14 @@ export interface CodexModelOptions {
   fastMode: boolean
 }
 
+export interface CursorModelOptions {
+  fastMode: boolean
+}
+
 export interface ProviderModelOptionsByProvider {
   claude: ClaudeModelOptions
   codex: CodexModelOptions
+  cursor: CursorModelOptions
 }
 
 export interface ProviderPreference<TModelOptions> {
@@ -195,6 +200,7 @@ export interface ProviderPreference<TModelOptions> {
 export type ChatProviderPreferences = {
   claude: ProviderPreference<ClaudeModelOptions>
   codex: ProviderPreference<CodexModelOptions>
+  cursor: ProviderPreference<CursorModelOptions>
 }
 
 export type ModelOptions = Partial<{
@@ -210,6 +216,10 @@ export const DEFAULT_CODEX_MODEL_OPTIONS = {
   reasoningEffort: "high",
   fastMode: false,
 } as const satisfies CodexModelOptions
+
+export const DEFAULT_CURSOR_MODEL_OPTIONS = {
+  fastMode: false,
+} as const satisfies CursorModelOptions
 
 export function isClaudeReasoningEffort(value: unknown): value is ClaudeReasoningEffort {
   return CLAUDE_REASONING_OPTIONS.some((option) => option.id === value)
@@ -295,6 +305,16 @@ export const PROVIDERS: ProviderCatalogEntry[] = [
       { id: "gpt-5.4", label: "GPT-5.4", supportsEffort: false },
       { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: false, aliases: ["gpt-5-codex"] },
       { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark", supportsEffort: false },
+    ],
+    efforts: [],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    defaultModel: "composer-2.5",
+    supportsPlanMode: false,
+    models: [
+      { id: "composer-2.5", label: "Composer 2.5", supportsEffort: false },
     ],
     efforts: [],
   },
@@ -468,6 +488,7 @@ export interface AppSettingsPatch {
   providerDefaults?: {
     claude?: Partial<ProviderPreference<ClaudeModelOptions>>
     codex?: Partial<ProviderPreference<CodexModelOptions>>
+    cursor?: Partial<ProviderPreference<CursorModelOptions>>
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a third agent provider, **Cursor** (`cursor-agent`), exposing **Composer 2.5** with a **Fast** toggle (`composer-2.5` / `composer-2.5-fast`).

Cursor runs one headless `cursor-agent -p --output-format stream-json --force` process per turn (prompt over stdin, `--force` to skip the interactive Workspace Trust prompt, auth via `CURSOR_API_KEY`). Its NDJSON stream is parsed into Kanna's transcript events, and multi-turn chats resume via `--resume <session>`. It plugs into the existing provider-agnostic `HarnessTurn`/`HarnessEvent` seam, so the generic turn loop, stop/interrupt, token-usage meter, and title generation all work unchanged.

## What's included

- **New adapter** `src/server/cursor-cli.ts` — `CursorCliManager` (one process per turn, interrupt/close) + pure, unit-tested `parseCursorLine`/`normalizeCursorUsage`. Cursor tool calls are translated to Claude-style names so they render natively via `normalizeToolCall`.
- **Provider wiring** through shared types, the provider catalog, the agent coordinator, settings persistence, and the composer UI (Cursor icon + Fast toggle, mirroring Codex fast mode).
- **Shared-helper cleanup** along the way: extracted `AsyncQueue` (was duplicated in `codex-app-server.ts`), plus `timestamped` and the JSON coercers into `src/server/transcript.ts` / `src/shared/json.ts`.
- **Tests** for the stream parser, usage/model normalization, and the `CursorCliManager.startTurn` spawn seam (argv/stdin/resume + error synthesis).

## Scope (v1)

Send + resume, full-access (`--force`), streaming tool calls, token usage, interrupt/stop. Not included: read-only "plan mode" (`supportsPlanMode: false`), importing existing Cursor sessions, and Cursor-based title generation (the existing OpenAI/Claude/Codex fallback chain still titles Cursor chats).

## Verification

`tsc --noEmit` clean, `bun run build` succeeds, provider/adapter/settings/store tests pass. Manually verified end-to-end against the live `cursor-agent` CLI (init/assistant/tool_call/result stream shapes, resume, token usage, the stderr/exit-0 error case).

## Demo

https://github.com/user-attachments/assets/619ee3b2-cd02-4ffa-9eb9-faaab7ff8775

<img width="1796" height="496" alt="image" src="https://github.com/user-attachments/assets/922c6d8e-ffd9-47f9-b46b-e4d918254de4" />
