### PR TITLE
Fix uploads in insecure browser contexts

### DIFF
--- a/src/client/components/chat-ui/ChatInput.test.ts
+++ b/src/client/components/chat-ui/ChatInput.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { PROVIDERS } from "../../../shared/types"
+import { generateUUID } from "../../lib/utils"
 import { ChatInput, getClipboardImageFiles, trimTrailingPastedNewlines, willExceedAttachmentLimit } from "./ChatInput"
 
 function createClipboardItem(args: {
@@ -100,6 +101,25 @@ describe("getClipboardImageFiles", () => {
       "clipboard-789.png",
       "clipboard-789-1.webp",
     ])
+  })
+})
+
+describe("attachment IDs", () => {
+  test("uses the UUID fallback when randomUUID is unavailable", () => {
+    const originalCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {},
+    })
+
+    try {
+      expect(generateUUID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: originalCrypto,
+      })
+    }
   })
 })
 

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -18,7 +18,7 @@ import { assertNever } from "../../../shared/assert"
 import { Button } from "../ui/button"
 import { Textarea } from "../ui/textarea"
 import { ScrollArea } from "../ui/scroll-area"
-import { cn } from "../../lib/utils"
+import { cn, generateUUID } from "../../lib/utils"
 import { useIsStandalone } from "../../hooks/useIsStandalone"
 import { useChatInputStore } from "../../stores/chatInputStore"
 import { NEW_CHAT_COMPOSER_ID, type ComposerState, useChatPreferencesStore } from "../../stores/chatPreferencesStore"
@@ -446,7 +446,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
       if (!file) break
 
       activeUploadsRef.current += 1
-      const tempId = crypto.randomUUID()
+      const tempId = generateUUID()
       const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined
       const generation = uploadGenerationRef.current
 


### PR DESCRIPTION
## What changed

- Use Kanna's existing browser-compatible UUID helper for temporary attachment IDs.
- Add regression coverage for browsers where `crypto.randomUUID()` is unavailable.

## Why

Kanna can be served over plain HTTP on a Tailscale address. In that non-secure browser context, `crypto.randomUUID()` is unavailable, so enqueueing an attachment threw before the upload request began. The existing `generateUUID()` helper already provides a compatible fallback.

## Impact

Image and file attachments can now be queued from remote HTTP browser sessions without crashing.

## Validation

- `bun test src/client/components/chat-ui/ChatInput.test.ts`
- `bun run check`