### PR TITLE
Add GPT-5.6 Sol, Terra, and Luna support

### DIFF
--- a/docs/gpt-5.6-codex-support-plan.zh-CN.md
+++ b/docs/gpt-5.6-codex-support-plan.zh-CN.md
@@ -1,0 +1,713 @@
+# Kanna 支持 GPT-5.6 Sol / Terra / Luna 的实现与测试计划
+
+> 调研日期：2026-07-10  
+> 目标项目版本：Kanna `0.41.7`  
+> 本地验证的 Codex CLI：`codex-cli 0.144.1`  
+> 实施状态：核心实现与发布构建已于 2026-07-10 完成，验证记录见第 11 节。
+
+## 1. 目标
+
+让 Kanna 的 Codex provider 正确支持 GPT-5.6 模型家族：
+
+- `gpt-5.6-sol`
+- `gpt-5.6-terra`
+- `gpt-5.6-luna`
+
+并支持用户要求的配置档位：
+
+- Low：`low`
+- Medium：`medium`
+- High：`high`
+- Extra High：`xhigh`
+- Max：`max`
+- Ultra：`ultra`
+
+目标不仅是让选项出现在 UI 中，还要保证模型、effort、设置持久化、排队消息、计划模式和 Codex app-server JSON-RPC 全链路一致。
+
+## 2. 结论摘要
+
+### 2.1 官方命名已经确认
+
+OpenAI 当前正式提供三个 GPT-5.6 模型：
+
+| 展示名称 | 模型 ID | 定位 |
+|---|---|---|
+| GPT-5.6 Sol | `gpt-5.6-sol` | 旗舰能力，适合复杂编码、研究和高价值任务 |
+| GPT-5.6 Terra | `gpt-5.6-terra` | 能力、成本和速度之间的日常平衡 |
+| GPT-5.6 Luna | `gpt-5.6-luna` | 更快、更经济，适合明确、重复和高吞吐任务 |
+
+`gpt-5.6` 是别名，在 OpenAI API 文档中会路由到 `gpt-5.6-sol`。
+
+官方依据：
+
+- [Using GPT-5.6](https://developers.openai.com/api/docs/guides/latest-model)
+- [Codex Models](https://learn.chatgpt.com/docs/models)
+- [Reasoning models](https://developers.openai.com/api/docs/guides/reasoning)
+
+### 2.2 Ultra 不是普通的“更高思考档位”
+
+从产品语义看：
+
+- Low 到 Max 控制单个模型在一个任务上的 reasoning 深度。
+- Ultra 启用主动的多 Agent/子 Agent 任务拆分和并行执行。
+
+因此 Ultra 的成本、行为和可观察事件可能与 Max 明显不同，UI 描述不能只写成“比 Max 思考更多”。
+
+但是在当前 Codex app-server 协议中，Ultra 的线格式确实是：
+
+```json
+{
+  "effort": "ultra"
+}
+```
+
+本机 `codex app-server generate-ts --experimental` 生成的 `TurnStartParams` 明确说明：旧的 `multiAgentMode` 已忽略，应使用 `effort: "ultra"` 获得主动多 Agent 行为。
+
+所以 Kanna 的内部类型可以将 `ultra` 保留在 Codex effort 联合类型中，但 UI 和文档必须将它解释为“多 Agent 编排模式”。
+
+### 2.3 GPT-5.6 的可选档位不是三个模型完全一致
+
+在本机 Codex CLI `0.144.1` 上实际调用 `model/list`，得到：
+
+| 模型 | Low | Medium | High | Extra High | Max | Ultra | app-server 默认 effort |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `gpt-5.6-sol` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | `low` |
+| `gpt-5.6-terra` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | `medium` |
+| `gpt-5.6-luna` | ✓ | ✓ | ✓ | ✓ | ✓ | — | `medium` |
+
+这意味着 UI 必须按模型过滤 effort，不能继续使用一份全局 Codex effort 列表。
+
+虽然 app-server 的 Sol catalog 默认值是 `low`，公开 Codex 文档中的默认 Power 配置是 Sol + Medium。为了与用户可理解的产品默认行为和 OpenAI API 默认行为一致，本文建议：
+
+```text
+Kanna 新用户默认：gpt-5.6-sol + medium
+```
+
+现有用户的已保存选择应尽量保留，不应被升级逻辑无条件覆盖。
+
+### 2.4 API 的 `none` 与旧 Kanna 的 `minimal`
+
+GPT-5.6 API 文档还列出了 `none`，但当前 Codex `model/list` 没有为这三个模型返回 `none` 或 `minimal`。
+
+当前 Kanna 却提供 `minimal`。因此本次改动建议：
+
+- GPT-5.6 UI 不展示 `minimal` 或 `none`。
+- 类型或迁移层暂时识别旧的 `minimal`，用于兼容已有设置。
+- 当旧设置中的 `minimal` 应用于 GPT-5.6 时，归一化为语义最接近且合法的 `low`，而不是直接把无效值发给 app-server。
+- 不在本次范围中增加原始 API 专用的 `none`，因为 Kanna 的正式聊天链路走的是 Codex app-server，不是直接调用 Responses API。
+
+### 2.5 本次范围边界
+
+本次目标是在 Kanna 现有静态模型目录和消息链路上完成 GPT-5.6 支持，不引入运行时模型发现系统。
+
+明确不做：
+
+- 不在 Kanna 启动时额外创建 app-server 进程查询 `model/list`。
+- 不新增 provider-catalog WebSocket 订阅。
+- 不增加动态 catalog 缓存、超时、fallback 和 warning 状态机。
+- 不将 README、changelog 或发布说明作为独立实施阶段。
+
+模型和 capability 使用当前 Codex CLI `0.144.1` 已验证的数据静态定义。未来如果 Kanna 需要适配大量不同 CLI 版本、账号权限或频繁变化的模型 rollout，再将动态 capability discovery 作为独立功能设计。
+
+## 3. Kanna 当前架构中的配置链路
+
+一次 Codex 消息的模型配置流如下：
+
+```text
+ChatPreferenceControls / SettingsPage
+        ↓
+chatPreferencesStore / AppSettingsSnapshot
+        ↓
+ChatInput.handleSubmit
+        ↓
+ClientCommand: chat.send / message.enqueue
+        ↓ WebSocket
+ws-router
+        ↓
+AgentCoordinator.send / startTurnForChat
+        ↓
+normalizeCodexModelOptions
+        ↓
+CodexAppServerManager.startSession
+        ↓
+CodexAppServerManager.startTurn
+        ↓ JSON-RPC
+codex app-server: thread/start + turn/start
+```
+
+核心文件：
+
+| 层级 | 文件 | 当前责任 |
+|---|---|---|
+| 共享类型/静态目录 | `src/shared/types.ts` | 模型、effort、默认值、归一化 |
+| 服务端目录 | `src/server/provider-catalog.ts` | 服务端模型白名单和 option 归一化 |
+| 协议类型 | `src/server/codex-app-server-protocol.ts` | app-server JSON-RPC 的最小类型子集 |
+| Codex 适配 | `src/server/codex-app-server.ts` | 启动 app-server、thread、turn 和事件转换 |
+| Agent 编排 | `src/server/agent.ts` | provider/model/effort 选择、队列、会话恢复 |
+| WebSocket | `src/shared/protocol.ts`、`src/server/ws-router.ts` | 命令和快照传输 |
+| 服务端设置 | `src/server/app-settings.ts` | 默认模型与 effort 的磁盘持久化 |
+| 浏览器状态 | `src/client/stores/chatPreferencesStore.ts` | provider 默认值、每个 composer 的选择 |
+| 输入控件 | `src/client/components/chat-ui/ChatPreferenceControls.tsx` | 模型和 effort 下拉菜单 |
+| 输入协调 | `src/client/components/chat-ui/ChatInput.tsx` | 将 UI 选择转成发送参数 |
+| 状态协调 | `src/client/app/useKannaState.ts` | 发送、排队、快照比较与设置同步 |
+
+## 4. 当前实现与目标之间的差距
+
+### 4.1 模型目录缺少 GPT-5.6
+
+`src/shared/types.ts` 和 `src/server/provider-catalog.ts` 都硬编码了：
+
+- GPT-5.5
+- GPT-5.4
+- GPT-5.3 Codex
+- GPT-5.3 Codex Spark
+
+当前没有 Sol、Terra、Luna，默认模型仍是 `gpt-5.5`。
+
+### 4.2 客户端和服务端各维护了一份 Codex 模型目录
+
+共享 `PROVIDERS` 和服务端 `HARD_CODED_CODEX_MODELS` 是平行数据源。增加模型时容易只改一处，从而造成：
+
+- 设置页能选但服务端归一化回旧模型。
+- 聊天快照与新聊天 fallback 显示不同选项。
+- 客户端发送的模型被服务端白名单替换。
+
+本次改动应建立单一静态数据源。
+
+### 4.3 Codex effort 类型缺少 `max` 和 `ultra`
+
+当前 `CodexReasoningEffort` 是：
+
+```ts
+"minimal" | "low" | "medium" | "high" | "xhigh"
+```
+
+必须增加：
+
+```ts
+"max" | "ultra"
+```
+
+`xhigh` 的展示文案应从 `XHigh` 改为用户更容易理解、也与官方产品一致的 `Extra High`。
+
+### 4.4 当前 UI 使用全局 effort 列表
+
+`ChatPreferenceControls.tsx` 对所有 Codex 模型直接遍历 `CODEX_REASONING_OPTIONS`，没有读取当前模型的 capability。
+
+这会导致 Luna 显示并发送它不支持的 Ultra，也无法兼容以后不同模型的 effort 子集。
+
+### 4.5 浏览器迁移逻辑会无条件把 Codex 模型改回 GPT-5.5
+
+`chatPreferencesStore.ts` 中存在：
+
+- `forcePersistedCodexPreference`
+- `forcePersistedCodexComposerState`
+- `forcePersistedCodexChatStates`
+
+这些函数会把所有已持久化 Codex model 强制写成 `gpt-5.5`。
+
+如果不先移除或版本化这段迁移，即使 UI 成功保存 GPT-5.6，重新载入旧浏览器状态时也可能回退到 GPT-5.5。
+
+### 4.6 `collaborationMode` 可能覆盖顶层 effort
+
+当前 `turn/start` 同时发送：
+
+```ts
+effort: args.effort,
+collaborationMode: {
+  mode: args.planMode ? "plan" : "default",
+  settings: {
+    model: args.model,
+    reasoning_effort: null,
+    developer_instructions: null,
+  },
+}
+```
+
+当前 Codex 协议说明 `collaborationMode` 的 settings 优先于顶层 model、reasoning effort 和 developer instructions。
+
+因此仅修改顶层 `effort` 并不足以证明配置生效。必须进行以下二选一修复：
+
+1. 推荐方案：顶层 `effort` 和 `collaborationMode.settings.reasoning_effort` 同时传递相同值。
+2. 备选方案：仅在确实需要切换 plan/default mode 时发送 collaborationMode，并验证 sticky 行为。
+
+推荐第一种，因为它保持当前 Kanna 的 plan/default 切换方式，同时消除两个字段不一致。
+
+### 4.7 当前 CLI 版本提示是 GPT-5.5 专用硬编码
+
+UI 只对 GPT-5.5 显示 `codex-cli >= 0.124` 提示。本次不增加运行时 capability 检测；GPT-5.6 可以显示静态说明，例如“Requires a Codex CLI and account with GPT-5.6 access”，但不能把本机验证版本 `0.144.1` 未经官方证据直接宣称为最低版本。
+
+## 5. 目标数据模型
+
+### 5.1 Codex effort 类型
+
+建议保留旧值以读取历史数据，但只按模型 capability 展示：
+
+```ts
+type CodexReasoningEffort =
+  | "minimal" // legacy compatibility only
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra"
+```
+
+展示表：
+
+```ts
+const CODEX_REASONING_OPTIONS = [
+  { id: "low", label: "Low" },
+  { id: "medium", label: "Medium" },
+  { id: "high", label: "High" },
+  { id: "xhigh", label: "Extra High" },
+  { id: "max", label: "Max" },
+  {
+    id: "ultra",
+    label: "Ultra",
+    description: "Uses subagents to delegate parts of complex tasks",
+  },
+]
+```
+
+`minimal` 不进入 GPT-5.6 的公开 options，只用于迁移旧状态。
+
+### 5.2 模型级 capability
+
+扩展 `ProviderModelOption`：
+
+```ts
+interface ProviderModelOption {
+  id: string
+  label: string
+  supportsEffort: boolean
+  aliases?: readonly string[]
+  supportedReasoningEfforts?: readonly CodexReasoningEffort[]
+  defaultReasoningEffort?: CodexReasoningEffort
+  supportsFastMode?: boolean
+}
+```
+
+静态 catalog：
+
+```ts
+{
+  id: "gpt-5.6-sol",
+  label: "GPT-5.6 Sol",
+  aliases: ["gpt-5.6"],
+  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  defaultReasoningEffort: "medium",
+  supportsFastMode: true,
+}
+
+{
+  id: "gpt-5.6-terra",
+  label: "GPT-5.6 Terra",
+  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  defaultReasoningEffort: "medium",
+  supportsFastMode: true,
+}
+
+{
+  id: "gpt-5.6-luna",
+  label: "GPT-5.6 Luna",
+  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+  defaultReasoningEffort: "medium",
+  supportsFastMode: true,
+}
+```
+
+### 5.3 归一化规则
+
+增加统一 helper，客户端和服务端都使用同一规则：
+
+```ts
+getCodexModelOption(modelId)
+getCodexReasoningOptions(modelId)
+normalizeCodexReasoningEffort(modelId, requestedEffort)
+```
+
+规则：
+
+1. `gpt-5.6` 归一化为 `gpt-5.6-sol`。
+2. 请求 effort 被当前模型支持时原样保留。
+3. 旧 `minimal` 应用于 GPT-5.6 时归一化为 `low`。
+4. 从 Sol/Terra Ultra 切换到 Luna 时归一化为 `max`，保持用户选择最高强度的意图，并显示一次轻量提示。
+5. 其他不受支持或未知 effort 回退到当前模型的 `defaultReasoningEffort`。
+6. 服务端再次执行同样归一化，不能只信任浏览器。
+7. 未知模型回退到 provider 默认模型，并保留可诊断错误信息。
+
+## 6. 分阶段实现计划
+
+### 阶段 0：建立基线
+
+1. 安装项目依赖：`bun install`。
+2. 记录当前 `bun test` 和 `bun run check` 基线。
+3. 记录 `codex --version`。
+4. 确认当前开发环境具备 GPT-5.6 entitlement；模型不可用时使用 mock 协议测试完成开发。
+
+### 阶段 1：共享类型和单一静态目录
+
+修改：
+
+- `src/shared/types.ts`
+- `src/server/provider-catalog.ts`
+- `src/shared/types.test.ts`
+- `src/server/provider-catalog.test.ts`
+
+任务：
+
+1. 增加 `max`、`ultra` Codex effort。
+2. 将 `xhigh` label 改为 `Extra High`。
+3. 给模型增加 supported/default effort metadata。
+4. 添加 Sol、Terra、Luna。
+5. 将 Codex 默认模型改为 `gpt-5.6-sol`。
+6. 将新用户默认 effort 改为 `medium`。
+7. 添加 `gpt-5.6` 到 Sol 的 aliases。
+8. 删除或改造服务端重复的 `HARD_CODED_CODEX_MODELS`，使服务端目录从共享目录派生。
+9. 实现模型级 effort 归一化。
+
+完成标准：共享层能独立回答“这个模型支持哪些 effort、默认是什么、某个输入应归一化为什么”。
+
+### 阶段 2：设置持久化和迁移
+
+修改：
+
+- `src/server/app-settings.ts`
+- `src/client/stores/chatPreferencesStore.ts`
+- 对应测试文件
+
+任务：
+
+1. 更新服务端默认设置为 Sol + Medium。
+2. 确保 Sol/Terra/Luna 和 `max/ultra` 能写入并读回 `settings.json`。
+3. 移除无条件 force-to-GPT-5.5 迁移。
+4. 如果仍需迁移旧 schema，增加显式 migration version，而不是每次载入都强制覆盖。
+5. 保留现有用户的合法 GPT-5.4/5.5 配置。
+6. 将 GPT-5.6 上的旧 `minimal` 归一化为 `low`。
+7. 将 Luna + Ultra 归一化为 Luna + Max，并给前端返回归一化后的有效配置。
+8. 确保浏览器 legacy settings 迁移到服务端后不再次覆盖服务端值。
+
+完成标准：保存设置、刷新浏览器、重启 Kanna 后配置一致。
+
+### 阶段 3：模型级 UI
+
+修改：
+
+- `src/client/components/chat-ui/ChatPreferenceControls.tsx`
+- `src/client/components/chat-ui/ChatInput.tsx`
+- `src/client/app/SettingsPage.tsx`
+- `src/client/stores/chatPreferencesStore.ts`
+- `src/client/app/useKannaState.ts`
+
+任务：
+
+1. 模型下拉显示 Sol、Terra、Luna。
+2. Reasoning Level 保持与 Codex CLI/App 一致的单一选择器，并读取当前模型的 `supportedReasoningEfforts`。
+3. Ultra 放在 Reasoning Level 的 Max 之后，同时增加多 Agent 行为说明。
+4. Luna 不显示 Ultra。
+5. 从 Sol/Terra Ultra 切换到 Luna 后立即改为 Max，并显示一次轻量提示。
+6. 设置页与聊天 composer 使用同一 helper。
+7. 删除或改写 GPT-5.5 专用 CLI 版本提示；GPT-5.6 只显示静态兼容性说明，不增加运行时检测。
+8. Provider 已被聊天锁定时，仍允许切换同一 Codex provider 下的模型和 effort，保持当前行为。
+
+完成标准：任何 UI 路径都不能构造 Luna + Ultra 或未知 effort。
+
+### 阶段 4：Codex app-server 协议
+
+修改：
+
+- `src/server/codex-app-server-protocol.ts`
+- `src/server/codex-app-server.ts`
+- `src/server/agent.ts`
+- 对应测试文件
+
+任务：
+
+1. 更新 vendored protocol subset，允许 `max` 和 `ultra`。
+2. `turn/start.effort` 传递归一化后的值。
+3. `collaborationMode.settings.reasoning_effort` 传递相同 effort，不能继续写 `null`。
+4. 保证 plan/default mode 切换不改变用户选择的 effort。
+5. 保证 plan mode 结束后的 `postToolFollowUp` 继续使用原 model、effort 和 service tier。
+6. 保证排队消息和 steer 消息保留原 model options。
+7. 在服务端拒绝或归一化不受支持的模型/effort 组合。
+8. 保持 fast mode 与 effort 独立；不要将 Ultra 实现成 fast mode 或 plan mode。
+
+完成标准：mock app-server 收到的 `turn/start` JSON 与 UI 选择完全一致。
+
+### 阶段 5：测试与验收
+
+1. 完成第 7 节定义的单元、设置迁移、UI、协议、AgentCoordinator、集成和回归测试。
+2. 使用 fake app-server 覆盖全部 17 个有效 GPT-5.6 模型/effort 组合。
+3. 在当前 Codex CLI 环境完成 Sol、Terra、Luna 的真实只读 smoke test。
+4. 完成 Ultra 子 Agent 行为和取消行为的真实验证。
+5. 运行 `bun test`。
+6. 运行 `bun run check`。
+7. 按第 8 节验收标准逐项确认。
+
+完成标准：核心功能、迁移、协议和回归测试全部通过；不依赖运行时 model catalog discovery。
+
+## 7. 测试计划
+
+### 7.1 共享类型与归一化单元测试
+
+文件：
+
+- `src/shared/types.test.ts`
+- `src/server/provider-catalog.test.ts`
+
+测试：
+
+1. `normalizeCodexModelId("gpt-5.6") === "gpt-5.6-sol"`。
+2. 三个正式 slug 保持不变。
+3. 未知 slug 回退到 Sol。
+4. `isCodexReasoningEffort` 接受 `max`、`ultra`。
+5. Sol effort 列表为 6 项。
+6. Terra effort 列表为 6 项。
+7. Luna effort 列表为 5 项且不包含 Ultra。
+8. `xhigh` label 为 `Extra High`。
+9. Luna + Ultra 归一化到 Luna + Max。
+10. GPT-5.6 + legacy minimal 归一化到 Low。
+11. Sol + Max、Sol + Ultra、Terra + Ultra 保持不变。
+12. 旧 GPT-5.4/5.5 的合法配置不因增加 5.6 而失效。
+
+建议使用表驱动测试覆盖完整 17 个有效组合：
+
+```text
+Sol:   low, medium, high, xhigh, max, ultra
+Terra: low, medium, high, xhigh, max, ultra
+Luna:  low, medium, high, xhigh, max
+```
+
+### 7.2 设置与迁移测试
+
+文件：
+
+- `src/server/app-settings.test.ts`
+- `src/client/stores/chatPreferencesStore.test.ts`
+
+测试：
+
+1. 新设置文件默认 Sol + Medium。
+2. Sol + Ultra 写入后可原样读回。
+3. Terra + Max 写入后可原样读回。
+4. Luna + Ultra 被归一化为 Luna + Max。
+5. 老的 GPT-5.5 + XHigh 设置被保留。
+6. 老的 GPT-5.3/5.4 composer state 不再无条件改成 GPT-5.5，除非产品明确要求淘汰。
+7. 新的 GPT-5.6 设置不会被 legacy migration 改回 GPT-5.5。
+8. 部分 patch 只修改 effort，不丢失 model、fastMode、planMode。
+9. 浏览器 legacy settings 只迁移一次。
+10. 无效 JSON 或未知 effort 仍产生已有 warning，并回退安全默认值。
+
+### 7.3 UI 组件测试
+
+文件：
+
+- `src/client/components/chat-ui/ChatPreferenceControls.test.tsx`
+- `src/client/components/chat-ui/ChatInput.test.ts`
+- `src/client/app/SettingsPage.test.tsx`
+
+测试：
+
+1. 模型菜单显示 GPT-5.6 Sol、Terra、Luna。
+2. Sol 显示 Low 到 Ultra。
+3. Terra 显示 Low 到 Ultra。
+4. Luna 显示 Low 到 Max，不显示 Ultra。
+5. Extra High 的展示文字正确，提交值仍为 `xhigh`。
+6. Ultra 有 subagent 描述。
+7. 从 Sol + Ultra 切到 Luna 后，选择值自动变为 Max，并显示轻量提示。
+8. 从 Luna 切回 Sol 不凭空恢复一个未保存的 Ultra。
+9. 设置页和聊天 composer 使用相同的过滤规则。
+10. fast mode、plan mode、model、effort 四个控件互不错误覆盖。
+11. provider locked 时模型和 effort 仍可按当前产品规则修改。
+12. 键盘和 popover 行为无回归。
+
+### 7.4 WebSocket 与快照测试
+
+文件：
+
+- `src/server/ws-router.test.ts`
+- `src/server/read-models.test.ts`
+- `src/client/app/socket.test.ts`
+- `src/client/app/useKannaState.test.ts`
+
+测试：
+
+1. ChatSnapshot 包含静态定义的三个 GPT-5.6 模型及模型级 capability。
+2. `chat.send` 能将 Max/Ultra 交给 AgentCoordinator。
+3. `message.enqueue` 能保留 model、Max/Ultra 和 fastMode。
+4. 现有 sidebar、chat、settings 等订阅和快照去重行为无回归。
+
+### 7.5 Codex app-server 协议测试
+
+文件：
+
+- `src/server/codex-app-server.test.ts`
+
+使用 fake app-server 进程验证：
+
+1. `thread/start` 使用所选 Sol/Terra/Luna slug。
+2. `turn/start.effort` 对全部 17 个有效组合传递正确。
+3. `collaborationMode.settings.reasoning_effort` 与顶层 effort 完全相同。
+4. Max 按字符串 `max` 发送。
+5. Ultra 按字符串 `ultra` 发送。
+6. 不发送旧的 `multiAgentMode`。
+7. Luna + Ultra 在进入 app-server 前已归一化为 Luna + Max。
+8. plan mode 和 default mode 都保留 effort。
+9. plan approval 后的 follow-up turn 保留 model/effort。
+10. resume、fork、queued、steer 后配置保持一致。
+11. fast mode 的 service tier 不被 Ultra 覆盖。
+12. interrupt/cancel Ultra turn 仍发送 `turn/interrupt` 并正确结束 queue。
+
+### 7.6 AgentCoordinator 测试
+
+文件：
+
+- `src/server/agent.test.ts`
+
+测试：
+
+1. 新聊天 Sol + Medium 正确启动。
+2. 显式 Terra + XHigh 正确启动。
+3. 显式 Luna + Max 正确启动。
+4. Sol/Terra + Ultra 正确启动。
+5. 同一聊天 provider 锁定逻辑不影响 Codex 内部模型选择。
+6. active turn 时发送的 queued message 保存所选模型和 effort。
+7. steer 后启动排队消息时仍使用其保存的 model options。
+8. cancel Ultra turn 后 active/draining 状态正确清理。
+9. title generation 和 quick-response fallback 不被正式聊天模型默认值误改。
+
+### 7.7 集成测试
+
+使用 fake JSON-RPC app-server 跑一条完整链路：
+
+```text
+UI command payload
+  → WebSocket command
+  → AgentCoordinator
+  → model/effort normalization
+  → thread/start
+  → turn/start
+  → transcript events
+  → ChatSnapshot
+```
+
+至少覆盖：
+
+- Sol + Medium 普通模式。
+- Terra + XHigh + fast mode。
+- Luna + Max + plan mode。
+- Sol + Ultra。
+- Ultra turn cancel。
+- Sol Ultra 切换到 Luna Max 后的归一化。
+
+### 7.8 真实 Codex smoke test
+
+真实测试默认不进入普通单元测试套件，使用显式环境变量开启，避免消耗账号额度：
+
+```bash
+KANNA_LIVE_CODEX_TEST=1 bun test src/server/codex-gpt56.live.test.ts
+```
+
+建议的最小真实矩阵：
+
+1. Sol + Medium：简单只读代码解释任务。
+2. Terra + Low：简单只读代码解释任务。
+3. Luna + Medium：简单只读代码解释任务。
+4. Sol + Max：短小但需要推理的无副作用任务。
+5. Sol + Ultra：可拆成两个只读子任务的任务，确认出现 subagent/collab 事件。
+6. Terra + Ultra：同类任务，确认 app-server 接受配置。
+7. Luna + Ultra：确认 Kanna 在发送前归一化为 Luna + Max，而不是依赖上游报错。
+8. plan + Ultra：验证当前 Codex 是否支持组合；如不支持，UI 必须禁用该组合并给出原因。
+
+真实测试任务必须：
+
+- 使用临时项目。
+- 不修改用户真实仓库。
+- 不访问敏感文件。
+- 设置超时。
+- 测试结束后终止 app-server 子进程。
+- 记录模型和有效 effort，不记录认证信息。
+
+### 7.9 回归测试
+
+必须覆盖：
+
+- Claude provider 的模型、context window、Max effort 不受影响。
+- GPT-5.4/5.5 仍可继续使用。
+- fast mode 继续映射到已有 service tier。
+- plan mode 的审批和 follow-up 不回归。
+- session resume/fork 不回归。
+- queued/steer/cancel/draining 不回归。
+- 设置同步、主题、终端和 Git 功能无关测试继续通过。
+- standalone export 能渲染 GPT-5.6 的 `system_init.model`。
+
+## 8. 验收标准
+
+实现完成必须同时满足：
+
+1. 新用户默认看到 GPT-5.6 Sol + Medium。
+2. 模型选择器包含 Sol、Terra、Luna。
+3. Sol/Terra 支持 Low、Medium、High、Extra High、Max、Ultra。
+4. Luna 支持 Low、Medium、High、Extra High、Max，不显示 Ultra。
+5. UI、服务端归一化和 app-server 收到的 model/effort 一致。
+6. Ultra 被解释和验证为多 Agent 模式，而不是普通 reasoning 档位。
+7. 刷新浏览器和重启 Kanna 后设置不丢失、不回退到 GPT-5.5。
+8. 旧 GPT-5.4/5.5 设置可兼容读取。
+9. mock 协议测试覆盖全部 17 个有效 GPT-5.6 组合。
+10. Luna + Ultra 在 UI 和服务端都稳定归一化为 Luna + Max。
+11. `bun test` 全部通过。
+12. `bun run check` 通过，包括 TypeScript 和两个 Vite build。
+13. 至少完成 Sol、Terra、Luna 各一次真实只读 smoke test。
+14. Ultra 至少完成一次真实 subagent 行为验证和一次取消验证。
+
+## 9. 推荐提交拆分
+
+为降低回归风险，建议拆成以下提交：
+
+1. `Add GPT-5.6 model metadata and effort normalization`
+2. `Preserve Codex model preferences during settings migration`
+3. `Render model-specific Codex reasoning controls`
+4. `Forward max and ultra through Codex app-server turns`
+5. `Add GPT-5.6 protocol, UI, migration, and live tests`
+
+每个提交都应带对应测试，避免最后一次性补测试。
+
+## 10. 风险与回滚
+
+### 风险 1：账号或 CLI 尚未获得 GPT-5.6
+
+处理：Kanna 使用当前已验证的静态 catalog；UI 提示 GPT-5.6 需要兼容的 Codex CLI 和账号权限。若上游不可用，保留 app-server 的明确错误，不额外引入运行时 capability discovery。
+
+### 风险 2：Ultra 与 plan mode 组合行为变化
+
+处理：先做真实 smoke test。若上游不支持，UI 按组合禁用，不发送猜测字段。
+
+### 风险 3：旧设置被错误迁移
+
+处理：移除无条件 GPT-5.5 重写；为迁移函数增加旧版本 fixture 和幂等测试。
+
+### 风险 4：collaborationMode 覆盖 effort
+
+处理：顶层和 collaboration settings 同时发送相同 effort，并在协议测试中逐项断言。
+
+### 回滚策略
+
+- 保留 GPT-5.4/5.5 模型，不在首个版本删除旧模型。
+- 不修改 EventStore 版本，避免为模型配置引入不必要的聊天历史重置。
+- 若 Ultra 上游行为不稳定，可以仅隐藏 Ultra UI，而不回滚 Sol/Terra/Luna 和 Max 支持。
+
+## 11. 实施与验证记录
+
+截至 2026-07-10：
+
+- 已安装依赖并在 `feat/gpt-5-6-codex-support` 分支完成实现。
+- 静态目录、设置迁移、模型级 UI、服务端二次归一化和 app-server 双字段传递均已完成。
+- fake app-server 协议测试覆盖全部 17 个合法 GPT-5.6 模型/effort 组合。
+- `bun run check` 通过，包括 TypeScript、主客户端构建和 standalone export viewer 构建。
+- 定向 GPT-5.6 测试共 130 项通过。
+- 真实只读 smoke test 已验证 Sol + Medium、Terra + Low、Luna + Medium，三个模型均返回预期结果。
+- 真实 Sol + Ultra 已产生 `collab_tool_call` 并完成任务；中断路径也已实际执行。当前网络代理偶发 WebSocket TLS 重连，但模型最终响应成功。
+
+完整 `bun test` 在本机得到 609 项通过、12 项失败。失败集中在本次未修改的三类既有测试环境问题：临时 Git merge preview、PTY `Ctrl+D` 时序，以及多个浏览器测试对只读 `globalThis.window` 的交叉污染；相关浏览器测试隔离运行时通过。为遵守本次范围边界，没有修改这些无关模块来掩盖环境差异。

--- a/docs/project-architecture-analysis.zh-CN.md
+++ b/docs/project-architecture-analysis.zh-CN.md
@@ -1,0 +1,475 @@
+# Kanna 项目原理与架构分析
+
+## 总体结论
+
+Kanna 是一个运行在本机的 AI 编程工作台：它自己不实现模型推理，而是为 Claude Code 和 Codex CLI 提供统一的 Web 界面、会话管理、终端、Git、文件上传、计划审批和历史持久化能力。
+
+它的核心价值可以概括为：
+
+```text
+React 浏览器界面
+       ↕ WebSocket
+Bun 本地服务
+       ↕ 统一 Agent 协调层
+Claude Agent SDK / Codex app-server
+       ↕
+项目目录、Git、终端和本地历史
+```
+
+## 一、项目基本信息
+
+| 项目 | 当前信息 |
+|---|---|
+| 包名 | `kanna-code` |
+| 本地版本 | `0.41.7` |
+| 定位 | Claude Code 与 Codex CLI 的本地 Web UI |
+| 运行时 | Bun 1.3.5+ |
+| 前端 | React 19、React Router、Zustand、Tailwind、Radix UI、xterm.js |
+| 后端 | Bun HTTP/WebSocket Server、TypeScript |
+| Agent 接入 | Claude Agent SDK、Codex `app-server` JSON-RPC |
+| 存储 | JSONL 事件日志、状态快照、每会话独立 transcript |
+| 默认端口 | `127.0.0.1:3210` |
+| 许可证 | MIT |
+| TypeScript/TSX 规模 | 约 57,419 行，包含测试 |
+
+主要项目信息位于 `package.json` 和 `README.md`。
+
+启动方式：
+
+```bash
+bun install
+bun run dev
+```
+
+或者安装全局包后，在任意项目目录运行：
+
+```bash
+kanna
+```
+
+生产构建由 Vite 生成前端资源，Bun 同时负责静态文件、HTTP API 和 WebSocket 服务。
+
+## 二、启动原理
+
+命令入口是 `bin/kanna`。
+
+实际启动分成两层进程：
+
+```text
+kanna supervisor
+    └── kanna server child process
+            ├── Bun HTTP/WS Server
+            ├── EventStore
+            ├── AgentCoordinator
+            ├── TerminalManager
+            └── Codex/Claude sessions
+```
+
+外层 supervisor 位于 `src/server/cli-supervisor.ts`，主要作用是：
+
+- 启动真正的 Kanna 子进程。
+- 转发 `SIGINT`、`SIGTERM`。
+- 更新安装完成后重新启动子进程。
+- 防止自动更新造成无限重启循环。
+
+内层 `src/server/cli.ts` 解析命令行参数，然后调用 `src/server/server.ts` 创建服务。
+
+生产模式中，一个 Bun 服务同时处理：
+
+- `/ws`：WebSocket。
+- `/api/...`：上传、文件读取等 HTTP API。
+- `/auth/...`：密码登录。
+- `/health`：健康检查。
+- 其他路径：Vite 构建出的 React SPA。
+
+开发模式稍有不同：
+
+```text
+浏览器 → Vite 开发服务器
+               ├── React HMR
+               └── /ws、/api、/auth 代理到 Bun 后端
+```
+
+相关配置位于 `vite.config.ts` 和 `scripts/dev.ts`。
+
+## 三、一条聊天消息如何运行
+
+这是项目最重要的调用链。
+
+### 1. 前端立即进行乐观更新
+
+用户点击发送后，`src/client/app/useKannaState.ts` 会：
+
+- 立即在浏览器内插入一条临时 `user_prompt`。
+- 显示用户刚发送的内容，不等待服务器响应。
+- 生成 `clientTraceId`，用于性能追踪。
+- 发送 `chat.send` WebSocket 命令。
+
+因此界面响应很快，即使 Agent 子进程还没有启动。
+
+### 2. WebSocket 路由命令
+
+WebSocket 协议定义在 `src/shared/protocol.ts`。
+
+协议有三类客户端消息：
+
+- `subscribe`：订阅聊天、侧边栏、Git、终端等数据。
+- `unsubscribe`：取消订阅。
+- `command`：执行发送消息、创建项目、提交 Git 等操作。
+
+服务端通过 `src/server/ws-router.ts` 把 `chat.send` 转交给 `AgentCoordinator`。
+
+### 3. AgentCoordinator 做发送前准备
+
+核心协调器是 `src/server/agent.ts`。
+
+它会依次：
+
+1. 新聊天则先创建聊天记录。
+2. 确定 provider、模型、推理强度和计划模式。
+3. 给新聊天生成一个基于首条消息的临时标题。
+4. 将真实用户消息写入 transcript。
+5. 写入 `turn_started` 事件。
+6. 在后台调用模型生成更合适的标题。
+7. 启动或复用 Claude/Codex 会话。
+8. 把当前聊天登记到内存中的 `activeTurns`。
+9. 通知 WebSocket 路由重新推送快照。
+
+### 4. Provider 返回流式事件
+
+Claude 或 Codex 返回的文本、工具调用、文件修改、token 用量等事件，都会转换成统一的 `TranscriptEntry`：
+
+```text
+system_init
+user_prompt
+assistant_text
+tool_call
+tool_result
+context_window_updated
+compact_boundary
+result
+interrupted
+```
+
+这些类型定义在 `src/shared/types.ts`。
+
+每个事件都先写入会话 transcript，然后服务器派生新的聊天快照并推给浏览器。
+
+### 5. 前端重新水合工具调用
+
+前端在 `src/client/lib/parseTranscript.ts` 中将：
+
+```text
+tool_call(id=123)
+...
+tool_result(toolId=123)
+```
+
+组合成一条完整的工具消息。这样 UI 可以显示：
+
+- 执行的命令及结果。
+- 读取或编辑了哪些文件。
+- Todo/计划执行进度。
+- AskUserQuestion 选项和回答。
+- MCP、子 Agent 和 Web 搜索信息。
+
+## 四、Claude 和 Codex 的接入差异
+
+Kanna 使用了一个统一的 `HarnessTurn` 抽象，把两种完全不同的上游接口隐藏在协调器后面。
+
+### Claude
+
+Claude 通过 `@anthropic-ai/claude-agent-sdk` 的 `query()` 接入。
+
+实现特点：
+
+- 每个聊天尽量复用一个长生命周期 Claude query。
+- 使用异步 prompt queue 给同一个会话继续发送消息。
+- 保存 SDK 返回的 `session_id`，用于恢复和 fork。
+- `AskUserQuestion` 和 `ExitPlanMode` 会暂停 Agent，等待浏览器响应。
+- 模型和 plan permission mode 可以在复用会话中动态切换。
+
+Claude 工具事件会由 `normalizeClaudeStreamMessage()` 转换成统一 transcript。
+
+### Codex
+
+Codex 接入位于 `src/server/codex-app-server.ts`。
+
+Kanna 会为聊天启动：
+
+```bash
+codex app-server
+```
+
+然后通过标准输入输出发送一行一个 JSON 的 JSON-RPC 消息：
+
+```text
+initialize
+thread/start、thread/resume 或 thread/fork
+turn/start
+turn/interrupt
+```
+
+Codex 发回的通知包括：
+
+- `item/started`
+- `item/completed`
+- `turn/plan/updated`
+- `thread/tokenUsage/updated`
+- `thread/compacted`
+- `turn/completed`
+
+Kanna 再将这些通知转换成和 Claude 相同的 transcript 类型。
+
+Codex 的计划模式不是直接复用 Claude 的实现。Codex 计划回合结束后，Kanna 会合成一个 `ExitPlanMode` 工具调用；用户批准后，再自动启动一个普通执行回合。
+
+### Provider 的重要规则
+
+聊天首次发送后，provider 会被固定在聊天记录上。后续消息即使带了另一个 provider 参数，协调器也优先使用聊天原有 provider。
+
+如果要切换 provider，通常应该新建聊天。
+
+## 五、消息排队、插话和取消
+
+一个聊天同一时刻只允许有一个 active turn。
+
+用户在 Agent 正在运行时继续发送，消息会进入持久化队列，而不是并行执行。当前回合结束后，协调器自动启动下一条消息。
+
+“Steer/插话”的处理方式是：
+
+1. 取消当前回合。
+2. 将排队消息标记为 steered。
+3. 给消息附加系统提示，告诉 Agent 这是用户在执行过程中追加的信息。
+4. 立即启动新回合。
+
+取消操作会先在 UI 层立即删除 active 状态，再以最多五秒的 best-effort 方式中断上游进程。因此即使 SDK 中断卡住，界面也不会一直停留在运行状态。
+
+此外，Codex 可能在发出最终结果后仍有后台输出。Kanna 将这种状态称为 `draining`，允许用户在 UI 中单独停止剩余流。
+
+## 六、WebSocket 的响应式快照机制
+
+Kanna 没有让浏览器自己维护完整业务状态，而是采用订阅式快照：
+
+```text
+浏览器订阅 chat:123
+        ↓
+服务器从 EventStore + activeTurns 派生 ChatSnapshot
+        ↓
+状态变化时推送新快照
+```
+
+可订阅主题包括：
+
+- `sidebar`
+- `chat`
+- `project-git`
+- `local-projects`
+- `terminal`
+- `update`
+- `keybindings`
+- `app-settings`
+
+服务端使用两个优化：
+
+- 16ms 内发生的多次状态变化会合并广播。
+- 每个连接保存上一次快照的 JSON 签名，相同快照不会重复发送。
+
+聊天默认只加载最近 200 条 transcript；更早历史通过游标分页读取。
+
+前端 `src/client/app/socket.ts` 还实现了：
+
+- 15 秒心跳检查。
+- 25 秒无消息后判断连接可能失效。
+- 最长 5 秒的渐进重连退避。
+- 页面重新聚焦、恢复可见或网络恢复时主动检查连接。
+- 重连后自动恢复全部订阅。
+
+## 七、存储原理
+
+数据目录由 `src/shared/branding.ts` 定义：
+
+```text
+生产：~/.kanna/
+开发：~/.kanna-dev/
+```
+
+当前实际结构大致是：
+
+```text
+~/.kanna/
+├── data/
+│   ├── projects.jsonl
+│   ├── chats.jsonl
+│   ├── queued-messages.jsonl
+│   ├── turns.jsonl
+│   ├── snapshot.json
+│   ├── sidebar-order.json
+│   ├── settings.json
+│   └── transcripts/
+│       └── <chat-id>.jsonl
+├── keybindings.json
+└── llm-provider.json
+```
+
+`src/server/event-store.ts` 使用串行 `writeChain`，保证同一个进程内的文件写入顺序。
+
+元数据采用事件形式，例如：
+
+```text
+project_opened
+chat_created
+chat_renamed
+chat_provider_set
+turn_started
+turn_finished
+turn_failed
+session_token_set
+```
+
+启动时先加载 `snapshot.json`，再重放快照之后的 JSONL 事件。事件日志超过 2 MB 时写入新快照并清空元数据日志。
+
+这里有一个值得注意的源码现状：README 仍将 `messages.jsonl` 描述为当前消息存储，但当前实现已经迁移为 `transcripts/<chat-id>.jsonl`。`messages.jsonl` 主要用于旧版本迁移，不再是新消息的主要写入位置。
+
+所以 Kanna 现在并不是“所有数据都严格事件溯源”：
+
+- 项目、聊天、回合等元数据是事件日志。
+- transcript 是每聊天一个追加文件。
+- 设置、快捷键、侧边栏顺序是独立 JSON 文件。
+
+这是一种实用型的 Event Sourcing/CQRS 混合设计。
+
+## 八、终端、Git 和项目发现
+
+### 嵌入式终端
+
+`src/server/terminal-manager.ts` 使用：
+
+- Bun 原生 `Bun.Terminal` 创建 PTY。
+- 系统默认 shell。
+- `@xterm/headless` 保存服务端终端状态。
+- `@xterm/addon-serialize` 在新订阅者连接时恢复屏幕。
+- WebSocket event 实时推送增量终端输出。
+
+关闭终端时会尽量杀死整个进程组，避免 shell 启动的子进程残留。
+
+该功能目前仅支持 macOS/Linux。
+
+### Git 工作区
+
+`src/server/diff-store.ts` 直接调用本地 `git` 和可选的 `gh` 命令，实现：
+
+- 工作区 diff 和文件变更统计。
+- 查看 patch。
+- 初始化 Git。
+- 创建、切换、同步和合并分支。
+- 拉取远程、推送、发布分支。
+- GitHub 仓库创建与 PR/分支信息。
+- 选中文件提交。
+- 丢弃和忽略文件。
+- AI 生成 commit message。
+
+Git 状态主要保存在内存中，并通过独立的 `project-git` 订阅推送，不属于 EventStore 的聊天历史。
+
+### 项目自动发现
+
+`src/server/discovery.ts` 会扫描：
+
+- `~/.claude/projects`
+- `~/.codex/session_index.jsonl`
+- `~/.codex/sessions`
+- `~/.codex/config.toml`
+
+只保留当前仍存在的本地目录，然后按规范化路径去重。因此 Kanna 可以显示用户以前在 Claude Code 或 Codex 中使用过的项目。
+
+## 九、标题和 Commit Message 的快速模型链
+
+Kanna 有一套独立的 `QuickResponseAdapter`，用于短小的结构化任务，而不是正式聊天。
+
+调用顺序是：
+
+```text
+用户配置的 OpenAI/OpenRouter/自定义接口
+    ↓ 失败
+Claude Haiku
+    ↓ 失败
+Codex 小模型
+    ↓ 失败
+本地规则兜底
+```
+
+它目前用于：
+
+- 生成聊天标题。
+- 生成 Git commit subject/body。
+
+例如标题生成失败时，会直接截取用户首条消息作为本地标题，不影响正式聊天运行。
+
+## 十、文件、分享和安全边界
+
+上传文件保存在项目内部：
+
+```text
+<project>/.kanna/uploads/
+```
+
+导出的独立会话保存在：
+
+```text
+<project>/.kanna/exports/
+```
+
+附件路径会被追加到模型 prompt，让 Agent 能直接读取真实文件。
+
+安全方面需要特别注意：
+
+- 默认只绑定 `127.0.0.1`，这是合理的本地安全默认值。
+- `--remote` 或 `--host 0.0.0.0` 会向局域网开放服务。
+- `--share` 会通过 Cloudflare tunnel 暴露服务。
+- 只有显式提供 `--password` 时才启用认证。
+- 密码会换成内存 session token，Cookie 使用 `HttpOnly` 和 `SameSite=Strict`。
+- 服务重启后内存 session 失效，需要重新登录。
+- Codex 会以 `approvalPolicy: "never"` 和 `sandbox: "danger-full-access"` 启动。
+- Claude 默认是 `acceptEdits` 权限模式。
+
+因此 Kanna 的计划确认界面不是一个通用的命令安全沙箱；运行中的 Agent 对项目和本机工具拥有很高权限。公开分享时最好始终同时启用强密码。
+
+普通聊天记录默认保存在本地，但有两个明确的网络出口：
+
+- Analytics 默认开启，只发送版本、启动模式、项目/聊天操作等事件，不发送 transcript 内容；可在设置中关闭。
+- 用户主动使用独立分享功能时，会将导出的会话和选择打包的附件上传到 `kanna.sh`。
+
+## 十一、架构优点与当前边界
+
+项目做得比较好的地方包括：
+
+- Claude/Codex 事件被统一成同一种 transcript，前端复杂度显著降低。
+- 会话 token 持久化，支持恢复和 fork。
+- 乐观 UI、WebSocket 快照与工具结果水合配合得比较完整。
+- 本地 JSONL 存储没有数据库部署成本。
+- Git、终端和聊天处在同一项目上下文中。
+- Provider 失败时，标题等辅助功能有多级回退。
+
+当前边界包括：
+
+- 它是单机、单进程、本地用户工具，不适合直接当多用户服务部署。
+- active turn、终端和子进程状态只在内存中；服务重启后只能通过 session token 恢复上下文，不能恢复正在执行的任务。
+- 每个活跃 Codex 聊天可能拥有自己的 `codex app-server` 子进程，大量并行聊天会增加资源占用。
+- 快照去重虽然减少了网络发送，但仍需先构建并序列化快照；历史很大时可能成为性能热点。
+- `ws-router.ts` 和 `agent.ts` 已经比较庞大，项目自己的 `docs/refactor-todo.md` 也记录了路由拆分、工具类型注册表等重构计划。
+- README 的消息存储说明落后于当前源码。
+- LICENSE 是 MIT，但版权声明中的姓名与许可正文中的姓名/公司不一致，发布前值得核对。
+
+## 十二、当前验证结果
+
+分析过程中没有修改项目业务代码。
+
+当前工作区没有安装 `node_modules`。执行 `bun test` 后，Bun 报告：
+
+- 279 项测试。
+- 241 项通过。
+- 38 项在模块加载阶段失败。
+- 失败原因是缺少 `react`、`zustand`、`file-type`、Claude SDK 等依赖。
+- 没有发现已经成功加载的测试出现断言失败。
+
+因此可以确认大量纯逻辑测试是通过的，但在执行 `bun install` 之前，不能把当前 checkout 认定为“完整测试通过”状态。
+

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -504,7 +504,7 @@ function composerStateFromSendOptions(options?: {
       provider: "codex",
       model: options.model,
       modelOptions: {
-        reasoningEffort: options.modelOptions.codex.reasoningEffort ?? "high",
+        reasoningEffort: options.modelOptions.codex.reasoningEffort ?? "medium",
         fastMode: options.modelOptions.codex.fastMode ?? false,
       },
       planMode: Boolean(options.planMode),

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -9,6 +9,8 @@ import {
   type ModelOptions,
   type ProviderCatalogEntry,
   normalizeClaudeContextWindow,
+  normalizeCodexModelId,
+  normalizeCodexReasoningEffort,
   resolveClaudeContextWindowTokens,
 } from "../../../shared/types"
 import { Button, buttonVariants } from "../ui/button"
@@ -135,7 +137,17 @@ function withNormalizedContextWindow(
   state: ComposerState,
   model: string
 ): ComposerState {
-  if (state.provider !== "claude") return { ...state, model }
+  if (state.provider !== "claude") {
+    const normalizedModel = normalizeCodexModelId(model)
+    return {
+      ...state,
+      model: normalizedModel,
+      modelOptions: {
+        ...state.modelOptions,
+        reasoningEffort: normalizeCodexReasoningEffort(normalizedModel, state.modelOptions.reasoningEffort),
+      },
+    }
+  }
   return {
     ...state,
     model,

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -779,7 +779,6 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             availableProviders={availableProviders}
             selectedProvider={selectedProvider}
             providerLocked={providerLocked}
-            showCodexCliRequirementHints
             model={providerPrefs.model}
             modelOptions={providerPrefs.modelOptions}
             onProviderChange={(provider) => {

--- a/src/client/components/chat-ui/ChatPreferenceControls.test.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.test.tsx
@@ -20,9 +20,27 @@ describe("ChatPreferenceControls", () => {
 
     expect(html).toContain("Codex")
     expect(html).toContain("GPT-5.3 Codex")
-    expect(html).toContain("XHigh")
+    expect(html).toContain("Extra High")
     expect(html).toContain("Fast Mode")
     expect(html).not.toContain("Plan Mode")
+  })
+
+  test("renders Ultra as a reasoning level for supported GPT-5.6 models", () => {
+    const html = renderToStaticMarkup(
+      <ChatPreferenceControls
+        availableProviders={PROVIDERS}
+        selectedProvider="codex"
+        model="gpt-5.6-sol"
+        modelOptions={{ reasoningEffort: "ultra", fastMode: false }}
+        onProviderChange={() => {}}
+        onModelChange={() => {}}
+        onModelOptionChange={() => {}}
+        includePlanMode={false}
+      />
+    )
+
+    expect(html).toContain("GPT-5.6 Sol")
+    expect(html).toContain("Ultra")
   })
 
   test("renders claude plan mode controls when enabled", () => {

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -143,7 +143,6 @@ interface ChatPreferenceControlsProps {
   selectedProvider: AgentProvider
   showProviderPicker?: boolean
   providerLocked?: boolean
-  showCodexCliRequirementHints?: boolean
   model: string
   modelOptions: ClaudeModelOptions | CodexModelOptions
   onProviderChange?: (provider: AgentProvider) => void
@@ -160,7 +159,6 @@ export function ChatPreferenceControls({
   selectedProvider,
   showProviderPicker = true,
   providerLocked = false,
-  showCodexCliRequirementHints = false,
   model,
   modelOptions,
   onProviderChange,
@@ -222,7 +220,6 @@ export function ChatPreferenceControls({
       >
         {(close) => providerConfig.models.map((candidate) => {
           const Icon = Box
-          const isGpt56Model = selectedProvider === "codex" && candidate.id.startsWith("gpt-5.6-")
           const downgradesUltraToMax = candidate.id === "gpt-5.6-luna"
             && modelOptions.reasoningEffort === "ultra"
           return (
@@ -235,15 +232,12 @@ export function ChatPreferenceControls({
               selected={model === candidate.id}
               icon={<Icon className="h-4 w-4 text-muted-foreground" />}
               label={
-                (showCodexCliRequirementHints && isGpt56Model) || downgradesUltraToMax
+                downgradesUltraToMax
                   ? (
                     <>
                       {candidate.label}{" "}
                       <span className="text-xs font-normal text-muted-foreground">
-                        {[
-                          showCodexCliRequirementHints && isGpt56Model ? "requires GPT-5.6 access" : null,
-                          downgradesUltraToMax ? "Ultra → Max" : null,
-                        ].filter(Boolean).join(" · ")}
+                        Ultra → Max
                       </span>
                     </>
                   )

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -3,7 +3,7 @@ import { Box, Brain, Gauge, ListTodo, LockOpen, SquareMenu, SquareMinus } from "
 import {
   CLAUDE_CONTEXT_WINDOW_OPTIONS,
   CLAUDE_REASONING_OPTIONS,
-  CODEX_REASONING_OPTIONS,
+  getCodexReasoningOptions,
   type AgentProvider,
   type ClaudeContextWindow,
   type ClaudeModelOptions,
@@ -177,6 +177,7 @@ export function ChatPreferenceControls({
   const showPlanMode = includePlanMode && providerConfig?.supportsPlanMode && onPlanModeChange
   const claudeModelOptions = selectedProvider === "claude" ? modelOptions as ClaudeModelOptions : null
   const codexModelOptions = selectedProvider === "codex" ? modelOptions as CodexModelOptions : null
+  const codexReasoningOptions = getCodexReasoningOptions(model)
   const contextWindowOptions = providerConfig.models.find((candidate) => candidate.id === model)?.contextWindowOptions ?? []
   const selectedContextWindow = claudeModelOptions?.contextWindow ?? CLAUDE_CONTEXT_WINDOW_OPTIONS[0].id
   const ContextWindowIcon = selectedContextWindow === "1m" ? SquareMenu : SquareMinus
@@ -221,6 +222,9 @@ export function ChatPreferenceControls({
       >
         {(close) => providerConfig.models.map((candidate) => {
           const Icon = Box
+          const isGpt56Model = selectedProvider === "codex" && candidate.id.startsWith("gpt-5.6-")
+          const downgradesUltraToMax = candidate.id === "gpt-5.6-luna"
+            && modelOptions.reasoningEffort === "ultra"
           return (
             <PopoverMenuItem
               key={candidate.id}
@@ -231,12 +235,15 @@ export function ChatPreferenceControls({
               selected={model === candidate.id}
               icon={<Icon className="h-4 w-4 text-muted-foreground" />}
               label={
-                showCodexCliRequirementHints && selectedProvider === "codex" && candidate.id === "gpt-5.5"
+                (showCodexCliRequirementHints && isGpt56Model) || downgradesUltraToMax
                   ? (
                     <>
                       {candidate.label}{" "}
                       <span className="text-xs font-normal text-muted-foreground">
-                        codex-cli &gt;= 0.124
+                        {[
+                          showCodexCliRequirementHints && isGpt56Model ? "requires GPT-5.6 access" : null,
+                          downgradesUltraToMax ? "Ultra → Max" : null,
+                        ].filter(Boolean).join(" · ")}
                       </span>
                     </>
                   )
@@ -254,7 +261,7 @@ export function ChatPreferenceControls({
             <span>{
               selectedProvider === "claude"
                 ? CLAUDE_REASONING_OPTIONS.find((effort) => effort.id === modelOptions.reasoningEffort)?.label ?? modelOptions.reasoningEffort
-                : CODEX_REASONING_OPTIONS.find((effort) => effort.id === modelOptions.reasoningEffort)?.label ?? modelOptions.reasoningEffort
+                : codexReasoningOptions.find((effort) => effort.id === modelOptions.reasoningEffort)?.label ?? modelOptions.reasoningEffort
             }</span>
           </>
         )}
@@ -274,7 +281,7 @@ export function ChatPreferenceControls({
                 disabled={effort.id === "max" && !supportsClaudeMaxReasoningEffort(model)}
               />
             ))
-            : CODEX_REASONING_OPTIONS.map((effort) => (
+            : codexReasoningOptions.map((effort) => (
               <PopoverMenuItem
                 key={effort.id}
                 onClick={() => {
@@ -284,6 +291,7 @@ export function ChatPreferenceControls({
                 selected={modelOptions.reasoningEffort === effort.id}
                 icon={<Brain className="h-4 w-4 text-muted-foreground" />}
                 label={effort.label}
+                description={effort.description}
               />
             ))
         )}

--- a/src/client/stores/chatPreferencesStore.test.ts
+++ b/src/client/stores/chatPreferencesStore.test.ts
@@ -63,7 +63,7 @@ describe("migrateChatPreferencesState", () => {
           planMode: true,
         },
         codex: {
-          model: "gpt-5.5",
+          model: "gpt-5.3-codex",
           modelOptions: { reasoningEffort: "minimal", fastMode: true },
           planMode: false,
         },
@@ -107,7 +107,7 @@ describe("migrateChatPreferencesState", () => {
     })
   })
 
-  test("rewrites persisted Codex defaults to gpt-5.5 during migration", () => {
+  test("preserves persisted legacy Codex defaults during migration", () => {
     const migrated = migrateChatPreferencesState({
       defaultProvider: "last_used",
       providerDefaults: {
@@ -120,13 +120,13 @@ describe("migrateChatPreferencesState", () => {
     })
 
     expect(migrated.providerDefaults.codex).toEqual({
-      model: "gpt-5.5",
+      model: "gpt-5.3-codex",
       modelOptions: { reasoningEffort: "low", fastMode: true },
       planMode: false,
     })
   })
 
-  test("rewrites persisted Codex composer state to gpt-5.5 during migration", () => {
+  test("preserves supported persisted Codex composer models during migration", () => {
     const migrated = migrateChatPreferencesState({
       defaultProvider: "codex",
       providerDefaults: {
@@ -153,31 +153,87 @@ describe("migrateChatPreferencesState", () => {
     })
 
     expect(migrated.providerDefaults.codex).toEqual({
-      model: "gpt-5.5",
+      model: "gpt-5.3-codex-spark",
       modelOptions: { reasoningEffort: "low", fastMode: true },
       planMode: true,
     })
     expect(migrated.chatStates.chatA).toEqual({
       provider: "codex",
-      model: "gpt-5.5",
+      model: "gpt-5.4",
       modelOptions: { reasoningEffort: "medium", fastMode: false },
       planMode: false,
     })
     expect(migrated.legacyComposerState).toEqual({
       provider: "codex",
-      model: "gpt-5.5",
+      model: "gpt-5.3-codex",
       modelOptions: { reasoningEffort: "xhigh", fastMode: true },
+      planMode: true,
+    })
+  })
+
+  test("preserves persisted GPT-5.6 defaults and Ultra during migration", () => {
+    const migrated = migrateChatPreferencesState({
+      defaultProvider: "codex",
+      providerDefaults: {
+        codex: {
+          model: "gpt-5.6-terra",
+          modelOptions: { reasoningEffort: "ultra", fastMode: true },
+          planMode: true,
+        },
+      },
+    })
+
+    expect(migrated.providerDefaults.codex).toEqual({
+      model: "gpt-5.6-terra",
+      modelOptions: { reasoningEffort: "ultra", fastMode: true },
       planMode: true,
     })
   })
 })
 
 describe("chat preference store", () => {
-  test("starts with gpt-5.5 as the default Codex model", () => {
+  test("starts with GPT-5.6 Sol and Medium as the default Codex configuration", () => {
     expect(INITIAL_STATE.providerDefaults.codex).toEqual({
-      model: "gpt-5.5",
-      modelOptions: { reasoningEffort: "high", fastMode: false },
+      model: "gpt-5.6-sol",
+      modelOptions: { reasoningEffort: "medium", fastMode: false },
       planMode: false,
+    })
+  })
+
+  test("normalizes legacy and unsupported GPT-5.6 reasoning levels", () => {
+    const store = useChatPreferencesStore.getState()
+
+    store.setComposerState("sol", {
+      provider: "codex",
+      model: "gpt-5.6-sol",
+      modelOptions: { reasoningEffort: "minimal", fastMode: false },
+      planMode: false,
+    })
+    store.setComposerState("luna", {
+      provider: "codex",
+      model: "gpt-5.6-luna",
+      modelOptions: { reasoningEffort: "ultra", fastMode: false },
+      planMode: false,
+    })
+
+    expect(useChatPreferencesStore.getState().getComposerState("sol").modelOptions.reasoningEffort).toBe("low")
+    expect(useChatPreferencesStore.getState().getComposerState("luna").modelOptions.reasoningEffort).toBe("max")
+  })
+
+  test("downgrades Ultra to Max when switching from Sol to Luna", () => {
+    const store = useChatPreferencesStore.getState()
+    store.setComposerState("chat-a", {
+      provider: "codex",
+      model: "gpt-5.6-sol",
+      modelOptions: { reasoningEffort: "ultra", fastMode: false },
+      planMode: false,
+    })
+
+    store.setChatComposerModel("chat-a", "gpt-5.6-luna")
+
+    expect(useChatPreferencesStore.getState().getComposerState("chat-a")).toMatchObject({
+      model: "gpt-5.6-luna",
+      modelOptions: { reasoningEffort: "max" },
     })
   })
 

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -5,6 +5,7 @@ import {
   normalizeClaudeContextWindow,
   normalizeClaudeModelId,
   normalizeCodexModelId,
+  normalizeCodexReasoningEffort,
   isClaudeReasoningEffort,
   isCodexReasoningEffort,
   supportsClaudeMaxReasoningEffort,
@@ -126,55 +127,21 @@ export function normalizeCodexPreference(value?: {
   modelOptions?: Partial<CodexModelOptions>
   planMode?: boolean
 }): ProviderPreference<CodexModelOptions> {
+  const model = normalizeCodexModelId(value?.model)
   const reasoningEffort = value?.modelOptions?.reasoningEffort
   return {
-    model: normalizeCodexModelId(value?.model),
+    model,
     modelOptions: {
-      reasoningEffort: isCodexReasoningEffort(reasoningEffort)
-        ? reasoningEffort
-        : isCodexReasoningEffort(value?.effort)
-          ? value.effort
-          : DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort,
+      reasoningEffort: normalizeCodexReasoningEffort(
+        model,
+        isCodexReasoningEffort(reasoningEffort) ? reasoningEffort : value?.effort,
+      ),
       fastMode: typeof value?.modelOptions?.fastMode === "boolean"
         ? value.modelOptions.fastMode
         : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,
     },
     planMode: Boolean(value?.planMode),
   }
-}
-
-function forcePersistedCodexPreference<T extends {
-  model?: string
-  effort?: string
-  modelOptions?: Partial<CodexModelOptions>
-  planMode?: boolean
-}>(value?: T): T | undefined {
-  if (!value) return value
-  return {
-    ...value,
-    model: "gpt-5.5",
-  }
-}
-
-function forcePersistedCodexComposerState<T extends PersistedComposerState | ComposerState>(value?: T): T | undefined {
-  if (!value || value.provider !== "codex") return value
-  return {
-    ...value,
-    model: "gpt-5.5",
-  }
-}
-
-function forcePersistedCodexChatStates(
-  value?: Record<string, PersistedComposerState | ComposerState>
-): Record<string, PersistedComposerState | ComposerState> | undefined {
-  if (!value) return value
-
-  return Object.fromEntries(
-    Object.entries(value).map(([chatId, composerState]) => [
-      chatId,
-      forcePersistedCodexComposerState(composerState) ?? composerState,
-    ])
-  )
 }
 
 export function createDefaultProviderDefaults(): ChatProviderPreferences {
@@ -185,7 +152,7 @@ export function createDefaultProviderDefaults(): ChatProviderPreferences {
       planMode: false,
     },
     codex: {
-      model: "gpt-5.5",
+      model: "gpt-5.6-sol",
       modelOptions: { ...DEFAULT_CODEX_MODEL_OPTIONS },
       planMode: false,
     },
@@ -428,12 +395,9 @@ interface ChatPreferencesState {
 export function migrateChatPreferencesState(
   persistedState: Partial<PersistedChatPreferencesState> | undefined
 ): Pick<ChatPreferencesState, "defaultProvider" | "providerDefaults" | "chatStates" | "legacyComposerState"> {
-  const providerDefaults = normalizeProviderDefaults({
-    ...persistedState?.providerDefaults,
-    codex: forcePersistedCodexPreference(persistedState?.providerDefaults?.codex),
-  })
+  const providerDefaults = normalizeProviderDefaults(persistedState?.providerDefaults)
   const legacyComposerState = normalizePersistedComposerState(
-    forcePersistedCodexComposerState(persistedState?.legacyComposerState ?? persistedState?.composerState),
+    persistedState?.legacyComposerState ?? persistedState?.composerState,
     providerDefaults
   )
   const legacyLiveComposerState = persistedState?.liveProvider
@@ -441,17 +405,14 @@ export function migrateChatPreferencesState(
       undefined,
       providerDefaults,
       persistedState.liveProvider,
-      {
-        ...persistedState?.livePreferences,
-        codex: forcePersistedCodexPreference(persistedState?.livePreferences?.codex),
-      }
+      persistedState?.livePreferences
     )
     : null
 
   return {
     defaultProvider: normalizeDefaultProvider(persistedState?.defaultProvider),
     providerDefaults,
-    chatStates: normalizeChatStates(forcePersistedCodexChatStates(persistedState?.chatStates), providerDefaults),
+    chatStates: normalizeChatStates(persistedState?.chatStates, providerDefaults),
     legacyComposerState: legacyComposerState ?? legacyLiveComposerState,
   }
 }
@@ -568,7 +529,12 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
                 modelOptions: normalizeClaudePreference(composerState).modelOptions,
                 planMode: composerState.planMode,
               }
-              : cloneComposerState(composerState),
+              : {
+                provider: "codex",
+                model: normalizeCodexPreference(composerState).model,
+                modelOptions: normalizeCodexPreference(composerState).modelOptions,
+                planMode: composerState.planMode,
+              },
           },
         })),
       setChatComposerProvider: (chatId, provider) =>
@@ -590,7 +556,10 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
             }
             : {
               provider: "codex",
-              model,
+              model: normalizeCodexPreference({
+                ...composerState,
+                model,
+              }).model,
               modelOptions: normalizeCodexPreference({
                 ...composerState,
                 model,

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -540,33 +540,30 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
       setChatComposerProvider: (chatId, provider) =>
         set((state) => withChatComposerState(state, chatId, () => composerFromProviderDefaults(provider, state.providerDefaults))),
       setChatComposerModel: (chatId, model) =>
-        set((state) => withChatComposerState(state, chatId, (composerState) => (
-          composerState.provider === "claude"
-            ? {
+        set((state) => withChatComposerState(state, chatId, (composerState) => {
+          if (composerState.provider === "claude") {
+            const normalized = normalizeClaudePreference({
+              ...composerState,
+              model,
+            })
+            return {
               provider: "claude",
-              model: normalizeClaudePreference({
-                ...composerState,
-                model,
-              }).model,
-              modelOptions: normalizeClaudePreference({
-                ...composerState,
-                model,
-              }).modelOptions,
+              model: normalized.model,
+              modelOptions: normalized.modelOptions,
               planMode: composerState.planMode,
             }
-            : {
-              provider: "codex",
-              model: normalizeCodexPreference({
-                ...composerState,
-                model,
-              }).model,
-              modelOptions: normalizeCodexPreference({
-                ...composerState,
-                model,
-              }).modelOptions,
-              planMode: composerState.planMode,
-            }
-        ))),
+          }
+          const normalized = normalizeCodexPreference({
+            ...composerState,
+            model,
+          })
+          return {
+            provider: "codex",
+            model: normalized.model,
+            modelOptions: normalized.modelOptions,
+            planMode: composerState.planMode,
+          }
+        })),
       setChatComposerModelOptions: (chatId, modelOptions) =>
         set((state) => withChatComposerState(state, chatId, (composerState) => (
           composerState.provider === "claude"

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -784,9 +784,10 @@ export class AgentCoordinator {
       }
     }
 
-    const modelOptions = normalizeCodexModelOptions(options.modelOptions, options.effort)
+    const model = normalizeServerModel(provider, options.model)
+    const modelOptions = normalizeCodexModelOptions(model, options.modelOptions, options.effort)
     return {
-      model: normalizeServerModel(provider, options.model),
+      model,
       effort: modelOptions.reasoningEffort,
       serviceTier: codexServiceTierFromModelOptions(modelOptions),
       planMode: catalog.supportsPlanMode ? Boolean(options.planMode) : false,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os"
 import type {
   AgentProvider,
   ChatAttachment,
+  CodexReasoningEffort,
   ContextWindowUsageSnapshot,
   ModelOptions,
   NormalizedToolCall,
@@ -984,7 +985,7 @@ export class AgentCoordinator {
         chatId: args.chatId,
         content: buildPromptText(args.content, args.attachments),
         model: args.model,
-        effort: args.effort as any,
+        effort: args.effort as CodexReasoningEffort | undefined,
         serviceTier: args.serviceTier,
         planMode: args.planMode,
         onToolRequest,

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -44,9 +44,9 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
         planMode: false,
       },
       codex: {
-        model: "gpt-5.5",
+        model: "gpt-5.6-sol",
         modelOptions: {
-          reasoningEffort: "high",
+          reasoningEffort: "medium",
           fastMode: false,
         },
         planMode: false,
@@ -156,6 +156,45 @@ describe("AppSettingsManager", () => {
     expect(nextPayload.analyticsUserId).toBe(initialPayload.analyticsUserId)
     expect(nextPayload.theme).toBe("dark")
     expect(nextPayload.chatSoundId).toBe("glass")
+
+    manager.dispose()
+  })
+
+  test("normalizes GPT-5.6 reasoning levels when settings are written", async () => {
+    const filePath = await createTempFilePath()
+    const manager = new AppSettingsManager(filePath)
+    await manager.initialize()
+
+    const sol = await manager.writePatch({
+      providerDefaults: {
+        codex: { model: "gpt-5.6-sol", modelOptions: { reasoningEffort: "ultra" } },
+      },
+    })
+    expect(sol.providerDefaults.codex.modelOptions.reasoningEffort).toBe("ultra")
+
+    const terra = await manager.writePatch({
+      providerDefaults: {
+        codex: { model: "gpt-5.6-terra", modelOptions: { reasoningEffort: "max" } },
+      },
+    })
+    expect(terra.providerDefaults.codex.modelOptions.reasoningEffort).toBe("max")
+
+    const luna = await manager.writePatch({
+      providerDefaults: {
+        codex: { model: "gpt-5.6-luna", modelOptions: { reasoningEffort: "ultra" } },
+      },
+    })
+    expect(luna.providerDefaults.codex.modelOptions.reasoningEffort).toBe("max")
+
+    const legacy = await manager.writePatch({
+      providerDefaults: {
+        codex: { model: "gpt-5.5", modelOptions: { reasoningEffort: "xhigh" } },
+      },
+    })
+    expect(legacy.providerDefaults.codex).toMatchObject({
+      model: "gpt-5.5",
+      modelOptions: { reasoningEffort: "xhigh", fastMode: false },
+    })
 
     manager.dispose()
   })

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -12,6 +12,7 @@ import {
   normalizeClaudeContextWindow,
   normalizeClaudeModelId,
   normalizeCodexModelId,
+  normalizeCodexReasoningEffort,
   supportsClaudeMaxReasoningEffort,
   type AppSettingsPatch,
   type AppSettingsSnapshot,
@@ -104,7 +105,7 @@ function createDefaultProviderDefaults(): ChatProviderPreferences {
       planMode: false,
     },
     codex: {
-      model: "gpt-5.5",
+      model: "gpt-5.6-sol",
       modelOptions: { ...DEFAULT_CODEX_MODEL_OPTIONS },
       planMode: false,
     },
@@ -187,15 +188,15 @@ function normalizeCodexPreference(value?: {
   modelOptions?: Partial<Record<keyof CodexModelOptions, unknown>>
   planMode?: unknown
 }): ProviderPreference<CodexModelOptions> {
+  const model = normalizeCodexModelId(typeof value?.model === "string" ? value.model : undefined)
   const reasoningEffort = value?.modelOptions?.reasoningEffort
   return {
-    model: normalizeCodexModelId(typeof value?.model === "string" ? value.model : undefined),
+    model,
     modelOptions: {
-      reasoningEffort: isCodexReasoningEffort(reasoningEffort)
-        ? reasoningEffort
-        : isCodexReasoningEffort(value?.effort)
-          ? value.effort
-          : DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort,
+      reasoningEffort: normalizeCodexReasoningEffort(
+        model,
+        isCodexReasoningEffort(reasoningEffort) ? reasoningEffort : value?.effort,
+      ),
       fastMode: typeof value?.modelOptions?.fastMode === "boolean"
         ? value.modelOptions.fastMode
         : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -210,7 +210,76 @@ describe("CodexAppServerManager", () => {
     expect(threadStart?.params.serviceTier).toBe("fast")
     expect(turnStart?.params.effort).toBe("xhigh")
     expect(turnStart?.params.serviceTier).toBe("fast")
-    expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBeNull()
+    expect(turnStart?.params.collaborationMode?.settings?.reasoning_effort).toBe("xhigh")
+  })
+
+  test("forwards every supported GPT-5.6 model and reasoning combination", async () => {
+    const combinations = [
+      ...(["low", "medium", "high", "xhigh", "max", "ultra"] as const)
+        .map((effort) => ({ model: "gpt-5.6-sol", effort })),
+      ...(["low", "medium", "high", "xhigh", "max", "ultra"] as const)
+        .map((effort) => ({ model: "gpt-5.6-terra", effort })),
+      ...(["low", "medium", "high", "xhigh", "max"] as const)
+        .map((effort) => ({ model: "gpt-5.6-luna", effort })),
+    ]
+
+    expect(combinations).toHaveLength(17)
+
+    for (const [index, combination] of combinations.entries()) {
+      const threadId = `thread-matrix-${index}`
+      const process = new FakeCodexProcess((message, child) => {
+        if (message.method === "initialize") {
+          child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+        } else if (message.method === "thread/start") {
+          child.writeServerMessage({
+            id: message.id,
+            result: { thread: { id: threadId }, model: combination.model, reasoningEffort: combination.effort },
+          })
+        } else if (message.method === "turn/start") {
+          child.writeServerMessage({
+            id: message.id,
+            result: { turn: { id: `turn-matrix-${index}`, status: "completed", error: null } },
+          })
+          child.writeServerMessage({
+            method: "turn/completed",
+            params: {
+              threadId,
+              turn: { id: `turn-matrix-${index}`, status: "completed", error: null },
+            },
+          })
+        }
+      })
+      const manager = new CodexAppServerManager({ spawnProcess: () => process as never })
+      const chatId = `chat-matrix-${index}`
+
+      await manager.startSession({
+        chatId,
+        cwd: "/tmp/project",
+        model: combination.model,
+        sessionToken: null,
+      })
+      const turn = await manager.startTurn({
+        chatId,
+        model: combination.model,
+        effort: combination.effort,
+        content: "matrix test",
+        planMode: false,
+        onToolRequest: async () => ({}),
+      })
+      await collectStream(turn.stream)
+
+      const threadStart = process.messages.find((message: any) => message.method === "thread/start") as any
+      const turnStart = process.messages.find((message: any) => message.method === "turn/start") as any
+      expect(threadStart.params.model).toBe(combination.model)
+      expect(turnStart.params.model).toBe(combination.model)
+      expect(turnStart.params.effort).toBe(combination.effort)
+      expect(turnStart.params.collaborationMode.settings).toMatchObject({
+        model: combination.model,
+        reasoning_effort: combination.effort,
+      })
+
+      manager.stopSession(chatId)
+    }
   })
 
   test("maps thread token usage updates into context window transcript entries", async () => {

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -880,7 +880,7 @@ export class CodexAppServerManager {
           mode: args.planMode ? "plan" : "default",
           settings: {
             model: args.model,
-            reasoning_effort: null,
+            reasoning_effort: args.effort ?? null,
             developer_instructions: null,
           },
         },

--- a/src/server/provider-catalog.test.ts
+++ b/src/server/provider-catalog.test.ts
@@ -44,12 +44,12 @@ describe("provider catalog normalization", () => {
   })
 
   test("normalizes Codex model options and fast mode defaults", () => {
-    expect(normalizeCodexModelOptions(undefined)).toEqual({
-      reasoningEffort: "high",
+    expect(normalizeCodexModelOptions("gpt-5.6-sol", undefined)).toEqual({
+      reasoningEffort: "medium",
       fastMode: false,
     })
 
-    const normalized = normalizeCodexModelOptions({
+    const normalized = normalizeCodexModelOptions("gpt-5.6-terra", {
       codex: {
         reasoningEffort: "xhigh",
         fastMode: true,
@@ -61,13 +61,22 @@ describe("provider catalog normalization", () => {
       fastMode: true,
     })
     expect(codexServiceTierFromModelOptions(normalized)).toBe("fast")
+
+    expect(normalizeCodexModelOptions("gpt-5.6-sol", {
+      codex: { reasoningEffort: "ultra" },
+    }).reasoningEffort).toBe("ultra")
+    expect(normalizeCodexModelOptions("gpt-5.6-luna", {
+      codex: { reasoningEffort: "ultra" },
+    }).reasoningEffort).toBe("max")
+    expect(normalizeCodexModelOptions("gpt-5.6-luna", undefined, "minimal").reasoningEffort).toBe("low")
   })
 
   test("normalizes server model ids through the shared alias catalog", () => {
-    expect(normalizeServerModel("codex")).toBe("gpt-5.5")
+    expect(normalizeServerModel("codex")).toBe("gpt-5.6-sol")
     expect(normalizeServerModel("claude", "fable")).toBe("fable")
     expect(normalizeServerModel("claude", "opus")).toBe("claude-opus-4-8")
     expect(normalizeServerModel("codex", "gpt-5-codex")).toBe("gpt-5.3-codex")
+    expect(normalizeServerModel("codex", "gpt-5.6")).toBe("gpt-5.6-sol")
   })
 
   test("resolves Claude API model ids for 1m context window", () => {

--- a/src/server/provider-catalog.ts
+++ b/src/server/provider-catalog.ts
@@ -13,17 +13,11 @@ import {
   DEFAULT_CODEX_MODEL_OPTIONS,
   PROVIDERS,
   normalizeClaudeContextWindow,
+  normalizeCodexReasoningEffort,
   normalizeProviderModelId,
   isClaudeReasoningEffort,
   isCodexReasoningEffort,
 } from "../shared/types"
-
-const HARD_CODED_CODEX_MODELS: ProviderModelOption[] = [
-  { id: "gpt-5.5", label: "GPT-5.5", supportsEffort: false },
-  { id: "gpt-5.4", label: "GPT-5.4", supportsEffort: false },
-  { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: false },
-  { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark", supportsEffort: false },
-]
 
 export interface ClaudeSdkModelInfo {
   value: string
@@ -35,15 +29,7 @@ export interface ClaudeSdkModelInfo {
 }
 
 function createServerProviders(): ProviderCatalogEntry[] {
-  return PROVIDERS.map((provider) =>
-    provider.id === "codex"
-      ? {
-          ...provider,
-          defaultModel: "gpt-5.5",
-          models: HARD_CODED_CODEX_MODELS,
-        }
-      : provider
-  )
+  return structuredClone(PROVIDERS)
 }
 
 export const SERVER_PROVIDERS: ProviderCatalogEntry[] = createServerProviders()
@@ -137,14 +123,17 @@ export function normalizeClaudeModelOptions(
   }
 }
 
-export function normalizeCodexModelOptions(modelOptions?: ModelOptions, legacyEffort?: string): CodexModelOptions {
+export function normalizeCodexModelOptions(
+  model: string,
+  modelOptions?: ModelOptions,
+  legacyEffort?: string,
+): CodexModelOptions {
   const reasoningEffort = modelOptions?.codex?.reasoningEffort
   return {
-    reasoningEffort: isCodexReasoningEffort(reasoningEffort)
-      ? reasoningEffort
-      : isCodexReasoningEffort(legacyEffort)
-        ? legacyEffort
-        : DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort,
+    reasoningEffort: normalizeCodexReasoningEffort(
+      model,
+      isCodexReasoningEffort(reasoningEffort) ? reasoningEffort : legacyEffort,
+    ),
     fastMode: typeof modelOptions?.codex?.fastMode === "boolean"
       ? modelOptions.codex.fastMode
       : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -146,6 +146,9 @@ describe("read models", () => {
     expect(chat?.history.recentLimit).toBe(200)
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.3-codex",

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -473,9 +473,9 @@ export function createWsRouter({
         planMode: false,
       },
       codex: {
-        model: "gpt-5.5",
+        model: "gpt-5.6-sol",
         modelOptions: {
-          reasoningEffort: "high",
+          reasoningEffort: "medium",
           fastMode: false,
         },
         planMode: false,

--- a/src/shared/types.test.ts
+++ b/src/shared/types.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import {
   deriveClaudeModelLabel,
+  getCodexReasoningOptions,
   normalizeClaudeModelId,
   normalizeCodexModelId,
+  normalizeCodexReasoningEffort,
+  isCodexReasoningEffort,
   supportsClaudeMaxReasoningEffort,
 } from "./types"
 
@@ -21,8 +24,54 @@ describe("shared model normalization", () => {
   })
 
   test("normalizes legacy Codex aliases and defaults to the latest catalog model", () => {
-    expect(normalizeCodexModelId()).toBe("gpt-5.5")
+    expect(normalizeCodexModelId()).toBe("gpt-5.6-sol")
+    expect(normalizeCodexModelId("gpt-5.6")).toBe("gpt-5.6-sol")
+    expect(normalizeCodexModelId("gpt-5.6-terra")).toBe("gpt-5.6-terra")
+    expect(normalizeCodexModelId("gpt-5.6-luna")).toBe("gpt-5.6-luna")
     expect(normalizeCodexModelId("gpt-5-codex")).toBe("gpt-5.3-codex")
+    expect(normalizeCodexModelId("not-a-real-model")).toBe("gpt-5.6-sol")
+  })
+
+  test("exposes model-specific GPT-5.6 reasoning efforts", () => {
+    expect(getCodexReasoningOptions("gpt-5.6-sol").map((option) => option.id)).toEqual([
+      "low", "medium", "high", "xhigh", "max", "ultra",
+    ])
+    expect(getCodexReasoningOptions("gpt-5.6-terra").map((option) => option.id)).toEqual([
+      "low", "medium", "high", "xhigh", "max", "ultra",
+    ])
+    expect(getCodexReasoningOptions("gpt-5.6-luna").map((option) => option.id)).toEqual([
+      "low", "medium", "high", "xhigh", "max",
+    ])
+  })
+
+  test("preserves all 17 supported GPT-5.6 model and reasoning combinations", () => {
+    const combinations = [
+      ["gpt-5.6-sol", ["low", "medium", "high", "xhigh", "max", "ultra"]],
+      ["gpt-5.6-terra", ["low", "medium", "high", "xhigh", "max", "ultra"]],
+      ["gpt-5.6-luna", ["low", "medium", "high", "xhigh", "max"]],
+    ] as const
+
+    expect(combinations.reduce((count, [, efforts]) => count + efforts.length, 0)).toBe(17)
+    for (const [model, efforts] of combinations) {
+      for (const effort of efforts) {
+        expect(normalizeCodexReasoningEffort(model, effort)).toBe(effort)
+      }
+    }
+  })
+
+  test("normalizes unsupported GPT-5.6 reasoning efforts", () => {
+    expect(normalizeCodexReasoningEffort("gpt-5.6-sol", "minimal")).toBe("low")
+    expect(normalizeCodexReasoningEffort("gpt-5.6-luna", "ultra")).toBe("max")
+    expect(normalizeCodexReasoningEffort("gpt-5.6-terra", "ultra")).toBe("ultra")
+    expect(normalizeCodexReasoningEffort("gpt-5.6-sol", "unknown")).toBe("medium")
+  })
+
+  test("recognizes public and legacy Codex reasoning values", () => {
+    expect(isCodexReasoningEffort("max")).toBe(true)
+    expect(isCodexReasoningEffort("ultra")).toBe(true)
+    expect(isCodexReasoningEffort("minimal")).toBe(true)
+    expect(getCodexReasoningOptions("gpt-5.6-sol").find((option) => option.id === "xhigh")?.label).toBe("Extra High")
+    expect(getCodexReasoningOptions("gpt-5.6-sol").find((option) => option.id === "ultra")?.description).toContain("subagents")
   })
 
   test("uses declarative metadata for Claude max-effort support", () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -137,6 +137,9 @@ export interface ProviderModelOption {
   label: string
   supportsEffort: boolean
   aliases?: readonly string[]
+  supportedReasoningEfforts?: readonly CodexReasoningEffortOption[]
+  defaultReasoningEffort?: CodexReasoningEffort
+  supportsFastMode?: boolean
   contextWindowOptions?: readonly ProviderContextWindowOption[]
   supportsMaxReasoningEffort?: boolean
 }
@@ -144,6 +147,13 @@ export interface ProviderModelOption {
 export interface ProviderEffortOption {
   id: string
   label: string
+  description?: string
+}
+
+export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+
+export interface CodexReasoningEffortOption extends ProviderEffortOption {
+  id: CodexReasoningEffort
 }
 
 export interface ProviderContextWindowOption {
@@ -159,15 +169,19 @@ export const CLAUDE_REASONING_OPTIONS = [
 ] as const satisfies readonly ProviderEffortOption[]
 
 export const CODEX_REASONING_OPTIONS = [
-  { id: "minimal", label: "Minimal" },
   { id: "low", label: "Low" },
   { id: "medium", label: "Medium" },
   { id: "high", label: "High" },
-  { id: "xhigh", label: "XHigh" },
-] as const satisfies readonly ProviderEffortOption[]
+  { id: "xhigh", label: "Extra High" },
+  { id: "max", label: "Max" },
+  {
+    id: "ultra",
+    label: "Ultra",
+    description: "Uses subagents to delegate parts of complex tasks",
+  },
+] as const satisfies readonly CodexReasoningEffortOption[]
 
 export type ClaudeReasoningEffort = (typeof CLAUDE_REASONING_OPTIONS)[number]["id"]
-export type CodexReasoningEffort = (typeof CODEX_REASONING_OPTIONS)[number]["id"]
 export type ClaudeContextWindow = "200k" | "1m"
 export type ServiceTier = "fast"
 
@@ -207,7 +221,7 @@ export const DEFAULT_CLAUDE_MODEL_OPTIONS = {
 } as const satisfies ClaudeModelOptions
 
 export const DEFAULT_CODEX_MODEL_OPTIONS = {
-  reasoningEffort: "high",
+  reasoningEffort: "medium",
   fastMode: false,
 } as const satisfies CodexModelOptions
 
@@ -216,8 +230,16 @@ export function isClaudeReasoningEffort(value: unknown): value is ClaudeReasonin
 }
 
 export function isCodexReasoningEffort(value: unknown): value is CodexReasoningEffort {
-  return CODEX_REASONING_OPTIONS.some((option) => option.id === value)
+  return value === "minimal" || CODEX_REASONING_OPTIONS.some((option) => option.id === value)
 }
+
+const LEGACY_CODEX_REASONING_OPTIONS = [
+  { id: "minimal", label: "Minimal" },
+  ...CODEX_REASONING_OPTIONS.filter((option) => option.id !== "max" && option.id !== "ultra"),
+] as const satisfies readonly ProviderEffortOption[]
+
+const GPT_5_6_REASONING_OPTIONS = [...CODEX_REASONING_OPTIONS]
+const GPT_5_6_LUNA_REASONING_OPTIONS = CODEX_REASONING_OPTIONS.filter((option) => option.id !== "ultra")
 
 export const CLAUDE_CONTEXT_WINDOW_OPTIONS = [
   { id: "200k", label: "200k" },
@@ -288,15 +310,70 @@ export const PROVIDERS: ProviderCatalogEntry[] = [
   {
     id: "codex",
     label: "Codex",
-    defaultModel: "gpt-5.5",
+    defaultModel: "gpt-5.6-sol",
+    defaultEffort: "medium",
     supportsPlanMode: true,
     models: [
-      { id: "gpt-5.5", label: "GPT-5.5", supportsEffort: false },
-      { id: "gpt-5.4", label: "GPT-5.4", supportsEffort: false },
-      { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", supportsEffort: false, aliases: ["gpt-5-codex"] },
-      { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark", supportsEffort: false },
+      {
+        id: "gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        supportsEffort: true,
+        aliases: ["gpt-5.6"],
+        supportedReasoningEfforts: GPT_5_6_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.6-terra",
+        label: "GPT-5.6 Terra",
+        supportsEffort: true,
+        supportedReasoningEfforts: GPT_5_6_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.6-luna",
+        label: "GPT-5.6 Luna",
+        supportsEffort: true,
+        supportedReasoningEfforts: GPT_5_6_LUNA_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.5",
+        label: "GPT-5.5",
+        supportsEffort: true,
+        supportedReasoningEfforts: LEGACY_CODEX_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+        supportsEffort: true,
+        supportedReasoningEfforts: LEGACY_CODEX_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.3-codex",
+        label: "GPT-5.3 Codex",
+        supportsEffort: true,
+        aliases: ["gpt-5-codex"],
+        supportedReasoningEfforts: LEGACY_CODEX_REASONING_OPTIONS,
+        defaultReasoningEffort: "high",
+        supportsFastMode: true,
+      },
+      {
+        id: "gpt-5.3-codex-spark",
+        label: "GPT-5.3 Codex Spark",
+        supportsEffort: true,
+        supportedReasoningEfforts: LEGACY_CODEX_REASONING_OPTIONS,
+        defaultReasoningEffort: "high",
+        supportsFastMode: false,
+      },
     ],
-    efforts: [],
+    efforts: [...CODEX_REASONING_OPTIONS],
   },
 ]
 
@@ -330,7 +407,7 @@ export function normalizeClaudeModelId(modelId?: string, fallbackModelId = "clau
   return normalizeProviderModelId("claude", modelId, fallbackModelId)
 }
 
-export function normalizeCodexModelId(modelId?: string, fallbackModelId = "gpt-5.5"): string {
+export function normalizeCodexModelId(modelId?: string, fallbackModelId = "gpt-5.6-sol"): string {
   return normalizeProviderModelId("codex", modelId, fallbackModelId)
 }
 
@@ -341,6 +418,35 @@ export function getProviderModelOption(provider: AgentProvider, modelId: string)
 
 export function getClaudeModelOption(modelId: string): ProviderModelOption | undefined {
   return getProviderModelOption("claude", modelId)
+}
+
+export function getCodexModelOption(modelId: string): ProviderModelOption | undefined {
+  return getProviderModelOption("codex", modelId)
+}
+
+export function getCodexReasoningOptions(modelId: string): readonly CodexReasoningEffortOption[] {
+  return getCodexModelOption(modelId)?.supportedReasoningEfforts ?? CODEX_REASONING_OPTIONS
+}
+
+export function normalizeCodexReasoningEffort(
+  modelId: string,
+  effort?: unknown,
+): CodexReasoningEffort {
+  const normalizedModel = normalizeCodexModelId(modelId)
+  const model = getCodexModelOption(normalizedModel)
+  const supported = model?.supportedReasoningEfforts ?? CODEX_REASONING_OPTIONS
+
+  if (effort === "minimal" && normalizedModel.startsWith("gpt-5.6-")) {
+    return "low"
+  }
+  if (effort === "ultra" && normalizedModel === "gpt-5.6-luna") {
+    return "max"
+  }
+  if (isCodexReasoningEffort(effort) && supported.some((option) => option.id === effort)) {
+    return effort
+  }
+
+  return model?.defaultReasoningEffort ?? DEFAULT_CODEX_MODEL_OPTIONS.reasoningEffort
 }
 
 export function supportsClaudeMaxReasoningEffort(modelId: string): boolean {
@@ -466,8 +572,12 @@ export interface AppSettingsPatch {
   editor?: Partial<AppSettingsSnapshot["editor"]>
   defaultProvider?: DefaultProviderPreference
   providerDefaults?: {
-    claude?: Partial<ProviderPreference<ClaudeModelOptions>>
-    codex?: Partial<ProviderPreference<CodexModelOptions>>
+    claude?: Partial<Omit<ProviderPreference<ClaudeModelOptions>, "modelOptions">> & {
+      modelOptions?: Partial<ClaudeModelOptions>
+    }
+    codex?: Partial<Omit<ProviderPreference<CodexModelOptions>, "modelOptions">> & {
+      modelOptions?: Partial<CodexModelOptions>
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Add first-class Codex support for GPT-5.6 Sol, Terra, and Luna.
- Add model-specific reasoning levels through Max and Ultra while keeping Ultra in the existing Reasoning Level control.
- Preserve existing Codex preferences and normalize legacy or unsupported model/effort combinations safely.

## What changed

### Model catalog and normalization

- Added `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the shared static provider catalog.
- Made Sol + Medium the default for new Codex preferences and mapped the `gpt-5.6` alias to Sol.
- Added model-level effort metadata: Sol and Terra support Low through Ultra; Luna supports Low through Max.
- Kept legacy `minimal` readable for existing settings, mapping it to Low only when used with GPT-5.6.
- Normalize Luna + Ultra to Luna + Max on both client and server.

### Settings and UI

- Removed the unconditional migration that rewrote persisted Codex models to GPT-5.5.
- Made app settings patches support partial model-option updates without losing model, Fast Mode, or Plan Mode state.
- Reused the shared capability helpers in both Settings and the chat composer.
- Display `xhigh` as Extra High and describe Ultra as proactive subagent delegation.
- Keep the Luna `Ultra → Max` transition visible without adding a new dialog or state layer.

### Codex app-server

- Forward the normalized effort through both `turn/start.effort` and `collaborationMode.settings.reasoning_effort`.
- Preserve the existing Fast Mode, Plan Mode, resume, fork, queue, steer, and cancellation paths.
- Added fake app-server coverage for all 17 supported GPT-5.6 model/effort combinations.

## Tests

- [x] `bun run check` — TypeScript, client build, and export-viewer build pass.
- [x] 130 focused provider catalog, settings migration, UI, AgentCoordinator, WebSocket, and app-server tests pass.
- [x] Fake app-server verifies all 17 supported GPT-5.6 model/effort combinations.
- [x] Read-only live smoke tests completed for Sol + Medium, Terra + Low, and Luna + Medium.
- [x] Sol + Ultra produced Codex collaboration events and completed; cancellation was also exercised.

## Notes

- This intentionally keeps the existing static provider catalog. It does not add runtime `model/list` discovery, catalog subscriptions, or new cache/fallback state.
- Existing GPT-5.3, GPT-5.4, and GPT-5.5 choices remain available.
- On this local machine, the full `bun test` run reported 609 passing and 12 unrelated existing environment failures in Git merge-preview fixtures, PTY Ctrl+D timing, and browser-global test isolation. The focused tests and release build are clean.
