### PR TITLE
Show project paths in Recents

### DIFF
--- a/src/client/components/LocalDev.test.ts
+++ b/src/client/components/LocalDev.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
 import type { LocalProjectSummary } from "../../shared/types"
-import { filterProjects, groupProjectsByRecency } from "./LocalDev"
+import { filterProjects, groupProjectsByRecency, LocalDev } from "./LocalDev"
+import { TooltipProvider } from "./ui/tooltip"
 
 const DAY_MS = 24 * 60 * 60 * 1_000
 const NOW_MS = Date.parse("2026-07-17T12:00:00.000Z")
@@ -63,5 +66,30 @@ describe("local project recency groups", () => {
       "alpha-quarter",
       "Zulu-quarter",
     ])
+  })
+})
+
+describe("LocalDev", () => {
+  test("shows each project's path below its name", () => {
+    const projectPage = createElement(LocalDev, {
+      connectionStatus: "connected",
+      ready: true,
+      snapshot: {
+        machine: { id: "local", displayName: "Test Mac", platform: "darwin" },
+        projects: [project("kanna", 1)],
+      },
+      startingLocalPath: null,
+      commandError: null,
+      newProjectOpen: false,
+      onNewProjectOpenChange: () => {},
+      onOpenProject: async () => {},
+      onCreateProject: async () => {},
+      onListDirectory: async () => { throw new Error("not called") },
+      onMakeDirectory: async () => { throw new Error("not called") },
+    })
+    const html = renderToStaticMarkup(createElement(TooltipProvider, null, projectPage))
+
+    expect(html).toContain(">kanna<")
+    expect(html).toContain(">/projects/kanna<")
   })
 })

--- a/src/client/components/LocalDev.tsx
+++ b/src/client/components/LocalDev.tsx
@@ -15,6 +15,7 @@ import type { FsListResult, LocalProjectSummary, LocalProjectsSnapshot } from ".
 import type { SocketStatus } from "../app/socket"
 import { PageHeader } from "../app/PageHeader"
 import { getPathBasename } from "../lib/formatters"
+import { formatPathWithTilde } from "../lib/pathUtils"
 import { cn } from "../lib/utils"
 import { NewProjectModal } from "./NewProjectModal"
 import { Button } from "./ui/button"
@@ -196,8 +197,13 @@ function ProjectCard({
           onClick={onClick}
         >
           <Folder className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          <span className="font-medium text-foreground truncate flex-1">
-            {getPathBasename(localPath)}
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="truncate font-medium text-foreground">
+              {getPathBasename(localPath)}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {formatPathWithTilde(localPath)}
+            </span>
           </span>
           {loading ? (
             <Loader2 className="h-4 w-4 text-muted-foreground group-hover:text-primary animate-spin flex-shrink-0" />

--- a/src/client/lib/pathUtils.test.ts
+++ b/src/client/lib/pathUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { parseLocalFileLink, shouldOpenLocalFileLinkInEditor } from "./pathUtils"
+import { formatPathWithTilde, parseLocalFileLink, shouldOpenLocalFileLinkInEditor } from "./pathUtils"
 
 describe("parseLocalFileLink", () => {
   test("parses an absolute file path with a line fragment", () => {
@@ -75,5 +75,16 @@ describe("shouldOpenLocalFileLinkInEditor", () => {
     expect(shouldOpenLocalFileLinkInEditor("/Users/jake/Projects/kanna/movie.mp4")).toBe(false)
     expect(shouldOpenLocalFileLinkInEditor("/Users/jake/Projects/kanna/report.docx")).toBe(false)
     expect(shouldOpenLocalFileLinkInEditor("/Users/jake/Projects/kanna/archive.zip")).toBe(false)
+  })
+})
+
+describe("formatPathWithTilde", () => {
+  test("abbreviates macOS and Linux home directory paths", () => {
+    expect(formatPathWithTilde("/Users/jake/Projects/kanna")).toBe("~/Projects/kanna")
+    expect(formatPathWithTilde("/home/jake/Projects/kanna")).toBe("~/Projects/kanna")
+  })
+
+  test("preserves paths outside a home directory", () => {
+    expect(formatPathWithTilde("/tmp/kanna")).toBe("/tmp/kanna")
   })
 })


### PR DESCRIPTION
## What changed

- Show each discovered project's path beneath its name in the Recents grid.
- Abbreviate macOS and Linux home directories with `~` and truncate long paths within the card.
- Add render coverage for the two-line project card and unit coverage for path abbreviation.

## Why

Repeated project folder names are difficult to distinguish in Recents. The path provides the missing context without widening the grid.

## Validation

- `bun test src/client/components/LocalDev.test.ts src/client/lib/pathUtils.test.ts`
- `bunx tsc --noEmit`
- `bun run build:client`
- Previously failing socket-based auth/upload tests pass outside the sandbox (`23 passed, 0 failed`).