### PR TITLE
Add Transcript Modes

### DIFF
--- a/src/client/app/ChatPage/ChatTranscriptViewport.tsx
+++ b/src/client/app/ChatPage/ChatTranscriptViewport.tsx
@@ -20,6 +20,7 @@ import { useScrollbarGutterVar } from "../../hooks/useScrollbarGutterVar"
 import { cn } from "../../lib/utils"
 import type { ChatJumpRole } from "../../lib/chat-navigation"
 import { formatPathWithTilde, shouldOpenLocalFileLinkInEditor } from "../../lib/pathUtils"
+import { DEFAULT_TRANSCRIPT_DETAIL, type TranscriptDetail } from "../../lib/transcriptDetail"
 import {
   buildResolvedTranscriptRows,
   KannaTranscriptRow,
@@ -190,6 +191,8 @@ interface ChatTranscriptViewportProps {
   transcriptPaddingBottom: number
   localPath: string | null | undefined
   latestToolIds: KannaState["latestToolIds"]
+  /** The export viewer has no picker, so it stays on the default. */
+  transcriptDetail?: TranscriptDetail
   isProcessing: boolean
   runtimeStatus: string | null
   isDraining: boolean
@@ -311,6 +314,7 @@ const TranscriptScrollerBody = memo(function TranscriptScrollerBody({
   transcriptPaddingBottom,
   localPath,
   latestToolIds,
+  transcriptDetail = DEFAULT_TRANSCRIPT_DETAIL,
   isProcessing,
   runtimeStatus,
   isDraining,
@@ -357,7 +361,8 @@ const TranscriptScrollerBody = memo(function TranscriptScrollerBody({
     isLoading: isProcessing,
     localPath: localPath ?? undefined,
     latestToolIds,
-  }), [isProcessing, latestToolIds, localPath, messages])
+    detail: transcriptDetail,
+  }), [isProcessing, latestToolIds, localPath, messages, transcriptDetail])
   const resolvedRows = useStableResolvedRows(rawRows)
 
   useEffect(() => {

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -21,6 +21,7 @@ import { useProjectRepoUrl } from "../../stores/sidebarStore"
 import { DEFAULT_PROJECT_TERMINAL_LAYOUT, useTerminalLayoutStore } from "../../stores/terminalLayoutStore"
 import { useTerminalPreferencesStore } from "../../stores/terminalPreferencesStore"
 import { useTranscriptDetail } from "../../stores/transcriptDetailStore"
+import { resolveTranscriptDetail } from "../../lib/transcriptDetail"
 import { shouldCloseTerminalPane } from "../terminalLayoutResize"
 import { TERMINAL_TOGGLE_ANIMATION_DURATION_MS } from "../terminalToggleAnimation"
 import { useRightSidebarToggleAnimation } from "../useRightSidebarToggleAnimation"
@@ -506,7 +507,10 @@ export function ChatPage() {
   const [pendingTerminalCommands, setPendingTerminalCommands] = useState<Record<string, string>>({})
   const [defaultModelsDialogOpen, setDefaultModelsDialogOpen] = useState(false)
   const showEmptyState = state.messages.length === 0 && state.runtime?.title === "New Chat"
-  const transcriptDetail = useTranscriptDetail(state.activeChatId)
+  const transcriptDetail = resolveTranscriptDetail(
+    useTranscriptDetail(state.activeChatId),
+    state.runtime?.provider ?? null
+  )
   const projectId = state.activeProjectId
   const projectTerminalLayout = useTerminalLayoutStore((store) => (projectId ? store.projects[projectId] : undefined))
   const storedTerminalLayout = projectTerminalLayout ?? DEFAULT_PROJECT_TERMINAL_LAYOUT

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -20,6 +20,7 @@ import {
 import { useProjectRepoUrl } from "../../stores/sidebarStore"
 import { DEFAULT_PROJECT_TERMINAL_LAYOUT, useTerminalLayoutStore } from "../../stores/terminalLayoutStore"
 import { useTerminalPreferencesStore } from "../../stores/terminalPreferencesStore"
+import { useTranscriptDetail } from "../../stores/transcriptDetailStore"
 import { shouldCloseTerminalPane } from "../terminalLayoutResize"
 import { TERMINAL_TOGGLE_ANIMATION_DURATION_MS } from "../terminalToggleAnimation"
 import { useRightSidebarToggleAnimation } from "../useRightSidebarToggleAnimation"
@@ -505,6 +506,7 @@ export function ChatPage() {
   const [pendingTerminalCommands, setPendingTerminalCommands] = useState<Record<string, string>>({})
   const [defaultModelsDialogOpen, setDefaultModelsDialogOpen] = useState(false)
   const showEmptyState = state.messages.length === 0 && state.runtime?.title === "New Chat"
+  const transcriptDetail = useTranscriptDetail(state.activeChatId)
   const projectId = state.activeProjectId
   const projectTerminalLayout = useTerminalLayoutStore((store) => (projectId ? store.projects[projectId] : undefined))
   const storedTerminalLayout = projectTerminalLayout ?? DEFAULT_PROJECT_TERMINAL_LAYOUT
@@ -1013,6 +1015,7 @@ export function ChatPage() {
           transcriptPaddingBottom={transcriptPaddingBottom}
           localPath={state.runtime?.localPath}
           latestToolIds={state.latestToolIds}
+          transcriptDetail={transcriptDetail}
           isProcessing={state.isProcessing}
           runtimeStatus={state.runtimeStatus}
           isDraining={state.isDraining}

--- a/src/client/app/ChatPage/transcriptRowSize.ts
+++ b/src/client/app/ChatPage/transcriptRowSize.ts
@@ -30,6 +30,9 @@ const LINE_HEIGHT = 22
 /** Markdown blocks add separation that raw character count misses. */
 const PARAGRAPH_SPACING = 10
 
+/** Stand-in body for a thought, whose text the snapshot trims away. */
+const THINKING_BODY = 4 * LINE_HEIGHT
+
 function textHeight(text: string | undefined) {
   if (!text) return LINE_HEIGHT
   let lines = 0
@@ -54,6 +57,8 @@ export function estimateTranscriptRowSize(row: ResolvedTranscriptRow): number {
       return textHeight(message.content) + ROW_CHROME + 16
     case "assistant_text":
       return textHeight(message.text) + ROW_CHROME
+    case "thinking":
+      return TOOL_ROW + (message.text ? textHeight(message.text) : THINKING_BODY) + ROW_CHROME
     case "tool":
       return TOOL_ROW + ROW_CHROME
     case "system_init":

--- a/src/client/app/KannaTranscript.test.tsx
+++ b/src/client/app/KannaTranscript.test.tsx
@@ -853,6 +853,20 @@ describe("transcript detail", () => {
     }
   }
 
+  function createDeleteMessage(id: string): HydratedTranscriptMessage {
+    return {
+      id,
+      kind: "tool",
+      toolKind: "delete_file",
+      toolName: "Delete",
+      toolId: id,
+      input: {
+        filePath: `/repo/${id}.ts`,
+      },
+      timestamp: new Date().toISOString(),
+    }
+  }
+
   const messages: HydratedTranscriptMessage[] = [
     {
       id: "user-1",
@@ -934,6 +948,18 @@ describe("transcript detail", () => {
     })
 
     expect(rows.map((row) => row.id)).toEqual(["user-1", "edit-1", "assistant-1"])
+  })
+
+  test("summary keeps file deletions", () => {
+    const rows = buildResolvedTranscriptRows([
+      createDeleteMessage("delete-1"),
+    ], {
+      isLoading: false,
+      latestToolIds,
+      detail: "summary",
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(["delete-1"])
   })
 
   test("summary keeps a pending question, which the user still has to answer", () => {

--- a/src/client/app/KannaTranscript.test.tsx
+++ b/src/client/app/KannaTranscript.test.tsx
@@ -833,3 +833,125 @@ Please check the latest error first.`,
     expect(stableState.result[0]).toBe(previousRows[0])
   })
 })
+
+describe("transcript detail", () => {
+  const latestToolIds = { AskUserQuestion: null, ExitPlanMode: null, TodoWrite: null }
+
+  function createEditMessage(id: string): HydratedTranscriptMessage {
+    return {
+      id,
+      kind: "tool",
+      toolKind: "edit_file",
+      toolName: "Edit",
+      toolId: id,
+      input: {
+        filePath: `/repo/${id}.ts`,
+        oldString: "before",
+        newString: "after",
+      },
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  const messages: HydratedTranscriptMessage[] = [
+    {
+      id: "user-1",
+      kind: "user_prompt",
+      content: "Fix the bug",
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: "think-1",
+      kind: "thinking",
+      text: "The router owns this",
+      timestamp: new Date().toISOString(),
+    },
+    createToolMessage("tool-1"),
+    createToolMessage("tool-2"),
+    createEditMessage("edit-1"),
+    {
+      id: "assistant-1",
+      kind: "assistant_text",
+      text: "Fixed it",
+      timestamp: new Date().toISOString(),
+    },
+  ]
+
+  test("normal groups consecutive tool calls and hides thinking", () => {
+    const rows = buildResolvedTranscriptRows(messages, { isLoading: false, latestToolIds })
+
+    expect(rows.map((row) => row.kind)).toEqual(["single", "tool-group", "single"])
+    expect(rows.map((row) => row.id)).not.toContain("think-1")
+  })
+
+  test("thinking shows reasoning in place of every tool row", () => {
+    const rows = buildResolvedTranscriptRows(messages, {
+      isLoading: false,
+      latestToolIds,
+      detail: "thinking",
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(["user-1", "think-1", "assistant-1"])
+    expect(rows.every((row) => row.kind === "single")).toBe(true)
+  })
+
+  test("thinking keeps a tool call the turn is blocked on", () => {
+    const question: HydratedTranscriptMessage = {
+      id: "ask-1",
+      kind: "tool",
+      toolKind: "ask_user_question",
+      toolName: "AskUserQuestion",
+      toolId: "ask-1",
+      input: {},
+      timestamp: new Date().toISOString(),
+    } as HydratedTranscriptMessage
+
+    const rows = buildResolvedTranscriptRows([...messages, question], {
+      isLoading: false,
+      latestToolIds: { ...latestToolIds, AskUserQuestion: "ask-1" },
+      detail: "thinking",
+    })
+
+    expect(rows.map((row) => row.id)).toContain("ask-1")
+  })
+
+  test("verbose gives every tool call its own row", () => {
+    const rows = buildResolvedTranscriptRows(messages, {
+      isLoading: false,
+      latestToolIds,
+      detail: "verbose",
+    })
+
+    expect(rows.every((row) => row.kind === "single")).toBe(true)
+    expect(rows.map((row) => row.id)).toEqual(["user-1", "think-1", "tool-1", "tool-2", "edit-1", "assistant-1"])
+  })
+
+  test("summary keeps file changes and drops the other tool calls", () => {
+    const rows = buildResolvedTranscriptRows(messages, {
+      isLoading: false,
+      latestToolIds,
+      detail: "summary",
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(["user-1", "edit-1", "assistant-1"])
+  })
+
+  test("summary keeps a pending question, which the user still has to answer", () => {
+    const question: HydratedTranscriptMessage = {
+      id: "question-1",
+      kind: "tool",
+      toolKind: "ask_user_question",
+      toolName: "AskUserQuestion",
+      toolId: "question-1",
+      input: { questions: [] },
+      timestamp: new Date().toISOString(),
+    }
+    const rows = buildResolvedTranscriptRows([createToolMessage("tool-1"), question], {
+      isLoading: true,
+      latestToolIds: { ...latestToolIds, AskUserQuestion: "question-1" },
+      detail: "summary",
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(["question-1"])
+  })
+})

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -6,6 +6,7 @@ import { RawJsonMessage } from "../components/messages/RawJsonMessage"
 import { SystemMessage, type SessionHandoff, type SessionRestore } from "../components/messages/SystemMessage"
 import { AccountInfoMessage } from "../components/messages/AccountInfoMessage"
 import { TextMessage } from "../components/messages/TextMessage"
+import { ThinkingMessage } from "../components/messages/ThinkingMessage"
 import { AskUserQuestionMessage } from "../components/messages/AskUserQuestionMessage"
 import { ExitPlanModeMessage } from "../components/messages/ExitPlanModeMessage"
 import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
@@ -18,6 +19,14 @@ import { StatusMessage } from "../components/messages/StatusMessage"
 import { CollapsedToolGroup } from "../components/messages/CollapsedToolGroup"
 import { CHAT_SELECTION_ZONE_ATTRIBUTE } from "./chatFocusPolicy"
 import { SPECIAL_TOOL_NAMES } from "./derived"
+import {
+  DEFAULT_TRANSCRIPT_DETAIL,
+  isBlockingToolKind,
+  isSummaryVisibleToolKind,
+  showsThinking,
+  showsToolCalls,
+  type TranscriptDetail,
+} from "../lib/transcriptDetail"
 
 const SPECIAL_TOOL_NAME_SET = new Set<string>(SPECIAL_TOOL_NAMES)
 
@@ -102,7 +111,8 @@ function getTranscriptMessageRenderState(
     hideResult,
     isFinalStatus,
     nextPromptTimestamp,
-  }: Omit<TranscriptMessageRenderState, "shouldRender">
+  }: Omit<TranscriptMessageRenderState, "shouldRender">,
+  detail: TranscriptDetail
 ): TranscriptMessageRenderState {
   let shouldRender = !message.hidden
 
@@ -124,8 +134,13 @@ function getTranscriptMessageRenderState(
       case "account_info":
         shouldRender = isFirstAccount
         break
+      case "thinking":
+        shouldRender = showsThinking(detail)
+        break
       case "tool":
-        shouldRender = message.toolKind !== "todo_write" || isLatestTodoWrite
+        shouldRender = (message.toolKind !== "todo_write" || isLatestTodoWrite)
+          && (detail !== "summary" || isSummaryVisibleToolKind(message.toolKind))
+          && (showsToolCalls(detail) || isBlockingToolKind(message.toolKind))
         break
       case "result":
         shouldRender = !hideResult
@@ -158,7 +173,8 @@ function getTranscriptMessageRenderState(
 
 function buildTranscriptMessageRenderStates(
   messages: HydratedTranscriptMessage[],
-  latestToolIds: Record<string, string | null>
+  latestToolIds: Record<string, string | null>,
+  detail: TranscriptDetail
 ) {
   // The transcript always arrives whole, so the first system/account row here
   // is genuinely the chat's first.
@@ -228,21 +244,23 @@ function buildTranscriptMessageRenderStates(
       hideResult: nextMessage?.kind === "context_cleared" || previousMessage?.kind === "context_cleared",
       isFinalStatus: index === messages.length - 1,
       nextPromptTimestamp: message.kind === "result" ? nextPromptTimestamps[index] : undefined,
-    })
+    }, detail)
   })
 }
 
 export function buildTranscriptRenderItems(
   messages: HydratedTranscriptMessage[],
-  renderStates: TranscriptMessageRenderState[]
+  renderStates: TranscriptMessageRenderState[],
+  detail: TranscriptDetail = DEFAULT_TRANSCRIPT_DETAIL
 ): TranscriptRenderItem[] {
   const result: TranscriptRenderItem[] = []
   let index = 0
+  const groupToolCalls = detail !== "verbose"
 
   while (index < messages.length) {
     const message = messages[index]
     const renderState = renderStates[index]
-    if (renderState?.shouldRender && isCollapsibleToolCall(message)) {
+    if (groupToolCalls && renderState?.shouldRender && isCollapsibleToolCall(message)) {
       const group: HydratedTranscriptMessage[] = [message]
       const startIndex = index
       index += 1
@@ -339,6 +357,8 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
       return right.kind === "account_info" && JSON.stringify(left.accountInfo) === JSON.stringify(right.accountInfo)
     case "assistant_text":
       return right.kind === "assistant_text" && left.text === right.text
+    case "thinking":
+      return right.kind === "thinking" && left.text === right.text
     case "tool":
       return right.kind === "tool"
         && left.toolKind === right.toolKind
@@ -527,6 +547,9 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
       case "assistant_text":
         rendered = <TextMessage key={message.id} message={message} />
         break
+      case "thinking":
+        rendered = <ThinkingMessage key={message.id} message={message} />
+        break
       case "tool":
         if (message.toolKind === "ask_user_question") {
           rendered = (
@@ -663,15 +686,17 @@ export function buildResolvedTranscriptRows(
     isLoading,
     localPath,
     latestToolIds,
+    detail = DEFAULT_TRANSCRIPT_DETAIL,
   }: {
     isLoading: boolean
     localPath?: string
     latestToolIds: Record<string, string | null>
+    detail?: TranscriptDetail
     /** True when the loaded window may not include the start of the transcript. */
   }
 ): ResolvedTranscriptRow[] {
-  const renderStates = buildTranscriptMessageRenderStates(messages, latestToolIds)
-  const renderItems = buildTranscriptRenderItems(messages, renderStates)
+  const renderStates = buildTranscriptMessageRenderStates(messages, latestToolIds, detail)
+  const renderItems = buildTranscriptRenderItems(messages, renderStates, detail)
   const rows: ResolvedTranscriptRow[] = []
 
   for (const item of renderItems) {

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -26,6 +26,7 @@ import { buildUploadErrorReport, simpleUploadError, type UploadErrorReport } fro
 import { useUnauthenticatedHarnesses } from "../../stores/providerAuthStore"
 import { SignInDialog } from "../auth/SignInDialog"
 import { ChatPreferenceControls } from "./ChatPreferenceControls"
+import { TranscriptDetailControl } from "./TranscriptDetailControl"
 import { ContextWindowMeter } from "./ContextWindowMeter"
 import { AttachmentFileCard, AttachmentImageCard } from "../messages/AttachmentCard"
 import { AttachmentPreviewModal } from "../messages/AttachmentPreviewModal"
@@ -1047,6 +1048,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             onModeChange={setEffectiveMode}
             includeMode={showModePicker}
             className="max-w-[840px] mx-auto"
+            trailing={chatId ? <TranscriptDetailControl chatId={chatId} /> : null}
           />
           {activeContextWindow ? (
             <div className="flex items-center md:hidden mx-[13px]">

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -30,6 +30,7 @@ import { TranscriptDetailControl } from "./TranscriptDetailControl"
 import { ContextWindowMeter } from "./ContextWindowMeter"
 import { AttachmentFileCard, AttachmentImageCard } from "../messages/AttachmentCard"
 import { AttachmentPreviewModal } from "../messages/AttachmentPreviewModal"
+import { transcriptDetailProvider } from "../../lib/transcriptDetail"
 import { classifyAttachmentPreview } from "../messages/attachmentPreview"
 import { overrideContextWindowMaxTokens, type ContextWindowSnapshot } from "../../lib/contextWindow"
 import {
@@ -1048,7 +1049,12 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             onModeChange={setEffectiveMode}
             includeMode={showModePicker}
             className="max-w-[840px] mx-auto"
-            trailing={chatId ? <TranscriptDetailControl chatId={chatId} provider={selectedProvider} /> : null}
+            trailing={chatId ? (
+              <TranscriptDetailControl
+                chatId={chatId}
+                provider={transcriptDetailProvider(activeProvider, selectedProvider)}
+              />
+            ) : null}
           />
           {activeContextWindow ? (
             <div className="flex items-center md:hidden mx-[13px]">

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -1048,7 +1048,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             onModeChange={setEffectiveMode}
             includeMode={showModePicker}
             className="max-w-[840px] mx-auto"
-            trailing={chatId ? <TranscriptDetailControl chatId={chatId} /> : null}
+            trailing={chatId ? <TranscriptDetailControl chatId={chatId} provider={selectedProvider} /> : null}
           />
           {activeContextWindow ? (
             <div className="flex items-center md:hidden mx-[13px]">

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -207,6 +207,8 @@ interface ChatPreferenceControlsProps {
   mode?: ChatMode
   onModeChange?: (mode: ChatMode) => void
   includeMode?: boolean
+  /** Extra control appended to the row. */
+  trailing?: ReactNode
   className?: string
 }
 
@@ -231,6 +233,7 @@ export function ChatPreferenceControls({
   mode = "full-access",
   onModeChange,
   includeMode = true,
+  trailing,
   className,
 }: ChatPreferenceControlsProps) {
   const providerConfig = availableProviders.find((provider) => provider.id === selectedProvider) ?? availableProviders[0]
@@ -483,6 +486,8 @@ export function ChatPreferenceControls({
           </InputPopover>
         )
       })() : null}
+
+      {trailing}
     </div>
   )
 }

--- a/src/client/components/chat-ui/TranscriptDetailControl.tsx
+++ b/src/client/components/chat-ui/TranscriptDetailControl.tsx
@@ -1,0 +1,49 @@
+import { AlignLeft, Brain, ListTree, Rows3, type LucideIcon } from "lucide-react"
+import {
+  TRANSCRIPT_DETAIL_LABELS,
+  TRANSCRIPT_DETAIL_ORDER,
+  type TranscriptDetail,
+} from "../../lib/transcriptDetail"
+import { setTranscriptDetail, useTranscriptDetail } from "../../stores/transcriptDetailStore"
+import { InputPopover, PopoverMenuItem } from "./ChatPreferenceControls"
+
+const TRANSCRIPT_DETAIL_ICONS: Record<TranscriptDetail, LucideIcon> = {
+  summary: AlignLeft,
+  normal: Rows3,
+  thinking: Brain,
+  verbose: ListTree,
+}
+
+/** Sits with the composer controls but writes none of the composer preferences. */
+export function TranscriptDetailControl({ chatId }: { chatId: string }) {
+  const detail = useTranscriptDetail(chatId)
+  const TriggerIcon = TRANSCRIPT_DETAIL_ICONS[detail]
+
+  return (
+    <InputPopover
+      trigger={(
+        <>
+          <TriggerIcon className="h-3.5 w-3.5" />
+          <span>{TRANSCRIPT_DETAIL_LABELS[detail].label}</span>
+        </>
+      )}
+    >
+      {(close) => TRANSCRIPT_DETAIL_ORDER.map((option) => {
+        const Icon = TRANSCRIPT_DETAIL_ICONS[option]
+        return (
+          <PopoverMenuItem
+            key={option}
+            onClick={() => {
+              setTranscriptDetail(chatId, option)
+              close()
+            }}
+            selected={detail === option}
+            icon={<Icon className="h-4 w-4 text-muted-foreground" />}
+            label={TRANSCRIPT_DETAIL_LABELS[option].label}
+            description={TRANSCRIPT_DETAIL_LABELS[option].description}
+          />
+        )
+      })}
+    </InputPopover>
+  )
+}

--- a/src/client/components/chat-ui/TranscriptDetailControl.tsx
+++ b/src/client/components/chat-ui/TranscriptDetailControl.tsx
@@ -1,10 +1,12 @@
 import { AlignLeft, Brain, ListTree, Rows3, type LucideIcon } from "lucide-react"
 import {
+  resolveTranscriptDetail,
   TRANSCRIPT_DETAIL_LABELS,
-  TRANSCRIPT_DETAIL_ORDER,
+  transcriptDetailOptions,
   type TranscriptDetail,
 } from "../../lib/transcriptDetail"
 import { setTranscriptDetail, useTranscriptDetail } from "../../stores/transcriptDetailStore"
+import type { AgentProvider } from "../../../shared/types"
 import { InputPopover, PopoverMenuItem } from "./ChatPreferenceControls"
 
 const TRANSCRIPT_DETAIL_ICONS: Record<TranscriptDetail, LucideIcon> = {
@@ -15,8 +17,14 @@ const TRANSCRIPT_DETAIL_ICONS: Record<TranscriptDetail, LucideIcon> = {
 }
 
 /** Sits with the composer controls but writes none of the composer preferences. */
-export function TranscriptDetailControl({ chatId }: { chatId: string }) {
-  const detail = useTranscriptDetail(chatId)
+export function TranscriptDetailControl({
+  chatId,
+  provider,
+}: {
+  chatId: string
+  provider: AgentProvider | null
+}) {
+  const detail = resolveTranscriptDetail(useTranscriptDetail(chatId), provider)
   const TriggerIcon = TRANSCRIPT_DETAIL_ICONS[detail]
 
   return (
@@ -28,7 +36,7 @@ export function TranscriptDetailControl({ chatId }: { chatId: string }) {
         </>
       )}
     >
-      {(close) => TRANSCRIPT_DETAIL_ORDER.map((option) => {
+      {(close) => transcriptDetailOptions(provider).map((option) => {
         const Icon = TRANSCRIPT_DETAIL_ICONS[option]
         return (
           <PopoverMenuItem

--- a/src/client/components/messages/ThinkingMessage.tsx
+++ b/src/client/components/messages/ThinkingMessage.tsx
@@ -1,0 +1,39 @@
+import { Brain } from "lucide-react"
+import type { ProcessedThinkingMessage } from "./types"
+import { MetaRow, MetaLabel, ExpandableRow, VerticalLineContainer, TranscriptMarkdown } from "./shared"
+import { useToolPayload, useToolPayloadPrefetch } from "./tool-payload-context"
+
+interface Props {
+  message: ProcessedThinkingMessage
+}
+
+/** Trimmed messages arrive with an empty text, so the body comes from the fetched entry. */
+function ThinkingBody({ message }: Props) {
+  const fetched = useToolPayload(message.trimmed ? message.id : undefined)
+  const text = fetched?.kind === "thinking" ? fetched.text : message.text
+
+  return (
+    <VerticalLineContainer className="my-4 text-sm text-muted-foreground">
+      <div className="prose prose-sm dark:prose-invert max-w-none prose-p:text-muted-foreground">
+        {text
+          ? <TranscriptMarkdown text={text} />
+          : <span className="text-muted-foreground">Loading...</span>}
+      </div>
+    </VerticalLineContainer>
+  )
+}
+
+export function ThinkingMessage({ message }: Props) {
+  const prefetchPayloads = useToolPayloadPrefetch()
+
+  return (
+    <MetaRow onPointerEnter={() => message.trimmed && prefetchPayloads([message.id])}>
+      <ExpandableRow defaultExpanded expandedContent={<ThinkingBody message={message} />}>
+        <div className="w-5 h-5 relative flex items-center justify-center">
+          <Brain className="h-4.5 w-4.5 text-muted-foreground" />
+        </div>
+        <MetaLabel>Thought</MetaLabel>
+      </ExpandableRow>
+    </MetaRow>
+  )
+}

--- a/src/client/components/messages/types.ts
+++ b/src/client/components/messages/types.ts
@@ -11,6 +11,11 @@ export type ProcessedTextMessage = Extract<
   { kind: "assistant_text" }
 >
 
+export type ProcessedThinkingMessage = Extract<
+  import("../../../shared/types").HydratedTranscriptMessage,
+  { kind: "thinking" }
+>
+
 export type ProcessedSystemMessage = Extract<
   import("../../../shared/types").HydratedTranscriptMessage,
   { kind: "system_init" }

--- a/src/client/lib/parseTranscript.ts
+++ b/src/client/lib/parseTranscript.ts
@@ -90,6 +90,14 @@ export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedT
           text: entry.text,
         })
         break
+      case "thinking":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "thinking",
+          text: entry.text,
+          trimmed: entry.trimmed,
+        })
+        break
       case "tool_call": {
         const toolCall = hydrateToolCall(entry)
         pendingToolCalls.set(entry.tool.toolId, { hydrated: toolCall, normalized: entry.tool })

--- a/src/client/lib/storageKeys.ts
+++ b/src/client/lib/storageKeys.ts
@@ -20,6 +20,9 @@ export const SIDEBAR_VIEW_STORAGE_KEY = "kanna:sidebar-view"
 /** localStorage: focus mode is on, so the sidebar shows only the open chat's project. */
 export const SIDEBAR_FOCUS_MODE_STORAGE_KEY = "kanna:sidebar-focus-mode"
 
+/** localStorage: transcript detail level, per chat, for the chats that left the default. */
+export const TRANSCRIPT_DETAIL_STORAGE_KEY = "kanna:transcript-detail"
+
 // Legacy setup-wizard markers. Onboarding progress is now machine-wide state
 // in the server's settings file (`setupShown`/`setupCompleted`/`setupDismissed`
 // on the app-settings snapshot) so a second browser — local or via the cloud

--- a/src/client/lib/transcriptDetail.test.ts
+++ b/src/client/lib/transcriptDetail.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import {
+  DEFAULT_TRANSCRIPT_DETAIL,
+  resolveTranscriptDetail,
+  supportsThinkingDetail,
+  transcriptDetailOptions,
+} from "./transcriptDetail"
+
+describe("transcript detail by provider", () => {
+  test("every harness that records reasoning keeps the thinking level", () => {
+    expect(supportsThinkingDetail("claude")).toBe(true)
+    expect(supportsThinkingDetail("cursor")).toBe(true)
+    expect(supportsThinkingDetail("pi")).toBe(true)
+    expect(supportsThinkingDetail("codex")).toBe(false)
+  })
+
+  test("a chat with no provider yet keeps every level", () => {
+    expect(supportsThinkingDetail(null)).toBe(true)
+    expect(transcriptDetailOptions(null)).toContain("thinking")
+  })
+
+  test("the picker drops thinking only for codex", () => {
+    expect(transcriptDetailOptions("codex")).toEqual(["summary", "normal", "verbose"])
+    expect(transcriptDetailOptions("claude")).toContain("thinking")
+    expect(transcriptDetailOptions("cursor")).toContain("thinking")
+    expect(transcriptDetailOptions("pi")).toContain("thinking")
+  })
+
+  test("a stored thinking level falls back when the chat switches provider", () => {
+    expect(resolveTranscriptDetail("thinking", "codex")).toBe(DEFAULT_TRANSCRIPT_DETAIL)
+    expect(resolveTranscriptDetail("thinking", "claude")).toBe("thinking")
+    expect(resolveTranscriptDetail("thinking", "cursor")).toBe("thinking")
+  })
+
+  test("every other level survives a provider switch", () => {
+    for (const provider of ["claude", "codex", "cursor", "pi"] as const) {
+      expect(resolveTranscriptDetail("verbose", provider)).toBe("verbose")
+      expect(resolveTranscriptDetail("summary", provider)).toBe("summary")
+    }
+  })
+})

--- a/src/client/lib/transcriptDetail.test.ts
+++ b/src/client/lib/transcriptDetail.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TRANSCRIPT_DETAIL,
   resolveTranscriptDetail,
   supportsThinkingDetail,
+  transcriptDetailProvider,
   transcriptDetailOptions,
 } from "./transcriptDetail"
 
@@ -37,5 +38,13 @@ describe("transcript detail by provider", () => {
       expect(resolveTranscriptDetail("verbose", provider)).toBe("verbose")
       expect(resolveTranscriptDetail("summary", provider)).toBe("summary")
     }
+  })
+
+  test("active provider wins over a staged provider", () => {
+    expect(transcriptDetailProvider("claude", "codex")).toBe("claude")
+  })
+
+  test("selected provider supplies the value before a chat starts", () => {
+    expect(transcriptDetailProvider(null, "codex")).toBe("codex")
   })
 })

--- a/src/client/lib/transcriptDetail.ts
+++ b/src/client/lib/transcriptDetail.ts
@@ -45,6 +45,13 @@ export function resolveTranscriptDetail(
   return detail
 }
 
+export function transcriptDetailProvider(
+  activeProvider: AgentProvider | null,
+  selectedProvider: AgentProvider
+) {
+  return activeProvider ?? selectedProvider
+}
+
 /** Hiding one of these would leave the turn stuck with no visible way to respond, so every level keeps them. */
 const BLOCKING_TOOL_KINDS = ["ask_user_question", "exit_plan_mode"] as const
 
@@ -54,6 +61,7 @@ const SUMMARY_VISIBLE_TOOL_KINDS = new Set<string>([
   "todo_write",
   "write_file",
   "edit_file",
+  "delete_file",
 ])
 
 const BLOCKING_TOOL_KIND_SET = new Set<string>(BLOCKING_TOOL_KINDS)

--- a/src/client/lib/transcriptDetail.ts
+++ b/src/client/lib/transcriptDetail.ts
@@ -1,0 +1,49 @@
+/** A view setting: every level reads the same snapshot, and the agent is never told which one is active. */
+
+export type TranscriptDetail = "summary" | "normal" | "thinking" | "verbose"
+
+export const DEFAULT_TRANSCRIPT_DETAIL: TranscriptDetail = "normal"
+
+/** Least detail first, so the picker reads top to bottom as quieter to louder. */
+export const TRANSCRIPT_DETAIL_ORDER = ["summary", "normal", "thinking", "verbose"] as const
+
+export const TRANSCRIPT_DETAIL_LABELS: Record<TranscriptDetail, { label: string; description: string }> = {
+  summary: { label: "Summary", description: "Replies and file changes only" },
+  normal: { label: "Normal", description: "Tool calls grouped into one row" },
+  thinking: { label: "Thinking", description: "Replies and the model's reasoning" },
+  verbose: { label: "Verbose", description: "Every tool call and every thought" },
+}
+
+export function isTranscriptDetail(value: unknown): value is TranscriptDetail {
+  return value === "summary" || value === "normal" || value === "thinking" || value === "verbose"
+}
+
+export function showsThinking(detail: TranscriptDetail) {
+  return detail === "thinking" || detail === "verbose"
+}
+
+/** Hiding one of these would leave the turn stuck with no visible way to respond, so every level keeps them. */
+const BLOCKING_TOOL_KINDS = ["ask_user_question", "exit_plan_mode"] as const
+
+/** The kinds that changed the workspace, plus the ones the user has to act on. */
+const SUMMARY_VISIBLE_TOOL_KINDS = new Set<string>([
+  ...BLOCKING_TOOL_KINDS,
+  "todo_write",
+  "write_file",
+  "edit_file",
+])
+
+const BLOCKING_TOOL_KIND_SET = new Set<string>(BLOCKING_TOOL_KINDS)
+
+export function isSummaryVisibleToolKind(toolKind: string) {
+  return SUMMARY_VISIBLE_TOOL_KINDS.has(toolKind)
+}
+
+export function isBlockingToolKind(toolKind: string) {
+  return BLOCKING_TOOL_KIND_SET.has(toolKind)
+}
+
+/** Thinking trades every tool row for the thoughts between them; Verbose shows both. */
+export function showsToolCalls(detail: TranscriptDetail) {
+  return detail !== "thinking"
+}

--- a/src/client/lib/transcriptDetail.ts
+++ b/src/client/lib/transcriptDetail.ts
@@ -1,3 +1,5 @@
+import type { AgentProvider } from "../../shared/types"
+
 /** A view setting: every level reads the same snapshot, and the agent is never told which one is active. */
 
 export type TranscriptDetail = "summary" | "normal" | "thinking" | "verbose"
@@ -20,6 +22,27 @@ export function isTranscriptDetail(value: unknown): value is TranscriptDetail {
 
 export function showsThinking(detail: TranscriptDetail) {
   return detail === "thinking" || detail === "verbose"
+}
+
+/** Codex sends no reasoning unless the user's `model_reasoning_summary` config asks for it, so the level would hide the tool rows and put nothing back. */
+const PROVIDERS_WITHOUT_REASONING = new Set<AgentProvider>(["codex"])
+
+export function supportsThinkingDetail(provider: AgentProvider | null | undefined) {
+  return provider == null || !PROVIDERS_WITHOUT_REASONING.has(provider)
+}
+
+export function transcriptDetailOptions(provider: AgentProvider | null | undefined) {
+  if (supportsThinkingDetail(provider)) return TRANSCRIPT_DETAIL_ORDER
+  return TRANSCRIPT_DETAIL_ORDER.filter((option) => option !== "thinking")
+}
+
+/** A stored level survives a provider switch, so an unusable one falls back at read time rather than being erased. */
+export function resolveTranscriptDetail(
+  detail: TranscriptDetail,
+  provider: AgentProvider | null | undefined
+): TranscriptDetail {
+  if (detail === "thinking" && !supportsThinkingDetail(provider)) return DEFAULT_TRANSCRIPT_DETAIL
+  return detail
 }
 
 /** Hiding one of these would leave the turn stuck with no visible way to respond, so every level keeps them. */

--- a/src/client/stores/transcriptDetailStore.test.ts
+++ b/src/client/stores/transcriptDetailStore.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import {
+  applyTranscriptDetail,
+  parseStoredTranscriptDetails,
+  pruneTranscriptDetails,
+} from "./transcriptDetailStore"
+
+describe("transcriptDetailStore", () => {
+  test("stores a non-default level for a chat", () => {
+    expect(applyTranscriptDetail({}, "chat-1", "verbose")).toEqual({ "chat-1": "verbose" })
+  })
+
+  test("returning to the default drops the entry instead of storing it", () => {
+    expect(applyTranscriptDetail({ "chat-1": "verbose" }, "chat-1", "normal")).toEqual({})
+  })
+
+  test("re-setting a chat moves it to the end, so pruning drops the least recent", () => {
+    const entries = applyTranscriptDetail({ "chat-1": "verbose", "chat-2": "summary" }, "chat-1", "summary")
+
+    expect(Object.keys(entries)).toEqual(["chat-2", "chat-1"])
+  })
+
+  test("prunes the oldest entries past the cap", () => {
+    const entries = { "chat-1": "verbose", "chat-2": "summary", "chat-3": "verbose" } as const
+
+    expect(pruneTranscriptDetails({ ...entries }, 2)).toEqual({ "chat-2": "summary", "chat-3": "verbose" })
+  })
+
+  test("ignores unparsable or unknown stored values", () => {
+    expect(parseStoredTranscriptDetails(null)).toEqual({})
+    expect(parseStoredTranscriptDetails("not json")).toEqual({})
+    expect(parseStoredTranscriptDetails('["verbose"]')).toEqual({})
+    expect(parseStoredTranscriptDetails('{"chat-1":"loud","chat-2":"summary"}')).toEqual({ "chat-2": "summary" })
+  })
+})

--- a/src/client/stores/transcriptDetailStore.ts
+++ b/src/client/stores/transcriptDetailStore.ts
@@ -1,0 +1,92 @@
+import { create } from "zustand"
+import {
+  DEFAULT_TRANSCRIPT_DETAIL,
+  isTranscriptDetail,
+  type TranscriptDetail,
+} from "../lib/transcriptDetail"
+import { TRANSCRIPT_DETAIL_STORAGE_KEY } from "../lib/storageKeys"
+
+/** Capped because a chat id is never cleaned up when its chat is deleted. */
+
+const MAX_REMEMBERED_CHATS = 100
+
+interface TranscriptDetailState {
+  byChatId: Record<string, TranscriptDetail>
+  setDetail: (chatId: string, detail: TranscriptDetail) => void
+}
+
+/** Relies on string keys keeping insertion order. */
+export function pruneTranscriptDetails(
+  entries: Record<string, TranscriptDetail>,
+  max = MAX_REMEMBERED_CHATS
+): Record<string, TranscriptDetail> {
+  const chatIds = Object.keys(entries)
+  if (chatIds.length <= max) return entries
+
+  const pruned: Record<string, TranscriptDetail> = {}
+  for (const chatId of chatIds.slice(chatIds.length - max)) {
+    pruned[chatId] = entries[chatId]!
+  }
+  return pruned
+}
+
+export function parseStoredTranscriptDetails(raw: string | null): Record<string, TranscriptDetail> {
+  if (!raw) return {}
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {}
+
+  const entries: Record<string, TranscriptDetail> = {}
+  for (const [chatId, detail] of Object.entries(parsed)) {
+    if (isTranscriptDetail(detail) && detail !== DEFAULT_TRANSCRIPT_DETAIL) {
+      entries[chatId] = detail
+    }
+  }
+  return pruneTranscriptDetails(entries)
+}
+
+export function applyTranscriptDetail(
+  entries: Record<string, TranscriptDetail>,
+  chatId: string,
+  detail: TranscriptDetail
+): Record<string, TranscriptDetail> {
+  const { [chatId]: _previous, ...rest } = entries
+  if (detail === DEFAULT_TRANSCRIPT_DETAIL) return rest
+  return pruneTranscriptDetails({ ...rest, [chatId]: detail })
+}
+
+function readStoredDetails() {
+  if (typeof window === "undefined") return {}
+  return parseStoredTranscriptDetails(window.localStorage.getItem(TRANSCRIPT_DETAIL_STORAGE_KEY))
+}
+
+function persistDetails(entries: Record<string, TranscriptDetail>) {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(TRANSCRIPT_DETAIL_STORAGE_KEY, JSON.stringify(entries))
+}
+
+export const useTranscriptDetailStore = create<TranscriptDetailState>()((set, get) => ({
+  byChatId: readStoredDetails(),
+
+  setDetail: (chatId, detail) => {
+    const byChatId = applyTranscriptDetail(get().byChatId, chatId, detail)
+    persistDetails(byChatId)
+    set({ byChatId })
+  },
+}))
+
+export function useTranscriptDetail(chatId: string | null | undefined): TranscriptDetail {
+  return useTranscriptDetailStore((state) =>
+    chatId ? state.byChatId[chatId] ?? DEFAULT_TRANSCRIPT_DETAIL : DEFAULT_TRANSCRIPT_DETAIL
+  )
+}
+
+/** For callers that must not subscribe. */
+export function setTranscriptDetail(chatId: string, detail: TranscriptDetail) {
+  useTranscriptDetailStore.getState().setDetail(chatId, detail)
+}

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -65,6 +65,38 @@ class AsyncEventQueue<T> implements AsyncIterable<T> {
 }
 
 describe("normalizeClaudeStreamMessage", () => {
+  test("records thinking blocks ahead of the text they precede", () => {
+    const entries = normalizeClaudeStreamMessage({
+      type: "assistant",
+      uuid: "msg-1",
+      message: {
+        content: [
+          { type: "thinking", thinking: "The router owns this", signature: "sig" },
+          { type: "text", text: "Found it." },
+        ],
+      },
+    })
+
+    expect(entries.map((entry) => entry.kind)).toEqual(["thinking", "assistant_text"])
+    expect(entries[0]).toMatchObject({ kind: "thinking", text: "The router owns this" })
+  })
+
+  test("skips empty and redacted thinking blocks", () => {
+    const entries = normalizeClaudeStreamMessage({
+      type: "assistant",
+      uuid: "msg-1",
+      message: {
+        content: [
+          { type: "thinking", thinking: "   ", signature: "sig" },
+          { type: "redacted_thinking", data: "encrypted" },
+          { type: "text", text: "Done." },
+        ],
+      },
+    })
+
+    expect(entries.map((entry) => entry.kind)).toEqual(["assistant_text"])
+  })
+
   test("normalizes assistant tool calls", () => {
     const entries = normalizeClaudeStreamMessage({
       type: "assistant",

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -448,6 +448,13 @@ export function normalizeClaudeStreamMessage(message: any): TranscriptEntry[] {
   if (message.type === "assistant" && Array.isArray(message.message?.content)) {
     const entries: TranscriptEntry[] = []
     for (const content of message.message.content) {
+      if (content.type === "thinking" && typeof content.thinking === "string" && content.thinking.trim()) {
+        entries.push(timestamped({
+          kind: "thinking",
+          messageId,
+          text: content.thinking,
+        }))
+      }
       if (content.type === "text" && typeof content.text === "string") {
         entries.push(timestamped({
           kind: "assistant_text",
@@ -733,6 +740,8 @@ async function startClaudeSession(args: {
       cwd: args.localPath,
       model: args.model,
       effort: args.effort as "low" | "medium" | "high" | "max" | undefined,
+      // Without an explicit display, current models return thinking blocks with an empty string.
+      thinking: { type: "adaptive", display: "summarized" },
       resume: args.sessionToken ?? undefined,
       forkSession: args.forkSession,
       permissionMode: args.planMode ? "plan" : "acceptEdits",

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { EventEmitter } from "node:events"
 import { PassThrough } from "node:stream"
-import { CodexAppServerManager } from "./codex-app-server"
+import { CodexAppServerManager, reasoningItemText } from "./codex-app-server"
 
 class FakeCodexProcess extends EventEmitter {
   readonly stdin = new PassThrough()
@@ -2000,5 +2000,40 @@ describe("CodexAppServerManager", () => {
     const resultEvent = events.find((event) => event.type === "transcript" && event.entry.kind === "result")
     expect(resultEvent?.entry.subtype).toBe("error")
     expect(resultEvent?.entry.result).toContain("fatal: app-server crashed")
+  })
+})
+
+describe("reasoningItemText", () => {
+  test("prefers the summary blocks and joins them", () => {
+    const text = reasoningItemText({
+      type: "reasoning",
+      id: "item-1",
+      summary: [{ type: "summary_text", text: "Checked the config" }, { type: "summary_text", text: "Ran the tests" }],
+      content: [{ type: "reasoning_text", text: "unused" }],
+    })
+
+    expect(text).toBe("Checked the config\n\nRan the tests")
+  })
+
+  test("falls back to content when there is no summary", () => {
+    const text = reasoningItemText({
+      type: "reasoning",
+      id: "item-1",
+      summary: [],
+      content: ["Thought about it"],
+    })
+
+    expect(text).toBe("Thought about it")
+  })
+
+  test("returns empty when no block carries readable text", () => {
+    const text = reasoningItemText({
+      type: "reasoning",
+      id: "item-1",
+      summary: [{ type: "summary_text" }, 42],
+      content: [],
+    })
+
+    expect(text).toBe("")
   })
 })

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -318,6 +318,25 @@ function dynamicToolPayload(value: Record<string, unknown> | unknown[] | string 
   return { value }
 }
 
+/**
+ * Block shape varies by Codex version, so every plausible carrier is probed.
+ * Empty output is normal: Codex sends no reasoning unless the user's
+ * `model_reasoning_summary` config asks for it.
+ */
+export function reasoningItemText(item: Extract<ThreadItem, { type: "reasoning" }>): string {
+  const blocks = item.summary?.length ? item.summary : item.content ?? []
+  return blocks
+    .map((block) => {
+      if (typeof block === "string") return block
+      const record = asRecord(block)
+      if (!record) return ""
+      return typeof record.text === "string" ? record.text : ""
+    })
+    .map((text) => text.trim())
+    .filter(Boolean)
+    .join("\n\n")
+}
+
 function webSearchQuery(item: Extract<ThreadItem, { type: "webSearch" }>): string {
   return item.query || item.action?.query || item.action?.queries?.find((query) => typeof query === "string") || ""
 }
@@ -1334,6 +1353,14 @@ export class CodexAppServerManager {
   }
 
   private handleItemCompleted(pendingTurn: PendingTurn, notification: ItemCompletedNotification) {
+    if (notification.item.type === "reasoning") {
+      const text = reasoningItemText(notification.item)
+      if (text) {
+        pendingTurn.queue.push({ type: "transcript", entry: timestamped({ kind: "thinking", text }) })
+      }
+      return
+    }
+
     if (notification.item.type === "agentMessage") {
       pendingTurn.queue.push({
         type: "transcript",

--- a/src/server/cursor-cli.test.ts
+++ b/src/server/cursor-cli.test.ts
@@ -105,7 +105,7 @@ describe("parseCursorLine", () => {
     expect(entries[0]).toMatchObject({ kind: "result", isError: true, subtype: "error", result: "boom" })
   })
 
-  test("prompt echo, reasoning, and malformed lines produce no entries", () => {
+  test("prompt echo, reasoning deltas, and malformed lines produce no entries", () => {
     expect(parseCursorLine(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}`, "composer-2.5")).toEqual([])
     expect(parseCursorLine(`{"type":"thinking","subtype":"delta"}`, "composer-2.5")).toEqual([])
     expect(parseCursorLine("not json", "composer-2.5")).toEqual([])
@@ -296,5 +296,30 @@ describe("clarifyCursorAuthError", () => {
 
   test("leaves unrelated stderr untouched", () => {
     expect(clarifyCursorAuthError("Cannot use this model: bad-model")).toBe("Cannot use this model: bad-model")
+  })
+})
+
+describe("cursor thinking events", () => {
+  test("a completed thinking event becomes a thinking entry", () => {
+    const events = parseCursorLine(
+      `{"type":"thinking","subtype":"completed","text":"Reading the router first"}`,
+      "composer-2.5"
+    )
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ type: "transcript", entry: { kind: "thinking", text: "Reading the router first" } })
+  })
+
+  test("reads thinking text out of a nested message payload", () => {
+    const events = parseCursorLine(
+      `{"type":"thinking","subtype":"completed","message":{"content":[{"type":"text","text":"Still reading"}]}}`,
+      "composer-2.5"
+    )
+
+    expect(events[0]).toMatchObject({ type: "transcript", entry: { kind: "thinking", text: "Still reading" } })
+  })
+
+  test("a thinking event with no readable text is dropped", () => {
+    expect(parseCursorLine(`{"type":"thinking","subtype":"completed"}`, "composer-2.5")).toEqual([])
   })
 })

--- a/src/server/cursor-cli.ts
+++ b/src/server/cursor-cli.ts
@@ -179,6 +179,23 @@ function extractAssistantText(message: unknown): string {
     .join("")
 }
 
+/** The field is undocumented and has moved between versions, so every plausible carrier is probed. */
+function extractCursorThinkingText(value: Record<string, unknown>): string {
+  const direct = asString(value.text) ?? asString(value.thinking)
+  if (direct?.trim()) return direct
+
+  const nested = asRecord(value.thinking) ?? asRecord(value.delta) ?? asRecord(value.message)
+  const nestedText = asString(nested?.text) ?? asString(nested?.thinking)
+  if (nestedText?.trim()) return nestedText
+
+  const content = nested?.content ?? value.content
+  if (!Array.isArray(content)) return ""
+  return content
+    .map((item) => asString(asRecord(item)?.text) ?? "")
+    .join("")
+    .trim()
+}
+
 /**
  * Parse a single NDJSON line from `cursor-agent` into Kanna harness events.
  * Pure and side-effect free so it can be unit tested against captured fixtures.
@@ -224,6 +241,14 @@ export function parseCursorLine(line: string, configuredModel: string): HarnessE
       const text = extractAssistantText(value.message)
       if (!text) return []
       return [{ type: "transcript", entry: timestamped({ kind: "assistant_text", text }) }]
+    }
+
+    case "thinking": {
+      // This parser sees one line at a time, so joining deltas is not possible here.
+      if (asString(value.subtype) === "delta") return []
+      const text = extractCursorThinkingText(value)
+      if (!text) return []
+      return [{ type: "transcript", entry: timestamped({ kind: "thinking", text }) }]
     }
 
     case "tool_call": {
@@ -289,8 +314,7 @@ export function parseCursorLine(line: string, configuredModel: string): HarnessE
       return events
     }
 
-    // "user" (prompt echo), "thinking" (reasoning), and unknown types are dropped —
-    // Kanna already records the user prompt and has no reasoning transcript kind.
+    // Kanna already records the user prompt, so the echo is dropped.
     default:
       return []
   }

--- a/src/server/events.test.ts
+++ b/src/server/events.test.ts
@@ -27,6 +27,14 @@ const inputOf = (entry: TranscriptEntry) => (entry as unknown as { tool: { input
 const asResult = (entry: TranscriptEntry) => entry as unknown as { content?: unknown; isError?: boolean; structuredResult?: unknown; trimmed?: true }
 
 describe("cloneTranscriptEntriesForClient", () => {
+  test("leaves thinking text on the server and marks the entry trimmed", () => {
+    const [thinking] = call([
+      { _id: "think-1", createdAt: 1, kind: "thinking", text: "a".repeat(5000) } as TranscriptEntry,
+    ])
+
+    expect(thinking).toMatchObject({ kind: "thinking", text: "", trimmed: true })
+  })
+
   test("drops the unbounded input field of each kind that has one", () => {
     const [write, edit, remove, mcp, unknown] = call([
       toolCall("write_file", { filePath: "a.ts", content: "x".repeat(1000) }),

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -473,6 +473,12 @@ export function cloneTranscriptEntriesForClient(entries: TranscriptEntry[]): Tra
       return INLINE_TOOL_KINDS.has(stripped.tool.toolKind) ? stripped : trimToolCallEntry(stripped)
     }
 
+    // Long, and shipped to every reader on every push, so the row fetches its own body instead.
+    if (entry.kind === "thinking") {
+      const { text, ...rest } = withoutDebugRaw(entry)
+      return { ...rest, text: "", trimmed: true } as TranscriptEntry
+    }
+
     if (entry.kind === "tool_result") {
       const structured = structuredToolIds.has(entry.toolId)
         ? readStructuredResult(entry.debugRaw)

--- a/src/server/handoff.ts
+++ b/src/server/handoff.ts
@@ -159,7 +159,8 @@ function blockFromEntry(entry: TranscriptEntry): Omit<HandoffBlock, "elided"> | 
         body: entry.result.slice(0, ERROR_RESULT_MAX_CHARS),
         elidableBody: false,
       }
-    // Harness/plumbing noise the new agent doesn't need.
+    // Harness/plumbing noise the new agent doesn't need, plus the previous agent's own reasoning.
+    case "thinking":
     case "system_init":
     case "account_info":
     case "status":

--- a/src/server/pi-agent.ts
+++ b/src/server/pi-agent.ts
@@ -549,14 +549,23 @@ export class PiAgentManager {
             aborted = true
           }
 
-          const text = Array.isArray(message.content)
-            ? message.content
-              .map((block) => {
-                const blockRecord = asRecord(block)
-                return blockRecord.type === "text" && typeof blockRecord.text === "string" ? blockRecord.text : ""
-              })
-              .join("")
-            : ""
+          const blocks = Array.isArray(message.content) ? message.content.map((block) => asRecord(block)) : []
+          // Redacted thinking carries only an encrypted payload, so it is skipped.
+          const thinking = blocks
+            .map((block) => (
+              block.type === "thinking" && !block.redacted && typeof block.thinking === "string"
+                ? block.thinking
+                : ""
+            ))
+            .filter(Boolean)
+            .join("\n\n")
+          if (thinking.trim()) {
+            queue.push({ type: "transcript", entry: timestamped({ kind: "thinking", text: thinking }) })
+          }
+
+          const text = blocks
+            .map((block) => (block.type === "text" && typeof block.text === "string" ? block.text : ""))
+            .join("")
           if (text.trim()) {
             queue.push({ type: "transcript", entry: timestamped({ kind: "assistant_text", text }) })
           }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1552,6 +1552,12 @@ export interface AssistantTextEntry extends TranscriptEntryBase {
   text: string
 }
 
+/** Providers deliver reasoning under different names; each adapter normalizes to this. */
+export interface ThinkingEntry extends TranscriptEntryBase {
+  kind: "thinking"
+  text: string
+}
+
 export interface ToolCallEntry extends TranscriptEntryBase {
   kind: "tool_call"
   tool: NormalizedToolCall
@@ -1835,6 +1841,7 @@ export type TranscriptEntry =
   | SystemInitEntry
   | AccountInfoEntry
   | AssistantTextEntry
+  | ThinkingEntry
   | ToolCallEntry
   | ToolResultEntry
   | ResultEntry
@@ -1949,6 +1956,7 @@ export type HydratedTranscriptMessage =
   | ({ kind: "system_init"; model: string; tools: string[]; agents: string[]; slashCommands: string[]; mcpServers: McpServerInfo[]; provider: AgentProvider; id: string; messageId?: string; timestamp: string; hidden?: boolean; debugRaw?: string })
   | ({ kind: "account_info"; accountInfo: AccountInfo; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "assistant_text"; text: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "thinking"; text: string; trimmed?: boolean; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "result"; success: boolean; cancelled?: boolean; result: string; durationMs: number; costUsd?: number; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "status"; status: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "context_window_updated"; usage: ContextWindowUsageSnapshot; id: string; messageId?: string; timestamp: string; hidden?: boolean })


### PR DESCRIPTION
Really liked this feature in the Claude Desktop app so decided to make a PR with it for Kanna. :)

This PR adds per-chat transcript detail modes and records model reasoning for supported providers.

## Summary

- Adds Summary, Normal, Thinking, and Verbose modes.
- Thinking shows replies and reasoning without tool rows.
- Verbose shows all tool calls and reasoning.
- Hides Thinking for Codex because it provides no reasoning by default.
- Keeps Thinking available for Claude, Cursor, and Pi.
- Stores the selected mode per chat.

## Breaking Changes

None.

## Tests

- TypeScript check passes.
- Client and export viewer builds pass.
- 719 client tests pass.
- Focused provider tests pass.

## Known Issues

- Pi reasoning capture lacks an end-to-end test.

## Screenshots
<img width="849" height="256" alt="Screenshot 2026-08-15 at 8 34 24 AM" src="https://github.com/user-attachments/assets/967d1cc2-330f-4967-a4d8-22b11e0ec14a" />
