### PR TITLE
Fix segmented control indicator right-bias from border offset

### DIFF
--- a/src/client/components/ui/segmented-control.tsx
+++ b/src/client/components/ui/segmented-control.tsx
@@ -52,7 +52,10 @@ export function SegmentedControl<T extends string>({
     }
     const containerRect = container.getBoundingClientRect()
     const rect = active.getBoundingClientRect()
-    setIndicator({ left: rect.left - containerRect.left, width: rect.width })
+    // `left` on the absolute indicator resolves against the container's padding
+    // box, but these rects are border-box — subtract the left border width so
+    // the indicator doesn't sit one border-width to the right at every position.
+    setIndicator({ left: rect.left - containerRect.left - container.clientLeft, width: rect.width })
     hasIndicator.current = true
   }, [value, options, size])
 


### PR DESCRIPTION
## Problem

The `SegmentedControl` sliding indicator sat slightly to the right of the active segment — at **every** position, by a constant amount.

## Root cause

A coordinate-space mismatch between how the offset was measured and how it was consumed:

- `getBoundingClientRect()` returns the **border** box, so `rect.left - containerRect.left` measures from the container's *outer border edge*.
- CSS resolves `left` on an absolutely positioned child against the containing block's **padding** box — i.e. `left: 0` sits just *inside* the container's `border-border`.

Every computed value was therefore one border width (1px) too large. Constant rather than accumulating, which is why the indicator looked uniformly off across all segments rather than drifting.

## Fix

Subtract `container.clientLeft` — the computed left border width — to convert the measurement into the padding-box space the style actually uses. Reading it off the element rather than hardcoding `1` keeps this correct if the border width ever changes.

## Notes

The vertical inset was already correct by coincidence: `top-[3px]`/`bottom-[3px]` are also padding-box relative and happen to match the container's `p-[3px]`, so only the horizontal axis was affected.

## Testing

`bun run check` passes (typecheck + both production builds).

Scope is deliberately limited to this one hunk; unrelated in-flight work in the tree is excluded.

🌸 Shipped with [Kanna](https://kanna.sh)