### PR TITLE
Support Codex approval mode and app permissions

### DIFF
--- a/src/client/app/ChatPage/ChatTranscriptViewport.tsx
+++ b/src/client/app/ChatPage/ChatTranscriptViewport.tsx
@@ -197,6 +197,7 @@ interface ChatTranscriptViewportProps {
   onOpenLocalLink: KannaState["handleOpenLocalLink"]
   onAskUserQuestionSubmit: KannaState["handleAskUserQuestion"]
   onExitPlanModeConfirm: KannaState["handleExitPlanMode"]
+  onCodexApprovalSubmit?: KannaState["handleCodexApproval"]
   showScrollButton: boolean
   onIsAtEndChange: (isAtEnd: boolean) => void
   scrollToBottom: () => void
@@ -318,6 +319,7 @@ const TranscriptScrollerBody = memo(function TranscriptScrollerBody({
   onOpenLocalLink,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  onCodexApprovalSubmit,
   showScrollButton,
   onIsAtEndChange,
   scrollToBottom,
@@ -848,7 +850,8 @@ const TranscriptScrollerBody = memo(function TranscriptScrollerBody({
                       toolGroupExpanded={row.kind === "tool-group" ? (toolGroupExpanded[row.id] ?? false) : undefined}
                       onToolGroupExpandedChange={handleToolGroupExpandedChange}
                       onAskUserQuestionSubmit={onAskUserQuestionSubmit}
-                      onExitPlanModeConfirm={onExitPlanModeConfirm}
+                       onExitPlanModeConfirm={onExitPlanModeConfirm}
+                       onCodexApprovalSubmit={onCodexApprovalSubmit}
                     />
                   </div>
                 </MessageScrollerItem>

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -1026,6 +1026,7 @@ export function ChatPage() {
           platform={state.localProjects?.machine.platform}
           onAskUserQuestionSubmit={state.handleAskUserQuestion}
           onExitPlanModeConfirm={state.handleExitPlanMode}
+          onCodexApprovalSubmit={state.handleCodexApproval}
           showScrollButton={showScrollToBottom && state.messages.length > 0}
           onIsAtEndChange={onIsAtEndChange}
           readAnchorState={state.readAnchorState}

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -557,6 +557,7 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
           message.toolKind === "codex_command_approval"
           || message.toolKind === "codex_file_change_approval"
           || message.toolKind === "codex_mcp_approval"
+          || message.toolKind === "codex_permissions_approval"
         ) {
           rendered = (
             <CodexApprovalMessage

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -42,7 +42,6 @@ export interface ResolvedSingleTranscriptRow {
   isFirstAccount: boolean
   isLatestAskUserQuestion: boolean
   isLatestExitPlanMode: boolean
-  isLatestCodexApproval: boolean
   isLatestTodoWrite: boolean
   hideResult: boolean
   isFinalStatus: boolean
@@ -468,7 +467,6 @@ interface TranscriptSingleRowProps {
   isFirstAccount: boolean
   isLatestAskUserQuestion: boolean
   isLatestExitPlanMode: boolean
-  isLatestCodexApproval: boolean
   isLatestTodoWrite: boolean
   hideResult: boolean
   isFinalStatus: boolean
@@ -495,7 +493,6 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
   isFirstAccount,
   isLatestAskUserQuestion,
   isLatestExitPlanMode,
-  isLatestCodexApproval,
   isLatestTodoWrite,
   hideResult,
   isFinalStatus,
@@ -562,7 +559,6 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
               key={message.id}
               message={message}
               onSubmit={onCodexApprovalSubmit ?? (() => undefined)}
-              isLatest={isLatestCodexApproval}
             />
           )
           break
@@ -720,7 +716,6 @@ export function buildResolvedTranscriptRows(
       isFirstAccount: renderState.isFirstAccount,
       isLatestAskUserQuestion: item.message.id === latestToolIds.AskUserQuestion,
        isLatestExitPlanMode: item.message.id === latestToolIds.ExitPlanMode,
-       isLatestCodexApproval: item.message.id === latestToolIds.CodexApproval,
       isLatestTodoWrite: renderState.isLatestTodoWrite,
       hideResult: renderState.hideResult,
       isFinalStatus: renderState.isFinalStatus,
@@ -792,8 +787,7 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
       restored={row.restored}
       isFirstAccount={row.isFirstAccount}
       isLatestAskUserQuestion={row.isLatestAskUserQuestion}
-       isLatestExitPlanMode={row.isLatestExitPlanMode}
-       isLatestCodexApproval={row.isLatestCodexApproval}
+      isLatestExitPlanMode={row.isLatestExitPlanMode}
       isLatestTodoWrite={row.isLatestTodoWrite}
       hideResult={row.hideResult}
       isFinalStatus={row.isFinalStatus}

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -7,6 +7,7 @@ import { SystemMessage, type SessionHandoff, type SessionRestore } from "../comp
 import { AccountInfoMessage } from "../components/messages/AccountInfoMessage"
 import { TextMessage } from "../components/messages/TextMessage"
 import { AskUserQuestionMessage } from "../components/messages/AskUserQuestionMessage"
+import { CodexApprovalMessage } from "../components/messages/CodexApprovalMessage"
 import { ExitPlanModeMessage } from "../components/messages/ExitPlanModeMessage"
 import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
 import { ToolCallMessage } from "../components/messages/ToolCallMessage"
@@ -41,6 +42,7 @@ export interface ResolvedSingleTranscriptRow {
   isFirstAccount: boolean
   isLatestAskUserQuestion: boolean
   isLatestExitPlanMode: boolean
+  isLatestCodexApproval: boolean
   isLatestTodoWrite: boolean
   hideResult: boolean
   isFinalStatus: boolean
@@ -466,6 +468,7 @@ interface TranscriptSingleRowProps {
   isFirstAccount: boolean
   isLatestAskUserQuestion: boolean
   isLatestExitPlanMode: boolean
+  isLatestCodexApproval: boolean
   isLatestTodoWrite: boolean
   hideResult: boolean
   isFinalStatus: boolean
@@ -476,6 +479,7 @@ interface TranscriptSingleRowProps {
     answers: AskUserQuestionAnswerMap
   ) => void
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
+  onCodexApprovalSubmit?: (toolUseId: string, decision: "accept" | "acceptForSession" | "decline") => void
 }
 
 const TranscriptSingleRow = memo(function TranscriptSingleRow({
@@ -491,12 +495,14 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
   isFirstAccount,
   isLatestAskUserQuestion,
   isLatestExitPlanMode,
+  isLatestCodexApproval,
   isLatestTodoWrite,
   hideResult,
   isFinalStatus,
   nextPromptTimestamp,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  onCodexApprovalSubmit,
 }: TranscriptSingleRowProps) {
   let rendered: React.ReactNode = null
 
@@ -546,6 +552,17 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
               message={message}
               onConfirm={onExitPlanModeConfirm}
               isLatest={isLatestExitPlanMode}
+            />
+          )
+          break
+        }
+        if (message.toolKind === "codex_command_approval" || message.toolKind === "codex_file_change_approval") {
+          rendered = (
+            <CodexApprovalMessage
+              key={message.id}
+              message={message}
+              onSubmit={onCodexApprovalSubmit ?? (() => undefined)}
+              isLatest={isLatestCodexApproval}
             />
           )
           break
@@ -702,7 +719,8 @@ export function buildResolvedTranscriptRows(
       restored: renderState.restored,
       isFirstAccount: renderState.isFirstAccount,
       isLatestAskUserQuestion: item.message.id === latestToolIds.AskUserQuestion,
-      isLatestExitPlanMode: item.message.id === latestToolIds.ExitPlanMode,
+       isLatestExitPlanMode: item.message.id === latestToolIds.ExitPlanMode,
+       isLatestCodexApproval: item.message.id === latestToolIds.CodexApproval,
       isLatestTodoWrite: renderState.isLatestTodoWrite,
       hideResult: renderState.hideResult,
       isFinalStatus: renderState.isFinalStatus,
@@ -735,6 +753,7 @@ interface KannaTranscriptRowProps {
     answers: AskUserQuestionAnswerMap
   ) => void
   onExitPlanModeConfirm: (toolUseId: string, confirmed: boolean, clearContext?: boolean, message?: string) => void
+  onCodexApprovalSubmit?: (toolUseId: string, decision: "accept" | "acceptForSession" | "decline") => void
 }
 
 export const KannaTranscriptRow = memo(function KannaTranscriptRow({
@@ -744,6 +763,7 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   onToolGroupExpandedChange,
   onAskUserQuestionSubmit,
   onExitPlanModeConfirm,
+  onCodexApprovalSubmit,
 }: KannaTranscriptRowProps) {
   if (row.kind === "tool-group") {
     return (
@@ -772,13 +792,15 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
       restored={row.restored}
       isFirstAccount={row.isFirstAccount}
       isLatestAskUserQuestion={row.isLatestAskUserQuestion}
-      isLatestExitPlanMode={row.isLatestExitPlanMode}
+       isLatestExitPlanMode={row.isLatestExitPlanMode}
+       isLatestCodexApproval={row.isLatestCodexApproval}
       isLatestTodoWrite={row.isLatestTodoWrite}
       hideResult={row.hideResult}
       isFinalStatus={row.isFinalStatus}
       nextPromptTimestamp={row.nextPromptTimestamp}
       onAskUserQuestionSubmit={onAskUserQuestionSubmit}
-      onExitPlanModeConfirm={onExitPlanModeConfirm}
+       onExitPlanModeConfirm={onExitPlanModeConfirm}
+       onCodexApprovalSubmit={onCodexApprovalSubmit}
     />
   )
 }, (prev, next) => {
@@ -789,6 +811,7 @@ export const KannaTranscriptRow = memo(function KannaTranscriptRow({
   if (prev.onToolGroupExpandedChange !== next.onToolGroupExpandedChange) return false
   if (prev.onAskUserQuestionSubmit !== next.onAskUserQuestionSubmit) return false
   if (prev.onExitPlanModeConfirm !== next.onExitPlanModeConfirm) return false
+  if (prev.onCodexApprovalSubmit !== next.onCodexApprovalSubmit) return false
   if (prev.row.kind !== next.row.kind) return false
   if (prev.row.id !== next.row.id) return false
 

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -553,7 +553,11 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
           )
           break
         }
-        if (message.toolKind === "codex_command_approval" || message.toolKind === "codex_file_change_approval") {
+        if (
+          message.toolKind === "codex_command_approval"
+          || message.toolKind === "codex_file_change_approval"
+          || message.toolKind === "codex_mcp_approval"
+        ) {
           rendered = (
             <CodexApprovalMessage
               key={message.id}

--- a/src/client/app/derived.ts
+++ b/src/client/app/derived.ts
@@ -1,7 +1,7 @@
 import type { HydratedTranscriptMessage } from "../../shared/types"
 import type { ProcessedToolCall } from "../components/messages/types"
 
-export const SPECIAL_TOOL_NAMES = ["AskUserQuestion", "ExitPlanMode", "TodoWrite"] as const
+export const SPECIAL_TOOL_NAMES = ["AskUserQuestion", "ExitPlanMode", "TodoWrite", "CodexApproval"] as const
 const RESOLVED_TOOL_NAMES = new Set<string>(["TodoWrite"])
 
 function findLatestUnresolvedToolId(messages: HydratedTranscriptMessage[], toolName: string): string | null {

--- a/src/client/app/settings/ProvidersSection.tsx
+++ b/src/client/app/settings/ProvidersSection.tsx
@@ -126,7 +126,17 @@ export function ProvidersSection({
   function handleProviderDefaultModeChange(provider: AgentProvider, mode: ChatMode) {
     setProviderDefaultMode(provider, mode)
     const flags = chatModeToFlags(mode, providerDefaults[provider].autoPlan)
-    void handleWriteAppSettings({ providerDefaults: { [provider]: flags } }).catch((error) => {
+    const modelOptions = provider === "codex"
+      ? { accessMode: mode === "approval" ? "approval" as const : "full-access" as const }
+      : undefined
+    void handleWriteAppSettings({
+      providerDefaults: {
+        [provider]: {
+          ...flags,
+          ...(modelOptions ? { modelOptions } : {}),
+        },
+      },
+    }).catch((error) => {
       setProvidersError(error instanceof Error ? error.message : "Unable to save provider settings.")
     })
   }
@@ -289,7 +299,11 @@ export function ProvidersSection({
                   handleProviderDefaultModelOptionsChange("codex", { fastMode: change.fastMode })
                 }
               }}
-              mode={chatModeFromFlags(providerDefaults.codex.planMode, providerDefaults.codex.autoPlan)}
+               mode={chatModeFromFlags(
+                 providerDefaults.codex.planMode,
+                 providerDefaults.codex.autoPlan,
+                 providerDefaults.codex.modelOptions.accessMode,
+               )}
               onModeChange={(mode) => handleProviderDefaultModeChange("codex", mode)}
               includeMode
               className="justify-start flex-wrap"

--- a/src/client/app/useChatCommands.ts
+++ b/src/client/app/useChatCommands.ts
@@ -115,6 +115,19 @@ export function useChatCommands(params: {
     }, { keepCommandError: true })
   }, [activeChatId, wrapCommand])
 
+  const handleCodexApproval = useCallback(async (
+    toolUseId: string,
+    decision: "accept" | "acceptForSession" | "decline",
+  ) => {
+    if (!activeChatId) return
+    await wrapCommand({
+      type: "chat.respondTool",
+      chatId: activeChatId,
+      toolUseId,
+      result: { decision },
+    }, { keepCommandError: true })
+  }, [activeChatId, wrapCommand])
+
   const handleCopyPath = useCallback(async (localPath: string) => {
     try {
       if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
@@ -199,6 +212,7 @@ export function useChatCommands(params: {
     handleRenameProject,
     handleAskUserQuestion,
     handleExitPlanMode,
+    handleCodexApproval,
     handleCopyPath,
     handleOpenExternal,
     handleOpenLocalLink,

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -248,6 +248,7 @@ export interface KannaState {
     clearContext?: boolean,
     message?: string
   ) => Promise<void>
+  handleCodexApproval: (toolUseId: string, decision: "accept" | "acceptForSession" | "decline") => Promise<void>
   handleExportStandalone: (chatId?: string | null) => Promise<StandaloneTranscriptExportCommandResult | null>
   handleCloseStandaloneShareDialog: () => void
   handleOpenStandaloneShareLink: () => void
@@ -855,6 +856,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleRenameProject,
     handleAskUserQuestion,
     handleExitPlanMode,
+    handleCodexApproval,
     handleCopyPath,
     handleOpenExternal,
     handleOpenLocalLink,
@@ -975,6 +977,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleCompose,
     handleAskUserQuestion,
     handleExitPlanMode,
+    handleCodexApproval,
     handleExportStandalone,
     handleCloseStandaloneShareDialog,
     handleOpenStandaloneShareLink,

--- a/src/client/components/chat-ui/ChatPreferenceControls.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react"
-import { Box, Brain, Gauge, ListTodo, LockOpen, Plus, Search, Sparkles, SquareMenu, SquareMinus } from "lucide-react"
+import { Box, Brain, Gauge, ListTodo, LockOpen, Plus, Search, ShieldCheck, Sparkles, SquareMenu, SquareMinus } from "lucide-react"
 import {
   resolveModelLabel,
   type AgentProvider,
@@ -212,6 +212,7 @@ interface ChatPreferenceControlsProps {
 
 const MODE_ICONS: Record<ChatMode, typeof LockOpen> = {
   "full-access": LockOpen,
+  "approval": ShieldCheck,
   "plan": ListTodo,
   "auto-plan": Sparkles,
 }

--- a/src/client/components/command-palette/CommandPalette.tsx
+++ b/src/client/components/command-palette/CommandPalette.tsx
@@ -29,6 +29,7 @@ import {
   Plus,
   Settings2,
   Share2,
+  ShieldCheck,
   Sparkles,
   SquareMenu,
   SquarePen,
@@ -202,12 +203,14 @@ const ICON_CLASS = "h-4 w-4 text-muted-foreground"
 
 const MODE_COMMAND_ICONS: Record<ChatMode, typeof LockOpen> = {
   "full-access": LockOpen,
+  "approval": ShieldCheck,
   "plan": ListTodo,
   "auto-plan": Sparkles,
 }
 
 const MODE_COMMAND_KEYWORDS: Record<ChatMode, string[]> = {
   "full-access": ["execute", "yolo", "no approval"],
+  "approval": ["approval", "safe", "workspace", "permission"],
   "plan": ["review", "safe", "approve"],
   "auto-plan": ["automatic", "decide", "enter plan mode"],
 }

--- a/src/client/components/messages/CodexApprovalMessage.test.tsx
+++ b/src/client/components/messages/CodexApprovalMessage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import type { ProcessedToolCall } from "./types"
+import { CodexApprovalMessage } from "./CodexApprovalMessage"
+
+type ApprovalMessage = Extract<
+  ProcessedToolCall,
+  { toolKind: "codex_command_approval" | "codex_file_change_approval" }
+>
+
+function commandApproval(toolId: string): ApprovalMessage {
+  return {
+    id: `message-${toolId}`,
+    kind: "tool",
+    toolKind: "codex_command_approval",
+    toolName: "CodexApproval",
+    toolId,
+    input: { command: `touch ${toolId}.txt`, cwd: "/tmp/project" },
+    timestamp: new Date().toISOString(),
+  }
+}
+
+describe("CodexApprovalMessage", () => {
+  test("renders controls for each unresolved approval", () => {
+    const html = ["approval-1", "approval-2"]
+      .map((toolId) => renderToStaticMarkup(
+        <CodexApprovalMessage
+          message={commandApproval(toolId)}
+          onSubmit={() => undefined}
+        />
+      ))
+      .join("")
+
+    expect((html.match(/Allow once/g) ?? []).length).toBe(2)
+    expect((html.match(/Allow for session/g) ?? []).length).toBe(2)
+    expect((html.match(/Deny/g) ?? []).length).toBe(2)
+  })
+})

--- a/src/client/components/messages/CodexApprovalMessage.tsx
+++ b/src/client/components/messages/CodexApprovalMessage.tsx
@@ -1,0 +1,65 @@
+import { Check, ShieldAlert, X } from "lucide-react"
+import type { ProcessedToolCall } from "./types"
+import { Button } from "../ui/button"
+import { cn } from "../../lib/utils"
+
+type ApprovalMessage = Extract<
+  ProcessedToolCall,
+  { toolKind: "codex_command_approval" | "codex_file_change_approval" }
+>
+
+interface Props {
+  message: ApprovalMessage
+  onSubmit: (toolUseId: string, decision: "accept" | "acceptForSession" | "decline") => void
+  isLatest: boolean
+}
+
+function resultDecision(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null
+  const decision = (result as { decision?: unknown }).decision
+  return typeof decision === "string" ? decision : null
+}
+
+export function CodexApprovalMessage({ message, onSubmit, isLatest }: Props) {
+  const commandApproval = message.toolKind === "codex_command_approval"
+  const decision = resultDecision(message.result)
+  const complete = decision !== null
+  const input = message.input as {
+    command?: string
+    cwd?: string
+    reason?: string
+    grantRoot?: string
+  }
+
+  return (
+    <div className={cn(
+      "my-2 w-full max-w-[680px] rounded-xl border p-3 text-sm",
+      complete ? "border-border bg-muted/20" : "border-amber-500/50 bg-amber-500/5",
+    )}>
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-500" />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium">{commandApproval ? "Codex wants to run a command" : "Codex wants to change files"}</div>
+          {commandApproval && input.command ? (
+            <pre className="mt-2 overflow-x-auto rounded-md bg-muted px-2 py-1.5 text-xs whitespace-pre-wrap">{input.command}</pre>
+          ) : null}
+          {commandApproval && input.cwd ? <div className="mt-1 text-xs text-muted-foreground">in {input.cwd}</div> : null}
+          {!commandApproval && input.grantRoot ? <div className="mt-1 text-xs text-muted-foreground">Access requested for {input.grantRoot}</div> : null}
+          {input.reason ? <div className="mt-2 text-xs text-muted-foreground">{input.reason}</div> : null}
+          {complete ? (
+            <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+              {decision === "decline" || decision === "cancel" ? <X className="size-3" /> : <Check className="size-3" />}
+              {decision === "acceptForSession" ? "Allowed for this session" : decision === "accept" ? "Allowed" : decision === "cancel" ? "Cancelled" : "Declined"}
+            </div>
+          ) : isLatest ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button size="sm" onClick={() => onSubmit(message.toolId, "accept")}>Allow once</Button>
+              <Button size="sm" variant="secondary" onClick={() => onSubmit(message.toolId, "acceptForSession")}>Allow for session</Button>
+              <Button size="sm" variant="outline" onClick={() => onSubmit(message.toolId, "decline")}>Deny</Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/client/components/messages/CodexApprovalMessage.tsx
+++ b/src/client/components/messages/CodexApprovalMessage.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../lib/utils"
 
 type ApprovalMessage = Extract<
   ProcessedToolCall,
-  { toolKind: "codex_command_approval" | "codex_file_change_approval" }
+  { toolKind: "codex_command_approval" | "codex_file_change_approval" | "codex_mcp_approval" }
 >
 
 interface Props {
@@ -21,14 +21,24 @@ function resultDecision(result: unknown): string | null {
 
 export function CodexApprovalMessage({ message, onSubmit }: Props) {
   const commandApproval = message.toolKind === "codex_command_approval"
+  const mcpApproval = message.toolKind === "codex_mcp_approval"
   const decision = resultDecision(message.result)
-  const complete = decision !== null
+  const action = message.result && typeof message.result === "object"
+    ? (message.result as { action?: unknown }).action
+    : null
+  const complete = decision !== null || typeof action === "string"
   const input = message.input as {
     command?: string
     cwd?: string
     reason?: string
     grantRoot?: string
+    serverName?: string
+    message?: string
+    mode?: "form" | "openai/form" | "url"
+    url?: string
+    persist?: "session" | "always" | Array<"session" | "always">
   }
+  const completedDecision = decision ?? (typeof action === "string" ? action : null)
 
   return (
     <div className={cn(
@@ -38,7 +48,23 @@ export function CodexApprovalMessage({ message, onSubmit }: Props) {
       <div className="flex items-start gap-2">
         <ShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-500" />
         <div className="min-w-0 flex-1">
-          <div className="font-medium">{commandApproval ? "Codex wants to run a command" : "Codex wants to change files"}</div>
+          <div className="font-medium">
+            {commandApproval
+              ? "Codex wants to run a command"
+              : mcpApproval
+                ? `${input.serverName || "An app"} needs your approval`
+                : "Codex wants to change files"}
+          </div>
+          {mcpApproval && input.message ? <div className="mt-2 text-sm text-foreground">{input.message}</div> : null}
+          {mcpApproval && input.url ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Button size="sm" variant="secondary" onClick={() => {
+                if (typeof window !== "undefined") window.open(input.url, "_blank", "noopener,noreferrer")
+              }}>
+                Open authorization
+              </Button>
+            </div>
+          ) : null}
           {commandApproval && input.command ? (
             <pre className="mt-2 overflow-x-auto rounded-md bg-muted px-2 py-1.5 text-xs whitespace-pre-wrap">{input.command}</pre>
           ) : null}
@@ -47,13 +73,19 @@ export function CodexApprovalMessage({ message, onSubmit }: Props) {
           {input.reason ? <div className="mt-2 text-xs text-muted-foreground">{input.reason}</div> : null}
           {complete ? (
             <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
-              {decision === "decline" || decision === "cancel" ? <X className="size-3" /> : <Check className="size-3" />}
-              {decision === "acceptForSession" ? "Allowed for this session" : decision === "accept" ? "Allowed" : decision === "cancel" ? "Cancelled" : "Declined"}
+              {completedDecision === "decline" || completedDecision === "cancel" ? <X className="size-3" /> : <Check className="size-3" />}
+              {completedDecision === "acceptForSession" ? "Allowed for this session" : completedDecision === "accept" ? "Allowed" : completedDecision === "cancel" ? "Cancelled" : "Declined"}
             </div>
           ) : !complete ? (
             <div className="mt-3 flex flex-wrap gap-2">
-              <Button size="sm" onClick={() => onSubmit(message.toolId, "accept")}>Allow once</Button>
-              <Button size="sm" variant="secondary" onClick={() => onSubmit(message.toolId, "acceptForSession")}>Allow for session</Button>
+              <Button size="sm" onClick={() => onSubmit(message.toolId, "accept")}>
+                {mcpApproval ? (input.url ? "Continue" : "Allow app") : "Allow once"}
+              </Button>
+              {!mcpApproval ? (
+                <Button size="sm" variant="secondary" onClick={() => onSubmit(message.toolId, "acceptForSession")}>
+                  Allow for session
+                </Button>
+              ) : null}
               <Button size="sm" variant="outline" onClick={() => onSubmit(message.toolId, "decline")}>Deny</Button>
             </div>
           ) : null}

--- a/src/client/components/messages/CodexApprovalMessage.tsx
+++ b/src/client/components/messages/CodexApprovalMessage.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../lib/utils"
 
 type ApprovalMessage = Extract<
   ProcessedToolCall,
-  { toolKind: "codex_command_approval" | "codex_file_change_approval" | "codex_mcp_approval" }
+  { toolKind: "codex_command_approval" | "codex_file_change_approval" | "codex_mcp_approval" | "codex_permissions_approval" }
 >
 
 interface Props {
@@ -22,6 +22,7 @@ function resultDecision(result: unknown): string | null {
 export function CodexApprovalMessage({ message, onSubmit }: Props) {
   const commandApproval = message.toolKind === "codex_command_approval"
   const mcpApproval = message.toolKind === "codex_mcp_approval"
+  const permissionsApproval = message.toolKind === "codex_permissions_approval"
   const decision = resultDecision(message.result)
   const action = message.result && typeof message.result === "object"
     ? (message.result as { action?: unknown }).action
@@ -37,6 +38,10 @@ export function CodexApprovalMessage({ message, onSubmit }: Props) {
     mode?: "form" | "openai/form" | "url"
     url?: string
     persist?: "session" | "always" | Array<"session" | "always">
+    permissions?: {
+      network?: { enabled?: boolean }
+      fileSystem?: { read?: string[]; write?: string[] }
+    }
   }
   const completedDecision = decision ?? (typeof action === "string" ? action : null)
 
@@ -53,6 +58,8 @@ export function CodexApprovalMessage({ message, onSubmit }: Props) {
               ? "Codex wants to run a command"
               : mcpApproval
                 ? `${input.serverName || "An app"} needs your approval`
+                : permissionsApproval
+                  ? "Codex needs additional permissions"
                 : "Codex wants to change files"}
           </div>
           {mcpApproval && input.message ? <div className="mt-2 text-sm text-foreground">{input.message}</div> : null}
@@ -63,6 +70,19 @@ export function CodexApprovalMessage({ message, onSubmit }: Props) {
               }}>
                 Open authorization
               </Button>
+            </div>
+          ) : null}
+          {permissionsApproval && input.permissions?.network?.enabled ? (
+            <div className="mt-2 text-xs text-muted-foreground">Network access</div>
+          ) : null}
+          {permissionsApproval && input.permissions?.fileSystem?.read?.length ? (
+            <div className="mt-2 text-xs text-muted-foreground">
+              Read access: {input.permissions.fileSystem.read.join(", ")}
+            </div>
+          ) : null}
+          {permissionsApproval && input.permissions?.fileSystem?.write?.length ? (
+            <div className="mt-2 text-xs text-muted-foreground">
+              Write access: {input.permissions.fileSystem.write.join(", ")}
             </div>
           ) : null}
           {commandApproval && input.command ? (

--- a/src/client/components/messages/CodexApprovalMessage.tsx
+++ b/src/client/components/messages/CodexApprovalMessage.tsx
@@ -11,7 +11,6 @@ type ApprovalMessage = Extract<
 interface Props {
   message: ApprovalMessage
   onSubmit: (toolUseId: string, decision: "accept" | "acceptForSession" | "decline") => void
-  isLatest: boolean
 }
 
 function resultDecision(result: unknown): string | null {
@@ -20,7 +19,7 @@ function resultDecision(result: unknown): string | null {
   return typeof decision === "string" ? decision : null
 }
 
-export function CodexApprovalMessage({ message, onSubmit, isLatest }: Props) {
+export function CodexApprovalMessage({ message, onSubmit }: Props) {
   const commandApproval = message.toolKind === "codex_command_approval"
   const decision = resultDecision(message.result)
   const complete = decision !== null
@@ -51,7 +50,7 @@ export function CodexApprovalMessage({ message, onSubmit, isLatest }: Props) {
               {decision === "decline" || decision === "cancel" ? <X className="size-3" /> : <Check className="size-3" />}
               {decision === "acceptForSession" ? "Allowed for this session" : decision === "accept" ? "Allowed" : decision === "cancel" ? "Cancelled" : "Declined"}
             </div>
-          ) : isLatest ? (
+          ) : !complete ? (
             <div className="mt-3 flex flex-wrap gap-2">
               <Button size="sm" onClick={() => onSubmit(message.toolId, "accept")}>Allow once</Button>
               <Button size="sm" variant="secondary" onClick={() => onSubmit(message.toolId, "acceptForSession")}>Allow for session</Button>

--- a/src/client/lib/composer.test.ts
+++ b/src/client/lib/composer.test.ts
@@ -218,7 +218,17 @@ describe("deriveComposerOptionControls", () => {
         autoPlan: false,
       } as ComposerState,
       codexConfig
-    ).mode).toEqual({ selected: "full-access", options: ["full-access", "plan"] })
+    ).mode).toEqual({ selected: "full-access", options: ["full-access", "approval", "plan"] })
+    expect(deriveComposerOptionControls(
+      {
+        provider: "codex",
+        model: providerDefaults.codex.model,
+        modelOptions: { ...providerDefaults.codex.modelOptions, accessMode: "approval" },
+        planMode: false,
+        autoPlan: false,
+      } as ComposerState,
+      codexConfig
+    ).mode?.selected).toBe("approval")
     // Providers without modes get no selector at all.
     expect(deriveComposerOptionControls(
       { provider: "cursor", model: "composer-2.5", modelOptions: {}, planMode: false, autoPlan: false } as ComposerState,

--- a/src/client/lib/composer.ts
+++ b/src/client/lib/composer.ts
@@ -206,6 +206,7 @@ export interface ComposerOptionControls {
 /** Labels/descriptions for each mode, shared by the picker and command palette. */
 export const CHAT_MODE_LABELS: Record<ChatMode, { label: string; description: string }> = {
   "full-access": { label: "Full Access", description: "Execution without approval" },
+  "approval": { label: "Approval Mode", description: "Workspace access with approval when needed" },
   "plan": { label: "Plan Mode", description: "Review a plan before execution" },
   "auto-plan": { label: "Auto Plan", description: "The agent decides when to plan first" },
 }
@@ -257,13 +258,19 @@ export function deriveComposerOptionControls(
     ? { enabled: Boolean(modelOptions.fastMode) }
     : null
 
-  const modeOptions: ChatMode[] = providerConfig?.supportsAutoPlanMode
+  const modeOptions: ChatMode[] = state.provider === "codex"
+    ? ["full-access", "approval", "plan"]
+    : providerConfig?.supportsAutoPlanMode
     ? ["full-access", "plan", "auto-plan"]
     : ["full-access", "plan"]
   // A composer state seeded from another harness can carry autoPlan into a
   // provider that has no Auto Plan (see getEffectiveComposerState), so clamp
   // the selection to what this provider actually offers.
-  const selectedMode = chatModeFromFlags(state.planMode, state.autoPlan)
+  const selectedMode = chatModeFromFlags(
+    state.planMode,
+    state.autoPlan,
+    state.provider === "codex" ? state.modelOptions.accessMode : undefined,
+  )
   const mode = providerConfig?.supportsPlanMode
     ? {
       selected: modeOptions.includes(selectedMode) ? selectedMode : "full-access" as ChatMode,

--- a/src/client/lib/parseTranscript.test.ts
+++ b/src/client/lib/parseTranscript.test.ts
@@ -309,6 +309,7 @@ describe("getLatestToolIds", () => {
 
     expect(getLatestToolIds(messages)).toEqual({
       AskUserQuestion: messages[0]?.kind === "tool" ? messages[0].id : null,
+      CodexApproval: null,
       ExitPlanMode: null,
       TodoWrite: messages[1]?.kind === "tool" ? messages[1].id : null,
     })
@@ -354,6 +355,7 @@ describe("getLatestToolIds", () => {
 
     expect(getLatestToolIds(messages)).toEqual({
       AskUserQuestion: null,
+      CodexApproval: null,
       ExitPlanMode: null,
       TodoWrite: null,
     })

--- a/src/client/stores/chatPreferencesStore.ts
+++ b/src/client/stores/chatPreferencesStore.ts
@@ -96,6 +96,15 @@ function cloneComposerState(state: ComposerState): ComposerState {
   return { ...state, modelOptions: { ...state.modelOptions } } as ComposerState
 }
 
+function codexModelOptionsForMode(
+  modelOptions: CodexModelOptions,
+  mode: ChatMode,
+): CodexModelOptions {
+  if (mode === "approval") return { ...modelOptions, accessMode: "approval" }
+  const { accessMode: _accessMode, ...rest } = modelOptions
+  return rest
+}
+
 function sameComposerState(left: ComposerState | undefined, right: ComposerState): boolean {
   if (!left || left.provider !== right.provider) return false
   if (left.model !== right.model || left.planMode !== right.planMode) return false
@@ -325,6 +334,9 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
             [provider]: {
               ...state.providerDefaults[provider],
               ...chatModeToFlags(mode, state.providerDefaults[provider].autoPlan),
+              ...(provider === "codex" ? {
+                modelOptions: codexModelOptionsForMode(state.providerDefaults[provider].modelOptions, mode),
+              } : {}),
             },
           },
         })),
@@ -379,7 +391,10 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
         set((state) => withChatComposerState(state, chatId, (composerState) => ({
           ...composerState,
           ...chatModeToFlags(mode, composerState.autoPlan),
-        }))),
+          ...(composerState.provider === "codex" ? {
+            modelOptions: codexModelOptionsForMode(composerState.modelOptions, mode),
+          } : {}),
+        } as ComposerState))),
       clearChatComposerPlanMode: (chatId) =>
         set((state) => withChatComposerState(state, chatId, (composerState) => ({
           ...composerState,

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -824,6 +824,94 @@ describe("AgentCoordinator codex integration", () => {
     expect(store.chat.sessionToken).toBe("thread-2")
   })
 
+  test("keeps concurrent Codex approval requests independently respondable", async () => {
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: {
+        onApprovalRequest: (request: any) => Promise<unknown>
+      }): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+
+          const first = args.onApprovalRequest({
+            requestId: "approval-1",
+            kind: "command_execution",
+            params: { command: "touch first.txt", cwd: "/tmp/project" },
+          })
+          const second = args.onApprovalRequest({
+            requestId: "approval-2",
+            kind: "command_execution",
+            params: { command: "touch second.txt", cwd: "/tmp/project" },
+          })
+          await Promise.all([first, second])
+
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "make both changes",
+    })
+
+    await waitFor(() => coordinator.getPendingTool("chat-1") != null)
+
+    await coordinator.respondTool({
+      type: "chat.respondTool",
+      chatId: "chat-1",
+      toolUseId: "approval-1",
+      result: { decision: "accept" },
+    })
+    await coordinator.respondTool({
+      type: "chat.respondTool",
+      chatId: "chat-1",
+      toolUseId: "approval-2",
+      result: { decision: "acceptForSession" },
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+
+    expect(store.messages.filter((entry) => entry.kind === "tool_result").map((entry) => entry.toolId))
+      .toEqual(["approval-1", "approval-2"])
+  })
+
   test("cancelling a waiting ask-user-question records a discarded tool result", async () => {
     let releaseInterrupt!: () => void
     const interrupted = new Promise<void>((resolve) => {

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -912,6 +912,179 @@ describe("AgentCoordinator codex integration", () => {
       .toEqual(["approval-1", "approval-2"])
   })
 
+  test("keeps a later Codex approval respondable after the first one settles", async () => {
+    let firstDecision: unknown
+    let secondDecision: unknown
+    let resolveSecondRequest!: () => void
+    const secondRequestReady = new Promise<void>((resolve) => {
+      resolveSecondRequest = resolve
+    })
+
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: {
+        onApprovalRequest: (request: any) => Promise<unknown>
+      }): Promise<HarnessTurn> {
+        async function* stream() {
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+
+          firstDecision = await args.onApprovalRequest({
+            requestId: "approval-1",
+            kind: "command_execution",
+            params: { command: "touch first.txt", cwd: "/tmp/project" },
+          })
+          resolveSecondRequest()
+          secondDecision = await args.onApprovalRequest({
+            requestId: "approval-2",
+            kind: "command_execution",
+            params: { command: "touch second.txt", cwd: "/tmp/project" },
+          })
+
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "make both changes",
+    })
+
+    await waitFor(() => coordinator.getPendingTool("chat-1")?.toolUseId === "approval-1")
+    await coordinator.respondTool({
+      type: "chat.respondTool",
+      chatId: "chat-1",
+      toolUseId: "approval-1",
+      result: { decision: "accept" },
+    })
+
+    await secondRequestReady
+    await waitFor(() => coordinator.getPendingTool("chat-1")?.toolUseId === "approval-2")
+    await coordinator.respondTool({
+      type: "chat.respondTool",
+      chatId: "chat-1",
+      toolUseId: "approval-2",
+      result: { decision: "acceptForSession" },
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+    expect(firstDecision).toBe("accept")
+    expect(secondDecision).toBe("acceptForSession")
+  })
+
+  test("declines an approval that arrives after Codex turn cleanup", async () => {
+    let pendingDecision: unknown
+    let lateDecision: unknown
+    const fakeCodexManager = {
+      async startSession() {},
+      async startTurn(args: {
+        onApprovalRequest: (request: any) => Promise<unknown>
+      }): Promise<HarnessTurn> {
+        async function* stream() {
+          const pendingApproval = args.onApprovalRequest({
+            requestId: "approval-pending",
+            kind: "command_execution",
+            params: { command: "touch pending.txt", cwd: "/tmp/project" },
+          })
+
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "system_init",
+              provider: "codex",
+              model: "gpt-5.4",
+              tools: [],
+              agents: [],
+              slashCommands: [],
+              mcpServers: [],
+            }),
+          }
+          yield {
+            type: "transcript" as const,
+            entry: timestamped({
+              kind: "result",
+              subtype: "success",
+              isError: false,
+              durationMs: 0,
+              result: "",
+            }),
+          }
+
+          pendingDecision = await pendingApproval
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          lateDecision = await args.onApprovalRequest({
+            requestId: "approval-late",
+            kind: "command_execution",
+            params: { command: "touch late.txt", cwd: "/tmp/project" },
+          })
+        }
+
+        return {
+          provider: "codex",
+          stream: stream(),
+          interrupt: async () => {},
+          close: () => {},
+        }
+      },
+    }
+
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: fakeCodexManager as never,
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "finish, then request another approval",
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+    await waitFor(() => pendingDecision !== undefined)
+    await waitFor(() => lateDecision !== undefined)
+    expect(pendingDecision).toBe("cancel")
+    expect(lateDecision).toBe("cancel")
+  })
+
   test("cancelling a waiting ask-user-question records a discarded tool result", async () => {
     let releaseInterrupt!: () => void
     const interrupted = new Promise<void>((resolve) => {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -125,7 +125,7 @@ interface ActiveTurn {
   planMode: boolean
   autoPlan: boolean
   status: KannaStatus
-  pendingTool: PendingToolRequest | null
+  pendingTools: Map<string, PendingToolRequest>
   postToolFollowUp: { content: string; planMode: boolean } | null
   hasFinalResult: boolean
   cancelRequested: boolean
@@ -926,7 +926,7 @@ export class AgentCoordinator {
   }
 
   getPendingTool(chatId: string): PendingToolSnapshot | null {
-    const pending = this.activeTurns.get(chatId)?.pendingTool
+    const pending = this.activeTurns.get(chatId)?.pendingTools.values().next().value
     if (!pending) return null
     return { toolUseId: pending.toolUseId, toolKind: pending.tool.toolKind }
   }
@@ -1344,11 +1344,12 @@ export class AgentCoordinator {
       this.emitStateChange(args.chatId)
 
       return await new Promise<unknown>((resolve) => {
-        active.pendingTool = {
+        const pending = {
           toolUseId: request.tool.toolId,
           tool: request.tool,
           resolve,
         }
+        active.pendingTools.set(pending.toolUseId, pending)
       })
     }
 
@@ -1516,7 +1517,7 @@ export class AgentCoordinator {
       planMode: args.planMode,
       autoPlan: args.autoPlan,
       status: args.provider === "claude" ? "running" : "starting",
-      pendingTool: null,
+      pendingTools: new Map(),
       postToolFollowUp: null,
       hasFinalResult: false,
       cancelRequested: false,
@@ -1912,7 +1913,7 @@ export class AgentCoordinator {
       planMode: session.planMode,
       autoPlan: session.autoPlan,
       status: "running",
-      pendingTool: null,
+      pendingTools: new Map(),
       postToolFollowUp: null,
       hasFinalResult: false,
       cancelRequested: false,
@@ -2246,10 +2247,10 @@ export class AgentCoordinator {
       }
     }
 
-    const pendingTool = active.pendingTool
-    active.pendingTool = null
+    const pendingTools = [...active.pendingTools.values()]
+    active.pendingTools.clear()
 
-    if (pendingTool) {
+    for (const pendingTool of pendingTools) {
       const result = discardedToolResult(pendingTool.tool)
       await this.store.appendMessage(
         chatId,
@@ -2295,14 +2296,18 @@ export class AgentCoordinator {
 
   async respondTool(command: Extract<ClientCommand, { type: "chat.respondTool" }>) {
     const active = this.activeTurns.get(command.chatId)
-    if (!active || !active.pendingTool) {
+    if (!active) {
       throw new Error("No pending tool request")
     }
 
-    const pending = active.pendingTool
-    if (pending.toolUseId !== command.toolUseId) {
+    const pending = active.pendingTools.get(command.toolUseId)
+    if (!pending) {
       throw new Error("Tool response does not match active request")
     }
+
+    // Claim this request before awaiting persistence so duplicate responses
+    // cannot both resolve the same harness request.
+    active.pendingTools.delete(command.toolUseId)
 
     await this.store.appendMessage(
       command.chatId,
@@ -2313,8 +2318,7 @@ export class AgentCoordinator {
       })
     )
 
-    active.pendingTool = null
-    active.status = "running"
+    active.status = active.pendingTools.size > 0 ? "waiting_for_user" : "running"
 
     if (pending.tool.toolKind === "exit_plan_mode") {
       const result = (command.result ?? {}) as {

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -115,6 +115,7 @@ interface PendingToolRequest {
       | "codex_command_approval"
       | "codex_file_change_approval"
       | "codex_mcp_approval"
+      | "codex_permissions_approval"
   }
   resolve: (result: unknown) => void
 }
@@ -340,6 +341,7 @@ function discardedToolResult(
       | "codex_command_approval"
       | "codex_file_change_approval"
       | "codex_mcp_approval"
+      | "codex_permissions_approval"
   }
 ) {
   if (tool.toolKind === "ask_user_question") {
@@ -355,6 +357,10 @@ function discardedToolResult(
 
   if (tool.toolKind === "codex_mcp_approval") {
     return { action: "cancel", content: null }
+  }
+
+  if (tool.toolKind === "codex_permissions_approval") {
+    return { scope: "turn", permissions: {} }
   }
 
   return {
@@ -1486,6 +1492,31 @@ export class AgentCoordinator {
         accessMode: args.accessMode,
         onToolRequest,
         onApprovalRequest: async (request) => {
+          if (request.kind === "permissions") {
+            const tool = {
+              kind: "tool" as const,
+              toolKind: "codex_permissions_approval" as const,
+              toolName: "CodexPermissionsApproval",
+              toolId: String(request.requestId),
+              input: {
+                reason: request.params.reason ?? undefined,
+                cwd: request.params.cwd ?? undefined,
+                environmentId: request.params.environmentId ?? undefined,
+                permissions: request.params.permissions,
+              },
+              rawInput: request.params as unknown as Record<string, unknown>,
+            }
+            const result = await onToolRequest({ tool })
+            const decision = result && typeof result === "object"
+              ? (result as { decision?: unknown }).decision
+              : result
+            const accepted = decision === "accept" || decision === "acceptForSession"
+            return {
+              scope: decision === "acceptForSession" ? "session" : "turn",
+              permissions: accepted ? request.params.permissions : {},
+            }
+          }
+
           if (request.kind === "mcp_elicitation") {
             const elicitation = request.params.request
             const persist: "session" | "always" | Array<"session" | "always"> | undefined = elicitation.meta?.persist === "session" || elicitation.meta?.persist === "always"

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -109,7 +109,12 @@ export function claudeToolset(autoPlan: boolean): string[] {
 interface PendingToolRequest {
   toolUseId: string
   tool: NormalizedToolCall & {
-    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+    toolKind:
+      | "ask_user_question"
+      | "exit_plan_mode"
+      | "codex_command_approval"
+      | "codex_file_change_approval"
+      | "codex_mcp_approval"
   }
   resolve: (result: unknown) => void
 }
@@ -329,7 +334,12 @@ export function buildPromptText(content: string, attachments: ChatAttachment[]) 
 
 function discardedToolResult(
   tool: NormalizedToolCall & {
-    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+    toolKind:
+      | "ask_user_question"
+      | "exit_plan_mode"
+      | "codex_command_approval"
+      | "codex_file_change_approval"
+      | "codex_mcp_approval"
   }
 ) {
   if (tool.toolKind === "ask_user_question") {
@@ -341,6 +351,10 @@ function discardedToolResult(
 
   if (tool.toolKind === "codex_command_approval" || tool.toolKind === "codex_file_change_approval") {
     return { decision: "cancel" }
+  }
+
+  if (tool.toolKind === "codex_mcp_approval") {
+    return { action: "cancel", content: null }
   }
 
   return {
@@ -1472,6 +1486,42 @@ export class AgentCoordinator {
         accessMode: args.accessMode,
         onToolRequest,
         onApprovalRequest: async (request) => {
+          if (request.kind === "mcp_elicitation") {
+            const elicitation = request.params.request
+            const persist: "session" | "always" | Array<"session" | "always"> | undefined = elicitation.meta?.persist === "session" || elicitation.meta?.persist === "always"
+              ? elicitation.meta.persist as "session" | "always"
+              : Array.isArray(elicitation.meta?.persist)
+                ? elicitation.meta.persist.filter((value): value is "session" | "always" => value === "session" || value === "always")
+                : undefined
+            const tool = {
+              kind: "tool" as const,
+              toolKind: "codex_mcp_approval" as const,
+              toolName: "CodexAppApproval",
+              toolId: String(request.requestId),
+              input: {
+                serverName: request.params.serverName,
+                message: elicitation.message,
+                mode: elicitation.mode,
+                ...(elicitation.mode === "url" ? { url: elicitation.url } : { requestedSchema: elicitation.requestedSchema }),
+                ...(persist === "session" || persist === "always" || Array.isArray(persist) ? { persist } : {}),
+              },
+              rawInput: request.params as unknown as Record<string, unknown>,
+            }
+            const result = await onToolRequest({ tool })
+            const record = result && typeof result === "object" ? result as Record<string, unknown> : {}
+            const action = record.action
+              ?? (record.decision === "accept" || record.decision === "acceptForSession" ? "accept" : record.decision)
+            return {
+              action: action === "accept" || action === "decline" || action === "cancel" ? action : "decline",
+              content: record.content && typeof record.content === "object" && !Array.isArray(record.content)
+                ? record.content as Record<string, unknown>
+                : null,
+              meta: record.meta && typeof record.meta === "object" && !Array.isArray(record.meta)
+                ? record.meta as Record<string, unknown>
+                : null,
+            }
+          }
+
           const tool = request.kind === "command_execution"
             ? {
                 kind: "tool" as const,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -4,6 +4,7 @@ import type {
   AgentProvider,
   ChatAttachment,
   ChatSkillsSnapshot,
+  CodexAccessMode,
   CodexReasoningEffort,
   ContextWindowUsageSnapshot,
   HarnessSkill,
@@ -107,7 +108,9 @@ export function claudeToolset(autoPlan: boolean): string[] {
 
 interface PendingToolRequest {
   toolUseId: string
-  tool: NormalizedToolCall & { toolKind: "ask_user_question" | "exit_plan_mode" }
+  tool: NormalizedToolCall & {
+    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+  }
   resolve: (result: unknown) => void
 }
 
@@ -325,13 +328,19 @@ export function buildPromptText(content: string, attachments: ChatAttachment[]) 
 }
 
 function discardedToolResult(
-  tool: NormalizedToolCall & { toolKind: "ask_user_question" | "exit_plan_mode" }
+  tool: NormalizedToolCall & {
+    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+  }
 ) {
   if (tool.toolKind === "ask_user_question") {
     return {
       discarded: true,
       answers: {},
     }
+  }
+
+  if (tool.toolKind === "codex_command_approval" || tool.toolKind === "codex_file_change_approval") {
+    return { decision: "cancel" }
   }
 
   return {
@@ -1038,6 +1047,7 @@ export class AgentCoordinator {
       serviceTier: serviceTierFromModelOptions(modelOptions),
       planMode: catalog.supportsPlanMode ? Boolean(options.planMode) : false,
       autoPlan: catalog.supportsAutoPlanMode ? Boolean(options.autoPlan) : false,
+      accessMode: modelOptions.accessMode,
     }
   }
 
@@ -1068,6 +1078,7 @@ export class AgentCoordinator {
       model: settings.model,
       effort: settings.effort,
       serviceTier: settings.serviceTier,
+      accessMode: settings.accessMode,
       planMode: settings.planMode,
       autoPlan: settings.autoPlan,
       appendUserPrompt: true,
@@ -1167,6 +1178,7 @@ export class AgentCoordinator {
     cwd: string
     model: string
     serviceTier?: "fast"
+    accessMode?: CodexAccessMode
     sessionToken: string | null | undefined
     pendingForkSessionToken: string | null | undefined
   }): Promise<boolean> {
@@ -1189,6 +1201,7 @@ export class AgentCoordinator {
             serviceTier: args.serviceTier,
             sessionToken: args.sessionToken,
             pendingForkSessionToken: null,
+            accessMode: args.accessMode,
           })
           return started?.resumeFellBack === true
         } catch {
@@ -1239,6 +1252,7 @@ export class AgentCoordinator {
     model: string
     effort?: string
     serviceTier?: "fast"
+    accessMode?: CodexAccessMode
     planMode: boolean
     autoPlan: boolean
     appendUserPrompt: boolean
@@ -1302,6 +1316,7 @@ export class AgentCoordinator {
         serviceTier: args.serviceTier,
         sessionToken: chat.sessionToken,
         pendingForkSessionToken: chat.pendingForkSessionToken,
+        accessMode: args.accessMode,
       })
       ? await this.prepareSessionRestore(args.chatId, args.provider, existingMessages)
       : null
@@ -1435,6 +1450,7 @@ export class AgentCoordinator {
         serviceTier: args.serviceTier,
         sessionToken: chat.sessionToken,
         pendingForkSessionToken: chat.pendingForkSessionToken,
+        accessMode: args.accessMode,
       })
       if (chat.pendingForkSessionToken && started?.sessionToken) {
         await this.store.setPendingForkSessionToken(args.chatId, null)
@@ -1449,7 +1465,44 @@ export class AgentCoordinator {
         effort: args.effort as CodexReasoningEffort | undefined,
         serviceTier: args.serviceTier,
         planMode: args.planMode,
+        accessMode: args.accessMode,
         onToolRequest,
+        onApprovalRequest: async (request) => {
+          const tool = request.kind === "command_execution"
+            ? {
+                kind: "tool" as const,
+                toolKind: "codex_command_approval" as const,
+                toolName: "CodexApproval",
+                toolId: String(request.requestId),
+                input: {
+                  command: request.params.command ?? undefined,
+                  cwd: request.params.cwd ?? undefined,
+                  reason: request.params.reason ?? undefined,
+                },
+                rawInput: request.params as unknown as Record<string, unknown>,
+              }
+            : {
+                kind: "tool" as const,
+                toolKind: "codex_file_change_approval" as const,
+                toolName: "CodexApproval",
+                toolId: String(request.requestId),
+                input: {
+                  reason: request.params.reason ?? undefined,
+                  grantRoot: request.params.grantRoot ?? undefined,
+                },
+                rawInput: request.params as unknown as Record<string, unknown>,
+              }
+          const result = await onToolRequest({ tool })
+          const decision = result && typeof result === "object"
+            ? (result as { decision?: unknown }).decision
+            : result
+          return decision === "accept"
+            || decision === "acceptForSession"
+            || decision === "decline"
+            || decision === "cancel"
+            ? decision
+            : "decline"
+        },
       })
     }
 
@@ -1659,6 +1712,7 @@ export class AgentCoordinator {
       model: settings.model,
       effort: settings.effort,
       serviceTier: settings.serviceTier,
+      accessMode: settings.accessMode,
       planMode: settings.planMode,
       autoPlan: settings.autoPlan,
       appendUserPrompt: true,
@@ -2205,7 +2259,7 @@ export class AgentCoordinator {
           content: result,
         })
       )
-      if (active.provider === "codex" && pendingTool.tool.toolKind === "exit_plan_mode") {
+      if (active.provider === "codex") {
         pendingTool.resolve(result)
       }
     }

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1337,7 +1337,10 @@ export class AgentCoordinator {
     const onToolRequest = async (request: HarnessToolRequest): Promise<unknown> => {
       const active = this.activeTurns.get(args.chatId)
       if (!active) {
-        throw new Error("Chat turn ended unexpectedly")
+        // A provider can emit a request just as its result is being drained.
+        // There is no UI turn left to wait on in that case, so resolve it as a
+        // discarded request instead of leaving the provider's RPC hanging.
+        return discardedToolResult(request.tool)
       }
 
       active.status = "waiting_for_user"
@@ -2114,6 +2117,7 @@ export class AgentCoordinator {
 
         if (event.entry.kind === "result") {
           active.hasFinalResult = true
+          await this.discardPendingTools(active)
           if (event.entry.isError) {
             await this.store.recordTurnFailed(active.chatId, event.entry.result || "Turn failed")
           } else if (!active.cancelRequested) {
@@ -2210,6 +2214,24 @@ export class AgentCoordinator {
           this.emitStateChange(active.chatId)
         }
       }
+    }
+  }
+
+  private async discardPendingTools(active: ActiveTurn) {
+    const pendingTools = [...active.pendingTools.values()]
+    active.pendingTools.clear()
+
+    for (const pendingTool of pendingTools) {
+      const result = discardedToolResult(pendingTool.tool)
+      await this.store.appendMessage(
+        active.chatId,
+        timestamped({
+          kind: "tool_result",
+          toolId: pendingTool.toolUseId,
+          content: result,
+        })
+      )
+      pendingTool.resolve(result)
     }
   }
 

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -251,7 +251,7 @@ describe("AppSettingsManager", () => {
       editor: { preset: "vscode" },
       providerDefaults: {
         codex: {
-          modelOptions: { reasoningEffort: "high", fastMode: true },
+          modelOptions: { reasoningEffort: "high", fastMode: true, accessMode: "approval" },
         },
       },
     })
@@ -261,7 +261,7 @@ describe("AppSettingsManager", () => {
       chatSoundId: string
       terminal: { scrollbackLines: number; minColumnWidth: number }
       editor: { preset: string; commandTemplate: string }
-      providerDefaults: { codex: { modelOptions: { fastMode: boolean } } }
+      providerDefaults: { codex: { modelOptions: { fastMode: boolean; accessMode?: string } } }
     }
 
     expect(snapshot.theme).toBe("dark")
@@ -271,6 +271,7 @@ describe("AppSettingsManager", () => {
     expect(snapshot.editor.preset).toBe("vscode")
     expect(snapshot.editor.commandTemplate).toBe("cursor {path}")
     expect(snapshot.providerDefaults.codex.modelOptions.fastMode).toBe(true)
+    expect(snapshot.providerDefaults.codex.modelOptions.accessMode).toBe("approval")
     expect(nextPayload.analyticsUserId).toBe(initialPayload.analyticsUserId)
     expect(nextPayload.theme).toBe("dark")
     expect(nextPayload.chatSoundId).toBe("glass")

--- a/src/server/codex-app-server-protocol.ts
+++ b/src/server/codex-app-server-protocol.ts
@@ -22,6 +22,7 @@ export interface InitializeParams {
   }
   capabilities: {
     experimentalApi: boolean
+    extensions?: Record<string, unknown>
   }
 }
 
@@ -285,6 +286,40 @@ export interface FileChangeRequestApprovalResponse {
   decision: FileChangeApprovalDecision
 }
 
+export interface McpServerElicitationFormRequest {
+  mode: "form" | "openai/form"
+  message: string
+  requestedSchema: Record<string, unknown>
+  meta?: Record<string, unknown> | null
+}
+
+export interface McpServerElicitationUrlRequest {
+  mode: "url"
+  message: string
+  url: string
+  elicitationId: string
+  meta?: Record<string, unknown> | null
+}
+
+export type McpServerElicitationRequest =
+  | McpServerElicitationFormRequest
+  | McpServerElicitationUrlRequest
+
+export interface McpServerElicitationRequestParams {
+  threadId: string
+  turnId: string | null
+  serverName: string
+  request: McpServerElicitationRequest
+}
+
+export type McpServerElicitationAction = "accept" | "decline" | "cancel"
+
+export interface McpServerElicitationRequestResponse {
+  action: McpServerElicitationAction
+  content?: Record<string, unknown> | null
+  meta?: Record<string, unknown> | null
+}
+
 export interface ToolRequestUserInputRequest {
   id: CodexRequestId
   method: "item/tool/requestUserInput"
@@ -328,11 +363,18 @@ export interface FileChangeRequestApprovalRequest {
   params: FileChangeRequestApprovalParams
 }
 
+export interface McpServerElicitationRequestRequest {
+  id: CodexRequestId
+  method: "mcpServer/elicitation/request"
+  params: McpServerElicitationRequestParams
+}
+
 export type ServerRequest =
   | ToolRequestUserInputRequest
   | DynamicToolCallRequest
   | CommandExecutionRequestApprovalRequest
   | FileChangeRequestApprovalRequest
+  | McpServerElicitationRequestRequest
 
 export interface UserMessageItem {
   type: "userMessage"
@@ -536,6 +578,7 @@ export function isServerRequest(value: unknown): value is ServerRequest {
     || candidate.method === "item/tool/call"
     || candidate.method === "item/commandExecution/requestApproval"
     || candidate.method === "item/fileChange/requestApproval"
+    || candidate.method === "mcpServer/elicitation/request"
 }
 
 export function isServerNotification(value: unknown): value is ServerNotification {

--- a/src/server/codex-app-server-protocol.ts
+++ b/src/server/codex-app-server-protocol.ts
@@ -286,6 +286,31 @@ export interface FileChangeRequestApprovalResponse {
   decision: FileChangeApprovalDecision
 }
 
+export interface PermissionProfile {
+  network?: {
+    enabled?: boolean
+  } | null
+  fileSystem?: {
+    read?: string[]
+    write?: string[]
+  } | null
+}
+
+export interface PermissionsRequestApprovalParams {
+  threadId: string
+  turnId: string
+  itemId: string
+  environmentId?: string | null
+  cwd?: string | null
+  reason?: string | null
+  permissions: PermissionProfile
+}
+
+export interface PermissionsRequestApprovalResponse {
+  scope?: "turn" | "session"
+  permissions: PermissionProfile
+}
+
 export interface McpServerElicitationFormRequest {
   mode: "form" | "openai/form"
   message: string
@@ -369,11 +394,18 @@ export interface McpServerElicitationRequestRequest {
   params: McpServerElicitationRequestParams
 }
 
+export interface PermissionsRequestApprovalRequest {
+  id: CodexRequestId
+  method: "item/permissions/requestApproval"
+  params: PermissionsRequestApprovalParams
+}
+
 export type ServerRequest =
   | ToolRequestUserInputRequest
   | DynamicToolCallRequest
   | CommandExecutionRequestApprovalRequest
   | FileChangeRequestApprovalRequest
+  | PermissionsRequestApprovalRequest
   | McpServerElicitationRequestRequest
 
 export interface UserMessageItem {
@@ -578,6 +610,7 @@ export function isServerRequest(value: unknown): value is ServerRequest {
     || candidate.method === "item/tool/call"
     || candidate.method === "item/commandExecution/requestApproval"
     || candidate.method === "item/fileChange/requestApproval"
+    || candidate.method === "item/permissions/requestApproval"
     || candidate.method === "mcpServer/elicitation/request"
 }
 

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -1831,6 +1831,77 @@ describe("CodexAppServerManager", () => {
     })
   })
 
+  test("returns granted permissions for permission approval requests", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "permissions-1",
+          method: "item/permissions/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "permissions-call-1",
+            environmentId: "local",
+            cwd: "/tmp/project",
+            reason: "GitHub needs network access to create the pull request.",
+            permissions: {
+              network: { enabled: true },
+              fileSystem: { write: ["/tmp/project"] },
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({ spawnProcess: () => process as never })
+    await manager.startSession({ chatId: "chat-1", cwd: "/tmp/project", model: "gpt-5.4", sessionToken: null })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "create a pull request",
+      planMode: false,
+      onToolRequest: async () => ({}),
+      onApprovalRequest: async (request) => {
+        expect(request.kind).toBe("permissions")
+        if (request.kind !== "permissions") throw new Error("unexpected approval request")
+        return { scope: "session", permissions: request.params.permissions }
+      },
+    })
+
+    const events = await collectStream(turn.stream)
+    const approvalEntry = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    expect(approvalEntry?.entry.tool.toolKind).toBe("codex_permissions_approval")
+    expect(process.messages.find((message: any) => message.id === "permissions-1")).toEqual({
+      id: "permissions-1",
+      result: {
+        scope: "session",
+        permissions: {
+          network: { enabled: true },
+          fileSystem: { write: ["/tmp/project"] },
+        },
+      },
+    })
+  })
+
   test("sends approval decisions back to the app-server", async () => {
     const process = new FakeCodexProcess((message, child) => {
       if (message.method === "initialize") {

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -1749,6 +1749,88 @@ describe("CodexAppServerManager", () => {
     })
   })
 
+  test("surfaces MCP app authorization elicitations and returns the approval action", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-1", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "elicitation-1",
+          method: "mcpServer/elicitation/request",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            serverName: "github",
+            request: {
+              mode: "url",
+              message: "GitHub needs authorization to create pull requests.",
+              url: "https://github.com/apps/example/installations/new",
+              elicitationId: "auth-1",
+              meta: {
+                codex_approval_kind: "mcp_tool_call",
+                persist: "session",
+              },
+            },
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+    })
+
+    await manager.startSession({
+      chatId: "chat-1",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-1",
+      model: "gpt-5.4",
+      content: "create a pull request",
+      planMode: false,
+      onToolRequest: async () => ({}),
+      onApprovalRequest: async (request) => {
+        expect(request.kind).toBe("mcp_elicitation")
+        if (request.kind !== "mcp_elicitation") throw new Error("unexpected approval request")
+        expect(request.params.serverName).toBe("github")
+        return { action: "accept", content: null }
+      },
+    })
+
+    const events = await collectStream(turn.stream)
+    const approvalEntry = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    expect(approvalEntry?.entry.tool.toolKind).toBe("codex_mcp_approval")
+
+    const response = process.messages.find((message: any) => message.id === "elicitation-1")
+    expect(response).toEqual({
+      id: "elicitation-1",
+      result: {
+        action: "accept",
+        content: null,
+      },
+    })
+  })
+
   test("sends approval decisions back to the app-server", async () => {
     const process = new FakeCodexProcess((message, child) => {
       if (message.method === "initialize") {

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -2001,4 +2001,77 @@ describe("CodexAppServerManager", () => {
     expect(resultEvent?.entry.subtype).toBe("error")
     expect(resultEvent?.entry.result).toContain("fatal: app-server crashed")
   })
+
+  test("maps approval mode and bridges command approvals", async () => {
+    const process = new FakeCodexProcess((message, child) => {
+      if (message.method === "initialize") {
+        child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+      } else if (message.method === "thread/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { thread: { id: "thread-approval" }, model: "gpt-5.4", reasoningEffort: "high" },
+        })
+      } else if (message.method === "turn/start") {
+        child.writeServerMessage({
+          id: message.id,
+          result: { turn: { id: "turn-approval", status: "inProgress", error: null } },
+        })
+        child.writeServerMessage({
+          id: "approval-1",
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-approval",
+            turnId: "turn-approval",
+            itemId: "command-1",
+            command: "touch approved.txt",
+            cwd: "/tmp/project",
+            reason: "The command writes a file",
+          },
+        })
+        child.writeServerMessage({
+          method: "turn/completed",
+          params: {
+            threadId: "thread-approval",
+            turn: { id: "turn-approval", status: "completed", error: null },
+          },
+        })
+      }
+    })
+
+    const manager = new CodexAppServerManager({ spawnProcess: () => process as never })
+    await manager.startSession({
+      chatId: "chat-approval",
+      cwd: "/tmp/project",
+      model: "gpt-5.4",
+      sessionToken: null,
+      accessMode: "approval",
+    })
+
+    const turn = await manager.startTurn({
+      chatId: "chat-approval",
+      model: "gpt-5.4",
+      content: "create a file",
+      planMode: false,
+      accessMode: "approval",
+      onToolRequest: async () => ({}),
+      onApprovalRequest: async (request) => {
+        expect(request.kind).toBe("command_execution")
+        expect((request.params as { command?: string }).command).toBe("touch approved.txt")
+        return "accept"
+      },
+    })
+
+    const events = await collectStream(turn.stream)
+
+    const threadStart = process.messages.find((message: any) => message.method === "thread/start") as any
+    const turnStart = process.messages.find((message: any) => message.method === "turn/start") as any
+    const approvalResponse = process.messages.find((message: any) => message.id === "approval-1")
+    const approvalToolCall = events.find((event) => event.type === "transcript" && event.entry.kind === "tool_call")
+    expect(threadStart.params).toMatchObject({ approvalPolicy: "on-request", sandbox: "workspace-write" })
+    expect(turnStart.params.approvalPolicy).toBe("on-request")
+    expect(approvalResponse).toEqual({ id: "approval-1", result: { decision: "accept" } })
+    expect(approvalToolCall?.entry.kind).toBe("tool_call")
+    if (!approvalToolCall || approvalToolCall.entry.kind !== "tool_call") throw new Error("missing approval tool call")
+    expect(approvalToolCall.entry.tool.toolKind).toBe("codex_command_approval")
+  })
 })

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -1069,7 +1069,32 @@ export class CodexAppServerManager {
         }
 
         if (isServerRequest(parsed)) {
-          void this.handleServerRequest(context, parsed)
+          void this.handleServerRequest(context, parsed).catch((error) => {
+            if (context.closed) return
+
+            const message = error instanceof Error ? error.message : String(error)
+            try {
+              if (
+                parsed.method === "item/commandExecution/requestApproval"
+                || parsed.method === "item/fileChange/requestApproval"
+              ) {
+                // Every approval request needs a response. A cancellation lets
+                // the app-server unwind instead of waiting forever when the
+                // chat was cleaned up while this request was in flight.
+                this.writeMessage(context, {
+                  id: parsed.id,
+                  result: { decision: "cancel" },
+                })
+              } else {
+                this.writeMessage(context, {
+                  id: parsed.id,
+                  error: { message },
+                })
+              }
+            } catch {
+              // The child may have exited between the request and fallback.
+            }
+          })
           continue
         }
 

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -41,6 +41,8 @@ import {
   type McpToolCallItem,
   type McpServerElicitationRequestParams,
   type McpServerElicitationRequestResponse,
+  type PermissionsRequestApprovalParams,
+  type PermissionsRequestApprovalResponse,
   type PlanDeltaNotification,
   type ServerNotification,
   type ServerRequest,
@@ -120,7 +122,12 @@ interface PendingTurn {
           kind: "mcp_elicitation"
           params: McpServerElicitationRequestParams
         }
-  ) => Promise<CommandExecutionApprovalDecision | FileChangeApprovalDecision | McpServerElicitationRequestResponse>
+      | {
+          requestId: CodexRequestId
+          kind: "permissions"
+          params: PermissionsRequestApprovalParams
+        }
+  ) => Promise<CommandExecutionApprovalDecision | FileChangeApprovalDecision | McpServerElicitationRequestResponse | PermissionsRequestApprovalResponse>
 }
 
 interface SessionContext {
@@ -1101,6 +1108,11 @@ export class CodexAppServerManager {
                   id: parsed.id,
                   result: { action: "cancel", content: null },
                 })
+              } else if (parsed.method === "item/permissions/requestApproval") {
+                this.writeMessage(context, {
+                  id: parsed.id,
+                  result: { scope: "turn", permissions: {} },
+                })
               } else {
                 this.writeMessage(context, {
                   id: parsed.id,
@@ -1161,6 +1173,8 @@ export class CodexAppServerManager {
         this.writeMessage(context, { id: request.id, result: { decision: "cancel" } })
       } else if (request.method === "mcpServer/elicitation/request") {
         this.writeMessage(context, { id: request.id, result: { action: "cancel", content: null } })
+      } else if (request.method === "item/permissions/requestApproval") {
+        this.writeMessage(context, { id: request.id, result: { scope: "turn", permissions: {} } })
       } else {
         this.writeMessage(context, {
           id: request.id,
@@ -1339,6 +1353,36 @@ export class CodexAppServerManager {
         kind: "mcp_elicitation",
         params: request.params,
       }) ?? { action: "decline" as const, content: null }
+      this.writeMessage(context, {
+        id: request.id,
+        result: response,
+      })
+      return
+    }
+
+    if (request.method === "item/permissions/requestApproval") {
+      const tool = {
+        kind: "tool" as const,
+        toolKind: "codex_permissions_approval" as const,
+        toolName: "CodexPermissionsApproval",
+        toolId: String(request.id),
+        input: {
+          reason: request.params.reason ?? undefined,
+          cwd: request.params.cwd ?? undefined,
+          environmentId: request.params.environmentId ?? undefined,
+          permissions: request.params.permissions,
+        },
+        rawInput: request.params as unknown as Record<string, unknown>,
+      }
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({ kind: "tool_call", tool }),
+      })
+      const response = await pendingTurn.onApprovalRequest?.({
+        requestId: request.id,
+        kind: "permissions",
+        params: request.params,
+      }) ?? { scope: "turn" as const, permissions: {} }
       this.writeMessage(context, {
         id: request.id,
         result: response,

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
 import type {
   AskUserQuestionItem,
+  CodexAccessMode,
   CodexReasoningEffort,
   ContextWindowUsageSnapshot,
   ServiceTier,
@@ -122,6 +123,7 @@ interface SessionContext {
   pendingRequests: Map<CodexRequestId, PendingRequest<unknown>>
   pendingTurn: PendingTurn | null
   sessionToken: string | null
+  accessMode: CodexAccessMode
   stderrLines: string[]
   closed: boolean
 }
@@ -133,6 +135,7 @@ export interface StartCodexSessionArgs {
   serviceTier?: ServiceTier
   sessionToken: string | null
   pendingForkSessionToken?: string | null
+  accessMode?: CodexAccessMode
 }
 
 export interface StartCodexTurnArgs {
@@ -150,6 +153,7 @@ export interface StartCodexTurnArgs {
    */
   skill?: { name: string; path: string }
   planMode: boolean
+  accessMode?: CodexAccessMode
   onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
   onApprovalRequest?: PendingTurn["onApprovalRequest"]
 }
@@ -193,6 +197,12 @@ function isRecoverableResumeError(error: unknown): boolean {
   return ["not found", "missing thread", "no such thread", "unknown thread", "does not exist"].some((snippet) =>
     message.includes(snippet)
   )
+}
+
+function codexPolicy(accessMode: CodexAccessMode = "full-access") {
+  return accessMode === "approval"
+    ? { approvalPolicy: "on-request" as const, sandbox: "workspace-write" as const }
+    : { approvalPolicy: "never" as const, sandbox: "danger-full-access" as const }
 }
 
 const MULTI_SELECT_HINT_PATTERN = /\b(all that apply|select all|choose all|pick all|select multiple|choose multiple|pick multiple|multiple selections?|multiple choice|more than one|one or more)\b/i
@@ -743,6 +753,7 @@ export class CodexAppServerManager {
       pendingRequests: new Map(),
       pendingTurn: null,
       sessionToken: null,
+      accessMode: "full-access",
       stderrLines: [],
       closed: false,
     }
@@ -769,8 +780,9 @@ export class CodexAppServerManager {
   }
 
   async startSession(args: StartCodexSessionArgs) {
+    const accessMode = args.accessMode ?? "full-access"
     const existing = this.sessions.get(args.chatId)
-    if (existing && !existing.closed && existing.cwd === args.cwd && !args.pendingForkSessionToken) {
+    if (existing && !existing.closed && existing.cwd === args.cwd && existing.accessMode === accessMode && !args.pendingForkSessionToken) {
       return
     }
 
@@ -786,6 +798,7 @@ export class CodexAppServerManager {
       pendingRequests: new Map(),
       pendingTurn: null,
       sessionToken: null,
+      accessMode,
       stderrLines: [],
       closed: false,
     }
@@ -810,8 +823,7 @@ export class CodexAppServerManager {
       model: args.model,
       cwd: args.cwd,
       serviceTier: args.serviceTier,
-      approvalPolicy: "never",
-      sandbox: "danger-full-access",
+      ...codexPolicy(accessMode),
       experimentalRawEvents: false,
       persistExtendedHistory: false,
     } satisfies ThreadStartParams
@@ -827,8 +839,7 @@ export class CodexAppServerManager {
         model: args.model,
         cwd: args.cwd,
         serviceTier: args.serviceTier,
-        approvalPolicy: "never",
-        sandbox: "danger-full-access",
+        ...codexPolicy(accessMode),
         persistExtendedHistory: false,
       } satisfies ThreadForkParams)
     } else if (args.sessionToken) {
@@ -838,8 +849,7 @@ export class CodexAppServerManager {
           model: args.model,
           cwd: args.cwd,
           serviceTier: args.serviceTier,
-          approvalPolicy: "never",
-          sandbox: "danger-full-access",
+          ...codexPolicy(accessMode),
           persistExtendedHistory: false,
         } satisfies ThreadResumeParams)
       } catch (error) {
@@ -905,7 +915,7 @@ export class CodexAppServerManager {
       const response = await this.sendRequest<TurnStartResponse>(context, "turn/start", {
         threadId: context.sessionToken ?? "",
         input,
-        approvalPolicy: "never",
+        approvalPolicy: codexPolicy(args.accessMode).approvalPolicy,
         model: args.model,
         effort: args.effort,
         serviceTier: args.serviceTier,
@@ -1221,6 +1231,22 @@ export class CodexAppServerManager {
     }
 
     if (request.method === "item/commandExecution/requestApproval") {
+      const tool = {
+        kind: "tool" as const,
+        toolKind: "codex_command_approval" as const,
+        toolName: "CodexApproval",
+        toolId: String(request.id),
+        input: {
+          command: request.params.command ?? undefined,
+          cwd: request.params.cwd ?? undefined,
+          reason: request.params.reason ?? undefined,
+        },
+        rawInput: request.params as unknown as Record<string, unknown>,
+      }
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({ kind: "tool_call", tool }),
+      })
       const decision = await pendingTurn.onApprovalRequest?.({
         requestId: request.id,
         kind: "command_execution",
@@ -1235,6 +1261,21 @@ export class CodexAppServerManager {
       return
     }
 
+    const tool = {
+      kind: "tool" as const,
+      toolKind: "codex_file_change_approval" as const,
+      toolName: "CodexApproval",
+      toolId: String(request.id),
+      input: {
+        reason: request.params.reason ?? undefined,
+        grantRoot: request.params.grantRoot ?? undefined,
+      },
+      rawInput: request.params as unknown as Record<string, unknown>,
+    }
+    pendingTurn.queue.push({
+      type: "transcript",
+      entry: timestamped({ kind: "tool_call", tool }),
+    })
     const decision = await pendingTurn.onApprovalRequest?.({
       requestId: request.id,
       kind: "file_change",

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -39,6 +39,8 @@ import {
   type ItemStartedNotification,
   type JsonRpcResponse,
   type McpToolCallItem,
+  type McpServerElicitationRequestParams,
+  type McpServerElicitationRequestResponse,
   type PlanDeltaNotification,
   type ServerNotification,
   type ServerRequest,
@@ -113,7 +115,12 @@ interface PendingTurn {
           kind: "file_change"
           params: FileChangeRequestApprovalParams
         }
-  ) => Promise<CommandExecutionApprovalDecision | FileChangeApprovalDecision>
+      | {
+          requestId: CodexRequestId
+          kind: "mcp_elicitation"
+          params: McpServerElicitationRequestParams
+        }
+  ) => Promise<CommandExecutionApprovalDecision | FileChangeApprovalDecision | McpServerElicitationRequestResponse>
 }
 
 interface SessionContext {
@@ -761,7 +768,10 @@ export class CodexAppServerManager {
     try {
       await this.sendRequest(context, "initialize", {
         clientInfo: { name: "kanna_desktop", title: "Kanna", version: "0.1.0" },
-        capabilities: { experimentalApi: true },
+        capabilities: {
+          experimentalApi: true,
+          extensions: { "openai/form": {} },
+        },
       } satisfies InitializeParams)
       this.writeMessage(context, { method: "initialized" })
       return await this.sendRequest<GetAccountRateLimitsResponse>(
@@ -813,6 +823,7 @@ export class CodexAppServerManager {
       },
       capabilities: {
         experimentalApi: true,
+        extensions: { "openai/form": {} },
       },
     } satisfies InitializeParams)
     this.writeMessage(context, {
@@ -1085,6 +1096,11 @@ export class CodexAppServerManager {
                   id: parsed.id,
                   result: { decision: "cancel" },
                 })
+              } else if (parsed.method === "mcpServer/elicitation/request") {
+                this.writeMessage(context, {
+                  id: parsed.id,
+                  result: { action: "cancel", content: null },
+                })
               } else {
                 this.writeMessage(context, {
                   id: parsed.id,
@@ -1141,12 +1157,18 @@ export class CodexAppServerManager {
   private async handleServerRequest(context: SessionContext, request: ServerRequest) {
     const pendingTurn = context.pendingTurn
     if (!pendingTurn) {
-      this.writeMessage(context, {
-        id: request.id,
-        error: {
-          message: "No active turn",
-        },
-      })
+      if (request.method === "item/commandExecution/requestApproval" || request.method === "item/fileChange/requestApproval") {
+        this.writeMessage(context, { id: request.id, result: { decision: "cancel" } })
+      } else if (request.method === "mcpServer/elicitation/request") {
+        this.writeMessage(context, { id: request.id, result: { action: "cancel", content: null } })
+      } else {
+        this.writeMessage(context, {
+          id: request.id,
+          error: {
+            message: "No active turn",
+          },
+        })
+      }
       return
     }
 
@@ -1276,12 +1298,50 @@ export class CodexAppServerManager {
         requestId: request.id,
         kind: "command_execution",
         params: request.params,
-      }) ?? "decline"
+      }) as CommandExecutionApprovalDecision | undefined ?? "decline"
       this.writeMessage(context, {
         id: request.id,
         result: {
           decision,
         } satisfies CommandExecutionRequestApprovalResponse,
+      })
+      return
+    }
+
+    if (request.method === "mcpServer/elicitation/request") {
+      const elicitation = request.params.request
+      const meta = elicitation.meta
+      const persist = meta?.persist === "session" || meta?.persist === "always"
+        ? meta.persist
+        : Array.isArray(meta?.persist)
+          ? meta.persist.filter((value): value is "session" | "always" => value === "session" || value === "always")
+          : undefined
+      const tool = {
+        kind: "tool" as const,
+        toolKind: "codex_mcp_approval" as const,
+        toolName: "CodexAppApproval",
+        toolId: String(request.id),
+        input: {
+          serverName: request.params.serverName,
+          message: elicitation.message,
+          mode: elicitation.mode,
+          ...(elicitation.mode === "url" ? { url: elicitation.url } : { requestedSchema: elicitation.requestedSchema }),
+          ...(persist === "session" || persist === "always" || Array.isArray(persist) ? { persist } : {}),
+        },
+        rawInput: request.params as unknown as Record<string, unknown>,
+      }
+      pendingTurn.queue.push({
+        type: "transcript",
+        entry: timestamped({ kind: "tool_call", tool }),
+      })
+      const response = await pendingTurn.onApprovalRequest?.({
+        requestId: request.id,
+        kind: "mcp_elicitation",
+        params: request.params,
+      }) ?? { action: "decline" as const, content: null }
+      this.writeMessage(context, {
+        id: request.id,
+        result: response,
       })
       return
     }
@@ -1305,7 +1365,7 @@ export class CodexAppServerManager {
       requestId: request.id,
       kind: "file_change",
       params: request.params,
-    }) ?? "decline"
+    }) as FileChangeApprovalDecision | undefined ?? "decline"
     this.writeMessage(context, {
       id: request.id,
       result: {

--- a/src/server/events.test.ts
+++ b/src/server/events.test.ts
@@ -85,7 +85,13 @@ describe("cloneTranscriptEntriesForClient", () => {
   })
 
   test("keeps interactive kinds whole — call and result — since they render inline", () => {
-    for (const kind of ["ask_user_question", "exit_plan_mode", "todo_write"]) {
+    for (const kind of [
+      "ask_user_question",
+      "exit_plan_mode",
+      "todo_write",
+      "codex_command_approval",
+      "codex_file_change_approval",
+    ]) {
       const [callEntry, resultEntry] = call([
         toolCall(kind, { plan: "p".repeat(5000), payload: { deep: true } }),
         toolResult(kind, { answers: { a: ["yes"] } }),

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -394,7 +394,12 @@ const STRUCTURED_RESULT_TOOL_KINDS = new Set(["ask_user_question", "exit_plan_mo
  * travel with the transcript rather than being fetched when a row is opened —
  * there is no row to open. Superset of the structured-result kinds.
  */
-const INLINE_TOOL_KINDS = new Set([...STRUCTURED_RESULT_TOOL_KINDS, "todo_write"])
+const INLINE_TOOL_KINDS = new Set([
+  ...STRUCTURED_RESULT_TOOL_KINDS,
+  "todo_write",
+  "codex_command_approval",
+  "codex_file_change_approval",
+])
 
 /** Strip the raw provider payload; it duplicates `content` and dwarfs it. */
 function withoutDebugRaw<TEntry extends TranscriptEntry>(entry: TEntry) {
@@ -413,7 +418,8 @@ function trimToolCallEntry(entry: Extract<TranscriptEntry, { kind: "tool_call" }
   let dropped = rawInput !== undefined
 
   // Only these five kinds carry input that can grow without bound. The other
-  // ten are already header-sized — a path, a pattern, a query — and travel
+  // interactive and tool kinds are already header-sized — a path, a pattern,
+  // a command, or an approval reason — and travel
   // whole.
   const unbounded: Record<string, readonly string[]> = {
     write_file: ["content"],
@@ -445,7 +451,7 @@ function trimToolCallEntry(entry: Extract<TranscriptEntry, { kind: "tool_call" }
  *
  * Two things are deliberately never dropped:
  *
- * - `ask_user_question` / `exit_plan_mode` / `todo_write` render inline, so
+ * - interactive tool kinds render inline, so
  *   there is no expansion to fetch on. The first two additionally get
  *   `tool_use_result` lifted out of `debugRaw` into `structuredResult`.
  * - `isError` and the entry ids, which is everything a collapsed row and its

--- a/src/server/harness-types.ts
+++ b/src/server/harness-types.ts
@@ -7,7 +7,9 @@ export interface HarnessEvent {
 }
 
 export interface HarnessToolRequest {
-  tool: NormalizedToolCall & { toolKind: "ask_user_question" | "exit_plan_mode" }
+  tool: NormalizedToolCall & {
+    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+  }
 }
 
 export interface HarnessTurn {

--- a/src/server/harness-types.ts
+++ b/src/server/harness-types.ts
@@ -14,6 +14,7 @@ export interface HarnessToolRequest {
       | "codex_command_approval"
       | "codex_file_change_approval"
       | "codex_mcp_approval"
+      | "codex_permissions_approval"
   }
 }
 

--- a/src/server/harness-types.ts
+++ b/src/server/harness-types.ts
@@ -8,7 +8,12 @@ export interface HarnessEvent {
 
 export interface HarnessToolRequest {
   tool: NormalizedToolCall & {
-    toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+    toolKind:
+      | "ask_user_question"
+      | "exit_plan_mode"
+      | "codex_command_approval"
+      | "codex_file_change_approval"
+      | "codex_mcp_approval"
   }
 }
 

--- a/src/server/provider-catalog.ts
+++ b/src/server/provider-catalog.ts
@@ -291,6 +291,9 @@ export function normalizeCodexModelOptions(
     // Spawn-time gating: fast mode only reaches models that support it
     // (per Codex docs: GPT-5.6/5.5/5.4 — not 5.3 Codex or Spark).
     fastMode: supportsProviderFastMode("codex", model) && modelOptions?.codex?.fastMode === true,
+    ...(modelOptions?.codex?.accessMode === "approval" || modelOptions?.codex?.accessMode === "full-access"
+      ? { accessMode: modelOptions.codex.accessMode }
+      : {}),
   }
 }
 

--- a/src/shared/provider-preferences.ts
+++ b/src/shared/provider-preferences.ts
@@ -37,6 +37,7 @@ export type ProviderModelOptionsInput = {
   reasoningEffort?: unknown
   contextWindow?: unknown
   fastMode?: unknown
+  accessMode?: unknown
 }
 
 /**
@@ -94,6 +95,9 @@ export function normalizeCodexPreference(value?: ProviderPreferenceInput): Provi
       fastMode: typeof value?.modelOptions?.fastMode === "boolean"
         ? value.modelOptions.fastMode
         : DEFAULT_CODEX_MODEL_OPTIONS.fastMode,
+      ...(value?.modelOptions?.accessMode === "approval" || value?.modelOptions?.accessMode === "full-access"
+        ? { accessMode: value.modelOptions.accessMode }
+        : {}),
     },
     planMode: value?.planMode === true,
     autoPlan: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1505,6 +1505,16 @@ export interface CodexFileChangeApprovalToolCall
     grantRoot?: string
   }> { }
 
+export interface CodexMcpApprovalToolCall
+  extends ToolCallBase<"codex_mcp_approval", {
+    serverName: string
+    message: string
+    mode: "form" | "openai/form" | "url"
+    url?: string
+    requestedSchema?: Record<string, unknown>
+    persist?: "session" | "always" | Array<"session" | "always">
+  }> { }
+
 export interface McpGenericToolCall
   extends ToolCallBase<"mcp_generic", { server: string; tool: string; payload?: Record<string, unknown> }> { }
 
@@ -1527,6 +1537,7 @@ export type NormalizedToolCall =
   | SubagentTaskToolCall
   | CodexCommandApprovalToolCall
   | CodexFileChangeApprovalToolCall
+  | CodexMcpApprovalToolCall
   | McpGenericToolCall
   | UnknownToolCall
 
@@ -2049,5 +2060,10 @@ export interface ResolvedChatReadAnchor {
 
 export interface PendingToolSnapshot {
   toolUseId: string
-  toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
+  toolKind:
+    | "ask_user_question"
+    | "exit_plan_mode"
+    | "codex_command_approval"
+    | "codex_file_change_approval"
+    | "codex_mcp_approval"
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -204,6 +204,7 @@ export interface ProviderEffortOption {
 }
 
 export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+export type CodexAccessMode = "approval" | "full-access"
 
 export interface CodexReasoningEffortOption extends ProviderEffortOption {
   id: CodexReasoningEffort
@@ -260,6 +261,7 @@ export interface ClaudeModelOptions {
 export interface CodexModelOptions {
   reasoningEffort: CodexReasoningEffort
   fastMode: boolean
+  accessMode?: CodexAccessMode
 }
 
 export interface CursorModelOptions {
@@ -297,12 +299,16 @@ export interface ProviderPreference<TModelOptions> {
  * swappable at runtime), autoPlan maps to the session's tool allowlist (fixed
  * at session creation).
  */
-export type ChatMode = "full-access" | "plan" | "auto-plan"
+export type ChatMode = "full-access" | "plan" | "approval" | "auto-plan"
 
-export function chatModeFromFlags(planMode: boolean, autoPlan: boolean): ChatMode {
+export function chatModeFromFlags(
+  planMode: boolean,
+  autoPlan: boolean,
+  codexAccessMode: CodexAccessMode = "full-access",
+): ChatMode {
   // planMode wins: a user who explicitly asked to start in plan mode sees
   // "Plan Mode" even while autoPlan is held underneath.
-  return planMode ? "plan" : autoPlan ? "auto-plan" : "full-access"
+  return planMode ? "plan" : autoPlan ? "auto-plan" : codexAccessMode === "approval" ? "approval" : "full-access"
 }
 
 export function chatModeToFlags(
@@ -316,6 +322,7 @@ export function chatModeToFlags(
       return { planMode: true, autoPlan: currentAutoPlan }
     case "auto-plan":
       return { planMode: false, autoPlan: true }
+    case "approval":
     case "full-access":
       return { planMode: false, autoPlan: false }
   }
@@ -1485,6 +1492,19 @@ export interface DeleteFileToolCall
 export interface SubagentTaskToolCall
   extends ToolCallBase<"subagent_task", { subagentType?: string }> { }
 
+export interface CodexCommandApprovalToolCall
+  extends ToolCallBase<"codex_command_approval", {
+    command?: string
+    cwd?: string
+    reason?: string
+  }> { }
+
+export interface CodexFileChangeApprovalToolCall
+  extends ToolCallBase<"codex_file_change_approval", {
+    reason?: string
+    grantRoot?: string
+  }> { }
+
 export interface McpGenericToolCall
   extends ToolCallBase<"mcp_generic", { server: string; tool: string; payload?: Record<string, unknown> }> { }
 
@@ -1505,6 +1525,8 @@ export type NormalizedToolCall =
   | EditFileToolCall
   | DeleteFileToolCall
   | SubagentTaskToolCall
+  | CodexCommandApprovalToolCall
+  | CodexFileChangeApprovalToolCall
   | McpGenericToolCall
   | UnknownToolCall
 
@@ -2027,5 +2049,5 @@ export interface ResolvedChatReadAnchor {
 
 export interface PendingToolSnapshot {
   toolUseId: string
-  toolKind: "ask_user_question" | "exit_plan_mode"
+  toolKind: "ask_user_question" | "exit_plan_mode" | "codex_command_approval" | "codex_file_change_approval"
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1515,6 +1515,17 @@ export interface CodexMcpApprovalToolCall
     persist?: "session" | "always" | Array<"session" | "always">
   }> { }
 
+export interface CodexPermissionsApprovalToolCall
+  extends ToolCallBase<"codex_permissions_approval", {
+    reason?: string
+    cwd?: string
+    environmentId?: string
+    permissions: {
+      network?: { enabled?: boolean } | null
+      fileSystem?: { read?: string[]; write?: string[] } | null
+    }
+  }> { }
+
 export interface McpGenericToolCall
   extends ToolCallBase<"mcp_generic", { server: string; tool: string; payload?: Record<string, unknown> }> { }
 
@@ -1538,6 +1549,7 @@ export type NormalizedToolCall =
   | CodexCommandApprovalToolCall
   | CodexFileChangeApprovalToolCall
   | CodexMcpApprovalToolCall
+  | CodexPermissionsApprovalToolCall
   | McpGenericToolCall
   | UnknownToolCall
 
@@ -2066,4 +2078,5 @@ export interface PendingToolSnapshot {
     | "codex_command_approval"
     | "codex_file_change_approval"
     | "codex_mcp_approval"
+    | "codex_permissions_approval"
 }


### PR DESCRIPTION
## What changed

- Add Codex approval mode for command and file-change requests.
- Keep concurrent and delayed approval requests independently resolvable.
- Surface Codex MCP/app authorization requests inline, including GitHub authorization URLs.
- Handle permission approval requests for network and filesystem access, including session-scoped grants.
- Cancel late approval requests safely so chats do not hang after turn cleanup.

## Root cause

The adapter handled command and file approvals but did not recognize Codex's MCP elicitation or permission approval request flows. GitHub app authorization and pull-request creation could therefore remain unresolved in approval mode.

## Validation

- `bunx tsc --noEmit`
- 79 focused tests passed
