### PR TITLE
Visible Usage Indicators

### DIFF
--- a/src/client/app/settings/GeneralSection.tsx
+++ b/src/client/app/settings/GeneralSection.tsx
@@ -202,6 +202,15 @@ export function GeneralSection({
     void playChatNotificationSound(nextValue, 1).catch(() => undefined)
   }
 
+  async function handleUsageLimitIndicatorsChange(nextValue: "enabled" | "disabled") {
+    try {
+      setAppSettingsError(null)
+      await handleWriteAppSettings({ usageLimitIndicatorsEnabled: nextValue === "enabled" })
+    } catch (error) {
+      setAppSettingsError(error instanceof Error ? error.message : "Unable to save usage indicator settings.")
+    }
+  }
+
   async function handleAnalyticsPreferenceChange(nextValue: "enabled" | "disabled") {
     try {
       setAppSettingsError(null)
@@ -216,6 +225,7 @@ export function GeneralSection({
     .replaceAll("{line}", "12")
     .replaceAll("{column}", "1")
   const analyticsSettingValue = appSettings?.analyticsEnabled === false ? "disabled" : "enabled"
+  const usageLimitIndicatorsValue = appSettings?.usageLimitIndicatorsEnabled === false ? "disabled" : "enabled"
 
   return (
     <>
@@ -403,6 +413,20 @@ export function GeneralSection({
               {minColumnWidth === DEFAULT_TERMINAL_MIN_COLUMN_WIDTH ? " (default)" : ""}
             </div>
           </div>
+        </SettingsRow>
+
+        <SettingsRow
+          def={SETTINGS_ROWS.usageLimitIndicators}
+          description="Show plan-limit rings next to the chat input's context meter. Claude Code shows its 5-hour and weekly windows; Codex shows its weekly window. Full details stay on the Usage page."
+        >
+          <SegmentedControl
+            value={usageLimitIndicatorsValue}
+            onValueChange={(value) => {
+              void handleUsageLimitIndicatorsChange(value)
+            }}
+            options={ENABLED_DISABLED_OPTIONS}
+            size="sm"
+          />
         </SettingsRow>
 
         <SettingsRow

--- a/src/client/app/settings/UsageSection.test.tsx
+++ b/src/client/app/settings/UsageSection.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import type { ProviderUsageSnapshot, UsageLimitWindow } from "../../../shared/types"
+import { ProviderCard } from "./UsageSection"
+
+function makeWindow(id: string, label: string): UsageLimitWindow {
+  return {
+    id,
+    label,
+    usedPercent: 10,
+    resetsAt: null,
+    windowMinutes: null,
+    modelLabel: null,
+    recordedAt: "2026-08-15T00:00:00.000Z",
+    source: "cache",
+  }
+}
+
+function makeSnapshot(windows: UsageLimitWindow[]): ProviderUsageSnapshot {
+  return {
+    provider: "claude",
+    status: "ok",
+    plan: null,
+    windows,
+    credits: null,
+    detail: null,
+    updatedAt: null,
+  }
+}
+
+describe("ProviderCard", () => {
+  test("renders Nimbus Quill after the other usage windows", () => {
+    const html = renderToStaticMarkup(
+      <ProviderCard
+        snapshot={makeSnapshot([
+          makeWindow("nimbus_quill", "Nimbus Quill"),
+          makeWindow("five_hour", "Current session"),
+        ])}
+      />,
+    )
+
+    expect(html.indexOf("Current session")).toBeLessThan(html.indexOf("Nimbus Quill"))
+  })
+})

--- a/src/client/app/settings/UsageSection.test.tsx
+++ b/src/client/app/settings/UsageSection.test.tsx
@@ -3,13 +3,13 @@ import { renderToStaticMarkup } from "react-dom/server"
 import type { ProviderUsageSnapshot, UsageLimitWindow } from "../../../shared/types"
 import { ProviderCard } from "./UsageSection"
 
-function makeWindow(id: string, label: string): UsageLimitWindow {
+function makeWindow(id: string, label: string, windowMinutes: number | null): UsageLimitWindow {
   return {
     id,
     label,
     usedPercent: 10,
     resetsAt: null,
-    windowMinutes: null,
+    windowMinutes,
     modelLabel: null,
     recordedAt: "2026-08-15T00:00:00.000Z",
     source: "cache",
@@ -29,16 +29,31 @@ function makeSnapshot(windows: UsageLimitWindow[]): ProviderUsageSnapshot {
 }
 
 describe("ProviderCard", () => {
-  test("renders Nimbus Quill after the other usage windows", () => {
+  test("renders a window of unknown period after the windows with a known period", () => {
     const html = renderToStaticMarkup(
       <ProviderCard
         snapshot={makeSnapshot([
-          makeWindow("nimbus_quill", "Nimbus Quill"),
-          makeWindow("five_hour", "Current session"),
+          makeWindow("nimbus_quill", "Nimbus Quill", null),
+          makeWindow("five_hour", "Current session", 300),
         ])}
       />,
     )
 
+    expect(html).toContain("Current session")
+    expect(html).toContain("Nimbus Quill")
     expect(html.indexOf("Current session")).toBeLessThan(html.indexOf("Nimbus Quill"))
+  })
+
+  test("keeps wire order when no window reports a period", () => {
+    const html = renderToStaticMarkup(
+      <ProviderCard
+        snapshot={makeSnapshot([
+          makeWindow("five_hour", "Current session", null),
+          makeWindow("seven_day", "Weekly", null),
+        ])}
+      />,
+    )
+
+    expect(html.indexOf("Current session")).toBeLessThan(html.indexOf("Weekly"))
   })
 })

--- a/src/client/app/settings/UsageSection.tsx
+++ b/src/client/app/settings/UsageSection.tsx
@@ -4,24 +4,9 @@ import type { ProviderUsageSnapshot, UsageLimitWindow, UsageLimitsSnapshot } fro
 import { PROVIDERS } from "../../../shared/types"
 import { PROVIDER_ICONS } from "../../components/chat-ui/ChatPreferenceControls"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip"
-import { formatRelativeTime } from "../../lib/formatters"
+import { formatRelativeTime, formatUntil } from "../../lib/formatters"
 import { cn } from "../../lib/utils"
 import type { KannaState } from "../useKannaState"
-
-const MINUTE_MS = 60_000
-const HOUR_MS = 60 * MINUTE_MS
-const DAY_MS = 24 * HOUR_MS
-
-/** "in 40m" / "in 3h" / "in 2d" — future counterpart of formatRelativeTime. */
-function formatUntil(isoTimestamp: string): string | null {
-  const timestamp = Date.parse(isoTimestamp)
-  if (!Number.isFinite(timestamp)) return null
-  const delta = timestamp - Date.now()
-  if (delta <= 0) return "now"
-  if (delta < HOUR_MS) return `in ${Math.max(1, Math.round(delta / MINUTE_MS))}m`
-  if (delta < DAY_MS) return `in ${Math.round(delta / HOUR_MS)}h`
-  return `in ${Math.round(delta / DAY_MS)}d`
-}
 
 function formatPercent(value: number | null): string {
   if (value === null || !Number.isFinite(value)) return "—"
@@ -83,6 +68,16 @@ function creditsSummary(credits: NonNullable<ProviderUsageSnapshot["credits"]>):
 
 function providerLabel(providerId: string): string {
   return PROVIDERS.find((entry) => entry.id === providerId)?.label ?? providerId
+}
+
+function isNimbusQuillWindow(window: UsageLimitWindow): boolean {
+  return window.id === "nimbus_quill" || window.label.trim().toLowerCase() === "nimbus quill"
+}
+
+function usageWindowsForDisplay(windows: UsageLimitWindow[]): UsageLimitWindow[] {
+  const regularWindows = windows.filter((window) => !isNimbusQuillWindow(window))
+  const nimbusQuillWindows = windows.filter(isNimbusQuillWindow)
+  return [...regularWindows, ...nimbusQuillWindows]
 }
 
 /**
@@ -236,7 +231,8 @@ export function ProviderCard({
   // the same grid the expanded rows use so every bar lines up card to card. The
   // row title and the freshness stamp (which the header no longer prints) live
   // in the bar's tooltip instead.
-  const summaryWindow = snapshot.windows[0] ?? null
+  const displayWindows = usageWindowsForDisplay(snapshot.windows)
+  const summaryWindow = displayWindows[0] ?? null
   const summaryResets = summaryWindow?.resetsAt ? formatUntil(summaryWindow.resetsAt) : null
 
   const header = showBody ? (
@@ -276,7 +272,7 @@ export function ProviderCard({
   const body = showBody ? (
     hasContent ? (
       <div className="mt-4 space-y-2.5">
-        {snapshot.windows.map((window) => (
+        {displayWindows.map((window) => (
           <WindowRow key={window.id} window={window} />
         ))}
         {snapshot.credits ? (

--- a/src/client/app/settings/UsageSection.tsx
+++ b/src/client/app/settings/UsageSection.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { ChevronRight } from "lucide-react"
 import type { ProviderUsageSnapshot, UsageLimitWindow, UsageLimitsSnapshot } from "../../../shared/types"
-import { PROVIDERS } from "../../../shared/types"
+import { PROVIDERS, usageLevel } from "../../../shared/types"
 import { PROVIDER_ICONS } from "../../components/chat-ui/ChatPreferenceControls"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip"
 import { formatRelativeTime, formatUntil } from "../../lib/formatters"
@@ -70,14 +70,11 @@ function providerLabel(providerId: string): string {
   return PROVIDERS.find((entry) => entry.id === providerId)?.label ?? providerId
 }
 
-function isNimbusQuillWindow(window: UsageLimitWindow): boolean {
-  return window.id === "nimbus_quill" || window.label.trim().toLowerCase() === "nimbus quill"
-}
-
+/** Windows whose period we recognize lead; anything else the provider reports follows, in wire order. */
 function usageWindowsForDisplay(windows: UsageLimitWindow[]): UsageLimitWindow[] {
-  const regularWindows = windows.filter((window) => !isNimbusQuillWindow(window))
-  const nimbusQuillWindows = windows.filter(isNimbusQuillWindow)
-  return [...regularWindows, ...nimbusQuillWindows]
+  const known = windows.filter((window) => window.windowMinutes != null)
+  const unknown = windows.filter((window) => window.windowMinutes == null)
+  return [...known, ...unknown]
 }
 
 /**
@@ -95,11 +92,15 @@ function accountScopeLabel(plan: string | null): string | null {
   return null
 }
 
+const BAR_LEVEL_CLASSES = {
+  unknown: "bg-muted-foreground/40",
+  ok: "bg-emerald-500",
+  warn: "bg-amber-500",
+  danger: "bg-red-500",
+} as const
+
 function barColorClass(usedPercent: number | null): string {
-  if (usedPercent === null) return "bg-muted-foreground/40"
-  if (usedPercent >= 90) return "bg-red-500"
-  if (usedPercent >= 75) return "bg-amber-500"
-  return "bg-emerald-500"
+  return BAR_LEVEL_CLASSES[usageLevel(usedPercent)]
 }
 
 function UsageBar({ usedPercent }: { usedPercent: number | null }) {

--- a/src/client/app/settings/registry.ts
+++ b/src/client/app/settings/registry.ts
@@ -126,6 +126,12 @@ export const SETTINGS_ROWS = defineRows({
     title: "Terminal Min Column Width",
     description: "Minimum width for each terminal pane",
   },
+  usageLimitIndicators: {
+    sectionId: "general",
+    title: "Usage Limit Indicators",
+    description: "Show plan-limit rings next to the chat input's context meter for Claude Code and Codex",
+    keywords: ["rate limit", "5-hour", "weekly", "quota", "meter", "ring", "composer"],
+  },
   anonymousAnalytics: {
     sectionId: "general",
     title: "Anonymous Analytics",

--- a/src/client/components/chat-ui/ChatInput.test.ts
+++ b/src/client/components/chat-ui/ChatInput.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
+import { MemoryRouter } from "react-router-dom"
 import { PROVIDERS } from "../../../shared/types"
 import { TooltipProvider } from "../ui/tooltip"
 import { ChatInput, getClipboardImageFiles, trimTrailingPastedNewlines, willExceedAttachmentLimit } from "./ChatInput"
@@ -125,15 +126,19 @@ describe("trimTrailingPastedNewlines", () => {
 describe("ChatInput", () => {
   test("renders the mobile attachment trigger as a native file input target in the controls row", () => {
     const html = renderToStaticMarkup(createElement(
-      TooltipProvider,
+      MemoryRouter,
       null,
-      createElement(ChatInput, {
-        onSubmit: async () => undefined,
-        disabled: false,
-        canCancel: false,
-        activeProvider: null,
-        availableProviders: PROVIDERS,
-      }),
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ChatInput, {
+          onSubmit: async () => undefined,
+          disabled: false,
+          canCancel: false,
+          activeProvider: null,
+          availableProviders: PROVIDERS,
+        }),
+      ),
     ))
 
     expect(html).toContain('aria-label="Add attachment"')

--- a/src/client/components/chat-ui/ChatInput.test.ts
+++ b/src/client/components/chat-ui/ChatInput.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { PROVIDERS } from "../../../shared/types"
+import { TooltipProvider } from "../ui/tooltip"
 import { ChatInput, getClipboardImageFiles, trimTrailingPastedNewlines, willExceedAttachmentLimit } from "./ChatInput"
 
 function createClipboardItem(args: {
@@ -123,13 +124,17 @@ describe("trimTrailingPastedNewlines", () => {
 
 describe("ChatInput", () => {
   test("renders the mobile attachment trigger as a native file input target in the controls row", () => {
-    const html = renderToStaticMarkup(createElement(ChatInput, {
-      onSubmit: async () => undefined,
-      disabled: false,
-      canCancel: false,
-      activeProvider: null,
-      availableProviders: PROVIDERS,
-    }))
+    const html = renderToStaticMarkup(createElement(
+      TooltipProvider,
+      null,
+      createElement(ChatInput, {
+        onSubmit: async () => undefined,
+        disabled: false,
+        canCancel: false,
+        activeProvider: null,
+        availableProviders: PROVIDERS,
+      }),
+    ))
 
     expect(html).toContain('aria-label="Add attachment"')
     expect(html).toContain('type="file"')

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -27,6 +27,7 @@ import { useUnauthenticatedHarnesses } from "../../stores/providerAuthStore"
 import { SignInDialog } from "../auth/SignInDialog"
 import { ChatPreferenceControls } from "./ChatPreferenceControls"
 import { ContextWindowMeter } from "./ContextWindowMeter"
+import { UsageLimitRings, useUsageLimitRingsVisible } from "./UsageLimitRings"
 import { AttachmentFileCard, AttachmentImageCard } from "../messages/AttachmentCard"
 import { AttachmentPreviewModal } from "../messages/AttachmentPreviewModal"
 import { classifyAttachmentPreview } from "../messages/attachmentPreview"
@@ -232,6 +233,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const { composerChatId, providerSwitchPending, selectedProvider } = composer
   const providerPrefs = composer.effectiveState
   const showModePicker = composer.supportsPlanMode
+  const showUsageLimitRings = useUsageLimitRingsVisible(selectedProvider)
   // Switching to a harness that isn't signed in is blocked: the pick is
   // stashed here, a sign-in dialog opens, and the switch applies
   // automatically once the auth store reports the service signed in.
@@ -1048,17 +1050,19 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
             includeMode={showModePicker}
             className="max-w-[840px] mx-auto"
           />
-          {activeContextWindow ? (
-            <div className="flex items-center md:hidden mx-[13px]">
-              <ContextWindowMeter usage={activeContextWindow} />
+          {activeContextWindow || showUsageLimitRings ? (
+            <div className="flex items-center gap-1 md:hidden mx-[13px]">
+              {activeContextWindow ? <ContextWindowMeter usage={activeContextWindow} /> : null}
+              {showUsageLimitRings ? <UsageLimitRings provider={selectedProvider} model={providerPrefs.model} /> : null}
             </div>
           ) : null}
           <div className={controlsScrollSpacer} />
         </div>
 
-        {activeContextWindow ? (
-          <div className="absolute right-[29px] top-1/2 translate-x-1/2 -translate-y-1/2 hidden md:block">
-            <ContextWindowMeter usage={activeContextWindow} />
+        {activeContextWindow || showUsageLimitRings ? (
+          <div className="absolute right-[17px] top-1/2 -translate-y-1/2 hidden md:flex items-center gap-1">
+            {activeContextWindow ? <ContextWindowMeter usage={activeContextWindow} /> : null}
+            {showUsageLimitRings ? <UsageLimitRings provider={selectedProvider} model={providerPrefs.model} /> : null}
           </div>
         ) : null}
       </div>

--- a/src/client/components/chat-ui/UsageLimitRings.tsx
+++ b/src/client/components/chat-ui/UsageLimitRings.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
-import type { AgentProvider, UsageLimitWindow, UsageLimitsSnapshot } from "../../../shared/types"
+import { useNavigate } from "react-router-dom"
+import type { AgentProvider, UsageLimitWindow } from "../../../shared/types"
 import { formatUntil } from "../../lib/formatters"
 import {
   LIMIT_RING_PROVIDERS,
@@ -9,7 +9,7 @@ import {
 } from "../../lib/usageLimitRings"
 import { cn } from "../../lib/utils"
 import { useAppSettingsStore } from "../../stores/appSettingsStore"
-import { useProviderAuthStore } from "../../stores/providerAuthStore"
+import { useUsageLimitsSnapshot } from "../../stores/usageLimitsStore"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 
 export function useUsageLimitRingsVisible(provider: AgentProvider): boolean {
@@ -20,12 +20,16 @@ export function useUsageLimitRingsVisible(provider: AgentProvider): boolean {
 function LimitRing({
   slotLabel,
   window,
+  alsoApplies,
   unavailableDetail,
+  onOpenUsagePage,
 }: {
   /** Fallback title used until the provider reports this window. */
   slotLabel: string
   window: UsageLimitWindow | null
+  alsoApplies: UsageLimitWindow | null
   unavailableDetail: string | null
+  onOpenUsagePage: () => void
 }) {
   const remaining = limitRingRemainingPercent(window?.usedPercent ?? null)
   const radius = 9.75
@@ -33,17 +37,19 @@ function LimitRing({
   const dashOffset = circumference - ((remaining ?? 0) / 100) * circumference
   const resets = window?.resetsAt ? formatUntil(window.resetsAt) : null
   const title = window?.label ?? slotLabel
+  const alsoRemaining = limitRingRemainingPercent(alsoApplies?.usedPercent ?? null)
 
   return (
     <Tooltip delayDuration={0}>
       <TooltipTrigger asChild>
         <button
           type="button"
+          onClick={onOpenUsagePage}
           className="group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85"
           aria-label={
             remaining !== null
-              ? `${title}: ${Math.round(remaining)}% remaining`
-              : `${title}: no usage data`
+              ? `${title}: ${Math.round(remaining)}% remaining. Open the Usage page.`
+              : `${title}: no usage data. Open the Usage page.`
           }
         >
           <span className="relative flex h-6 w-6 items-center justify-center">
@@ -93,6 +99,11 @@ function LimitRing({
               ? `${Math.round(remaining)}% left${resets ? ` · Resets ${resets}` : ""}`
               : unavailableDetail ?? "No usage data yet."}
           </div>
+          {alsoApplies && alsoRemaining !== null ? (
+            <div className="whitespace-nowrap text-xs text-muted-foreground">
+              {`${alsoApplies.label}: ${Math.round(alsoRemaining)}% left`}
+            </div>
+          ) : null}
         </div>
       </TooltipContent>
     </Tooltip>
@@ -107,14 +118,9 @@ export function UsageLimitRings({
   /** Selects the model-scoped weekly lane when the provider reports one. */
   model: string | null
 }) {
-  const socket = useProviderAuthStore((store) => store.socket)
+  const navigate = useNavigate()
   const visible = useUsageLimitRingsVisible(provider)
-  const [snapshot, setSnapshot] = useState<UsageLimitsSnapshot | null>(null)
-
-  useEffect(() => {
-    if (!socket || !visible) return
-    return socket.subscribe<UsageLimitsSnapshot>({ type: "usage-limits" }, setSnapshot)
-  }, [socket, visible])
+  const snapshot = useUsageLimitsSnapshot(visible)
 
   if (!visible) return null
 
@@ -128,7 +134,9 @@ export function UsageLimitRings({
           key={slot.key}
           slotLabel={slot.label}
           window={slot.window}
+          alsoApplies={slot.alsoApplies}
           unavailableDetail={unavailableDetail}
+          onOpenUsagePage={() => navigate("/settings/usage")}
         />
       ))}
     </div>

--- a/src/client/components/chat-ui/UsageLimitRings.tsx
+++ b/src/client/components/chat-ui/UsageLimitRings.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react"
+import type { AgentProvider, UsageLimitWindow, UsageLimitsSnapshot } from "../../../shared/types"
+import { formatUntil } from "../../lib/formatters"
+import {
+  LIMIT_RING_PROVIDERS,
+  limitRingColorClass,
+  limitRingRemainingPercent,
+  selectLimitRingWindows,
+} from "../../lib/usageLimitRings"
+import { cn } from "../../lib/utils"
+import { useAppSettingsStore } from "../../stores/appSettingsStore"
+import { useProviderAuthStore } from "../../stores/providerAuthStore"
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
+
+export function useUsageLimitRingsVisible(provider: AgentProvider): boolean {
+  const enabled = useAppSettingsStore((store) => store.settings?.usageLimitIndicatorsEnabled !== false)
+  return enabled && LIMIT_RING_PROVIDERS.has(provider)
+}
+
+function LimitRing({
+  slotLabel,
+  window,
+  unavailableDetail,
+}: {
+  /** Fallback title used until the provider reports this window. */
+  slotLabel: string
+  window: UsageLimitWindow | null
+  unavailableDetail: string | null
+}) {
+  const remaining = limitRingRemainingPercent(window?.usedPercent ?? null)
+  const radius = 9.75
+  const circumference = 2 * Math.PI * radius
+  const dashOffset = circumference - ((remaining ?? 0) / 100) * circumference
+  const resets = window?.resetsAt ? formatUntil(window.resetsAt) : null
+  const title = window?.label ?? slotLabel
+
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85"
+          aria-label={
+            remaining !== null
+              ? `${title}: ${Math.round(remaining)}% remaining`
+              : `${title}: no usage data`
+          }
+        >
+          <span className="relative flex h-6 w-6 items-center justify-center">
+            <svg
+              viewBox="0 0 24 24"
+              className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
+              aria-hidden="true"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r={radius}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="text-muted-foreground/20"
+              />
+              {remaining !== null ? (
+                <circle
+                  cx="12"
+                  cy="12"
+                  r={radius}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeDasharray={circumference}
+                  strokeDashoffset={dashOffset}
+                  className={cn(
+                    "transition-[stroke-dashoffset] duration-500 ease-out",
+                    limitRingColorClass(window?.usedPercent ?? null),
+                  )}
+                />
+              ) : null}
+            </svg>
+            <span className="relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[9px] font-medium text-muted-foreground">
+              {remaining !== null ? Math.round(remaining) : "–"}
+            </span>
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="center" className="w-max max-w-none px-3 py-2">
+        <div className="space-y-1 leading-tight">
+          <div className="whitespace-nowrap text-xs font-medium text-foreground">{title}</div>
+          <div className="whitespace-nowrap text-xs text-muted-foreground">
+            {remaining !== null
+              ? `${Math.round(remaining)}% left${resets ? ` · Resets ${resets}` : ""}`
+              : unavailableDetail ?? "No usage data yet."}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function UsageLimitRings({
+  provider,
+  model,
+}: {
+  provider: AgentProvider
+  /** Selects the model-scoped weekly lane when the provider reports one. */
+  model: string | null
+}) {
+  const socket = useProviderAuthStore((store) => store.socket)
+  const visible = useUsageLimitRingsVisible(provider)
+  const [snapshot, setSnapshot] = useState<UsageLimitsSnapshot | null>(null)
+
+  useEffect(() => {
+    if (!socket || !visible) return
+    return socket.subscribe<UsageLimitsSnapshot>({ type: "usage-limits" }, setSnapshot)
+  }, [socket, visible])
+
+  if (!visible) return null
+
+  const { snapshot: providerSnapshot, slots } = selectLimitRingWindows(snapshot, provider, model)
+  const unavailableDetail = providerSnapshot?.detail ?? null
+
+  return (
+    <div className="flex items-center gap-1">
+      {slots.map((slot) => (
+        <LimitRing
+          key={slot.key}
+          slotLabel={slot.label}
+          window={slot.window}
+          unavailableDetail={unavailableDetail}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/client/lib/formatters.ts
+++ b/src/client/lib/formatters.ts
@@ -102,3 +102,13 @@ export function formatRelativeTime(isoTimestamp: string): string {
   }
   return formatRelativeAge(Date.now() - timestamp, TIMESTAMP_AGE_STYLE)
 }
+
+export function formatUntil(isoTimestamp: string): string | null {
+  const timestamp = Date.parse(isoTimestamp)
+  if (!Number.isFinite(timestamp)) return null
+  const delta = timestamp - Date.now()
+  if (delta <= 0) return "now"
+  if (delta < HOUR_MS) return `in ${Math.max(1, Math.round(delta / MINUTE_MS))}m`
+  if (delta < DAY_MS) return `in ${Math.round(delta / HOUR_MS)}h`
+  return `in ${Math.round(delta / DAY_MS)}d`
+}

--- a/src/client/lib/usageLimitRings.test.ts
+++ b/src/client/lib/usageLimitRings.test.ts
@@ -66,10 +66,47 @@ describe("selectLimitRingWindows", () => {
     }
   })
 
-  test("claude never substitutes a fixed per-model key for the all-models weekly", () => {
-    const windows = [makeWindow("seven_day_opus", 90, WEEKLY), makeWindow("five_hour", 5, FIVE_HOUR)]
+  test("claude weekly names the account-wide window as the second cap on the model lane", () => {
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", CLAUDE_WINDOWS), "claude", "claude-fable-5")
+    expect(slots[1]?.alsoApplies?.id).toBe("seven_day")
+    expect(slots[0]?.alsoApplies).toBeNull()
+  })
+
+  test("claude weekly reports no second cap when the ring already shows the account-wide window", () => {
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", CLAUDE_WINDOWS), "claude", "claude-opus-5")
+    expect(slots[1]?.window?.id).toBe("seven_day")
+    expect(slots[1]?.alsoApplies).toBeNull()
+  })
+
+  test("a per-model weekly key fills the ring for its own model", () => {
+    const windows = [makeWindow("seven_day_opus", 90, WEEKLY, "Opus"), makeWindow("five_hour", 5, FIVE_HOUR)]
     const { slots } = selectLimitRingWindows(makeSnapshot("claude", windows), "claude", "claude-opus-5")
-    expect(slots[1]?.window).toBeNull()
+    expect(slots[1]?.window?.id).toBe("seven_day_opus")
+    expect(slots[1]?.alsoApplies).toBeNull()
+  })
+
+  test("a weekly window the selected model does not match still fills the ring", () => {
+    // The tooltip prints the window's own label, so a lane from another model reads as that lane.
+    const windows = [makeWindow("seven_day_opus", 90, WEEKLY, "Opus"), makeWindow("five_hour", 5, FIVE_HOUR)]
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", windows), "claude", "claude-sonnet-5")
+    expect(slots[1]?.window?.id).toBe("seven_day_opus")
+  })
+
+  test("a per-model key from an older cache never passes as the account-wide weekly", () => {
+    const windows = [
+      makeWindow("seven_day_opus", 90, WEEKLY),
+      makeWindow("model_scoped:fable", 17, WEEKLY, "Fable"),
+      makeWindow("five_hour", 5, FIVE_HOUR),
+    ]
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", windows), "claude", "claude-fable-5")
+    expect(slots[1]?.window?.id).toBe("model_scoped:fable")
+    expect(slots[1]?.alsoApplies).toBeNull()
+  })
+
+  test("codex fills the weekly ring from a lone model-scoped bucket", () => {
+    const windows = [makeWindow("codex_bengalfox:primary", 21, WEEKLY, "GPT 5.3 Codex Spark")]
+    const { slots } = selectLimitRingWindows(makeSnapshot("codex", windows), "codex", "gpt-5.3-codex")
+    expect(slots[0]?.window?.id).toBe("codex_bengalfox:primary")
   })
 
   test("codex shows one weekly ring, taken from the window's duration not its slot", () => {

--- a/src/client/lib/usageLimitRings.test.ts
+++ b/src/client/lib/usageLimitRings.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test"
+import type { ProviderUsageSnapshot, UsageLimitWindow, UsageLimitsSnapshot } from "../../shared/types"
+import {
+  LIMIT_RING_PROVIDERS,
+  limitRingColorClass,
+  limitRingRemainingPercent,
+  modelScopeMatches,
+  selectLimitRingWindows,
+} from "./usageLimitRings"
+
+const FIVE_HOUR = 300
+const WEEKLY = 10_080
+
+function makeWindow(
+  id: string,
+  usedPercent: number | null,
+  windowMinutes: number | null,
+  modelLabel: string | null = null,
+): UsageLimitWindow {
+  return {
+    id,
+    label: id,
+    usedPercent,
+    resetsAt: null,
+    windowMinutes,
+    modelLabel,
+    recordedAt: "2026-08-15T00:00:00.000Z",
+    source: "on_demand",
+  }
+}
+
+function makeSnapshot(provider: "claude" | "codex", windows: UsageLimitWindow[]): UsageLimitsSnapshot {
+  const providerSnapshot: ProviderUsageSnapshot = {
+    provider,
+    status: "ok",
+    plan: null,
+    windows,
+    credits: null,
+    detail: null,
+    updatedAt: null,
+  }
+  return { providers: [providerSnapshot] }
+}
+
+/** Mirrors a real Claude Max response: keyed windows plus a model_scoped lane. */
+const CLAUDE_WINDOWS = [
+  makeWindow("five_hour", 18, FIVE_HOUR),
+  makeWindow("seven_day", 15, WEEKLY),
+  makeWindow("model_scoped:fable", 17, WEEKLY, "Fable"),
+]
+
+describe("selectLimitRingWindows", () => {
+  test("claude weekly follows the selected model when a lane exists", () => {
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", CLAUDE_WINDOWS), "claude", "claude-fable-5")
+    expect(slots.map((slot) => slot.key)).toEqual(["session", "weekly"])
+    expect(slots[0]?.window?.id).toBe("five_hour")
+    expect(slots[1]?.window?.id).toBe("model_scoped:fable")
+    expect(slots[1]?.window?.usedPercent).toBe(17)
+  })
+
+  test("claude weekly falls back to the all-models window for other models", () => {
+    for (const model of ["claude-opus-5", "claude-sonnet-5", "claude-fable-5[1m]"]) {
+      const { slots } = selectLimitRingWindows(makeSnapshot("claude", CLAUDE_WINDOWS), "claude", model)
+      const expected = model.startsWith("claude-fable") ? "model_scoped:fable" : "seven_day"
+      expect(slots[1]?.window?.id).toBe(expected)
+    }
+  })
+
+  test("claude never substitutes a fixed per-model key for the all-models weekly", () => {
+    const windows = [makeWindow("seven_day_opus", 90, WEEKLY), makeWindow("five_hour", 5, FIVE_HOUR)]
+    const { slots } = selectLimitRingWindows(makeSnapshot("claude", windows), "claude", "claude-opus-5")
+    expect(slots[1]?.window).toBeNull()
+  })
+
+  test("codex shows one weekly ring, taken from the window's duration not its slot", () => {
+    const windows = [
+      makeWindow("codex:primary", 21, WEEKLY),
+      makeWindow("codex_bengalfox:primary", 4, WEEKLY, "GPT 5.3 Codex Spark"),
+    ]
+    const { slots } = selectLimitRingWindows(makeSnapshot("codex", windows), "codex", "gpt-5.3-codex")
+    expect(slots.map((slot) => slot.key)).toEqual(["weekly"])
+    expect(slots[0]?.window?.id).toBe("codex:primary")
+  })
+
+  test("codex weekly switches to the model lane when that exact model is selected", () => {
+    const windows = [
+      makeWindow("codex:primary", 21, WEEKLY),
+      makeWindow("codex_bengalfox:primary", 4, WEEKLY, "GPT 5.3 Codex Spark"),
+    ]
+    const { slots } = selectLimitRingWindows(makeSnapshot("codex", windows), "codex", "gpt-5.3-codex-spark")
+    expect(slots[0]?.window?.id).toBe("codex_bengalfox:primary")
+  })
+
+  test("codex session window is never shown, even when the plan reports one", () => {
+    const windows = [makeWindow("codex:primary", 30, FIVE_HOUR), makeWindow("codex:secondary", 21, WEEKLY)]
+    const { slots } = selectLimitRingWindows(makeSnapshot("codex", windows), "codex", null)
+    expect(slots.map((slot) => slot.key)).toEqual(["weekly"])
+    expect(slots[0]?.window?.id).toBe("codex:secondary")
+  })
+
+  test("a snapshot from an older server still fills the rings", () => {
+    const legacy = (id: string, label: string, usedPercent: number) => ({
+      id,
+      label,
+      usedPercent,
+      resetsAt: null,
+      recordedAt: "2026-08-15T00:00:00.000Z",
+      source: "cache" as const,
+    }) as unknown as UsageLimitWindow
+
+    const claude = selectLimitRingWindows(
+      makeSnapshot("claude", [
+        legacy("five_hour", "Current session (5-hour)", 21),
+        legacy("seven_day", "Weekly · All models", 14),
+        legacy("nimbus_quill", "Nimbus Quill", 0),
+      ]),
+      "claude",
+      "claude-opus-5",
+    )
+    expect(claude.slots.map((slot) => slot.window?.usedPercent)).toEqual([21, 14])
+
+    const codex = selectLimitRingWindows(
+      makeSnapshot("codex", [
+        legacy("codex:primary", "Weekly", 21),
+        legacy("codex_bengalfox:primary", "Weekly · GPT 5.3 Codex Spark", 0),
+      ]),
+      "codex",
+      "gpt-5.3-codex",
+    )
+    expect(codex.slots[0]?.window?.id).toBe("codex:primary")
+  })
+
+  test("missing windows keep their slot with a null window", () => {
+    const empty = selectLimitRingWindows(null, "claude", "claude-fable-5")
+    expect(empty.snapshot).toBeNull()
+    expect(empty.slots.map((slot) => slot.window)).toEqual([null, null])
+
+    const partial = selectLimitRingWindows(
+      makeSnapshot("claude", [makeWindow("five_hour", 5, FIVE_HOUR)]),
+      "claude",
+      "claude-fable-5",
+    )
+    expect(partial.slots[0]?.window?.id).toBe("five_hour")
+    expect(partial.slots[1]?.window).toBeNull()
+  })
+
+  test("only claude and codex are ring providers", () => {
+    expect([...LIMIT_RING_PROVIDERS].sort()).toEqual(["claude", "codex"])
+    expect(selectLimitRingWindows(makeSnapshot("claude", CLAUDE_WINDOWS), "pi", null).slots).toEqual([])
+  })
+})
+
+describe("modelScopeMatches", () => {
+  test("a one-word scope matches the selected model's family", () => {
+    expect(modelScopeMatches("Fable", "claude-fable-5")).toBe(true)
+    expect(modelScopeMatches("Fable", "claude-fable-5[1m]")).toBe(true)
+    expect(modelScopeMatches("Fable", "fable")).toBe(true)
+    expect(modelScopeMatches("Opus", "claude-opus-4-8")).toBe(true)
+    expect(modelScopeMatches("Fable", "claude-opus-5")).toBe(false)
+  })
+
+  test("a multi-word scope requires the whole model, so a shorter name cannot claim it", () => {
+    expect(modelScopeMatches("GPT 5.3 Codex Spark", "gpt-5.3-codex-spark")).toBe(true)
+    expect(modelScopeMatches("GPT 5.3 Codex Spark", "gpt-5.3-codex")).toBe(false)
+  })
+
+  test("no selected model never matches", () => {
+    expect(modelScopeMatches("Fable", null)).toBe(false)
+  })
+})
+
+describe("limitRingRemainingPercent", () => {
+  test("inverts used percent and clamps", () => {
+    expect(limitRingRemainingPercent(0)).toBe(100)
+    expect(limitRingRemainingPercent(40)).toBe(60)
+    expect(limitRingRemainingPercent(120)).toBe(0)
+    expect(limitRingRemainingPercent(null)).toBeNull()
+  })
+})
+
+describe("limitRingColorClass", () => {
+  test("matches the Usage page thresholds", () => {
+    expect(limitRingColorClass(10)).toBe("text-emerald-500")
+    expect(limitRingColorClass(74.9)).toBe("text-emerald-500")
+    expect(limitRingColorClass(75)).toBe("text-amber-500")
+    expect(limitRingColorClass(90)).toBe("text-red-500")
+    expect(limitRingColorClass(null)).toBe("text-muted-foreground/40")
+  })
+})

--- a/src/client/lib/usageLimitRings.ts
+++ b/src/client/lib/usageLimitRings.ts
@@ -1,5 +1,8 @@
 import {
   deriveModelLabel,
+  FIVE_HOUR_WINDOW_MINUTES,
+  usageLevel,
+  WEEKLY_WINDOW_MINUTES,
   type AgentProvider,
   type ProviderUsageSnapshot,
   type UsageLimitWindow,
@@ -9,14 +12,13 @@ import {
 /** Providers whose plan limits render as rings in the chat input. */
 export const LIMIT_RING_PROVIDERS: ReadonlySet<AgentProvider> = new Set(["claude", "codex"])
 
-const FIVE_HOUR_WINDOW_MINUTES = 300
-const WEEKLY_WINDOW_MINUTES = 10_080
-
 export interface LimitRingSlot {
   key: "session" | "weekly"
   /** Fallback title shown until the provider reports this window. */
   label: string
   window: UsageLimitWindow | null
+  /** A second window that also caps this slot, when the ring shows a model lane. */
+  alsoApplies: UsageLimitWindow | null
 }
 
 export interface LimitRingSelection {
@@ -56,18 +58,24 @@ function isSession(window: UsageLimitWindow): boolean {
   return window.id === "five_hour"
 }
 
-/** Claude's seven_day_opus/_sonnet keys are per-model, so they cannot serve as the account-wide fallback. */
-function selectWeeklyWindow(
+/** Preference order: the selected model's lane, the account-wide window, then any weekly window. */
+function selectWeeklyWindows(
   windows: UsageLimitWindow[],
   selectedModel: string | null,
-): UsageLimitWindow | null {
-  const scoped = windows.find(
-    (window) => window.modelLabel && isWeekly(window) && modelScopeMatches(window.modelLabel, selectedModel),
-  )
-  if (scoped) return scoped
-  return windows.find(
-    (window) => !window.modelLabel && isWeekly(window) && !window.id.startsWith("seven_day_"),
+): { window: UsageLimitWindow | null; alsoApplies: UsageLimitWindow | null } {
+  const weeklyWindows = windows.filter(isWeekly)
+  // Claude's seven_day_opus/_sonnet keys are per-model even in caches written before they carried a modelLabel.
+  const accountWide = weeklyWindows.find(
+    (window) => !window.modelLabel && !window.id.startsWith("seven_day_"),
   ) ?? null
+  const scoped = weeklyWindows.find(
+    (window) => window.modelLabel && modelScopeMatches(window.modelLabel, selectedModel),
+  ) ?? null
+  const window = scoped ?? accountWide ?? weeklyWindows[0] ?? null
+  return {
+    window,
+    alsoApplies: window && accountWide && window !== accountWide ? accountWide : null,
+  }
 }
 
 function selectSessionWindow(windows: UsageLimitWindow[]): UsageLimitWindow | null {
@@ -85,13 +93,13 @@ export function selectLimitRingWindows(
   const weekly: LimitRingSlot = {
     key: "weekly",
     label: "Weekly limit",
-    window: selectWeeklyWindow(windows, selectedModel),
+    ...selectWeeklyWindows(windows, selectedModel),
   }
   if (provider === "claude") {
     return {
       snapshot: providerSnapshot,
       slots: [
-        { key: "session", label: "5-hour limit", window: selectSessionWindow(windows) },
+        { key: "session", label: "5-hour limit", window: selectSessionWindow(windows), alsoApplies: null },
         weekly,
       ],
     }
@@ -107,10 +115,13 @@ export function limitRingRemainingPercent(usedPercent: number | null): number | 
   return Math.max(0, Math.min(100, 100 - usedPercent))
 }
 
-/** Thresholds must stay in step with the Usage page bars. */
+const RING_LEVEL_CLASSES = {
+  unknown: "text-muted-foreground/40",
+  ok: "text-emerald-500",
+  warn: "text-amber-500",
+  danger: "text-red-500",
+} as const
+
 export function limitRingColorClass(usedPercent: number | null): string {
-  if (usedPercent === null) return "text-muted-foreground/40"
-  if (usedPercent >= 90) return "text-red-500"
-  if (usedPercent >= 75) return "text-amber-500"
-  return "text-emerald-500"
+  return RING_LEVEL_CLASSES[usageLevel(usedPercent)]
 }

--- a/src/client/lib/usageLimitRings.ts
+++ b/src/client/lib/usageLimitRings.ts
@@ -1,0 +1,116 @@
+import {
+  deriveModelLabel,
+  type AgentProvider,
+  type ProviderUsageSnapshot,
+  type UsageLimitWindow,
+  type UsageLimitsSnapshot,
+} from "../../shared/types"
+
+/** Providers whose plan limits render as rings in the chat input. */
+export const LIMIT_RING_PROVIDERS: ReadonlySet<AgentProvider> = new Set(["claude", "codex"])
+
+const FIVE_HOUR_WINDOW_MINUTES = 300
+const WEEKLY_WINDOW_MINUTES = 10_080
+
+export interface LimitRingSlot {
+  key: "session" | "weekly"
+  /** Fallback title shown until the provider reports this window. */
+  label: string
+  window: UsageLimitWindow | null
+}
+
+export interface LimitRingSelection {
+  snapshot: ProviderUsageSnapshot | null
+  slots: LimitRingSlot[]
+}
+
+/** Lowercased alphanumerics only, so "GPT-5.3-Codex" and "GPT 5.3 Codex" compare equal. */
+function compactLabel(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "")
+}
+
+/**
+ * A one-word scope names a model family, so it matches on the family word alone.
+ * A multi-word scope must match in full, or "GPT 5.3 Codex" claims the Spark lane.
+ */
+export function modelScopeMatches(modelLabel: string, selectedModel: string | null): boolean {
+  if (!selectedModel) return false
+  const scope = compactLabel(modelLabel)
+  if (!scope) return false
+  const selectedLabel = deriveModelLabel(selectedModel)
+  if (compactLabel(selectedLabel) === scope) return true
+  if (modelLabel.trim().split(/\s+/).length > 1) return false
+  const family = selectedLabel.split(/\s+/)[0] ?? ""
+  return compactLabel(family) === scope
+}
+
+/** A snapshot cached by an older Kanna has no windowMinutes, so id and label decide. */
+function isWeekly(window: UsageLimitWindow): boolean {
+  if (window.windowMinutes != null) return window.windowMinutes === WEEKLY_WINDOW_MINUTES
+  if (window.id === "seven_day" || window.id.startsWith("model_scoped:")) return true
+  return /^weekly\b/i.test(window.label)
+}
+
+function isSession(window: UsageLimitWindow): boolean {
+  if (window.windowMinutes != null) return window.windowMinutes === FIVE_HOUR_WINDOW_MINUTES
+  return window.id === "five_hour"
+}
+
+/** Claude's seven_day_opus/_sonnet keys are per-model, so they cannot serve as the account-wide fallback. */
+function selectWeeklyWindow(
+  windows: UsageLimitWindow[],
+  selectedModel: string | null,
+): UsageLimitWindow | null {
+  const scoped = windows.find(
+    (window) => window.modelLabel && isWeekly(window) && modelScopeMatches(window.modelLabel, selectedModel),
+  )
+  if (scoped) return scoped
+  return windows.find(
+    (window) => !window.modelLabel && isWeekly(window) && !window.id.startsWith("seven_day_"),
+  ) ?? null
+}
+
+function selectSessionWindow(windows: UsageLimitWindow[]): UsageLimitWindow | null {
+  return windows.find(isSession) ?? null
+}
+
+/** Windows are matched by duration, not by key: Codex reports its weekly window in the "primary" slot. */
+export function selectLimitRingWindows(
+  snapshot: UsageLimitsSnapshot | null,
+  provider: AgentProvider,
+  selectedModel: string | null = null,
+): LimitRingSelection {
+  const providerSnapshot = snapshot?.providers.find((entry) => entry.provider === provider) ?? null
+  const windows = providerSnapshot?.windows ?? []
+  const weekly: LimitRingSlot = {
+    key: "weekly",
+    label: "Weekly limit",
+    window: selectWeeklyWindow(windows, selectedModel),
+  }
+  if (provider === "claude") {
+    return {
+      snapshot: providerSnapshot,
+      slots: [
+        { key: "session", label: "5-hour limit", window: selectSessionWindow(windows) },
+        weekly,
+      ],
+    }
+  }
+  if (provider === "codex") {
+    return { snapshot: providerSnapshot, slots: [weekly] }
+  }
+  return { snapshot: providerSnapshot, slots: [] }
+}
+
+export function limitRingRemainingPercent(usedPercent: number | null): number | null {
+  if (usedPercent === null || !Number.isFinite(usedPercent)) return null
+  return Math.max(0, Math.min(100, 100 - usedPercent))
+}
+
+/** Thresholds must stay in step with the Usage page bars. */
+export function limitRingColorClass(usedPercent: number | null): string {
+  if (usedPercent === null) return "text-muted-foreground/40"
+  if (usedPercent >= 90) return "text-red-500"
+  if (usedPercent >= 75) return "text-amber-500"
+  return "text-emerald-500"
+}

--- a/src/client/stores/usageLimitsStore.ts
+++ b/src/client/stores/usageLimitsStore.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react"
+import type { UsageLimitsSnapshot } from "../../shared/types"
+import type { KannaSocket } from "../app/socket"
+import { useProviderAuthStore } from "./providerAuthStore"
+
+type Listener = (snapshot: UsageLimitsSnapshot) => void
+
+interface SharedSubscription {
+  socket: KannaSocket
+  snapshot: UsageLimitsSnapshot | null
+  listeners: Set<Listener>
+  dispose: () => void
+}
+
+let active: SharedSubscription | null = null
+
+/** One `usage-limits` subscription per socket: every subscribe makes the server kick a fresh provider read. */
+function subscribeShared(socket: KannaSocket, listener: Listener): () => void {
+  if (active && active.socket !== socket) {
+    active.dispose()
+    active = null
+  }
+  if (!active) {
+    const entry: SharedSubscription = { socket, snapshot: null, listeners: new Set(), dispose: () => {} }
+    entry.dispose = socket.subscribe<UsageLimitsSnapshot>({ type: "usage-limits" }, (snapshot) => {
+      entry.snapshot = snapshot
+      for (const each of entry.listeners) each(snapshot)
+    })
+    active = entry
+  }
+  const entry = active
+  entry.listeners.add(listener)
+  if (entry.snapshot) listener(entry.snapshot)
+  return () => {
+    entry.listeners.delete(listener)
+    if (entry.listeners.size > 0) return
+    entry.dispose()
+    if (active === entry) active = null
+  }
+}
+
+export function useUsageLimitsSnapshot(enabled: boolean): UsageLimitsSnapshot | null {
+  const socket = useProviderAuthStore((store) => store.socket)
+  const [snapshot, setSnapshot] = useState<UsageLimitsSnapshot | null>(null)
+
+  useEffect(() => {
+    if (!socket || !enabled) return
+    return subscribeShared(socket, setSnapshot)
+  }, [socket, enabled])
+
+  return snapshot
+}

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -77,6 +77,7 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
       },
     },
     newSidebarEnabled: true,
+    usageLimitIndicatorsEnabled: true,
     newProjectsDirectory: "~/Kanna",
     warning: null,
     filePathDisplay: filePath,

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -45,6 +45,7 @@ interface AppSettingsFile {
     pi?: ProviderPreferenceInput
   }
   newSidebarEnabled?: unknown
+  usageLimitIndicatorsEnabled?: unknown
   newProjectsDirectory?: unknown
   setupShown?: unknown
   setupCompleted?: unknown
@@ -152,6 +153,7 @@ function toFilePayload(state: AppSettingsState) {
     defaultProvider: state.defaultProvider,
     providerDefaults: state.providerDefaults,
     newSidebarEnabled: state.newSidebarEnabled,
+    usageLimitIndicatorsEnabled: state.usageLimitIndicatorsEnabled,
     newProjectsDirectory: state.newProjectsDirectory,
     setupShown: state.setupShown,
     setupCompleted: state.setupCompleted,
@@ -172,6 +174,7 @@ function toSnapshot(state: AppSettingsState, devbox = false): AppSettingsSnapsho
     defaultProvider: state.defaultProvider,
     providerDefaults: state.providerDefaults,
     newSidebarEnabled: state.newSidebarEnabled,
+    usageLimitIndicatorsEnabled: state.usageLimitIndicatorsEnabled,
     newProjectsDirectory: state.newProjectsDirectory,
     setupShown: state.setupShown,
     setupCompleted: state.setupCompleted,
@@ -216,6 +219,13 @@ function normalizeAppSettings(
     warnings.push("newSidebarEnabled must be a boolean")
   }
 
+  const usageLimitIndicatorsEnabled = typeof source?.usageLimitIndicatorsEnabled === "boolean"
+    ? source.usageLimitIndicatorsEnabled
+    : true
+  if (source?.usageLimitIndicatorsEnabled !== undefined && typeof source.usageLimitIndicatorsEnabled !== "boolean") {
+    warnings.push("usageLimitIndicatorsEnabled must be a boolean")
+  }
+
   const rawNewProjectsDirectory = typeof source?.newProjectsDirectory === "string"
     ? source.newProjectsDirectory.trim()
     : ""
@@ -244,6 +254,7 @@ function normalizeAppSettings(
     defaultProvider: normalizeDefaultProvider(source?.defaultProvider),
     providerDefaults: normalizeProviderDefaults(source?.providerDefaults),
     newSidebarEnabled,
+    usageLimitIndicatorsEnabled,
     newProjectsDirectory,
     // Onboarding markers default to false so a machine that has never run the
     // wizard still gets it; once set they stay set for every browser.
@@ -279,6 +290,7 @@ function toComparablePayload(source: AppSettingsFile) {
     defaultProvider: source.defaultProvider,
     providerDefaults: source.providerDefaults,
     newSidebarEnabled: source.newSidebarEnabled,
+    usageLimitIndicatorsEnabled: source.usageLimitIndicatorsEnabled,
     newProjectsDirectory: typeof source.newProjectsDirectory === "string"
       ? source.newProjectsDirectory.trim()
       : source.newProjectsDirectory,

--- a/src/server/usage-limits.test.ts
+++ b/src/server/usage-limits.test.ts
@@ -110,6 +110,44 @@ describe("normalizeClaudeUsage", () => {
     expect(snapshot.status).toBe("unavailable")
     expect(snapshot.windows).toHaveLength(0)
   })
+
+  test("per-model weekly lanes from model_scoped become windows", () => {
+    const snapshot = normalizeClaudeUsage(
+      {
+        rate_limits_available: true,
+        rate_limits: {
+          five_hour: { utilization: 18, resets_at: "2026-08-15T12:19:59+00:00" },
+          seven_day: { utilization: 15, resets_at: "2026-08-20T03:00:00+00:00" },
+          model_scoped: [
+            { display_name: "Fable", utilization: 17, resets_at: "2026-08-20T03:00:00+00:00" },
+          ],
+        },
+      },
+      NOW,
+    )
+
+    expect(snapshot.windows.find((w) => w.id === "five_hour")?.windowMinutes).toBe(300)
+    const scoped = snapshot.windows.find((w) => w.id === "model_scoped:fable")
+    expect(scoped).toMatchObject({
+      label: "Weekly · Fable",
+      usedPercent: 17,
+      windowMinutes: 10_080,
+      modelLabel: "Fable",
+    })
+    expect(snapshot.windows.find((w) => w.id === "seven_day")?.usedPercent).toBe(15)
+    expect(snapshot.windows.find((w) => w.id === "seven_day")?.modelLabel).toBeNull()
+  })
+
+  test("model_scoped entries without a display name are skipped", () => {
+    const snapshot = normalizeClaudeUsage(
+      {
+        rate_limits_available: true,
+        rate_limits: { model_scoped: [{ utilization: 5 }, { display_name: "  ", utilization: 5 }] },
+      },
+      NOW,
+    )
+    expect(snapshot.windows).toHaveLength(0)
+  })
 })
 
 describe("mergeClaudeRateLimitPush", () => {
@@ -146,6 +184,24 @@ describe("mergeClaudeRateLimitPush", () => {
     const merged = mergeClaudeRateLimitPush(null, { rateLimitType: "seven_day", utilization: 0.2 }, NOW)
     expect(merged.windows).toHaveLength(1)
     expect(merged.windows[0]).toMatchObject({ id: "seven_day", usedPercent: 20 })
+  })
+
+  test("a push without utilization updates the reset time but keeps the known percentage", () => {
+    const prev = normalizeClaudeUsage(
+      {
+        rate_limits_available: true,
+        rate_limits: { five_hour: { utilization: 21, resets_at: "2026-07-22T14:00:00Z" } },
+      },
+      "2026-07-22T09:00:00.000Z",
+    )
+
+    const merged = mergeClaudeRateLimitPush(prev, { rateLimitType: "five_hour", resetsAt: 1784736000 }, NOW)
+
+    const fiveHour = merged.windows.find((w) => w.id === "five_hour")
+    expect(fiveHour?.usedPercent).toBe(21)
+    expect(fiveHour?.resetsAt).toBe(new Date(1784736000 * 1000).toISOString())
+    // The figure is still the older reading, so its timestamp must stay older too.
+    expect(fiveHour?.recordedAt).toBe("2026-07-22T09:00:00.000Z")
   })
 
   test("ignores overage-only pushes", () => {
@@ -209,6 +265,21 @@ describe("normalizeCodexRateLimits", () => {
       "Weekly · All models",
       "Weekly · GPT 5.3 Codex Spark",
     ])
+    expect(snapshot.windows.map((w) => w.modelLabel)).toEqual([null, "GPT 5.3 Codex Spark"])
+  })
+
+  test("a plan with one weekly window reports it in the primary slot", () => {
+    const snapshot = normalizeCodexRateLimits(
+      { rateLimits: { limitId: "codex", primary: { usedPercent: 21, windowDurationMins: 10080 }, planType: "prolite" } },
+      NOW,
+    )
+    expect(snapshot.windows).toHaveLength(1)
+    expect(snapshot.windows[0]).toMatchObject({
+      id: "codex:primary",
+      label: "Weekly",
+      windowMinutes: 10_080,
+      modelLabel: null,
+    })
   })
 
   test("empty response is unavailable", () => {

--- a/src/server/usage-limits.test.ts
+++ b/src/server/usage-limits.test.ts
@@ -105,6 +105,26 @@ describe("normalizeClaudeUsage", () => {
     expect(snapshot.windows[0]?.label).toBe("Seven Day Fable")
   })
 
+  test("the fixed per-model weekly keys carry their model label", () => {
+    const snapshot = normalizeClaudeUsage(
+      {
+        rate_limits_available: true,
+        rate_limits: {
+          seven_day: { utilization: 15 },
+          seven_day_opus: { utilization: 40 },
+          seven_day_sonnet: { utilization: 12 },
+          seven_day_oauth_apps: { utilization: 3 },
+        },
+      },
+      NOW,
+    )
+    const byId = new Map(snapshot.windows.map((w) => [w.id, w]))
+    expect(byId.get("seven_day_opus")?.modelLabel).toBe("Opus")
+    expect(byId.get("seven_day_sonnet")?.modelLabel).toBe("Sonnet")
+    expect(byId.get("seven_day")?.modelLabel).toBeNull()
+    expect(byId.get("seven_day_oauth_apps")?.modelLabel).toBeNull()
+  })
+
   test("API-key sessions come back unavailable", () => {
     const snapshot = normalizeClaudeUsage({ rate_limits_available: false, rate_limits: null }, NOW)
     expect(snapshot.status).toBe("unavailable")

--- a/src/server/usage-limits.ts
+++ b/src/server/usage-limits.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { LOG_PREFIX } from "../shared/branding"
-import { deriveModelLabel } from "../shared/types"
+import { deriveModelLabel, FIVE_HOUR_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES } from "../shared/types"
 import type {
   AgentProvider,
   ProviderUsageSnapshot,
@@ -102,14 +102,21 @@ function claudeWindowLabel(key: string): string {
   return CLAUDE_WINDOW_LABELS[key] ?? prettifyKey(key)
 }
 
-export const FIVE_HOUR_WINDOW_MINUTES = 300
-export const WEEKLY_WINDOW_MINUTES = 10_080
-
 /** Claude keys its windows by period rather than reporting a duration. */
 function claudeWindowMinutes(key: string): number | null {
   if (key === "five_hour") return FIVE_HOUR_WINDOW_MINUTES
   if (key.startsWith("seven_day")) return WEEKLY_WINDOW_MINUTES
   return null
+}
+
+/** These keyed weekly windows cover one model family, so they carry a model label like `model_scoped` entries do. */
+const CLAUDE_WINDOW_MODEL_LABELS: Record<string, string> = {
+  seven_day_opus: "Opus",
+  seven_day_sonnet: "Sonnet",
+}
+
+function claudeWindowModelLabel(key: string): string | null {
+  return CLAUDE_WINDOW_MODEL_LABELS[key] ?? null
 }
 
 /** Stable id for a model-scoped weekly window: "Fable" becomes "model_scoped:fable". */
@@ -240,7 +247,7 @@ export function normalizeClaudeUsage(
       usedPercent: clampPercent(window.utilization),
       resetsAt: window.resets_at ?? null,
       windowMinutes: claudeWindowMinutes(key),
-      modelLabel: null,
+      modelLabel: claudeWindowModelLabel(key),
       recordedAt: now,
       source,
     })
@@ -307,7 +314,7 @@ export function mergeClaudeRateLimitPush(
     usedPercent: keepPrevious ? existing.usedPercent : usedPercent,
     resetsAt: resetsAt ?? existing?.resetsAt ?? null,
     windowMinutes: claudeWindowMinutes(id),
-    modelLabel: null,
+    modelLabel: claudeWindowModelLabel(id),
     recordedAt: keepPrevious ? existing.recordedAt : now,
     source: keepPrevious ? existing.source : "turn_push",
   }

--- a/src/server/usage-limits.ts
+++ b/src/server/usage-limits.ts
@@ -22,6 +22,13 @@ interface ClaudeUsageWindowRaw {
   resets_at?: string | null
 }
 
+/** One entry of `rate_limits.model_scoped`: a weekly window for a single model. */
+interface ClaudeModelScopedRaw {
+  display_name?: string | null
+  utilization?: number | null
+  resets_at?: string | null
+}
+
 interface ClaudeExtraUsageRaw {
   is_enabled?: boolean
   /** Minor currency units (e.g. cents when decimal_places is 2). */
@@ -93,6 +100,22 @@ function prettifyKey(key: string): string {
 
 function claudeWindowLabel(key: string): string {
   return CLAUDE_WINDOW_LABELS[key] ?? prettifyKey(key)
+}
+
+export const FIVE_HOUR_WINDOW_MINUTES = 300
+export const WEEKLY_WINDOW_MINUTES = 10_080
+
+/** Claude keys its windows by period rather than reporting a duration. */
+function claudeWindowMinutes(key: string): number | null {
+  if (key === "five_hour") return FIVE_HOUR_WINDOW_MINUTES
+  if (key.startsWith("seven_day")) return WEEKLY_WINDOW_MINUTES
+  return null
+}
+
+/** Stable id for a model-scoped weekly window: "Fable" becomes "model_scoped:fable". */
+function modelScopedWindowId(displayName: string): string {
+  const slug = displayName.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "")
+  return `model_scoped:${slug || "model"}`
 }
 
 function codexWindowLabel(windowDurationMins: number | null | undefined, suffix: string): string {
@@ -186,6 +209,26 @@ export function normalizeClaudeUsage(
       }
       continue
     }
+    // Per-model weekly windows arrive as an array of {display_name,
+    // utilization, resets_at} rather than as keyed entries.
+    if (key === "model_scoped") {
+      if (!Array.isArray(value)) continue
+      for (const entry of value as ClaudeModelScopedRaw[]) {
+        const displayName = typeof entry?.display_name === "string" ? entry.display_name.trim() : ""
+        if (!displayName) continue
+        windows.push({
+          id: modelScopedWindowId(displayName),
+          label: `Weekly · ${displayName}`,
+          usedPercent: clampPercent(entry.utilization),
+          resetsAt: entry.resets_at ?? null,
+          windowMinutes: WEEKLY_WINDOW_MINUTES,
+          modelLabel: displayName,
+          recordedAt: now,
+          source,
+        })
+      }
+      continue
+    }
     // Only keyed entries shaped like windows count; the response also carries
     // non-window keys (a `limits` array, a `spend` object, booleans) we skip.
     if (!value || typeof value !== "object" || Array.isArray(value)) continue
@@ -196,6 +239,8 @@ export function normalizeClaudeUsage(
       label: claudeWindowLabel(key),
       usedPercent: clampPercent(window.utilization),
       resetsAt: window.resets_at ?? null,
+      windowMinutes: claudeWindowMinutes(key),
+      modelLabel: null,
       recordedAt: now,
       source,
     })
@@ -253,13 +298,18 @@ export function mergeClaudeRateLimitPush(
 
   const windows = [...base.windows]
   const existingIndex = windows.findIndex((w) => w.id === id)
+  const existing = windows[existingIndex]
+  // A push can carry only a reset time, so the last known figure and its own recordedAt survive it.
+  const keepPrevious = usedPercent === null && existing?.usedPercent != null
   const merged: UsageLimitWindow = {
     id,
     label: claudeWindowLabel(id),
-    usedPercent,
-    resetsAt: resetsAt ?? windows[existingIndex]?.resetsAt ?? null,
-    recordedAt: now,
-    source: "turn_push",
+    usedPercent: keepPrevious ? existing.usedPercent : usedPercent,
+    resetsAt: resetsAt ?? existing?.resetsAt ?? null,
+    windowMinutes: claudeWindowMinutes(id),
+    modelLabel: null,
+    recordedAt: keepPrevious ? existing.recordedAt : now,
+    source: keepPrevious ? existing.source : "turn_push",
   }
   if (existingIndex >= 0) {
     windows[existingIndex] = merged
@@ -283,24 +333,21 @@ function codexBucketWindows(
   now: string,
   source: UsageLimitSource,
   labelSuffix: string,
+  modelLabel: string | null,
 ): UsageLimitWindow[] {
   const windows: UsageLimitWindow[] = []
-  if (bucket.primary) {
+  // primary/secondary are positional slots, not fixed periods: a plan with one
+  // window reports it as primary whatever its duration.
+  for (const slot of ["primary", "secondary"] as const) {
+    const window = bucket[slot]
+    if (!window) continue
     windows.push({
-      id: `${keyPrefix}:primary`,
-      label: codexWindowLabel(bucket.primary.windowDurationMins, labelSuffix),
-      usedPercent: clampPercent(bucket.primary.usedPercent),
-      resetsAt: unixSecondsToIso(bucket.primary.resetsAt),
-      recordedAt: now,
-      source,
-    })
-  }
-  if (bucket.secondary) {
-    windows.push({
-      id: `${keyPrefix}:secondary`,
-      label: codexWindowLabel(bucket.secondary.windowDurationMins, labelSuffix),
-      usedPercent: clampPercent(bucket.secondary.usedPercent),
-      resetsAt: unixSecondsToIso(bucket.secondary.resetsAt),
+      id: `${keyPrefix}:${slot}`,
+      label: codexWindowLabel(window.windowDurationMins, labelSuffix),
+      usedPercent: clampPercent(window.usedPercent),
+      resetsAt: unixSecondsToIso(window.resetsAt),
+      windowMinutes: window.windowDurationMins ?? null,
+      modelLabel,
       recordedAt: now,
       source,
     })
@@ -361,14 +408,12 @@ export function normalizeCodexRateLimits(
     // model-specific lanes whose limitName is a model id — run it through the
     // shared model-label formatter so "GPT-5.3-Codex-Spark" → "GPT 5.3 Codex
     // Spark", matching the rest of the app.
+    const modelLabel = bucket.limitName ? deriveModelLabel(bucket.limitName) : null
     const suffix = !multiple
       ? ""
-      : bucket.limitName
-        ? deriveModelLabel(bucket.limitName)
-        : limitId === "codex"
-          ? "All models"
-          : limitId
-    windows.push(...codexBucketWindows(bucket, limitId, now, source, suffix))
+      : modelLabel
+        ?? (limitId === "codex" ? "All models" : limitId)
+    windows.push(...codexBucketWindows(bucket, limitId, now, source, suffix, modelLabel))
     if (!credits && bucket.credits && (bucket.credits.hasCredits || bucket.credits.unlimited)) {
       credits = {
         label: "Credits",
@@ -509,9 +554,15 @@ export class UsageLimitsManager {
           const persisted = parsed.providers?.[provider]
           if (persisted && typeof persisted === "object") {
             // Mark persisted windows as cache-sourced so the UI can show staleness.
+            // Fields added after a cache was written come back undefined.
             this.snapshots.set(provider, {
               ...persisted,
-              windows: persisted.windows?.map((w) => ({ ...w, source: "cache" as const })) ?? [],
+              windows: persisted.windows?.map((w) => ({
+                ...w,
+                windowMinutes: w.windowMinutes ?? null,
+                modelLabel: w.modelLabel ?? null,
+                source: "cache" as const,
+              })) ?? [],
               credits: persisted.credits ? { ...persisted.credits, source: "cache" } : null,
             })
           }

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -131,6 +131,7 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
     },
   },
   newSidebarEnabled: false,
+  usageLimitIndicatorsEnabled: true,
   newProjectsDirectory: "~/Kanna",
   warning: null,
   filePathDisplay: "~/.kanna/data/settings.json",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1081,6 +1081,7 @@ export interface AppSettingsSnapshot {
   providerDefaults: ChatProviderPreferences
   /** Labs: the tabbed Chats/Projects "New Sidebar". On by default; false opts back into the legacy sidebar. */
   newSidebarEnabled: boolean
+  usageLimitIndicatorsEnabled: boolean
   /** Base directory where cloned and newly created projects are placed. */
   newProjectsDirectory: string
   /**
@@ -1108,6 +1109,7 @@ export interface AppSettingsPatch {
   chatSoundPreference?: ChatSoundPreference
   chatSoundId?: ChatSoundId
   newSidebarEnabled?: boolean
+  usageLimitIndicatorsEnabled?: boolean
   newProjectsDirectory?: string
   setupShown?: boolean
   setupCompleted?: boolean
@@ -1151,6 +1153,10 @@ export interface UsageLimitWindow {
   usedPercent: number | null
   /** ISO 8601 timestamp when this window resets, or null when unknown. */
   resetsAt: string | null
+  /** Rolling window length in minutes when known (300 = 5-hour, 10080 = weekly). */
+  windowMinutes: number | null
+  /** Display label of the model this window is scoped to, or null when it covers all models. */
+  modelLabel: string | null
   /** When this specific window value was recorded (ISO 8601). */
   recordedAt: string
   /** Source of this window's value. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1143,6 +1143,20 @@ export interface AppSettingsPatch {
  */
 export type UsageLimitSource = "on_demand" | "turn_push" | "cache"
 
+/** Rolling window lengths, shared by the normalizers and the UI that matches on them. */
+export const FIVE_HOUR_WINDOW_MINUTES = 300
+export const WEEKLY_WINDOW_MINUTES = 10_080
+
+/** Severity of a usage reading. Bars and rings must classify alike. */
+export type UsageLevel = "unknown" | "ok" | "warn" | "danger"
+
+export function usageLevel(usedPercent: number | null): UsageLevel {
+  if (usedPercent === null || !Number.isFinite(usedPercent)) return "unknown"
+  if (usedPercent >= 90) return "danger"
+  if (usedPercent >= 75) return "warn"
+  return "ok"
+}
+
 /** One rolling rate-limit window (e.g. Claude 5-hour, Codex weekly). */
 export interface UsageLimitWindow {
   /** Stable id within a provider (e.g. "five_hour", "seven_day_opus", "codex:primary"). */


### PR DESCRIPTION
This PR adds provider usage-limit indicators and detailed usage window tracking.

## Summary

- Adds usage-limit rings to the chat composer for Claude and Codex.
- Shows remaining usage and reset times in ring tooltips.
- Adds model-scoped usage windows for Claude and Codex.
- Displays detailed usage windows and reset times on the Usage settings page.
- Adds a General setting to hide usage-limit indicators.
- Persists the indicator visibility setting.
- Caches usage-limit snapshots and preserves stale data during refresh failures.
- Keeps usage indicators unavailable for Cursor and Pi.

## Breaking Changes

None.

## Tests

- Focused provider, settings, router, ring, and chat input tests pass: 102 tests.
- TypeScript check passes.
- Client build passes.
- Export viewer build passes.
- Full suite: 1,649 tests pass.

## Known Issues

- Cursor usage limits are not available yet.
- Pi does not expose subscription usage limits because it uses pay-per-token models.

## Screenshots
<img width="253" height="142" alt="Screenshot 2026-08-15 at 9 15 54 AM" src="https://github.com/user-attachments/assets/6b777993-2b22-4757-b332-00e32e1f0a2b" />
<img width="269" height="173" alt="Screenshot 2026-08-15 at 9 16 02 AM" src="https://github.com/user-attachments/assets/7142415b-5bfb-4558-a2f6-6a614fea399a" />
