### PR TITLE
Add chat reminders and mark as unread

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -281,6 +281,15 @@ function KannaLayout() {
   const handleSidebarDeleteChat = useCallback((chat: Parameters<typeof state.handleDeleteChat>[0]) => {
     void state.handleDeleteChat(chat)
   }, [state.handleDeleteChat])
+  const handleSidebarSetChatUnread = useCallback((chatId: string, unread: boolean) => {
+    void state.handleSetChatUnread(chatId, unread)
+  }, [state.handleSetChatUnread])
+  const handleSidebarSetChatReminder = useCallback((chatId: string, dueAt: number) => {
+    void state.handleSetChatReminder(chatId, dueAt)
+  }, [state.handleSetChatReminder])
+  const handleSidebarClearChatReminder = useCallback((chatId: string) => {
+    void state.handleClearChatReminder(chatId)
+  }, [state.handleClearChatReminder])
   const handleSidebarCopyPath = useCallback((localPath: string) => {
     void state.handleCopyPath(localPath)
   }, [state.handleCopyPath])
@@ -328,6 +337,9 @@ function KannaLayout() {
       onOpenArchivedChat={handleOpenArchivedChat}
       onRestoreChat={handleRestoreChat}
       onDeleteChat={handleSidebarDeleteChat}
+      onSetChatUnread={handleSidebarSetChatUnread}
+      onSetChatReminder={handleSidebarSetChatReminder}
+      onClearChatReminder={handleSidebarClearChatReminder}
       onCopyPath={handleSidebarCopyPath}
       onOpenExternalPath={handleSidebarOpenExternalPath}
       onSetupGit={handleSidebarSetupGit}
@@ -345,6 +357,9 @@ function KannaLayout() {
     handleSidebarCreateChat,
     handleSidebarArchiveChat,
     handleSidebarDeleteChat,
+    handleSidebarSetChatUnread,
+    handleSidebarSetChatReminder,
+    handleSidebarClearChatReminder,
     handleOpenArchivedChat,
     handleRestoreChat,
     handleSidebarForkChat,

--- a/src/client/app/ChatPage/ChatInputDock.tsx
+++ b/src/client/app/ChatPage/ChatInputDock.tsx
@@ -1,6 +1,7 @@
 import { memo, type RefObject } from "react"
 import { ChatInput, type ChatInputHandle } from "../../components/chat-ui/ChatInput"
 import { SecretRequestCard } from "../../components/secrets/SecretRequestCard"
+import { ReminderDockCard } from "../../components/reminders/ReminderDockCard"
 import type { ContextWindowSnapshot } from "../../lib/contextWindow"
 import type { KannaState } from "../useKannaState"
 import type { AgentProvider, ChatSkillsSnapshot } from "../../../shared/types"
@@ -22,6 +23,7 @@ interface ChatInputDockProps {
   availableProviders: KannaState["availableProviders"]
   contextWindowSnapshot: ContextWindowSnapshot | null
   secretRequests: KannaState["secretRequests"]
+  chatReminder: KannaState["chatReminder"]
   onSubmit: KannaState["handleSend"]
   onCancel: () => void
   onEditModels: () => void
@@ -45,6 +47,7 @@ export const ChatInputDock = memo(function ChatInputDock({
   availableProviders,
   contextWindowSnapshot,
   secretRequests,
+  chatReminder,
   onSubmit,
   onCancel,
   onEditModels,
@@ -67,6 +70,16 @@ export const ChatInputDock = memo(function ChatInputDock({
             request={secretRequests.activeRequest}
             onSubmit={secretRequests.submit}
             onCancel={secretRequests.cancel}
+          />
+        </div>
+        {/* Below the secret prompt and above the composer: a pending reminder
+            is ambient context, not an interruption, so it must never push a
+            prompt the agent is blocked on further from the eye. */}
+        <div className="relative">
+          <ReminderDockCard
+            dueAt={chatReminder.dueAt}
+            nowMs={chatReminder.nowMs}
+            onClear={chatReminder.clear}
           />
         </div>
         <div className="relative">

--- a/src/client/app/ChatPage/ChatInputDock.tsx
+++ b/src/client/app/ChatPage/ChatInputDock.tsx
@@ -1,5 +1,6 @@
 import { memo, type RefObject } from "react"
 import { ChatInput, type ChatInputHandle } from "../../components/chat-ui/ChatInput"
+import { SecretRequestCard } from "../../components/secrets/SecretRequestCard"
 import type { ContextWindowSnapshot } from "../../lib/contextWindow"
 import type { KannaState } from "../useKannaState"
 import type { AgentProvider, ChatSkillsSnapshot } from "../../../shared/types"
@@ -20,6 +21,7 @@ interface ChatInputDockProps {
   activeProvider: AgentProvider | null
   availableProviders: KannaState["availableProviders"]
   contextWindowSnapshot: ContextWindowSnapshot | null
+  secretRequests: KannaState["secretRequests"]
   onSubmit: KannaState["handleSend"]
   onCancel: () => void
   onEditModels: () => void
@@ -42,6 +44,7 @@ export const ChatInputDock = memo(function ChatInputDock({
   activeProvider,
   availableProviders,
   contextWindowSnapshot,
+  secretRequests,
   onSubmit,
   onCancel,
   onEditModels,
@@ -57,6 +60,15 @@ export const ChatInputDock = memo(function ChatInputDock({
             stays full width so the composer inside it remains centred on the
             card, not on the card minus the gutter. */}
         <div className="absolute inset-y-0 left-0 right-[var(--transcript-scrollbar-w,0px)] bg-gradient-to-t from-background via-background to-background/10 md:to-background/0 pointer-events-none" />
+        {/* Sits above the composer inside the dock so it rides the same wash
+            and stays pinned while the transcript scrolls behind it. */}
+        <div className="relative">
+          <SecretRequestCard
+            request={secretRequests.activeRequest}
+            onSubmit={secretRequests.submit}
+            onCancel={secretRequests.cancel}
+          />
+        </div>
         <div className="relative">
           <ChatInput
             ref={chatInputRef}

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -1059,6 +1059,7 @@ export function ChatPage() {
         availableProviders={state.availableProviders}
         contextWindowSnapshot={contextWindowSnapshot}
         secretRequests={state.secretRequests}
+        chatReminder={state.chatReminder}
         onSubmit={handleChatSubmit}
         onCancel={handleCancel}
         onEditModels={() => setDefaultModelsDialogOpen(true)}

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -1058,6 +1058,7 @@ export function ChatPage() {
         activeProvider={state.runtime?.provider ?? null}
         availableProviders={state.availableProviders}
         contextWindowSnapshot={contextWindowSnapshot}
+        secretRequests={state.secretRequests}
         onSubmit={handleChatSubmit}
         onCancel={handleCancel}
         onEditModels={() => setDefaultModelsDialogOpen(true)}

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -79,6 +79,9 @@ interface KannaSidebarProps {
   onOpenArchivedChat: (chatId: string) => void
   onRestoreChat: (chatId: string) => void
   onDeleteChat: (chat: SidebarChatRow) => void
+  onSetChatUnread: (chatId: string, unread: boolean) => void
+  onSetChatReminder: (chatId: string, dueAt: number) => void
+  onClearChatReminder: (chatId: string) => void
   onCopyPath: (localPath: string) => void
   onOpenExternalPath: (action: "open_finder" | "open_editor", localPath: string) => void
   /** Fetches what a chat changed, for the hover card's file list. */
@@ -115,6 +118,9 @@ function KannaSidebarImpl({
   onOpenArchivedChat,
   onRestoreChat,
   onDeleteChat,
+  onSetChatUnread,
+  onSetChatReminder,
+  onClearChatReminder,
   onCopyPath,
   onOpenExternalPath,
   onLoadTouchedFiles,
@@ -278,10 +284,13 @@ function KannaSidebarImpl({
         onForkChat={onForkChat}
         onArchiveChat={onArchiveChat}
         onRestoreChat={onRestoreChat}
+        onSetChatUnread={onSetChatUnread}
+        onSetChatReminder={onSetChatReminder}
+        onClearChatReminder={onClearChatReminder}
         onDeleteChat={onDeleteChat}
       />
     )
-  }, [activeChatId, editorLabel, nowMs, onArchiveChat, onCopyPath, onCreateChat, onDeleteChat, onForkChat, onLoadTouchedFiles, onOpenExternalPath, onRenameChat, onRestoreChat, onSetupGit, onShareChat, resolvedKeybindings, selectChat, selectChatMessage, showNumberJumpHints, threadByChatId, visibleIndexByChatId])
+  }, [activeChatId, editorLabel, nowMs, onArchiveChat, onClearChatReminder, onCopyPath, onCreateChat, onDeleteChat, onForkChat, onLoadTouchedFiles, onOpenExternalPath, onRenameChat, onRestoreChat, onSetChatReminder, onSetChatUnread, onSetupGit, onShareChat, resolvedKeybindings, selectChat, selectChatMessage, showNumberJumpHints, threadByChatId, visibleIndexByChatId])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -716,6 +725,9 @@ function KannaSidebarImpl({
                 onForkChat={onForkChat}
                 onArchiveChat={onArchiveChat}
                 onDeleteChat={onDeleteChat}
+                onSetChatUnread={onSetChatUnread}
+                onSetChatReminder={onSetChatReminder}
+                onClearChatReminder={onClearChatReminder}
                 onCopyPath={onCopyPath}
                 onOpenExternalPath={onOpenExternalPath}
               />

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -12,7 +12,7 @@ import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
 import { ToolCallMessage } from "../components/messages/ToolCallMessage"
 import { ResultMessage } from "../components/messages/ResultMessage"
 import { InterruptedMessage } from "../components/messages/InterruptedMessage"
-import { CompactBoundaryMessage, ContextClearedMessage, SecretNoticeMessage } from "../components/messages/CompactBoundaryMessage"
+import { CompactBoundaryMessage, ContextClearedMessage, ReminderNoticeMessage, SecretNoticeMessage } from "../components/messages/CompactBoundaryMessage"
 import { CompactSummaryMessage } from "../components/messages/CompactSummaryMessage"
 import { StatusMessage } from "../components/messages/StatusMessage"
 import { CollapsedToolGroup } from "../components/messages/CollapsedToolGroup"
@@ -373,6 +373,11 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
         && left.secretName === right.secretName
         && left.outcome === right.outcome
         && left.scope === right.scope
+    case "reminder_notice":
+      return right.kind === "reminder_notice"
+        && left.scheduledAt === right.scheduledAt
+        && left.createdBy === right.createdBy
+        && left.wokeAgent === right.wokeAgent
     case "handoff_boundary":
       return right.kind === "handoff_boundary"
         && left.fromProvider === right.fromProvider
@@ -578,6 +583,9 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
         break
       case "secret_notice":
         rendered = <SecretNoticeMessage key={message.id} message={message} />
+        break
+      case "reminder_notice":
+        rendered = <ReminderNoticeMessage key={message.id} message={message} />
         break
       case "compact_summary":
         rendered = <CompactSummaryMessage key={message.id} message={message} />

--- a/src/client/app/KannaTranscript.tsx
+++ b/src/client/app/KannaTranscript.tsx
@@ -12,7 +12,7 @@ import { TodoWriteMessage } from "../components/messages/TodoWriteMessage"
 import { ToolCallMessage } from "../components/messages/ToolCallMessage"
 import { ResultMessage } from "../components/messages/ResultMessage"
 import { InterruptedMessage } from "../components/messages/InterruptedMessage"
-import { CompactBoundaryMessage, ContextClearedMessage } from "../components/messages/CompactBoundaryMessage"
+import { CompactBoundaryMessage, ContextClearedMessage, SecretNoticeMessage } from "../components/messages/CompactBoundaryMessage"
 import { CompactSummaryMessage } from "../components/messages/CompactSummaryMessage"
 import { StatusMessage } from "../components/messages/StatusMessage"
 import { CollapsedToolGroup } from "../components/messages/CollapsedToolGroup"
@@ -368,6 +368,11 @@ function sameMessage(left: HydratedTranscriptMessage, right: HydratedTranscriptM
     case "context_cleared":
     case "interrupted":
       return true
+    case "secret_notice":
+      return right.kind === "secret_notice"
+        && left.secretName === right.secretName
+        && left.outcome === right.outcome
+        && left.scope === right.scope
     case "handoff_boundary":
       return right.kind === "handoff_boundary"
         && left.fromProvider === right.fromProvider
@@ -570,6 +575,9 @@ const TranscriptSingleRow = memo(function TranscriptSingleRow({
         break
       case "context_cleared":
         rendered = <ContextClearedMessage key={message.id} />
+        break
+      case "secret_notice":
+        rendered = <SecretNoticeMessage key={message.id} message={message} />
         break
       case "compact_summary":
         rendered = <CompactSummaryMessage key={message.id} message={message} />

--- a/src/client/app/useChatReminder.ts
+++ b/src/client/app/useChatReminder.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { DEFAULT_REMINDER_PROMPT } from "../../shared/reminders"
+import type { SidebarProjectGroup } from "../../shared/types"
+import type { KannaSocket } from "./socket"
+
+export interface ChatReminderState {
+  /** When the active chat's pending reminder fires, or null when it has none. */
+  dueAt: number | null
+  /** Re-rendered on a tick so the countdown stays honest without a reload. */
+  nowMs: number
+  set: (dueAt: number) => Promise<unknown>
+  clear: () => Promise<unknown>
+}
+
+/**
+ * How often the countdown re-renders. A minute: the label is rounded to
+ * minutes, so anything faster redraws the same characters.
+ */
+const TICK_MS = 60_000
+
+/**
+ * The active chat's pending reminder, read straight off the sidebar snapshot
+ * rather than fetched — the same trick `useLinkedPullRequest` uses, and for the
+ * same reason. `reminderAt` already rides the sidebar row (see
+ * `read-models.ts`), the sidebar is a subscription this app always has open,
+ * and a chat-scoped topic would be a second copy of one number with its own
+ * staleness.
+ */
+export function useChatReminder(
+  socket: KannaSocket,
+  activeChatId: string | null,
+  projectGroups: SidebarProjectGroup[],
+): ChatReminderState {
+  const dueAt = useMemo(() => {
+    if (!activeChatId) return null
+    for (const group of projectGroups) {
+      for (const chat of [...group.chats, ...(group.archivedChats ?? [])]) {
+        if (chat.chatId === activeChatId) return chat.reminderAt ?? null
+      }
+    }
+    return null
+  }, [activeChatId, projectGroups])
+
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    // No pending reminder, no countdown to drive — don't hold a timer for
+    // every chat that will never show one.
+    if (dueAt == null) return
+    setNowMs(Date.now())
+    const id = window.setInterval(() => setNowMs(Date.now()), TICK_MS)
+    return () => window.clearInterval(id)
+  }, [dueAt])
+
+  const set = useCallback(
+    (nextDueAt: number) => activeChatId
+      ? socket.command({
+        type: "chat.setReminder",
+        chatId: activeChatId,
+        dueAt: nextDueAt,
+        prompt: DEFAULT_REMINDER_PROMPT,
+      })
+      : Promise.resolve(undefined),
+    [activeChatId, socket],
+  )
+
+  const clear = useCallback(
+    () => activeChatId
+      ? socket.command({ type: "chat.clearReminder", chatId: activeChatId })
+      : Promise.resolve(undefined),
+    [activeChatId, socket],
+  )
+
+  return { dueAt, nowMs, set, clear }
+}

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -15,6 +15,7 @@ import { useTheme } from "../hooks/useTheme"
 import { processTranscriptMessages } from "../lib/parseTranscript"
 import { formatProjectRepoBranch } from "../lib/project-label"
 import { canCancelStatus, getLatestToolIds, isProcessingStatus } from "./derived"
+import { useSecretRequests, type SecretRequestsState } from "./useSecretRequests"
 import {
   applySidebarProjectOrder,
   getActiveChatSnapshot,
@@ -142,6 +143,8 @@ function useKannaSocket() {
 
 export interface KannaState {
   socket: KannaSocket
+  /** Agent-raised credential prompts, rendered inline above the composer. */
+  secretRequests: SecretRequestsState
   activeChatId: string | null
   activeProjectId: string | null
   sidebarData: SidebarData
@@ -244,6 +247,7 @@ export interface KannaState {
 export function useKannaState(activeChatId: string | null): KannaState {
   const navigate = useNavigate()
   const socket = useKannaSocket()
+  const secretRequests = useSecretRequests(socket)
   const dialog = useAppDialog()
   const { resolvedTheme } = useTheme()
 
@@ -909,6 +913,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
 
   return {
     socket,
+    secretRequests,
     activeChatId,
     activeProjectId,
     sidebarData: resolvedSidebarData,

--- a/src/client/app/useKannaState.ts
+++ b/src/client/app/useKannaState.ts
@@ -16,6 +16,7 @@ import { processTranscriptMessages } from "../lib/parseTranscript"
 import { formatProjectRepoBranch } from "../lib/project-label"
 import { canCancelStatus, getLatestToolIds, isProcessingStatus } from "./derived"
 import { useSecretRequests, type SecretRequestsState } from "./useSecretRequests"
+import { useChatReminder, type ChatReminderState } from "./useChatReminder"
 import {
   applySidebarProjectOrder,
   getActiveChatSnapshot,
@@ -51,6 +52,7 @@ import { useChatReadAnchor, type ChatReadAnchorState } from "./useChatReadAnchor
 import { useSendMessage } from "./useSendMessage"
 import { useShareExport } from "./useShareExport"
 import { useUpdateRestart } from "./useUpdateRestart"
+import { DEFAULT_REMINDER_PROMPT } from "../../shared/reminders"
 import type { EditorOpenSettings, OpenExternalAction } from "../../shared/protocol"
 
 export {
@@ -145,6 +147,8 @@ export interface KannaState {
   socket: KannaSocket
   /** Agent-raised credential prompts, rendered inline above the composer. */
   secretRequests: SecretRequestsState
+  /** The active chat's pending reminder, for the dock indicator. */
+  chatReminder: ChatReminderState
   activeChatId: string | null
   activeProjectId: string | null
   sidebarData: SidebarData
@@ -219,6 +223,9 @@ export interface KannaState {
   handleOpenArchivedChat: (chatId: string) => Promise<void>
   handleRestoreChat: (chatId: string) => Promise<void>
   handleDeleteChat: (chat: SidebarChatRow) => Promise<void>
+  handleSetChatUnread: (chatId: string, unread: boolean) => Promise<void>
+  handleSetChatReminder: (chatId: string, dueAt: number) => Promise<void>
+  handleClearChatReminder: (chatId: string) => Promise<void>
   handleSetupGit: (chatId: string) => Promise<void>
   handleHideProject: (projectId: string) => Promise<void>
   handleReorderProjectGroups: (projectIds: string[]) => Promise<void>
@@ -282,6 +289,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
     () => applySidebarProjectOrder(sidebarData.projectGroups, optimisticSidebarProjectOrder),
     [optimisticSidebarProjectOrder, sidebarData.projectGroups]
   )
+  const chatReminder = useChatReminder(socket, activeChatId, sidebarProjectGroups)
   const resolvedSidebarData = useMemo(
     () => (
       sidebarProjectGroups === sidebarData.projectGroups
@@ -452,11 +460,19 @@ export function useKannaState(activeChatId: string | null): KannaState {
     sidebarGroupsRef.current = sidebarProjectGroups
   }, [sidebarProjectGroups])
 
+  // Chats the user deliberately marked unread while they were the active chat.
+  // Without this the effect below would clear the flag the instant they
+  // navigated away — which is precisely when "mark as unread" is supposed to
+  // start meaning something. One suppression per mark: leaving consumes it, so
+  // the next visit reads and clears as normal.
+  const deliberatelyUnreadRef = useRef(new Set<string>())
+
   const previousActiveChatIdRef = useRef<string | null>(null)
   useEffect(() => {
     const previousChatId = previousActiveChatIdRef.current
     previousActiveChatIdRef.current = activeChatId ?? null
     if (!previousChatId || previousChatId === activeChatId) return
+    if (deliberatelyUnreadRef.current.delete(previousChatId)) return
     const previousChat = sidebarGroupsRef.current
       .flatMap((group) => group.chats)
       .find((chat) => chat.chatId === previousChatId)
@@ -779,6 +795,49 @@ export function useKannaState(activeChatId: string | null): KannaState {
     }
   }, [activeChatId, navigate, sidebarProjectGroups, socket])
 
+  const handleSetChatUnread = useCallback(async (chatId: string, unread: boolean) => {
+    // Only the active chat needs shielding from the read-on-leave effect: it
+    // fires for the chat being left, so any other row is already safe. Marking
+    // read again drops the shield rather than leaving it to misfire later.
+    if (unread && chatId === activeChatId) {
+      deliberatelyUnreadRef.current.add(chatId)
+    } else {
+      deliberatelyUnreadRef.current.delete(chatId)
+    }
+    try {
+      await socket.command({ type: "chat.setUnread", chatId, unread })
+      setCommandError(null)
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }, [activeChatId, socket])
+
+  // The menu's presets carry the default prompt, so a sidebar reminder wakes
+  // the chat rather than only flagging it. Reminders with no prompt are the
+  // agent-facing path (`kanna remind` without a message).
+  const handleSetChatReminder = useCallback(async (chatId: string, dueAt: number) => {
+    try {
+      await socket.command({
+        type: "chat.setReminder",
+        chatId,
+        dueAt,
+        prompt: DEFAULT_REMINDER_PROMPT,
+      })
+      setCommandError(null)
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }, [socket])
+
+  const handleClearChatReminder = useCallback(async (chatId: string) => {
+    try {
+      await socket.command({ type: "chat.clearReminder", chatId })
+      setCommandError(null)
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    }
+  }, [socket])
+
   // Viewing an archived chat is read-only navigation — it stays archived.
   // Restoring is explicit (context menu) or implicit via sending a message
   // (the server unarchives on chat.send).
@@ -914,6 +973,7 @@ export function useKannaState(activeChatId: string | null): KannaState {
   return {
     socket,
     secretRequests,
+    chatReminder,
     activeChatId,
     activeProjectId,
     sidebarData: resolvedSidebarData,
@@ -981,6 +1041,9 @@ export function useKannaState(activeChatId: string | null): KannaState {
     handleOpenArchivedChat,
     handleRestoreChat,
     handleDeleteChat,
+    handleSetChatUnread,
+    handleSetChatReminder,
+    handleClearChatReminder,
     handleSetupGit,
     handleHideProject,
     handleReorderProjectGroups,

--- a/src/client/app/useSecretRequests.ts
+++ b/src/client/app/useSecretRequests.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react"
+import type { PendingSecretRequest, SecretRequestsSnapshot, SecretScope } from "../../shared/secrets"
+import type { KannaSocket } from "./socket"
+
+export interface SecretRequestsState {
+  activeRequest: PendingSecretRequest | null
+  requests: PendingSecretRequest[]
+  submit: (args: { requestId: string; scope: SecretScope; value: string }) => Promise<unknown>
+  cancel: (requestId: string) => void
+}
+
+/**
+ * Pending ask-for-secret prompts, newest last. App-level rather than
+ * chat-level: the CLI that raises one is spawned by a harness process and has
+ * no chat id to attach to, so there is no transcript position to anchor it to.
+ * It surfaces inline above the composer instead.
+ */
+export function useSecretRequests(socket: KannaSocket): SecretRequestsState {
+  const [requests, setRequests] = useState<PendingSecretRequest[]>([])
+
+  useEffect(() => {
+    return socket.subscribe<SecretRequestsSnapshot>({ type: "secret-requests" }, (snapshot) => {
+      setRequests(snapshot?.requests ?? [])
+    })
+  }, [socket])
+
+  const submit = useCallback(
+    (args: { requestId: string; scope: SecretScope; value: string }) =>
+      socket.command({
+        type: "secret.submit",
+        requestId: args.requestId,
+        scope: args.scope,
+        value: args.value,
+      }),
+    [socket],
+  )
+
+  const cancel = useCallback(
+    (requestId: string) => {
+      void socket.command({ type: "secret.cancel", requestId })
+    },
+    [socket],
+  )
+
+  return {
+    // One at a time: two stacked prompts would be unreadable, and the next
+    // request surfaces as soon as this one settles.
+    activeRequest: requests[0] ?? null,
+    requests,
+    submit,
+    cancel,
+  }
+}

--- a/src/client/components/chat-ui/ThreadRowContent.tsx
+++ b/src/client/components/chat-ui/ThreadRowContent.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react"
-import { Loader2, MessageCircle, PencilLine } from "lucide-react"
+import { Clock, Loader2, MessageCircle, PencilLine } from "lucide-react"
 import type { SidebarChatRow } from "../../../shared/types"
+import { formatReminderDue } from "../../lib/reminder-presets"
 import type { SidebarThread } from "../../lib/thread-sections"
 import { cn } from "../../lib/utils"
 import { AnimatedShinyText } from "../ui/animated-shiny-text"
@@ -147,6 +148,10 @@ export function ThreadRowContent({
   // opted out of receding entirely.
   const needsAttention = thread.row.status !== "idle" || thread.row.unread
   const dimTitle = dimIdleTitles && !isActive && !hasUncommittedWork && !needsAttention
+  // Only one trailing element may claim the free space. The clock takes it when
+  // there is one, and the label then just sits next to it.
+  const reminderAt = thread.archived ? undefined : thread.row.reminderAt
+  const trailingMarginClass = reminderAt ? "ml-1" : "ml-auto"
   return (
     <>
       {statusDot ?? (HarnessIcon
@@ -170,12 +175,26 @@ export function ThreadRowContent({
         // of the parent gap so it hugs the title.
         <span className="-ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">{previewText}</span>
       ) : null}
+      {/* Left of the trailing label and outside its hover-swap wrapper, so the
+          clock stays put while the hover actions are showing rather than fading
+          out with the age label. */}
+      {reminderAt ? (
+        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+          <Clock
+            className="size-3 shrink-0 text-muted-foreground/70"
+            aria-label={`Reminder ${formatReminderDue(reminderAt, Date.now())}`}
+          />
+        </span>
+      ) : null}
       {hoverActions ? (
         // The label keeps its natural width and the title takes what's left —
         // but never less than half, because a `repo/branch` label is far longer
         // than the bare folder name this used to show. Proportional rather than
         // a fixed px cap: the sidebar is resizable.
-        <span className="ml-auto relative flex h-6 min-w-12 max-w-[50%] shrink-0 items-center justify-end pl-3 text-xs">
+        <span className={cn(
+          "relative flex h-6 min-w-12 max-w-[50%] shrink-0 items-center justify-end pl-3 text-xs",
+          trailingMarginClass,
+        )}>
           {/* z-10 + pointer-events-none on the label: while the label's opacity
               transition runs, opacity<1 creates a stacking context that would
               otherwise lift the later-DOM label above the icons and steal the
@@ -192,7 +211,7 @@ export function ThreadRowContent({
         </span>
       ) : (
         // See above: natural width, capped at half the row.
-        <span className="ml-auto flex max-w-[50%] shrink-0 items-center gap-1.5 pl-3 text-xs">
+        <span className={cn("flex max-w-[50%] shrink-0 items-center gap-1.5 pl-3 text-xs", trailingMarginClass)}>
           {detailLabel == null ? null : (
             <span className="min-w-0 truncate text-muted-foreground">{detailLabel}</span>
           )}

--- a/src/client/components/chat-ui/sidebar/Menus.tsx
+++ b/src/client/components/chat-ui/sidebar/Menus.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from "react"
-import { Archive, Code, Copy, EyeOff, FolderOpen, Github, Pencil, PencilOff, RotateCcw, Split, SquarePen, Trash2, UserRoundPlus } from "lucide-react"
+import { Archive, Clock, Code, Copy, EyeOff, FolderOpen, Github, Mail, MailOpen, Pencil, PencilOff, RotateCcw, Split, SquarePen, Trash2, UserRoundPlus } from "lucide-react"
 import { getRepoUrlLabel } from "../../../../shared/git-url"
+import { formatReminderDue, REMINDER_PRESETS } from "../../../lib/reminder-presets"
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "../../ui/context-menu"
 
@@ -130,6 +134,8 @@ export function ChatRowMenu({
   archived,
   editorLabel,
   repoUrl,
+  unread,
+  reminderAt,
   onNewChat,
   onRename,
   onShare,
@@ -140,6 +146,9 @@ export function ChatRowMenu({
   onArchive,
   onRestore,
   onClearDraft,
+  onSetUnread,
+  onSetReminder,
+  onClearReminder,
   onDelete,
   children,
 }: {
@@ -149,6 +158,10 @@ export function ChatRowMenu({
   editorLabel: string
   /** The project's forge page; absent when it has no browsable origin. */
   repoUrl?: string
+  /** Current unread state — decides whether the item reads "Unread" or "Read". */
+  unread?: boolean
+  /** When this chat's pending reminder fires, if it has one. */
+  reminderAt?: number
   /** Starts a fresh chat in this chat's project. */
   onNewChat: () => void
   onRename: () => void
@@ -165,6 +178,15 @@ export function ChatRowMenu({
    * clear beats a permanently greyed-out item in every menu.
    */
   onClearDraft?: () => void
+  /**
+   * Flip the unread flag. Absent on surfaces with no socket to send it (the
+   * archived list, tests), which simply get no item — same contract as
+   * `onClearDraft`.
+   */
+  onSetUnread?: (unread: boolean) => void
+  /** Schedule a reminder at an absolute time. Absent hides the submenu. */
+  onSetReminder?: (dueAt: number) => void
+  onClearReminder?: () => void
   onDelete: () => void
   children: ReactNode
 }) {
@@ -206,6 +228,60 @@ export function ChatRowMenu({
             <ContextMenuSeparator />
           </>
         ) : null}
+
+        {/* Triage: what you do to a row you are not opening right now. Leads
+            the chat actions because that is the common case for a right-click
+            on a row you just glanced at. */}
+        {onSetUnread ? (
+          <ContextMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              onSetUnread(!unread)
+            }}
+          >
+            {unread ? <MailOpen className="h-3.5 w-3.5" /> : <Mail className="h-3.5 w-3.5" />}
+            <span className="text-xs font-medium">
+              {unread ? "Mark as Read" : "Mark as Unread"}
+            </span>
+          </ContextMenuItem>
+        ) : null}
+        {onSetReminder ? (
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <Clock className="h-3.5 w-3.5" />
+              <span className="text-xs font-medium">
+                {reminderAt ? `Reminder ${formatReminderDue(reminderAt, Date.now())}` : "Remind Me"}
+              </span>
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {REMINDER_PRESETS.map((preset) => (
+                <ContextMenuItem
+                  key={preset.label}
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    onSetReminder(preset.resolve(Date.now()))
+                  }}
+                >
+                  <span className="text-xs font-medium">{preset.label}</span>
+                </ContextMenuItem>
+              ))}
+              {reminderAt && onClearReminder ? (
+                <>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      onClearReminder()
+                    }}
+                  >
+                    <span className="text-xs font-medium">Cancel Reminder</span>
+                  </ContextMenuItem>
+                </>
+              ) : null}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        ) : null}
+        {onSetUnread || onSetReminder ? <ContextMenuSeparator /> : null}
 
         {/* Chat actions */}
         <ContextMenuItem

--- a/src/client/components/chat-ui/sidebar/ThreadRow.tsx
+++ b/src/client/components/chat-ui/sidebar/ThreadRow.tsx
@@ -37,6 +37,9 @@ export function ThreadRow({
   onForkChat,
   onArchiveChat,
   onRestoreChat,
+  onSetChatUnread,
+  onSetChatReminder,
+  onClearChatReminder,
   onDeleteChat,
 }: {
   thread: SidebarThread
@@ -81,6 +84,14 @@ export function ThreadRow({
   onForkChat: (chat: SidebarThread["row"]) => void
   onArchiveChat: (chat: SidebarThread["row"]) => void
   onRestoreChat: (chatId: string) => void
+  /**
+   * Triage actions. Optional on the same terms as `onSelectMessage` above: a
+   * surface without a socket (the archived list, tests) shows no such items
+   * rather than items that would throw.
+   */
+  onSetChatUnread?: (chatId: string, unread: boolean) => void
+  onSetChatReminder?: (chatId: string, dueAt: number) => void
+  onClearChatReminder?: (chatId: string) => void
   onDeleteChat: (chat: SidebarThread["row"]) => void
 }) {
   // Read once here and handed to both the row and its card: the icon slot and
@@ -137,6 +148,17 @@ export function ThreadRow({
       archived={archived}
       editorLabel={editorLabel}
       repoUrl={thread.projectLabel.repoUrl}
+      unread={thread.row.unread}
+      reminderAt={thread.row.reminderAt}
+      onSetUnread={onSetChatUnread
+        ? (unread) => onSetChatUnread(thread.row.chatId, unread)
+        : undefined}
+      onSetReminder={onSetChatReminder
+        ? (dueAt) => onSetChatReminder(thread.row.chatId, dueAt)
+        : undefined}
+      onClearReminder={onClearChatReminder
+        ? () => onClearChatReminder(thread.row.chatId)
+        : undefined}
       onNewChat={() => onCreateChat(thread.projectId)}
       onRestore={archived ? () => onRestoreChat(thread.row.chatId) : undefined}
       onRename={() => onRenameChat(thread.row)}

--- a/src/client/components/chat-ui/sidebar/ThreadSections.tsx
+++ b/src/client/components/chat-ui/sidebar/ThreadSections.tsx
@@ -124,6 +124,9 @@ interface Props {
   onForkChat: (chat: SidebarChatRow) => void
   onArchiveChat: (chat: SidebarChatRow) => void
   onDeleteChat: (chat: SidebarChatRow) => void
+  onSetChatUnread: (chatId: string, unread: boolean) => void
+  onSetChatReminder: (chatId: string, dueAt: number) => void
+  onClearChatReminder: (chatId: string) => void
   onCopyPath: (localPath: string) => void
   onOpenExternalPath: (action: "open_finder" | "open_editor", localPath: string) => void
 }
@@ -154,6 +157,9 @@ function ThreadSectionsImpl({
   onForkChat,
   onArchiveChat,
   onDeleteChat,
+  onSetChatUnread,
+  onSetChatReminder,
+  onClearChatReminder,
   onCopyPath,
   onOpenExternalPath,
 }: Props) {
@@ -214,6 +220,9 @@ function ThreadSectionsImpl({
       onForkChat={onForkChat}
       onArchiveChat={onArchiveChat}
       onRestoreChat={onRestoreChat}
+      onSetChatUnread={onSetChatUnread}
+      onSetChatReminder={onSetChatReminder}
+      onClearChatReminder={onClearChatReminder}
       onDeleteChat={onDeleteChat}
     />
   )

--- a/src/client/components/messages/AskUserQuestionMessage.tsx
+++ b/src/client/components/messages/AskUserQuestionMessage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
-import { Check, ChevronLeft, MessageCircleQuestion } from "lucide-react"
+import { ChevronLeft, MessageCircleQuestion } from "lucide-react"
 import type { ProcessedToolCall, AskUserQuestionItem, AskUserQuestionOption } from "./types"
 import type { AskUserQuestionAnswerMap } from "../../../shared/types"
 import { Button } from "../ui/button"
+import { ChoiceCheckbox, ChoiceRow } from "../ui/choice"
 import { cn } from "../../lib/utils"
 import { useTranscriptRenderOptions } from "./render-context"
 
@@ -60,44 +61,6 @@ function QuestionCard({
   )
 }
 
-function OptionContent({ label, description }: { label: string; description?: string }) {
-  return (
-    <>
-      <span className="text-foreground text-sm">{label}</span>
-      {description && (
-        <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
-      )}
-    </>
-  )
-}
-
-function Checkbox({
-  selected,
-  multiSelect,
-  onClick
-}: {
-  selected: boolean
-  multiSelect?: boolean
-  onClick?: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex-shrink-0 w-5 h-5 border-1 flex items-center justify-center",
-        multiSelect ? "rounded" : "rounded-full",
-        selected
-          ? "border-slate-500/0 bg-foreground"
-          : "border-muted-foreground/50 bg-background",
-        onClick && selected && "cursor-pointer"
-      )}
-    >
-      {selected && <Check strokeWidth={3} className="translate-y-[0.5px] h-3 w-3 text-white dark:text-background" />}
-    </button>
-  )
-}
-
 function OptionRow({
   option,
   selected,
@@ -111,29 +74,15 @@ function OptionRow({
   onClick?: () => void
   isLast?: boolean
 }) {
-  const baseClasses = "w-full text-left p-3 pt-2.5 pl-4 pr-5 bg-background"
-  const borderClass = !isLast ? "border-b border-border" : ""
-
-  if (onClick) {
-    return (
-      <button
-        onClick={onClick}
-        className={cn(baseClasses, borderClass, "transition-all cursor-pointer")}
-      >
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            <OptionContent label={option.label} description={option.description} />
-          </div>
-          <Checkbox selected={selected} multiSelect={multiSelect} />
-        </div>
-      </button>
-    )
-  }
-
   return (
-    <div className={cn(baseClasses, borderClass)}>
-      <OptionContent label={option.label} description={option.description} />
-    </div>
+    <ChoiceRow
+      label={option.label}
+      description={option.description}
+      selected={selected}
+      multiSelect={multiSelect}
+      onClick={onClick}
+      isLast={isLast}
+    />
   )
 }
 
@@ -373,7 +322,7 @@ export function AskUserQuestionMessage({ message, onSubmit, isLatest }: Props) {
               placeholder="Other..."
               className="flex-1 px-3 !py-1 pl-4 min-h-[55px] min-w-0 text-sm bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
             />
-            <Checkbox
+            <ChoiceCheckbox
               selected={!!customInput}
               multiSelect={currentQuestion.multiSelect}
               onClick={currentQuestion.multiSelect && customInput ? () => clearCustomInput(currentQuestion) : undefined}

--- a/src/client/components/messages/CompactBoundaryMessage.tsx
+++ b/src/client/components/messages/CompactBoundaryMessage.tsx
@@ -57,3 +57,52 @@ export function SecretNoticeMessage({
     </div>
   )
 }
+
+/**
+ * A reminder fired and woke this chat.
+ *
+ * Reads as a divider rather than a message because that is its job: the prompt
+ * directly below it was posted by the schedule, not typed by the user, and
+ * without this line it reads as something they said and forgot.
+ */
+export function ReminderNoticeMessage({
+  message,
+}: {
+  message: Extract<
+    import("../../../shared/types").HydratedTranscriptMessage,
+    { kind: "reminder_notice" }
+  >
+}) {
+  const ago = formatScheduledAgo(message.scheduledAt, Date.parse(message.timestamp))
+  const who = message.createdBy === "agent" ? "scheduled follow-up" : "reminder"
+  const label = message.wokeAgent
+    ? `${who}${ago ? ` · set ${ago} ago` : ""}`
+    : `${who}${ago ? ` · set ${ago} ago` : ""} · no turn started`
+
+  return (
+    <div className="flex items-center gap-3">
+      <ZigZagLine />
+      <span className="flex-shrink-0 text-[11px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </span>
+      <ZigZagLine />
+    </div>
+  )
+}
+
+/**
+ * How long before firing the reminder was set. Coarse on purpose — "set 3h ago"
+ * is the useful fact; minutes of precision on a thing that already happened is
+ * noise. Returns null when the gap is under a minute or the timestamps are
+ * unusable, so the label simply omits the clause.
+ */
+function formatScheduledAgo(scheduledAt: number, firedAt: number): string | null {
+  if (!Number.isFinite(scheduledAt) || !Number.isFinite(firedAt)) return null
+  const elapsed = firedAt - scheduledAt
+  if (elapsed < 60_000) return null
+  const minutes = Math.round(elapsed / 60_000)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.round(elapsed / 3_600_000)
+  if (hours < 24) return `${hours}h`
+  return `${Math.round(hours / 24)}d`
+}

--- a/src/client/components/messages/CompactBoundaryMessage.tsx
+++ b/src/client/components/messages/CompactBoundaryMessage.tsx
@@ -28,3 +28,32 @@ export function ContextClearedMessage() {
     </div>
   )
 }
+
+/**
+ * Outcome of an ask-for-secret prompt. Carries the name and what happened —
+ * never the value, which is the point of the whole mechanism.
+ */
+export function SecretNoticeMessage({
+  message,
+}: {
+  message: Extract<
+    import("../../../shared/types").HydratedTranscriptMessage,
+    { kind: "secret_notice" }
+  >
+}) {
+  const label = message.outcome === "saved"
+    ? `${message.secretName} saved${message.scope ? ` · ${message.scope}` : ""}`
+    : message.outcome === "declined"
+      ? `${message.secretName} declined`
+      : `${message.secretName} expired`
+
+  return (
+    <div className="flex items-center gap-3">
+      <ZigZagLine />
+      <span className="flex-shrink-0 text-[11px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </span>
+      <ZigZagLine />
+    </div>
+  )
+}

--- a/src/client/components/reminders/ReminderDockCard.test.tsx
+++ b/src/client/components/reminders/ReminderDockCard.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { ReminderDockCard } from "./ReminderDockCard"
+
+const NOW = new Date(2026, 7, 26, 17, 15, 0).getTime()
+
+function render(dueAt: number | null, nowMs: number = NOW) {
+  return renderToStaticMarkup(
+    <ReminderDockCard dueAt={dueAt} nowMs={nowMs} onClear={async () => {}} />,
+  )
+}
+
+describe("ReminderDockCard", () => {
+  test("renders nothing when the chat has no reminder", () => {
+    expect(render(null)).toBe("")
+  })
+
+  test("counts down in minutes and names the clock time", () => {
+    const markup = render(NOW + 25 * 60_000)
+    expect(markup).toContain("Reminder in 25 minutes")
+    // Both readings are present: how long, and when.
+    expect(markup).toMatch(/5:40/)
+  })
+
+  test("uses the singular for one minute and one hour", () => {
+    expect(render(NOW + 60_000)).toContain("Reminder in 1 minute")
+    expect(render(NOW + 3_600_000)).toContain("Reminder in 1 hour")
+  })
+
+  test("switches to hours, then to days with a weekday", () => {
+    expect(render(NOW + 3 * 3_600_000)).toContain("Reminder in 3 hours")
+    const twoDays = render(NOW + 2 * 86_400_000)
+    expect(twoDays).toContain("Reminder in 2 days")
+    expect(twoDays).toContain("Friday")
+  })
+
+  test("never rounds a pending reminder down to zero minutes", () => {
+    expect(render(NOW + 20_000)).toContain("Reminder in 1 minute")
+  })
+
+  test("reads calmly when due but not yet swept by the tick", () => {
+    const markup = render(NOW - 5_000)
+    expect(markup).toContain("any moment now")
+    expect(markup).not.toContain("in 0")
+    // A negative countdown is the failure this guards; bare hyphens are all
+    // over the class names and SVG paths, so match the countdown shape.
+    expect(markup).not.toMatch(/in -\d/)
+  })
+
+  test("offers a labelled cancel control", () => {
+    expect(render(NOW + 60_000)).toContain("Cancel this reminder")
+  })
+})

--- a/src/client/components/reminders/ReminderDockCard.tsx
+++ b/src/client/components/reminders/ReminderDockCard.tsx
@@ -1,0 +1,93 @@
+import { Clock, LoaderCircle, X } from "lucide-react"
+import { useState } from "react"
+import { ChoiceCard } from "../ui/choice"
+
+/**
+ * The "you'll be reminded" line above the composer, shown only while the chat
+ * has a pending reminder.
+ *
+ * Deliberately live state rather than a transcript entry: a reminder can still
+ * be cancelled, and its countdown changes, neither of which a transcript entry
+ * can express. The transcript gets its line when the reminder actually *fires*
+ * (`ReminderNoticeMessage`) — that one is history and belongs there.
+ *
+ * Sits below `SecretRequestCard` in the dock and is quiet where that card is
+ * loud: the agent is not blocked on this, so it must never push a prompt that
+ * *is* blocking further from the eye.
+ */
+export function ReminderDockCard({
+  dueAt,
+  nowMs,
+  onClear,
+}: {
+  dueAt: number | null
+  /** Ticked by the owning hook so the countdown re-renders. */
+  nowMs: number
+  onClear: () => Promise<unknown>
+}) {
+  const [isBusy, setIsBusy] = useState(false)
+
+  if (dueAt == null) return null
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-3 pb-2">
+      <ChoiceCard className="bg-background/80 backdrop-blur">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-xs font-medium">
+              {describeReminder(dueAt, nowMs)}
+            </span>
+            <span className="truncate text-[11px] text-muted-foreground">
+              This chat will pick the task back up on its own.
+            </span>
+          </div>
+          <button
+            type="button"
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:opacity-50"
+            title="Cancel this reminder"
+            aria-label="Cancel this reminder"
+            disabled={isBusy}
+            onClick={() => {
+              setIsBusy(true)
+              void Promise.resolve(onClear()).finally(() => setIsBusy(false))
+            }}
+          >
+            {isBusy
+              ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              : <X className="h-3.5 w-3.5" />}
+          </button>
+        </div>
+      </ChoiceCard>
+    </div>
+  )
+}
+
+/**
+ * "Reminder in 25 minutes · 5:41 PM".
+ *
+ * Carries both the relative and the absolute time because they answer different
+ * questions — "how long have I got" and "will I still be at my desk" — and the
+ * line has room for both.
+ */
+function describeReminder(dueAt: number, nowMs: number): string {
+  const clock = new Date(dueAt).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  })
+  const remaining = dueAt - nowMs
+  // Due but not yet swept up by the scheduler's tick. Saying "in 0 minutes"
+  // would read as broken; "any moment now" is both true and calmer.
+  if (remaining <= 0) return `Reminder due any moment now · ${clock}`
+
+  const minutes = Math.round(remaining / 60_000)
+  if (minutes < 60) {
+    return `Reminder in ${Math.max(1, minutes)} ${minutes === 1 ? "minute" : "minutes"} · ${clock}`
+  }
+  const hours = Math.round(remaining / 3_600_000)
+  if (hours < 24) return `Reminder in ${hours} ${hours === 1 ? "hour" : "hours"} · ${clock}`
+
+  const days = Math.round(hours / 24)
+  const date = new Date(dueAt).toLocaleDateString(undefined, { weekday: "long" })
+  return `Reminder in ${days} ${days === 1 ? "day" : "days"} · ${date} ${clock}`
+}

--- a/src/client/components/secrets/SecretRequestCard.tsx
+++ b/src/client/components/secrets/SecretRequestCard.tsx
@@ -1,0 +1,169 @@
+import { Eye, EyeOff, FolderLock, Globe, KeyRound, LoaderCircle, ShieldCheck } from "lucide-react"
+import { useEffect, useState } from "react"
+import type { PendingSecretRequest, SecretScope } from "../../../shared/secrets"
+import { cn } from "../../lib/utils"
+import { Button } from "../ui/button"
+import { ChoiceCard, ChoiceRow } from "../ui/choice"
+
+/**
+ * The user-facing half of ask-for-secret, rendered inline above the composer
+ * rather than as a modal — same shape as the AskUserQuestion prompt, because
+ * it is the same kind of interruption: the agent is blocked waiting on you.
+ *
+ * The value typed here goes over the socket once, straight to a 0600 file on
+ * disk. It is never echoed back in a snapshot, never written to the
+ * transcript, and never shown to the agent.
+ */
+export function SecretRequestCard({
+  request,
+  onSubmit,
+  onCancel,
+}: {
+  request: PendingSecretRequest | null
+  onSubmit: (args: { requestId: string; scope: SecretScope; value: string }) => Promise<unknown>
+  onCancel: (requestId: string) => void
+}) {
+  const [value, setValue] = useState("")
+  const [scope, setScope] = useState<SecretScope>("project")
+  const [isSaving, setIsSaving] = useState(false)
+  const [isRevealed, setIsRevealed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canUseProjectScope = Boolean(request?.projectPath)
+
+  // Reset per request so a second prompt never inherits the first one's typing.
+  useEffect(() => {
+    if (!request) return
+    setValue("")
+    setError(null)
+    setIsSaving(false)
+    // Back to masked for each new prompt — revealing is a per-value choice.
+    setIsRevealed(false)
+    setScope(!canUseProjectScope ? "global" : request.suggestedScope ?? "project")
+  }, [request?.id, canUseProjectScope])
+
+  if (!request) return null
+
+  const submit = async () => {
+    if (!value || isSaving) return
+    setIsSaving(true)
+    setError(null)
+    try {
+      await onSubmit({ requestId: request.id, scope, value })
+      setValue("")
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : String(submitError))
+      setIsSaving(false)
+    }
+  }
+
+  const projectLabel = request.projectTitle ?? request.projectPath ?? "this project"
+
+  return (
+    <div className="mx-auto w-full max-w-[840px] space-y-3 px-1 pb-3">
+      <ChoiceCard>
+        <div className="flex items-center gap-2 border-b border-border bg-card p-3 px-4 text-sm font-medium text-foreground">
+          <KeyRound className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate">{request.name}</span>
+        </div>
+
+        {request.reason ? (
+          <p className="border-b border-border bg-background px-4 pb-2.5 pt-2.5 text-sm text-muted-foreground">
+            {request.reason}
+          </p>
+        ) : null}
+
+        {/* pl-4/pr-5 matches ChoiceRow so the reveal toggle lines up with the
+            scope check indicators directly below it. */}
+        <div className="flex items-center gap-3 border-b border-border bg-background py-2.5 pl-4 pr-5">
+          <input
+            autoFocus
+            type={isRevealed ? "text" : "password"}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={`Value for ${request.name}`}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && value) {
+                event.preventDefault()
+                void submit()
+              }
+              if (event.key === "Escape") {
+                event.preventDefault()
+                onCancel(request.id)
+              }
+            }}
+            className="min-h-[34px] min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <button
+            type="button"
+            onClick={() => setIsRevealed((previous) => !previous)}
+            aria-label={isRevealed ? "Hide value" : "Reveal value"}
+            title={isRevealed ? "Hide value" : "Reveal value"}
+            className={cn(
+              "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded transition-opacity",
+              "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {isRevealed ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+          </button>
+        </div>
+
+        <ChoiceRow
+          icon={<FolderLock className="size-4" />}
+          label="This project only"
+          description={
+            canUseProjectScope
+              ? `${projectLabel} · .kanna/secrets/ (git-ignored)`
+              : "Unavailable — the agent did not run inside a known project"
+          }
+          selected={scope === "project"}
+          disabled={!canUseProjectScope}
+          onClick={canUseProjectScope ? () => setScope("project") : undefined}
+        />
+        <ChoiceRow
+          icon={<Globe className="size-4" />}
+          label="All projects on this machine"
+          description="~/.kanna/secrets/"
+          selected={scope === "global"}
+          onClick={() => setScope("global")}
+          isLast
+        />
+      </ChoiceCard>
+
+      <div className="flex items-center justify-between gap-3 px-2">
+        <p className="flex min-w-0 items-start gap-2 text-xs text-muted-foreground">
+          <ShieldCheck className="mt-0.5 size-3.5 shrink-0" />
+          <span className="min-w-0">
+            Saved to a file the agent loads into a shell — the value never enters its context or
+            this transcript.
+          </span>
+        </p>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="rounded-full"
+            onClick={() => onCancel(request.id)}
+            disabled={isSaving}
+          >
+            Decline
+          </Button>
+          <Button
+            size="sm"
+            className={cn("rounded-full", (!value || isSaving) && "cursor-not-allowed opacity-50")}
+            onClick={() => void submit()}
+            disabled={!value || isSaving}
+          >
+            {isSaving ? <LoaderCircle className="size-4 animate-spin" /> : null}
+            Save secret
+          </Button>
+        </div>
+      </div>
+
+      {error ? <p className="px-2 text-xs text-destructive">{error}</p> : null}
+    </div>
+  )
+}

--- a/src/client/components/ui/choice.tsx
+++ b/src/client/components/ui/choice.tsx
@@ -1,0 +1,147 @@
+import { Check } from "lucide-react"
+import { cn } from "../../lib/utils"
+
+/**
+ * Building blocks for the inline "pick one of these" cards that appear in the
+ * transcript flow — the AskUserQuestion prompt and the ask-for-secret prompt.
+ *
+ * Shared rather than copied so the two read as the same control. Each card
+ * builds its own header (they differ: one carries a progress bar, the other a
+ * secret name), but the rows and the check indicator come from here.
+ */
+
+/** The card shell. Rows inside separate themselves with `border-b`. */
+export function ChoiceCard({
+  className,
+  children,
+}: {
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={cn("overflow-hidden rounded-2xl border border-border", className)}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Circle for single-select, square for multi — matching native radio/checkbox
+ * semantics.
+ *
+ * Renders a `span` unless given its own `onClick`: inside `ChoiceRow` the row
+ * is already the button, and a nested `button` is invalid markup.
+ */
+export function ChoiceCheckbox({
+  selected,
+  multiSelect,
+  onClick,
+  disabled,
+}: {
+  selected: boolean
+  multiSelect?: boolean
+  onClick?: () => void
+  disabled?: boolean
+}) {
+  const className = cn(
+    "flex h-5 w-5 flex-shrink-0 items-center justify-center border-1",
+    multiSelect ? "rounded" : "rounded-full",
+    selected ? "border-slate-500/0 bg-foreground" : "border-muted-foreground/50 bg-background",
+    onClick && selected && "cursor-pointer",
+  )
+
+  const mark = selected ? (
+    <Check strokeWidth={3} className="h-3 w-3 translate-y-[0.5px] text-white dark:text-background" />
+  ) : null
+
+  if (!onClick) {
+    return (
+      <span aria-hidden className={className}>
+        {mark}
+      </span>
+    )
+  }
+
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} className={className}>
+      {mark}
+    </button>
+  )
+}
+
+export function ChoiceOptionContent({
+  label,
+  description,
+}: {
+  label: string
+  description?: string
+}) {
+  return (
+    <>
+      <span className="text-sm text-foreground">{label}</span>
+      {description && <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>}
+    </>
+  )
+}
+
+/**
+ * One selectable row. Renders as a plain div when `onClick` is omitted, which
+ * is how the read-only transcript views show the same list without offering
+ * to change it.
+ */
+export function ChoiceRow({
+  label,
+  description,
+  icon,
+  selected,
+  multiSelect,
+  onClick,
+  disabled,
+  isLast,
+}: {
+  label: string
+  description?: string
+  icon?: React.ReactNode
+  selected: boolean
+  multiSelect?: boolean
+  onClick?: () => void
+  disabled?: boolean
+  isLast?: boolean
+}) {
+  const baseClasses = "w-full bg-background p-3 pl-4 pr-5 pt-2.5 text-left"
+  const borderClass = !isLast ? "border-b border-border" : ""
+
+  const body = (
+    <div className="flex items-center justify-between gap-3">
+      {icon ? (
+        <span className={cn("flex-shrink-0", selected ? "text-foreground" : "text-muted-foreground")}>
+          {icon}
+        </span>
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <ChoiceOptionContent label={label} description={description} />
+      </div>
+      <ChoiceCheckbox selected={selected} multiSelect={multiSelect} disabled={disabled} />
+    </div>
+  )
+
+  if (!onClick) {
+    return <div className={cn(baseClasses, borderClass)}>{body}</div>
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        baseClasses,
+        borderClass,
+        "cursor-pointer transition-all",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {body}
+    </button>
+  )
+}

--- a/src/client/components/ui/context-menu.tsx
+++ b/src/client/components/ui/context-menu.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import { ChevronRight } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 const ContextMenuCloseContext = React.createContext<(() => void) | null>(null)
@@ -68,6 +69,48 @@ const ContextMenuItem = React.forwardRef<
 })
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
 
+const ContextMenuSub = ContextMenuPrimitive.Sub
+
+/**
+ * Note what this deliberately does *not* do: unlike `ContextMenuItem` it never
+ * calls `closeContextMenu`. Opening a submenu is navigation inside the menu,
+ * not a choice — closing here would shut the whole thing on the way in.
+ */
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium text-foreground outline-hidden transition-colors hover:bg-muted focus:bg-muted data-[state=open]:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-3.5 w-3.5 opacity-60" />
+  </ContextMenuPrimitive.SubTrigger>
+))
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[170px] overflow-hidden rounded-xl border border-border bg-background p-1 shadow-lg outline-hidden animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+))
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
+
 const ContextMenuSeparator = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
@@ -86,4 +129,7 @@ export {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
 }

--- a/src/client/lib/parseTranscript.ts
+++ b/src/client/lib/parseTranscript.ts
@@ -165,6 +165,15 @@ export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedT
           kind: "context_cleared",
         })
         break
+      case "secret_notice":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "secret_notice",
+          secretName: entry.secretName,
+          outcome: entry.outcome,
+          scope: entry.scope,
+        })
+        break
       case "handoff_boundary":
         messages.push({
           ...createBaseMessage(entry),

--- a/src/client/lib/parseTranscript.ts
+++ b/src/client/lib/parseTranscript.ts
@@ -174,6 +174,15 @@ export function processTranscriptMessages(entries: TranscriptEntry[]): HydratedT
           scope: entry.scope,
         })
         break
+      case "reminder_notice":
+        messages.push({
+          ...createBaseMessage(entry),
+          kind: "reminder_notice",
+          scheduledAt: entry.scheduledAt,
+          createdBy: entry.createdBy,
+          wokeAgent: entry.wokeAgent,
+        })
+        break
       case "handoff_boundary":
         messages.push({
           ...createBaseMessage(entry),

--- a/src/client/lib/reminder-presets.test.ts
+++ b/src/client/lib/reminder-presets.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { formatReminderDue, nextMorning, REMINDER_PRESETS } from "./reminder-presets"
+
+/** Local time, so the assertions read the same way the code computes them. */
+function local(year: number, month: number, day: number, hour: number, minute = 0) {
+  return new Date(year, month - 1, day, hour, minute, 0, 0).getTime()
+}
+
+describe("nextMorning", () => {
+  test("an afternoon lands on the next day's 9am", () => {
+    const now = local(2026, 3, 10, 14, 30)
+    const morning = new Date(nextMorning(now))
+    expect(morning.getDate()).toBe(11)
+    expect(morning.getHours()).toBe(9)
+    expect(morning.getMinutes()).toBe(0)
+  })
+
+  test("the small hours land on this morning, not tomorrow's", () => {
+    const now = local(2026, 3, 10, 2, 15)
+    const morning = new Date(nextMorning(now))
+    expect(morning.getDate()).toBe(10)
+    expect(morning.getHours()).toBe(9)
+  })
+
+  test("exactly 9am rolls forward rather than resolving to now", () => {
+    const now = local(2026, 3, 10, 9)
+    const morning = new Date(nextMorning(now))
+    expect(morning.getDate()).toBe(11)
+    expect(nextMorning(now)).toBeGreaterThan(now)
+  })
+
+  test("lands on the clock hour across a spring-forward boundary", () => {
+    // US DST begins 2026-03-08. Asking on the 7th must still mean 9am local on
+    // the 8th, which is not 24 hours later in zones that observe it.
+    const now = local(2026, 3, 7, 20)
+    const morning = new Date(nextMorning(now))
+    expect(morning.getDate()).toBe(8)
+    expect(morning.getHours()).toBe(9)
+  })
+
+  test("crosses a month boundary", () => {
+    const now = local(2026, 3, 31, 22)
+    const morning = new Date(nextMorning(now))
+    expect(morning.getMonth()).toBe(3) // April, zero-based
+    expect(morning.getDate()).toBe(1)
+  })
+})
+
+describe("REMINDER_PRESETS", () => {
+  test("every preset resolves into the future", () => {
+    const now = local(2026, 3, 10, 14, 30)
+    for (const preset of REMINDER_PRESETS) {
+      expect(preset.resolve(now)).toBeGreaterThan(now)
+    }
+  })
+
+  test("presets are offered in ascending order", () => {
+    const now = local(2026, 3, 10, 14, 30)
+    const resolved = REMINDER_PRESETS.map((preset) => preset.resolve(now))
+    expect([...resolved].sort((a, b) => a - b)).toEqual(resolved)
+  })
+})
+
+describe("formatReminderDue", () => {
+  const now = 1_700_000_000_000
+
+  test("renders minutes, hours and days", () => {
+    expect(formatReminderDue(now + 12 * 60_000, now)).toBe("in 12m")
+    expect(formatReminderDue(now + 3 * 3_600_000, now)).toBe("in 3h")
+    expect(formatReminderDue(now + 2 * 86_400_000, now)).toBe("in 2d")
+  })
+
+  test("a due-but-unfired reminder reads as now rather than a negative", () => {
+    expect(formatReminderDue(now - 5_000, now)).toBe("now")
+    expect(formatReminderDue(now, now)).toBe("now")
+  })
+
+  test("never rounds a pending reminder down to zero minutes", () => {
+    expect(formatReminderDue(now + 20_000, now)).toBe("in 1m")
+  })
+})

--- a/src/client/lib/reminder-presets.ts
+++ b/src/client/lib/reminder-presets.ts
@@ -1,0 +1,55 @@
+/**
+ * The reminder choices offered in the sidebar's right-click menu.
+ *
+ * Presets rather than a time picker: the menu is for the two-second decision
+ * ("not now — after lunch"). Anything more specific is what `kanna remind --at`
+ * is for, and an agent can set one from inside the chat.
+ */
+
+export interface ReminderPreset {
+  label: string
+  /** Absolute epoch ms this preset means, given the current time. */
+  resolve: (now: number) => number
+}
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+
+/** Local-time hour that "tomorrow morning" means. */
+const MORNING_HOUR = 9
+
+/**
+ * The next {@link MORNING_HOUR} in the *viewer's* timezone.
+ *
+ * Built from local date parts rather than by adding 24h, so it lands on the
+ * clock hour across a DST boundary instead of an hour either side of it. Late
+ * evening still means the next calendar day; 2am means later this morning,
+ * which is what someone awake at 2am means by "the morning".
+ */
+export function nextMorning(now: number, hour: number = MORNING_HOUR): number {
+  const date = new Date(now)
+  const morning = new Date(date.getFullYear(), date.getMonth(), date.getDate(), hour, 0, 0, 0)
+  if (morning.getTime() <= now) morning.setDate(morning.getDate() + 1)
+  return morning.getTime()
+}
+
+export const REMINDER_PRESETS: ReminderPreset[] = [
+  { label: "In 15 minutes", resolve: (now) => now + 15 * MINUTE_MS },
+  { label: "In 1 hour", resolve: (now) => now + HOUR_MS },
+  { label: "In 3 hours", resolve: (now) => now + 3 * HOUR_MS },
+  { label: "Tomorrow morning", resolve: (now) => nextMorning(now) },
+]
+
+/**
+ * How a pending reminder reads in the menu and on the row: "in 12m", "in 3h",
+ * "in 2d", or "now" once it is due but the tick has not yet caught it.
+ */
+export function formatReminderDue(dueAt: number, now: number): string {
+  const remaining = dueAt - now
+  if (remaining <= 0) return "now"
+  const minutes = Math.round(remaining / MINUTE_MS)
+  if (minutes < 60) return `in ${Math.max(1, minutes)}m`
+  const hours = Math.round(remaining / HOUR_MS)
+  if (hours < 24) return `in ${hours}h`
+  return `in ${Math.round(hours / 24)}d`
+}

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -58,6 +58,7 @@ import { resolveClaudeApiModelId } from "../shared/types"
 import { fallbackTitleFromMessage } from "./generate-title"
 import { asNumber, asRecord } from "../shared/json"
 import { buildHandoffContext, buildHandoffMessageContent, type HandoffContext } from "./handoff"
+import { buildAskSecretInstructions } from "./secret-instructions"
 import { checkSessionArtifact, type SessionArtifactStatus } from "./session-artifacts"
 import { timestamped } from "./transcript"
 
@@ -744,7 +745,10 @@ async function startClaudeSession(args: {
       systemPrompt: {
         type: "preset",
         preset: "claude_code",
-        append: buildKannaAttributionInstructions(buildKannaAgentId("claude", args.model)),
+        append: [
+          buildKannaAttributionInstructions(buildKannaAgentId("claude", args.model)),
+          buildAskSecretInstructions(),
+        ].join("\n\n"),
       },
       // fastMode must go through the flag-settings layer: the CLI only allows
       // fast mode in Agent SDK sessions when flagSettings.fastMode is true,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -59,6 +59,7 @@ import { fallbackTitleFromMessage } from "./generate-title"
 import { asNumber, asRecord } from "../shared/json"
 import { buildHandoffContext, buildHandoffMessageContent, type HandoffContext } from "./handoff"
 import { buildAskSecretInstructions } from "./secret-instructions"
+import { reminderInstructionsBlock } from "./reminder-instructions"
 import { SECRET_CHAT_ID_ENV_VAR } from "../shared/secrets"
 import { checkSessionArtifact, type SessionArtifactStatus } from "./session-artifacts"
 import { timestamped } from "./transcript"
@@ -751,7 +752,8 @@ async function startClaudeSession(args: {
         append: [
           buildKannaAttributionInstructions(buildKannaAgentId("claude", args.model)),
           buildAskSecretInstructions(),
-        ].join("\n\n"),
+          reminderInstructionsBlock(),
+        ].filter((block): block is string => block !== null).join("\n\n"),
       },
       // fastMode must go through the flag-settings layer: the CLI only allows
       // fast mode in Agent SDK sessions when flagSettings.fastMode is true,

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -59,6 +59,7 @@ import { fallbackTitleFromMessage } from "./generate-title"
 import { asNumber, asRecord } from "../shared/json"
 import { buildHandoffContext, buildHandoffMessageContent, type HandoffContext } from "./handoff"
 import { buildAskSecretInstructions } from "./secret-instructions"
+import { SECRET_CHAT_ID_ENV_VAR } from "../shared/secrets"
 import { checkSessionArtifact, type SessionArtifactStatus } from "./session-artifacts"
 import { timestamped } from "./transcript"
 
@@ -194,6 +195,7 @@ interface AgentCoordinatorArgs {
   resolvePiConnection?: () => Promise<import("./pi-agent").PiConnection | null>
   generateTitle?: (messageContent: string, cwd: string) => Promise<GenerateChatTitleResult>
   startClaudeSession?: (args: {
+    chatId: string
     localPath: string
     model: string
     effort?: string
@@ -659,6 +661,7 @@ async function* createClaudeHarnessStream(
 
 
 async function startClaudeSession(args: {
+  chatId: string
   localPath: string
   model: string
   effort?: string
@@ -756,7 +759,12 @@ async function startClaudeSession(args: {
       // enabling it while the UI shows "Standard".
       settings: { enableWorkflows: true, fastMode: args.serviceTier === "fast" },
       pathToClaudeCodeExecutable: process.env.CLAUDE_EXECUTABLE?.replace(/^~(?=\/|$)/, homedir()) || undefined,
-      env: (() => { const { CLAUDECODE: _, ...env } = process.env; return env })(),
+      // KANNA_CHAT_ID lets `kanna ask-secret`, spawned somewhere under this
+      // session's Bash tool, name the chat it belongs to.
+      env: (() => {
+        const { CLAUDECODE: _, ...env } = process.env
+        return { ...env, [SECRET_CHAT_ID_ENV_VAR]: args.chatId }
+      })(),
     },
   })
 
@@ -886,6 +894,8 @@ export class AgentCoordinator {
     let probe: ClaudeSessionHandle | null = null
     try {
       probe = await this.startClaudeSessionFn({
+        // Not a chat session — a throwaway probe for the usage read.
+        chatId: "",
         localPath: homedir(),
         // Model choice is irrelevant for the usage read; use the catalog default.
         model: "sonnet",
@@ -1561,6 +1571,7 @@ export class AgentCoordinator {
       }
 
       const started = await this.startClaudeSessionFn({
+        chatId: args.chatId,
         localPath: args.localPath,
         model: args.model,
         effort: args.effort,

--- a/src/server/ask-secret-command.test.ts
+++ b/src/server/ask-secret-command.test.ts
@@ -232,7 +232,20 @@ describe("runAskSecretCommand", () => {
       cwd: "/tmp/proj",
       scope: "global",
       force: true,
+      chatId: null,
     })
+  })
+
+  test("forwards the chat id when the harness environment carries one", async () => {
+    const { deps, calls } = harness([
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+
+    await runAskSecretCommand(baseArgs, {
+      ...deps,
+      env: { ...deps.env, KANNA_CHAT_ID: "chat-42" },
+    })
+    expect(JSON.parse(calls[0].body!).chatId).toBe("chat-42")
   })
 
   test("environment overrides win over the instance file", async () => {

--- a/src/server/ask-secret-command.test.ts
+++ b/src/server/ask-secret-command.test.ts
@@ -260,3 +260,36 @@ describe("runAskSecretCommand", () => {
     expect(calls[0].token).toBe("env-token")
   })
 })
+
+describe("instance token handling", () => {
+  test("does not send the instance token to an overridden KANNA_URL", async () => {
+    const { deps, calls } = harness([
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+    const warns: string[] = []
+
+    const code = await runAskSecretCommand(baseArgs, {
+      ...deps,
+      warn: (message) => warns.push(message),
+      env: { ...deps.env, KANNA_URL: "https://not-your-machine.example" },
+    })
+
+    expect(code).toBe(1)
+    expect(calls).toHaveLength(0)
+    expect(warns.join("\n")).toContain("KANNA_TOKEN")
+  })
+
+  test("allows an overridden URL when its own token is supplied", async () => {
+    const { deps, calls } = harness([
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+
+    const code = await runAskSecretCommand(baseArgs, {
+      ...deps,
+      env: { ...deps.env, KANNA_URL: "http://127.0.0.1:9999", KANNA_TOKEN: "explicit" },
+    })
+
+    expect(code).toBe(0)
+    expect(calls[0].token).toBe("explicit")
+  })
+})

--- a/src/server/ask-secret-command.test.ts
+++ b/src/server/ask-secret-command.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test"
+import { SECRETS_API_TOKEN_HEADER } from "../shared/secrets"
+import {
+  ASK_SECRET_DEFAULT_TIMEOUT_MS,
+  parseAskSecretArgs,
+  runAskSecretCommand,
+  type AskSecretArgs,
+} from "./ask-secret-command"
+
+describe("parseAskSecretArgs", () => {
+  test("takes the name positionally", () => {
+    const args = parseAskSecretArgs(["OPENAI_API_KEY"])
+    expect(args.name).toBe("OPENAI_API_KEY")
+    expect(args.reason).toBe("")
+    expect(args.scope).toBeNull()
+    expect(args.force).toBe(false)
+    expect(args.timeoutMs).toBe(ASK_SECRET_DEFAULT_TIMEOUT_MS)
+  })
+
+  test("parses every flag", () => {
+    const args = parseAskSecretArgs([
+      "TOKEN",
+      "--reason",
+      "deploy the app",
+      "--scope",
+      "global",
+      "--timeout",
+      "30",
+      "--force",
+    ])
+    expect(args).toEqual({
+      name: "TOKEN",
+      reason: "deploy the app",
+      scope: "global",
+      timeoutMs: 30_000,
+      force: true,
+    })
+  })
+
+  test("requires a name", () => {
+    expect(() => parseAskSecretArgs([])).toThrow(/Usage/)
+  })
+
+  test("rejects a name that could not be sourced into a shell", () => {
+    expect(() => parseAskSecretArgs(["MY-KEY"])).toThrow(/Invalid secret name/)
+    expect(() => parseAskSecretArgs(["../escape"])).toThrow(/Invalid secret name/)
+  })
+
+  test("rejects malformed flags", () => {
+    expect(() => parseAskSecretArgs(["TOKEN", "--scope", "team"])).toThrow(/--scope/)
+    expect(() => parseAskSecretArgs(["TOKEN", "--timeout", "soon"])).toThrow(/--timeout/)
+    expect(() => parseAskSecretArgs(["TOKEN", "--reason"])).toThrow(/Missing value/)
+    expect(() => parseAskSecretArgs(["TOKEN", "--nope"])).toThrow(/Unexpected argument/)
+    expect(() => parseAskSecretArgs(["TOKEN", "EXTRA"])).toThrow(/Unexpected argument/)
+  })
+})
+
+const baseArgs: AskSecretArgs = {
+  name: "OPENAI_API_KEY",
+  reason: "call the API",
+  scope: null,
+  timeoutMs: 10_000,
+  force: false,
+}
+
+function harness(responses: Array<unknown>, options: { instance?: unknown } = {}) {
+  const logs: string[] = []
+  const warns: string[] = []
+  const calls: Array<{ url: string; method: string; body?: string; token?: string | null }> = []
+  let index = 0
+  let clock = 0
+
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input as string, init)
+    calls.push({
+      url: request.url,
+      method: request.method,
+      body: init?.body ? String(init.body) : undefined,
+      token: request.headers.get(SECRETS_API_TOKEN_HEADER),
+    })
+    const payload = responses[Math.min(index, responses.length - 1)]
+    index += 1
+    if (payload instanceof Error) throw payload
+    const { __status, ...body } = (payload ?? {}) as Record<string, unknown> & { __status?: number }
+    return Response.json(body, { status: (__status as number) ?? 200 })
+  }) as unknown as typeof fetch
+
+  const deps = {
+    log: (message: string) => logs.push(message),
+    warn: (message: string) => warns.push(message),
+    fetchImpl,
+    sleep: async (ms: number) => {
+      clock += ms
+    },
+    now: () => clock,
+    cwd: () => "/tmp/proj",
+    env: {} as Record<string, string | undefined>,
+    readInstance: async () =>
+      (options.instance === undefined
+        ? { port: 3000, url: "http://127.0.0.1:3000", token: "tok", pid: 1, instance: "x", startedAt: 0 }
+        : options.instance) as never,
+  }
+
+  return { logs, warns, calls, deps }
+}
+
+describe("runAskSecretCommand", () => {
+  test("prints the load command when the secret is already stored", async () => {
+    const { deps, logs } = harness([
+      {
+        status: "saved",
+        existing: true,
+        scope: "project",
+        path: "/tmp/proj/.kanna/secrets/OPENAI_API_KEY.env",
+        loadCommand: "set -a; . '/tmp/proj/.kanna/secrets/OPENAI_API_KEY.env'; set +a",
+      },
+    ])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(0)
+    const output = logs.join("\n")
+    expect(output).toContain("already stored")
+    expect(output).toContain("set -a; . '/tmp/proj/.kanna/secrets/OPENAI_API_KEY.env'; set +a")
+    expect(output).toContain("Never cat, read, echo or grep the file")
+  })
+
+  test("polls a pending prompt until the user answers", async () => {
+    const { deps, logs, calls } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "pending" },
+      { status: "pending" },
+      {
+        status: "saved",
+        scope: "global",
+        path: "/home/u/.kanna/secrets/OPENAI_API_KEY.env",
+        loadCommand: "set -a; . '/home/u/.kanna/secrets/OPENAI_API_KEY.env'; set +a",
+        gitignoreUpdated: false,
+      },
+    ])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(0)
+    expect(calls[0].method).toBe("POST")
+    expect(calls[1].url).toContain("/requests/req-1")
+    expect(calls).toHaveLength(4)
+    expect(logs.join("\n")).toContain("saved (global scope)")
+  })
+
+  test("mentions the .gitignore edit when one happened", async () => {
+    const { deps, logs } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "saved", scope: "project", path: "/p/TOKEN.env", loadCommand: "load", gitignoreUpdated: true },
+    ])
+
+    await runAskSecretCommand(baseArgs, deps)
+    expect(logs.join("\n")).toContain("Added .kanna/secrets/ to .gitignore")
+  })
+
+  test("exits 3 and says not to ask again when the user declines", async () => {
+    const { deps, warns } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "cancelled" },
+    ])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(3)
+    expect(warns.join("\n")).toContain("declined")
+    expect(warns.join("\n")).toContain("Do not ask again")
+  })
+
+  test("exits 2 when the prompt expires server-side", async () => {
+    const { deps, warns } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "expired" },
+    ])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(2)
+    expect(warns.join("\n")).toContain("expired")
+  })
+
+  test("exits 2 on timeout and tells the agent re-running resumes the same prompt", async () => {
+    const { deps, warns } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "pending" },
+    ])
+
+    expect(await runAskSecretCommand({ ...baseArgs, timeoutMs: 3_000 }, deps)).toBe(2)
+    expect(warns.join("\n")).toContain("still open")
+    expect(warns.join("\n")).toContain("ask-secret OPENAI_API_KEY")
+  })
+
+  test("keeps waiting through a transient network blip", async () => {
+    const { deps } = harness([
+      { status: "pending", requestId: "req-1" },
+      new Error("ECONNRESET"),
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(0)
+  })
+
+  test("reports a server-side rejection instead of polling forever", async () => {
+    const { deps, warns } = harness([{ __status: 400, error: "Invalid secret name" }])
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(1)
+    expect(warns.join("\n")).toContain("Invalid secret name")
+  })
+
+  test("explains itself when no server is running", async () => {
+    const { deps, warns } = harness([], { instance: null })
+
+    expect(await runAskSecretCommand(baseArgs, deps)).toBe(1)
+    expect(warns.join("\n")).toContain("No running kanna server")
+  })
+
+  test("presents the instance token on every call", async () => {
+    const { deps, calls } = harness([
+      { status: "pending", requestId: "req-1" },
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+
+    await runAskSecretCommand(baseArgs, deps)
+    expect(calls.every((call) => call.token === "tok")).toBe(true)
+  })
+
+  test("sends the name, reason, cwd and flags the server needs", async () => {
+    const { deps, calls } = harness([
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+
+    await runAskSecretCommand({ ...baseArgs, scope: "global", force: true }, deps)
+    expect(JSON.parse(calls[0].body!)).toEqual({
+      name: "OPENAI_API_KEY",
+      reason: "call the API",
+      cwd: "/tmp/proj",
+      scope: "global",
+      force: true,
+    })
+  })
+
+  test("environment overrides win over the instance file", async () => {
+    const { deps, calls } = harness([
+      { status: "saved", scope: "global", path: "/p/T.env", loadCommand: "load" },
+    ])
+    deps.env.KANNA_URL = "http://127.0.0.1:9999"
+    deps.env.KANNA_TOKEN = "env-token"
+
+    await runAskSecretCommand(baseArgs, deps)
+    expect(calls[0].url).toStartWith("http://127.0.0.1:9999")
+    expect(calls[0].token).toBe("env-token")
+  })
+})

--- a/src/server/ask-secret-command.ts
+++ b/src/server/ask-secret-command.ts
@@ -134,8 +134,24 @@ export async function runAskSecretCommand(
   const env = deps.env ?? process.env
 
   const instance = await (deps.readInstance ?? readInstanceFile)()
-  const baseUrl = env.KANNA_URL ?? instance?.url
-  const token = env.KANNA_TOKEN ?? instance?.token
+  const overrideUrl = env.KANNA_URL?.trim() || null
+  const overrideToken = env.KANNA_TOKEN?.trim() || null
+
+  // The instance token is only ever presented to the instance that minted it.
+  // An agent controls its own environment, so pairing these matters: letting
+  // an overridden KANNA_URL borrow the token from ~/.kanna/instance.json
+  // would hand the capability to enumerate secrets and queue prompts to
+  // whatever endpoint the agent named.
+  const baseUrl = overrideUrl ?? instance?.url
+  const token = overrideUrl ? overrideToken : overrideToken ?? instance?.token
+
+  if (overrideUrl && !overrideToken) {
+    deps.warn(
+      "KANNA_URL is set without KANNA_TOKEN. The token from ~/.kanna/instance.json is not sent "
+      + "to an overridden URL — set KANNA_TOKEN explicitly if that endpoint is really yours.",
+    )
+    return 1
+  }
 
   if (!baseUrl || !token) {
     deps.warn(

--- a/src/server/ask-secret-command.ts
+++ b/src/server/ask-secret-command.ts
@@ -1,0 +1,278 @@
+/**
+ * `kanna ask-secret <NAME>` — the agent-facing half of ask-for-secret.
+ *
+ * This is the one entry point every provider can reach, because every
+ * provider has a shell. It posts a prompt to the running Kanna server, polls
+ * until the user answers in the UI, and prints only the shell snippet that
+ * loads the secret — never the secret.
+ *
+ * Polling (rather than one long-held request) keeps a fifteen-minute wait
+ * from tripping over any socket idle timeout between here and the server.
+ */
+
+import { homedir } from "node:os"
+import { CLI_COMMAND } from "../shared/branding"
+import {
+  isValidSecretName,
+  SECRETS_API_PATH_PREFIX,
+  SECRETS_API_TOKEN_HEADER,
+  type SecretRequestResolution,
+  type SecretScope,
+} from "../shared/secrets"
+import { readInstanceFile } from "./instance-file"
+
+export const ASK_SECRET_POLL_INTERVAL_MS = 1_000
+/**
+ * Chosen to sit inside a typical agent Bash timeout. Timing out is not a
+ * failure: the prompt stays open and re-running resumes the same wait.
+ */
+export const ASK_SECRET_DEFAULT_TIMEOUT_MS = 300_000
+
+export interface AskSecretArgs {
+  name: string
+  reason: string
+  scope: SecretScope | null
+  timeoutMs: number
+  force: boolean
+}
+
+export interface AskSecretDeps {
+  log: (message: string) => void
+  warn: (message: string) => void
+  fetchImpl?: typeof fetch
+  sleep?: (ms: number) => Promise<void>
+  now?: () => number
+  cwd?: () => string
+  env?: Record<string, string | undefined>
+  readInstance?: typeof readInstanceFile
+}
+
+export function parseAskSecretArgs(argv: string[]): AskSecretArgs {
+  let name: string | null = null
+  let reason = ""
+  let scope: SecretScope | null = null
+  let timeoutMs = ASK_SECRET_DEFAULT_TIMEOUT_MS
+  let force = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--reason") {
+      const next = argv[index + 1]
+      if (!next) throw new Error("Missing value for --reason")
+      reason = next
+      index += 1
+      continue
+    }
+    if (arg === "--scope") {
+      const next = argv[index + 1]
+      if (next !== "project" && next !== "global") {
+        throw new Error("--scope must be 'project' or 'global'")
+      }
+      scope = next
+      index += 1
+      continue
+    }
+    if (arg === "--timeout") {
+      const next = argv[index + 1]
+      const seconds = Number(next)
+      if (!next || !Number.isFinite(seconds) || seconds <= 0) {
+        throw new Error("--timeout takes a number of seconds")
+      }
+      timeoutMs = seconds * 1000
+      index += 1
+      continue
+    }
+    if (arg === "--force") {
+      force = true
+      continue
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unexpected argument for ${CLI_COMMAND} ask-secret: ${arg}`)
+    }
+    if (name === null) {
+      name = arg
+      continue
+    }
+    throw new Error(`Unexpected argument for ${CLI_COMMAND} ask-secret: ${arg}`)
+  }
+
+  if (!name) {
+    throw new Error(`Usage: ${CLI_COMMAND} ask-secret <NAME> --reason "why you need it"`)
+  }
+  if (!isValidSecretName(name)) {
+    throw new Error(
+      `Invalid secret name '${name}' — use letters, digits and underscores, starting with a letter or underscore (e.g. OPENAI_API_KEY)`,
+    )
+  }
+
+  return { name, reason, scope, timeoutMs, force }
+}
+
+interface CreateResponse {
+  status?: string
+  requestId?: string
+  existing?: boolean
+  scope?: SecretScope
+  path?: string
+  loadCommand?: string
+  error?: string
+}
+
+/**
+ * Exit codes: 0 saved, 1 error, 2 still waiting (timed out), 3 declined.
+ * Non-zero is informational for the agent, not a crash.
+ */
+export async function runAskSecretCommand(
+  args: AskSecretArgs,
+  deps: AskSecretDeps,
+): Promise<number> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const now = deps.now ?? (() => Date.now())
+  const cwd = (deps.cwd ?? (() => process.cwd()))()
+  const env = deps.env ?? process.env
+
+  const instance = await (deps.readInstance ?? readInstanceFile)()
+  const baseUrl = env.KANNA_URL ?? instance?.url
+  const token = env.KANNA_TOKEN ?? instance?.token
+
+  if (!baseUrl || !token) {
+    deps.warn(
+      `No running ${CLI_COMMAND} server found (looked for ~/.kanna/instance.json). `
+      + `Ask the user to start ${CLI_COMMAND}, or ask them for the value directly.`,
+    )
+    return 1
+  }
+
+  const endpoint = `${baseUrl.replace(/\/$/, "")}${SECRETS_API_PATH_PREFIX}`
+  const headers = {
+    "content-type": "application/json",
+    [SECRETS_API_TOKEN_HEADER]: token,
+  }
+
+  let created: CreateResponse
+  try {
+    const response = await fetchImpl(`${endpoint}/requests`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: args.name,
+        reason: args.reason,
+        cwd,
+        scope: args.scope,
+        force: args.force,
+      }),
+    })
+    created = (await response.json()) as CreateResponse
+    if (!response.ok) {
+      deps.warn(created.error ?? `Request failed with status ${response.status}`)
+      return 1
+    }
+  } catch (error) {
+    deps.warn(`Could not reach ${CLI_COMMAND}: ${(error as Error).message}`)
+    return 1
+  }
+
+  if (created.status === "saved") {
+    printSaved(deps.log, args.name, {
+      status: "saved",
+      scope: created.scope,
+      path: created.path,
+      loadCommand: created.loadCommand,
+    }, created.existing === true)
+    return 0
+  }
+
+  const requestId = created.requestId
+  if (!requestId) {
+    deps.warn("Server did not return a request id")
+    return 1
+  }
+
+  deps.log(`Waiting for the user to enter ${args.name} in ${CLI_COMMAND}…`)
+
+  const deadline = now() + args.timeoutMs
+  while (now() < deadline) {
+    await sleep(ASK_SECRET_POLL_INTERVAL_MS)
+
+    let resolution: SecretRequestResolution
+    try {
+      const response = await fetchImpl(`${endpoint}/requests/${encodeURIComponent(requestId)}`, {
+        headers: { [SECRETS_API_TOKEN_HEADER]: token },
+      })
+      if (!response.ok) {
+        deps.warn(`Polling failed with status ${response.status}`)
+        return 1
+      }
+      resolution = (await response.json()) as SecretRequestResolution
+    } catch (error) {
+      // A transient blip shouldn't abandon a prompt the user may be mid-typing.
+      continue
+    }
+
+    if (resolution.status === "pending") continue
+
+    if (resolution.status === "saved") {
+      printSaved(deps.log, args.name, resolution, false)
+      return 0
+    }
+
+    if (resolution.status === "cancelled") {
+      deps.warn(
+        `The user declined to provide ${args.name}. Do not ask again for it — `
+        + "continue without it or pick a different approach.",
+      )
+      return 3
+    }
+
+    deps.warn(`The prompt for ${args.name} expired without an answer.`)
+    return 2
+  }
+
+  deps.warn(
+    `Timed out waiting for ${args.name}, but the prompt is still open in ${CLI_COMMAND}. `
+    + `Re-run \`${CLI_COMMAND} ask-secret ${args.name}\` to keep waiting (it resumes the same prompt).`,
+  )
+  return 2
+}
+
+function printSaved(
+  log: (message: string) => void,
+  name: string,
+  resolution: SecretRequestResolution,
+  existing: boolean,
+) {
+  const scopeLabel = resolution.scope === "global" ? "global" : "project"
+  log(
+    existing
+      ? `${name} is already stored (${scopeLabel} scope).`
+      : `${name} saved (${scopeLabel} scope).`,
+  )
+  if (resolution.gitignoreUpdated) {
+    log("Added .kanna/secrets/ to .gitignore.")
+  }
+  log("")
+  log("Load it into a shell with:")
+  log(`  ${resolution.loadCommand}`)
+  log("")
+  log(
+    `Then use $${name} in that same command. Never cat, read, echo or grep the file — `
+    + "the value is deliberately kept out of your context.",
+  )
+}
+
+/** Shown by `kanna --help`. */
+export function askSecretHelpLines(): string[] {
+  return [
+    `  ${CLI_COMMAND} ask-secret <NAME>   Ask the user for a secret, saved outside your context`,
+    "      --reason <text>            Why you need it (shown to the user)",
+    "      --scope project|global     Suggested scope; the user still chooses",
+    "      --timeout <seconds>        How long to wait (default 300)",
+    "      --force                    Prompt again even if already stored",
+  ]
+}
+
+/** Absolute path to this CLI, for agents whose PATH lacks a global install. */
+export function resolveCliPathHint(): string {
+  return new URL("../../bin/kanna", import.meta.url).pathname.replace(homedir(), "~")
+}

--- a/src/server/ask-secret-command.ts
+++ b/src/server/ask-secret-command.ts
@@ -14,6 +14,7 @@ import { homedir } from "node:os"
 import { CLI_COMMAND } from "../shared/branding"
 import {
   isValidSecretName,
+  SECRET_CHAT_ID_ENV_VAR,
   SECRETS_API_PATH_PREFIX,
   SECRETS_API_TOKEN_HEADER,
   type SecretRequestResolution,
@@ -161,6 +162,9 @@ export async function runAskSecretCommand(
         cwd,
         scope: args.scope,
         force: args.force,
+        // Only set when Kanna spawned this agent with a per-chat environment;
+        // the server falls back to cwd matching when it is absent.
+        chatId: env[SECRET_CHAT_ID_ENV_VAR] ?? null,
       }),
     })
     created = (await response.json()) as CreateResponse

--- a/src/server/ask-secret-flow.test.ts
+++ b/src/server/ask-secret-flow.test.ts
@@ -1,0 +1,218 @@
+/**
+ * End-to-end for ask-for-secret, everything but the browser: the real CLI
+ * talks real HTTP to the real API handler, a simulated UI answers the prompt,
+ * and the assertions land on the actual file written to disk.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { runAskSecretCommand, type AskSecretDeps } from "./ask-secret-command"
+import { SecretRequestStore } from "./secret-requests"
+import { createSecretsApi, resolveProjectFromCwd } from "./secrets-api"
+
+const TOKEN = "integration-token"
+
+let project: string
+let requests: SecretRequestStore
+let server: ReturnType<typeof Bun.serve>
+let logs: string[]
+let warns: string[]
+
+/** Bun types `server.port` as optional; a listening test server always has one. */
+function servedPort(): number {
+  const port = server.port
+  if (port === undefined) throw new Error("test server is not listening")
+  return port
+}
+
+function deps(overrides: Partial<AskSecretDeps> = {}): AskSecretDeps {
+  return {
+    log: (message) => logs.push(message),
+    warn: (message) => warns.push(message),
+    cwd: () => project,
+    env: {},
+    readInstance: async () => ({
+      port: servedPort(),
+      url: `http://127.0.0.1:${servedPort()}`,
+      token: TOKEN,
+      pid: process.pid,
+      instance: "test",
+      startedAt: 0,
+    }),
+    ...overrides,
+  }
+}
+
+/** Poll the store the way the UI's snapshot subscription would, then answer. */
+async function answerWhenPrompted(answer: { scope: "project" | "global"; value: string }) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const [pending] = requests.list()
+    if (pending) {
+      return requests.submit(pending.id, answer)
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error("no prompt ever appeared")
+}
+
+beforeEach(async () => {
+  logs = []
+  warns = []
+  project = await mkdtemp(path.join(tmpdir(), "kanna-ask-secret-e2e-"))
+  await mkdir(path.join(project, ".git"))
+
+  requests = new SecretRequestStore()
+  const handle = createSecretsApi({
+    requests,
+    token: TOKEN,
+    resolveProject: (cwd) => resolveProjectFromCwd(cwd, [{ path: project, title: "demo" }]),
+  })
+
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url)
+      return (await handle(req, url)) ?? new Response("Not found", { status: 404 })
+    },
+  })
+})
+
+afterEach(async () => {
+  server.stop(true)
+  requests.dispose()
+  await rm(project, { recursive: true, force: true })
+})
+
+describe("ask-secret end to end", () => {
+  test("agent asks, user answers, secret lands on disk and only the load command is printed", async () => {
+    const run = runAskSecretCommand(
+      { name: "OPENAI_API_KEY", reason: "call the API", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await answerWhenPrompted({ scope: "project", value: "sk-super-secret-value" })
+
+    expect(await run).toBe(0)
+
+    const secretPath = path.join(project, ".kanna", "secrets", "OPENAI_API_KEY.env")
+    expect((await stat(secretPath)).mode & 0o777).toBe(0o600)
+    expect(await readFile(secretPath, "utf8")).toContain("OPENAI_API_KEY='sk-super-secret-value'")
+
+    const output = [...logs, ...warns].join("\n")
+    expect(output).toContain(`set -a; . '${secretPath}'; set +a`)
+    // The whole point: the value never reaches the agent's stdout.
+    expect(output).not.toContain("sk-super-secret-value")
+  })
+
+  test("the written file actually loads in a real shell", async () => {
+    const run = runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await answerWhenPrompted({ scope: "project", value: "pa'ss w$rd`x`" })
+    expect(await run).toBe(0)
+
+    const loadLine = logs.find((line) => line.includes("set -a"))!.trim()
+    const shell = Bun.spawnSync(["sh", "-c", `${loadLine}; printf '%s' "$TOKEN"`])
+
+    expect(shell.exitCode).toBe(0)
+    expect(shell.stdout.toString()).toBe("pa'ss w$rd`x`")
+  })
+
+  test("project scope adds the gitignore entry exactly once", async () => {
+    const first = runAskSecretCommand(
+      { name: "ONE", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await answerWhenPrompted({ scope: "project", value: "a" })
+    await first
+
+    const second = runAskSecretCommand(
+      { name: "TWO", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await answerWhenPrompted({ scope: "project", value: "b" })
+    await second
+
+    const gitignore = await readFile(path.join(project, ".gitignore"), "utf8")
+    expect(gitignore.match(/\.kanna\/secrets\//g)).toHaveLength(1)
+  })
+
+  test("a second ask for a stored secret answers instantly, without prompting", async () => {
+    const first = runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await answerWhenPrompted({ scope: "project", value: "v" })
+    await first
+
+    logs = []
+    const code = await runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+
+    expect(code).toBe(0)
+    expect(logs.join("\n")).toContain("already stored")
+    expect(requests.list()).toHaveLength(0)
+  })
+
+  test("declining reports exit 3 and writes nothing", async () => {
+    const run = runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+
+    for (let attempt = 0; attempt < 200 && requests.list().length === 0; attempt += 1) {
+      await Bun.sleep(10)
+    }
+    requests.cancel(requests.list()[0].id)
+
+    expect(await run).toBe(3)
+    expect(warns.join("\n")).toContain("declined")
+    await expect(stat(path.join(project, ".kanna", "secrets", "TOKEN.env"))).rejects.toThrow()
+  })
+
+  test("a re-run while a prompt is open joins it instead of stacking a second one", async () => {
+    const first = runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    for (let attempt = 0; attempt < 200 && requests.list().length === 0; attempt += 1) {
+      await Bun.sleep(10)
+    }
+
+    const second = runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 15_000, force: false },
+      deps(),
+    )
+    await Bun.sleep(50)
+    expect(requests.list()).toHaveLength(1)
+
+    // Project scope throughout: a global-scope answer would write into the
+    // real ~/.kanna/secrets on the machine running the suite.
+    await answerWhenPrompted({ scope: "project", value: "shared" })
+    expect(await first).toBe(0)
+    expect(await second).toBe(0)
+  })
+
+  test("an unauthenticated caller gets nowhere", async () => {
+    const code = await runAskSecretCommand(
+      { name: "TOKEN", reason: "", scope: null, timeoutMs: 5_000, force: false },
+      deps({
+        readInstance: async () => ({
+          port: servedPort(),
+          url: `http://127.0.0.1:${servedPort()}`,
+          token: "wrong-token",
+          pid: 0,
+          instance: "",
+          startedAt: 0,
+        }),
+      }),
+    )
+
+    expect(code).toBe(1)
+    expect(requests.list()).toHaveLength(0)
+  })
+})

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -859,3 +859,43 @@ describe("runCli single-instance guard + hosted open", () => {
   })
 })
 
+
+describe("ask-secret subcommand", () => {
+  test("parses the name and flags", () => {
+    expect(parseArgs(["ask-secret", "OPENAI_API_KEY", "--reason", "call the API"])).toEqual({
+      kind: "ask-secret",
+      args: {
+        name: "OPENAI_API_KEY",
+        reason: "call the API",
+        scope: null,
+        timeoutMs: 300_000,
+        force: false,
+      },
+    })
+  })
+
+  test("rejects a name that could not be sourced into a shell", () => {
+    expect(() => parseArgs(["ask-secret", "MY-KEY"])).toThrow("Invalid secret name")
+  })
+
+  test("runs against the existing server and never starts one", async () => {
+    const seen: unknown[] = []
+    const { calls, deps } = createDeps({
+      runAskSecretCommandImpl: async (args) => {
+        seen.push(args)
+        return 0
+      },
+    })
+
+    const result = await runCli(["ask-secret", "TOKEN", "--reason", "deploy"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 0 })
+    expect(calls.startServer).toEqual([])
+    expect(seen).toHaveLength(1)
+  })
+
+  test("propagates the command's exit code so the agent can read it", async () => {
+    const { deps } = createDeps({ runAskSecretCommandImpl: async () => 3 })
+    expect(await runCli(["ask-secret", "TOKEN"], deps)).toEqual({ kind: "exited", code: 3 })
+  })
+})

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -20,6 +20,12 @@ import {
   runAskSecretCommand,
   type AskSecretArgs,
 } from "./ask-secret-command"
+import {
+  parseRemindArgs,
+  remindHelpLines,
+  runRemindCommand,
+  type RemindArgs,
+} from "./remind-command"
 
 export interface CliOptions {
   port: number
@@ -86,6 +92,7 @@ export interface CliRuntimeDeps {
   startShareTunnel?: (localUrl: string, shareMode: Exclude<ShareMode, false>) => Promise<StartedShareTunnel>
   runPairCommandImpl?: typeof runPairCommand
   runAskSecretCommandImpl?: typeof runAskSecretCommand
+  runRemindCommandImpl?: typeof runRemindCommand
   readCloudIdentityImpl?: (warn: (message: string) => void) => Promise<CloudIdentity | null>
   createCloudRuntimeImpl?: (identity: CloudIdentity) => CloudRuntime
   probeExistingInstanceImpl?: (port: number) => Promise<ExistingInstance | null>
@@ -102,6 +109,7 @@ type ParsedArgs =
   | { kind: "run"; options: CliOptions }
   | { kind: "pair"; args: PairCommandArgs }
   | { kind: "ask-secret"; args: AskSecretArgs }
+  | { kind: "remind"; args: RemindArgs }
   | { kind: "help" }
   | { kind: "version" }
 
@@ -122,6 +130,7 @@ Usage:
 
 Agent commands:
 ${askSecretHelpLines().join("\n")}
+${remindHelpLines().join("\n")}
 
 Options:
   --port <number>      Port to listen on (default: ${PROD_SERVER_PORT})
@@ -172,6 +181,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   if (argv[0] === "ask-secret") {
     return { kind: "ask-secret", args: parseAskSecretArgs(argv.slice(1)) }
+  }
+
+
+  if (argv[0] === "remind") {
+    return { kind: "remind", args: parseRemindArgs(argv.slice(1)) }
   }
 
   let port = PROD_SERVER_PORT
@@ -357,6 +371,14 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
   // Runs against the server that is already up; never starts one.
   if (parsedArgs.kind === "ask-secret") {
     const code = await (deps.runAskSecretCommandImpl ?? runAskSecretCommand)(parsedArgs.args, {
+      log: deps.log,
+      warn: deps.warn,
+    })
+    return { kind: "exited", code }
+  }
+
+  if (parsedArgs.kind === "remind") {
+    const code = await (deps.runRemindCommandImpl ?? runRemindCommand)(parsedArgs.args, {
       log: deps.log,
       warn: deps.warn,
     })

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -14,6 +14,12 @@ import type { AnalyticsReporter } from "./analytics"
 import { createCloudRuntime, type CloudRuntime } from "./cloud"
 import { readCloudIdentity, type CloudIdentity } from "./cloud/identity"
 import { runPairCommand, type PairCommandArgs, type PairAction } from "./cloud/pair-command"
+import {
+  askSecretHelpLines,
+  parseAskSecretArgs,
+  runAskSecretCommand,
+  type AskSecretArgs,
+} from "./ask-secret-command"
 
 export interface CliOptions {
   port: number
@@ -79,6 +85,7 @@ export interface CliRuntimeDeps {
   renderShareQr?: (url: string) => Promise<string>
   startShareTunnel?: (localUrl: string, shareMode: Exclude<ShareMode, false>) => Promise<StartedShareTunnel>
   runPairCommandImpl?: typeof runPairCommand
+  runAskSecretCommandImpl?: typeof runAskSecretCommand
   readCloudIdentityImpl?: (warn: (message: string) => void) => Promise<CloudIdentity | null>
   createCloudRuntimeImpl?: (identity: CloudIdentity) => CloudRuntime
   probeExistingInstanceImpl?: (port: number) => Promise<ExistingInstance | null>
@@ -94,6 +101,7 @@ export interface UpdateInstallAttemptResult {
 type ParsedArgs =
   | { kind: "run"; options: CliOptions }
   | { kind: "pair"; args: PairCommandArgs }
+  | { kind: "ask-secret"; args: AskSecretArgs }
   | { kind: "help" }
   | { kind: "version" }
 
@@ -111,6 +119,9 @@ Usage:
   ${CLI_COMMAND} pair          Claim this machine on kanna.sh (prints a link + QR) and start
   ${CLI_COMMAND} pair <code>   Same, using a code from https://kanna.sh/machines
   ${CLI_COMMAND} pair --status|--disable|--enable|--remove
+
+Agent commands:
+${askSecretHelpLines().join("\n")}
 
 Options:
   --port <number>      Port to listen on (default: ${PROD_SERVER_PORT})
@@ -157,6 +168,10 @@ function parsePairArgs(argv: string[]): ParsedArgs {
 export function parseArgs(argv: string[]): ParsedArgs {
   if (argv[0] === "pair") {
     return parsePairArgs(argv.slice(1))
+  }
+
+  if (argv[0] === "ask-secret") {
+    return { kind: "ask-secret", args: parseAskSecretArgs(argv.slice(1)) }
   }
 
   let port = PROD_SERVER_PORT
@@ -337,6 +352,15 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
   if (parsedArgs.kind === "help") {
     printHelp()
     return { kind: "exited", code: 0 }
+  }
+
+  // Runs against the server that is already up; never starts one.
+  if (parsedArgs.kind === "ask-secret") {
+    const code = await (deps.runAskSecretCommandImpl ?? runAskSecretCommand)(parsedArgs.args, {
+      log: deps.log,
+      warn: deps.warn,
+    })
+    return { kind: "exited", code }
   }
 
   if (parsedArgs.kind === "pair") {

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -13,6 +13,7 @@ import type {
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
 import { appendSystemMessageBlock, buildSkillSystemMessage } from "./harness-skills"
 import { buildKannaAgentId, buildKannaAttributionInstructions } from "./attribution"
+import { buildAskSecretInstructions } from "./secret-instructions"
 import { AsyncQueue } from "./async-queue"
 import { asNumber, asRecord } from "../shared/json"
 import { timestamped } from "./transcript"
@@ -917,7 +918,10 @@ export class CodexAppServerManager {
             // Codex's instruction channel is per-turn, not per-session: this is
             // re-sent every turn by design. It appends to the built-in
             // developer message rather than replacing it.
-            developer_instructions: buildKannaAttributionInstructions(buildKannaAgentId("codex", args.model)),
+            developer_instructions: [
+              buildKannaAttributionInstructions(buildKannaAgentId("codex", args.model)),
+              buildAskSecretInstructions(),
+            ].join("\n\n"),
           },
         },
       } satisfies TurnStartParams)

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -14,6 +14,7 @@ import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-ty
 import { appendSystemMessageBlock, buildSkillSystemMessage } from "./harness-skills"
 import { buildKannaAgentId, buildKannaAttributionInstructions } from "./attribution"
 import { buildAskSecretInstructions } from "./secret-instructions"
+import { reminderInstructionsBlock } from "./reminder-instructions"
 import { AsyncQueue } from "./async-queue"
 import { asNumber, asRecord } from "../shared/json"
 import { timestamped } from "./transcript"
@@ -921,7 +922,8 @@ export class CodexAppServerManager {
             developer_instructions: [
               buildKannaAttributionInstructions(buildKannaAgentId("codex", args.model)),
               buildAskSecretInstructions(),
-            ].join("\n\n"),
+              reminderInstructionsBlock(args.chatId),
+            ].filter((block): block is string => block !== null).join("\n\n"),
           },
         },
       } satisfies TurnStartParams)

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -1353,6 +1353,158 @@ describe("on-demand tool payloads", () => {
   })
 })
 
+describe("chat reminders", () => {
+  test("stores a reminder and survives compaction and restart", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    expect(store.getChat(chat.id)?.reminder).toBeUndefined()
+
+    const dueAt = Date.now() + 30 * 60_000
+    await store.setChatReminder(chat.id, { dueAt, prompt: "check metrics", createdBy: "agent" })
+
+    expect(store.getChat(chat.id)?.reminder).toMatchObject({
+      dueAt,
+      prompt: "check metrics",
+      createdBy: "agent",
+    })
+
+    await store.compact()
+    const reloaded = new EventStore(dataDir)
+    await reloaded.initialize()
+
+    // The whole point: the schedule outlives the process that took it.
+    expect(reloaded.getChat(chat.id)?.reminder).toMatchObject({ dueAt, prompt: "check metrics" })
+  })
+
+  test("replays from the log without a snapshot", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    const dueAt = Date.now() + 60_000
+    await store.setChatReminder(chat.id, { dueAt, createdBy: "user" })
+
+    const reloaded = new EventStore(dataDir)
+    await reloaded.initialize()
+    expect(reloaded.getChat(chat.id)?.reminder?.dueAt).toBe(dueAt)
+  })
+
+  test("setting a second reminder replaces the first", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+
+    await store.setChatReminder(chat.id, { dueAt: 1_000, prompt: "first", createdBy: "user" })
+    await store.setChatReminder(chat.id, { dueAt: 2_000, createdBy: "agent" })
+
+    const reminder = store.getChat(chat.id)?.reminder
+    expect(reminder?.dueAt).toBe(2_000)
+    // Replaced wholesale, not merged — the old prompt must not survive.
+    expect(reminder?.prompt).toBeUndefined()
+    expect(reminder?.createdBy).toBe("agent")
+  })
+
+  test("clearing removes it, and clearing again is silent", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    await store.setChatReminder(chat.id, { dueAt: Date.now() + 60_000, createdBy: "user" })
+
+    await store.clearChatReminder(chat.id)
+    expect(store.getChat(chat.id)?.reminder).toBeUndefined()
+    await store.clearChatReminder(chat.id)
+    expect(store.getChat(chat.id)?.reminder).toBeUndefined()
+  })
+
+  test("scheduling does not bump updatedAt — a reminder is not activity", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    const before = store.getChat(chat.id)!.updatedAt
+
+    await store.setChatReminder(chat.id, { dueAt: Date.now() + 60_000, createdBy: "user" })
+
+    expect(store.getChat(chat.id)?.updatedAt).toBe(before)
+  })
+
+  test("listChatsWithReminders is the scheduler's work list", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const withReminder = await store.createChat(project.id)
+    const without = await store.createChat(project.id)
+    const deleted = await store.createChat(project.id)
+
+    await store.setChatReminder(withReminder.id, { dueAt: 5_000, createdBy: "user" })
+    await store.setChatReminder(deleted.id, { dueAt: 5_000, createdBy: "user" })
+    await store.deleteChat(deleted.id)
+
+    const rows = store.listChatsWithReminders()
+    expect(rows.map((row) => row.chat.id)).toEqual([withReminder.id])
+    expect(rows[0]?.reminder.dueAt).toBe(5_000)
+    expect(store.getChat(without.id)?.reminder).toBeUndefined()
+  })
+
+  test("a pending reminder spares a chat from every staleness sweep", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const reminded = await store.createChat(project.id)
+    await store.appendMessage(reminded.id, entry("user_prompt", reminded.createdAt + 1, { content: "old" }))
+    const oldActivityAt = store.getChat(reminded.id)!.lastMessageAt!
+    await store.setChatReminder(reminded.id, {
+      dueAt: oldActivityAt + 200 * 24 * 60 * 60 * 1000,
+      createdBy: "user",
+    })
+
+    // A fresh chat drags the staleness reference far past both windows.
+    const fresh = await store.createChat(project.id)
+    const farFuture = oldActivityAt + 200 * 24 * 60 * 60 * 1000
+    await store.appendMessage(fresh.id, entry("user_prompt", farFuture, { content: "fresh" }))
+
+    expect(await store.deleteStaleChats({ now: farFuture + 1 })).toEqual([])
+    expect(await store.autoArchiveStaleChats({ now: farFuture + 1 })).toEqual([])
+    expect(store.getChat(reminded.id)?.archivedAt).toBeUndefined()
+    expect(store.getChat(reminded.id)).not.toBeNull()
+  })
+
+  test("a pending reminder spares an empty chat from the prune sweep", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const empty = await store.createChat(project.id)
+    await store.setChatReminder(empty.id, { dueAt: Date.now() + 60_000, createdBy: "agent" })
+
+    const pruned = await store.pruneStaleEmptyChats({
+      now: empty.createdAt + 10 * 60 * 1000,
+    })
+
+    expect(pruned).toEqual([])
+    expect(store.getChat(empty.id)).not.toBeNull()
+  })
+})
+
 describe("stale empty chat pruning", () => {
   test("keeps a cached chat that actually has messages", async () => {
     // The prune sweep only deletes chats it believes are empty. `hasMessages`

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -4,10 +4,12 @@ import { homedir } from "node:os"
 import path from "node:path"
 import { getDataDir, LOG_PREFIX } from "../shared/branding"
 import { toMessagePreview } from "../shared/message-preview"
+import type { ChatReminder, ReminderSource } from "../shared/reminders"
 import type { AgentProvider, QueuedChatMessage, ResolvedChatReadAnchor, TranscriptEntry } from "../shared/types"
 import { STORE_VERSION } from "../shared/types"
 import {
   type ChatEvent,
+  type ChatRecord,
   type ProjectEvent,
   type QueuedMessageEvent,
   type SnapshotFile,
@@ -200,6 +202,8 @@ function getReplayEventPriority(event: StoreEvent) {
     case "chat_read_anchor_set":
     case "chat_files_touched":
     case "chat_last_message_at_set":
+    case "chat_reminder_set":
+    case "chat_reminder_cleared":
       return 9
     case "chat_deleted":
     case "chat_archived":
@@ -741,6 +745,27 @@ export class EventStore {
         chat.updatedAt = event.timestamp
         break
       }
+      case "chat_reminder_set": {
+        const chat = this.state.chatsById.get(event.chatId)
+        if (!chat) break
+        chat.reminder = {
+          dueAt: event.dueAt,
+          createdAt: event.timestamp,
+          createdBy: event.createdBy,
+          ...(event.prompt ? { prompt: event.prompt } : {}),
+        }
+        // Deliberately does not bump `updatedAt`, for the same reason
+        // `chat_read_anchor_set` doesn't: scheduling something for later is not
+        // activity, and an old chat should not climb the sidebar because the
+        // user asked to be reminded of it.
+        break
+      }
+      case "chat_reminder_cleared": {
+        const chat = this.state.chatsById.get(event.chatId)
+        if (!chat) break
+        delete chat.reminder
+        break
+      }
       case "message_appended": {
         this.applyMessageMetadata(event.chatId, event.entry)
         const existing = this.legacyMessagesByChatId.get(event.chatId) ?? []
@@ -1171,6 +1196,8 @@ export class EventStore {
 
     for (const chat of this.state.chatsById.values()) {
       if (chat.deletedAt || chat.archivedAt || protectedChatIds.has(chat.id)) continue
+      // Even an empty chat is spoken for once a reminder is scheduled on it.
+      if (chat.reminder) continue
       if (now - chat.createdAt < maxAgeMs) continue
       if (chat.hasMessages) continue
       // Peek without inserting into the transcript cache — the prune sweep
@@ -1243,6 +1270,9 @@ export class EventStore {
 
     for (const chat of this.state.chatsById.values()) {
       if (chat.deletedAt || chat.archivedAt || protectedChatIds.has(chat.id)) continue
+      // A pending reminder means the chat is due to come back on its own.
+      // Archiving it first would hide it right up until it reappears.
+      if (chat.reminder) continue
       // Empty chats are the prune sweep's job (hard delete), not ours.
       if (!chat.hasMessages && chat.lastMessageAt == null) continue
       const lastActivityAt = chat.lastMessageAt ?? chat.createdAt
@@ -1285,6 +1315,9 @@ export class EventStore {
 
     for (const chat of this.state.chatsById.values()) {
       if (chat.deletedAt || protectedChatIds.has(chat.id)) continue
+      // A chat someone scheduled a reminder for is not idle — something is
+      // going to happen to it. Deleting it would silently drop the reminder.
+      if (chat.reminder) continue
       const lastActivityAt = chat.lastMessageAt ?? chat.createdAt
       if (reference - lastActivityAt < maxAgeMs) continue
 
@@ -1369,6 +1402,57 @@ export class EventStore {
       done,
     }
     await this.append(this.chatsLogPath, event)
+  }
+
+  /**
+   * Schedule a reminder, replacing any pending one. No no-op guard: setting the
+   * same time twice is a deliberate act (the user reaching for the menu again),
+   * and unlike a scroll anchor it is not written on a throttle.
+   */
+  async setChatReminder(chatId: string, args: {
+    dueAt: number
+    prompt?: string
+    createdBy: ReminderSource
+  }) {
+    this.requireChat(chatId)
+    const event: ChatEvent = {
+      v: STORE_VERSION,
+      type: "chat_reminder_set",
+      timestamp: Date.now(),
+      chatId,
+      dueAt: args.dueAt,
+      createdBy: args.createdBy,
+      ...(args.prompt ? { prompt: args.prompt } : {}),
+    }
+    await this.append(this.chatsLogPath, event)
+  }
+
+  /** Cancel or consume the pending reminder. Silent when there is none. */
+  async clearChatReminder(chatId: string) {
+    const chat = this.state.chatsById.get(chatId)
+    if (!chat?.reminder) return
+    const event: ChatEvent = {
+      v: STORE_VERSION,
+      type: "chat_reminder_cleared",
+      timestamp: Date.now(),
+      chatId,
+    }
+    await this.append(this.chatsLogPath, event)
+  }
+
+  /**
+   * Every chat with a pending reminder — the scheduler's work list.
+   *
+   * Rebuilt on each tick rather than held as timers, so reminders survive a
+   * restart: the schedule lives in the log, not in the process.
+   */
+  listChatsWithReminders(): Array<{ chat: ChatRecord; reminder: ChatReminder }> {
+    const rows: Array<{ chat: ChatRecord; reminder: ChatReminder }> = []
+    for (const chat of this.state.chatsById.values()) {
+      if (chat.deletedAt || !chat.reminder) continue
+      rows.push({ chat, reminder: chat.reminder })
+    }
+    return rows
   }
 
   /**

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,3 +1,4 @@
+import type { ChatReminder, ReminderSource } from "../shared/reminders"
 import type { AgentProvider, ProjectSummary, QueuedChatMessage, TranscriptEntry } from "../shared/types"
 
 export interface ProjectRecord extends ProjectSummary {
@@ -47,6 +48,17 @@ export interface ChatRecord {
    * rather than pin to a message.
    */
   readAnchor?: ChatReadAnchor | null
+  /**
+   * The GitHub pull request this chat is working on, if any. At most one — a
+   * chat is a unit of work, and "which PR is this" should have one answer.
+   * Absent on every chat until someone links one.
+   */
+  /**
+   * A pending "come back to this later". At most one — setting a second
+   * replaces the first. Cleared the moment it fires, so its presence is
+   * exactly "something is still scheduled".
+   */
+  reminder?: ChatReminder
   provider: AgentProvider | null
   planMode: boolean
   /** "Auto Plan": the harness keeps its EnterPlanMode tool. Claude only. */
@@ -265,6 +277,31 @@ export type ChatEvent =
       timestamp: number
       chatId: string
       done: boolean
+    }
+  /**
+   * Schedule (or reschedule) this chat's reminder. Replaces any pending one —
+   * a chat has at most one.
+   */
+  | {
+      v: 2
+      type: "chat_reminder_set"
+      timestamp: number
+      chatId: string
+      dueAt: number
+      prompt?: string
+      createdBy: ReminderSource
+    }
+  /**
+   * The reminder is gone: either it fired, or someone cancelled it. Both write
+   * the same event — what happens *after* firing is a separate concern (an
+   * unread flag and possibly a posted prompt), and folding it in here would
+   * make replay re-run side effects.
+   */
+  | {
+      v: 2
+      type: "chat_reminder_cleared"
+      timestamp: number
+      chatId: string
     }
   | {
       v: 2

--- a/src/server/handoff.ts
+++ b/src/server/handoff.ts
@@ -137,6 +137,17 @@ function blockFromEntry(entry: TranscriptEntry): Omit<HandoffBlock, "elided"> | 
       }
     case "interrupted":
       return { entry, header: "--- turn interrupted by user ---", body: "", elidableBody: false }
+    case "secret_notice":
+      // Worth carrying: the incoming agent needs to know the credential
+      // exists and is loadable. The value is not here and never was.
+      return {
+        entry,
+        header: entry.outcome === "saved"
+          ? `--- secret ${entry.secretName} saved (${entry.scope ?? "project"} scope) ---`
+          : `--- secret ${entry.secretName} ${entry.outcome} ---`,
+        body: "",
+        elidableBody: false,
+      }
     case "handoff_boundary":
       return {
         entry,

--- a/src/server/handoff.ts
+++ b/src/server/handoff.ts
@@ -148,6 +148,17 @@ function blockFromEntry(entry: TranscriptEntry): Omit<HandoffBlock, "elided"> | 
         body: "",
         elidableBody: false,
       }
+    case "reminder_notice":
+      // Worth carrying: it explains why the prompt after it exists. Without it
+      // the incoming agent reads a scheduled wake-up as a user instruction.
+      return {
+        entry,
+        header: entry.wokeAgent
+          ? "--- scheduled reminder fired; the message below was posted by it, not typed ---"
+          : "--- scheduled reminder fired ---",
+        body: "",
+        elidableBody: false,
+      }
     case "handoff_boundary":
       return {
         entry,

--- a/src/server/instance-file.test.ts
+++ b/src/server/instance-file.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  mintInstanceToken,
+  readInstanceFile,
+  removeInstanceFile,
+  writeInstanceFile,
+  type InstanceFile,
+} from "./instance-file"
+
+let dir: string
+let filePath: string
+
+const sample: InstanceFile = {
+  port: 3000,
+  url: "http://127.0.0.1:3000",
+  token: "abc123",
+  pid: 42,
+  instance: "fingerprint",
+  startedAt: 1_700_000_000_000,
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), "kanna-instance-"))
+  filePath = path.join(dir, "nested", "instance.json")
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe("mintInstanceToken", () => {
+  test("produces a long random hex token that differs each call", () => {
+    const a = mintInstanceToken()
+    const b = mintInstanceToken()
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe("writeInstanceFile", () => {
+  test("creates parent directories and round-trips", async () => {
+    await writeInstanceFile(sample, filePath)
+    expect(await readInstanceFile(filePath)).toEqual(sample)
+  })
+
+  test("is owner-read/write only — the token is a capability", async () => {
+    await writeInstanceFile(sample, filePath)
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+  })
+
+  test("overwrites a stale file from a previous run", async () => {
+    await writeInstanceFile(sample, filePath)
+    await writeInstanceFile({ ...sample, port: 3111, token: "fresh" }, filePath)
+
+    const read = await readInstanceFile(filePath)
+    expect(read?.port).toBe(3111)
+    expect(read?.token).toBe("fresh")
+  })
+})
+
+describe("readInstanceFile", () => {
+  test("returns null when there is no file", async () => {
+    expect(await readInstanceFile(filePath)).toBeNull()
+  })
+
+  test("returns null for unparseable or incomplete contents", async () => {
+    const broken = path.join(dir, "broken.json")
+
+    await writeFile(broken, "{ not json")
+    expect(await readInstanceFile(broken)).toBeNull()
+
+    await writeFile(broken, JSON.stringify({ port: 3000 }))
+    expect(await readInstanceFile(broken)).toBeNull()
+
+    await writeFile(broken, JSON.stringify({ ...sample, token: "" }))
+    expect(await readInstanceFile(broken)).toBeNull()
+
+    await writeFile(broken, JSON.stringify({ ...sample, port: "3000" }))
+    expect(await readInstanceFile(broken)).toBeNull()
+  })
+
+  test("tolerates missing optional metadata", async () => {
+    const partial = path.join(dir, "partial.json")
+    await writeFile(partial, JSON.stringify({ port: 1, url: "http://x", token: "t" }))
+
+    expect(await readInstanceFile(partial)).toEqual({
+      port: 1,
+      url: "http://x",
+      token: "t",
+      pid: 0,
+      instance: "",
+      startedAt: 0,
+    })
+  })
+})
+
+describe("removeInstanceFile", () => {
+  test("deletes the file and is safe to call twice", async () => {
+    await writeInstanceFile(sample, filePath)
+    await removeInstanceFile(filePath)
+    await removeInstanceFile(filePath)
+    expect(await readInstanceFile(filePath)).toBeNull()
+  })
+})

--- a/src/server/instance-file.ts
+++ b/src/server/instance-file.ts
@@ -1,0 +1,89 @@
+/**
+ * `~/.kanna/instance.json` — how a `kanna` subcommand finds the server that
+ * is already running on this machine.
+ *
+ * `instance.ts` answers "is something already on this port?" over /health.
+ * This answers the inverse: "which port, and what credential do I present?"
+ * The token is minted per server start and the file is 0600, so it is a
+ * same-user capability and nothing more. It is not a substitute for the
+ * password gate — the endpoints it unlocks are loopback-only by construction.
+ */
+
+import { randomBytes } from "node:crypto"
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+import { getInstanceFilePath } from "../shared/branding"
+
+const FILE_MODE = 0o600
+
+export interface InstanceFile {
+  port: number
+  url: string
+  token: string
+  pid: number
+  /** Fingerprint of the data dir being served (see instance.ts). */
+  instance: string
+  startedAt: number
+}
+
+export function mintInstanceToken(): string {
+  return randomBytes(32).toString("hex")
+}
+
+export async function writeInstanceFile(
+  contents: InstanceFile,
+  filePath: string = getInstanceFilePath(homedir()),
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(contents, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: FILE_MODE,
+  })
+  await chmod(filePath, FILE_MODE)
+}
+
+/** Returns null for anything unreadable or malformed — callers fall back to a clear error. */
+export async function readInstanceFile(
+  filePath: string = getInstanceFilePath(homedir()),
+): Promise<InstanceFile | null> {
+  let raw: string
+  try {
+    raw = await readFile(filePath, "utf8")
+  } catch {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<InstanceFile>
+    if (
+      typeof parsed.port !== "number"
+      || typeof parsed.url !== "string"
+      || typeof parsed.token !== "string"
+      || parsed.token.length === 0
+    ) {
+      return null
+    }
+    return {
+      port: parsed.port,
+      url: parsed.url,
+      token: parsed.token,
+      pid: typeof parsed.pid === "number" ? parsed.pid : 0,
+      instance: typeof parsed.instance === "string" ? parsed.instance : "",
+      startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Best-effort: a stale file is harmless, since the token stops matching. */
+export async function removeInstanceFile(
+  filePath: string = getInstanceFilePath(homedir()),
+): Promise<void> {
+  try {
+    await rm(filePath, { force: true })
+  } catch {
+    // ignore
+  }
+}

--- a/src/server/pi-agent.ts
+++ b/src/server/pi-agent.ts
@@ -19,6 +19,7 @@ import type { HarnessEvent, HarnessTurn } from "./harness-types"
 import { AsyncQueue } from "./async-queue"
 import { buildKannaAgentCorrection, buildKannaAgentId, buildKannaAttributionInstructions } from "./attribution"
 import { buildAskSecretInstructions } from "./secret-instructions"
+import { reminderInstructionsBlock } from "./reminder-instructions"
 import { appendSystemMessageBlock } from "./harness-skills"
 import { OPENROUTER_BASE_URL, readLlmProviderSnapshot } from "./llm-provider"
 import { timestamped } from "./transcript"
@@ -433,7 +434,8 @@ export class PiAgentManager {
       appendSystemPrompt: [
         buildKannaAttributionInstructions(buildKannaAgentId("pi", args.model)),
         buildAskSecretInstructions(),
-      ],
+        reminderInstructionsBlock(args.chatId),
+      ].filter((block): block is string => block !== null),
     })
     await resourceLoader.reload()
 

--- a/src/server/pi-agent.ts
+++ b/src/server/pi-agent.ts
@@ -18,6 +18,7 @@ import { normalizeToolCall } from "../shared/tools"
 import type { HarnessEvent, HarnessTurn } from "./harness-types"
 import { AsyncQueue } from "./async-queue"
 import { buildKannaAgentCorrection, buildKannaAgentId, buildKannaAttributionInstructions } from "./attribution"
+import { buildAskSecretInstructions } from "./secret-instructions"
 import { appendSystemMessageBlock } from "./harness-skills"
 import { OPENROUTER_BASE_URL, readLlmProviderSnapshot } from "./llm-provider"
 import { timestamped } from "./transcript"
@@ -429,7 +430,10 @@ export class PiAgentManager {
       settingsManager,
       noExtensions: true,
       noThemes: true,
-      appendSystemPrompt: [buildKannaAttributionInstructions(buildKannaAgentId("pi", args.model))],
+      appendSystemPrompt: [
+        buildKannaAttributionInstructions(buildKannaAgentId("pi", args.model)),
+        buildAskSecretInstructions(),
+      ],
     })
     await resourceLoader.reload()
 

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -232,6 +232,7 @@ export function deriveSidebarData(
           title: chat.title,
           status: deriveStatus(chat, activeStatuses.get(chat.id)),
           unread: chat.unread,
+          ...(chat.reminder ? { reminderAt: chat.reminder.dueAt } : {}),
           ...(chat.doneAt ? { done: true, doneAt: chat.doneAt } : {}),
           localPath: project.localPath,
           provider: chat.provider,

--- a/src/server/remind-command.test.ts
+++ b/src/server/remind-command.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from "bun:test"
+import { REMINDERS_API_PATH_PREFIX, REMINDERS_API_TOKEN_HEADER } from "../shared/reminders"
+import type { InstanceFile } from "./instance-file"
+import { parseRemindArgs, runRemindCommand, type RemindArgs } from "./remind-command"
+
+const NOW = 1_700_000_000_000
+
+describe("parseRemindArgs", () => {
+  test("reads a delay and a positional message", () => {
+    expect(parseRemindArgs(["--in", "30m", "check the metrics"])).toEqual({
+      clear: false,
+      in: "30m",
+      at: null,
+      message: "check the metrics",
+      chatId: null,
+    })
+  })
+
+  test("reads the message from --message too", () => {
+    expect(parseRemindArgs(["--in", "1h", "--message", "check"]).message).toBe("check")
+  })
+
+  test("reads --at", () => {
+    const args = parseRemindArgs(["--at", "2030-01-01T09:00:00Z", "morning check"])
+    expect(args.at).toBe("2030-01-01T09:00:00Z")
+    expect(args.in).toBeNull()
+  })
+
+  test("reads --chat", () => {
+    expect(parseRemindArgs(["--in", "5m", "--chat", "chat-9"]).chatId).toBe("chat-9")
+  })
+
+  test("--clear needs no time", () => {
+    expect(parseRemindArgs(["--clear"])).toEqual({
+      clear: true,
+      in: null,
+      at: null,
+      message: null,
+      chatId: null,
+    })
+    expect(parseRemindArgs(["--cancel"]).clear).toBe(true)
+  })
+
+  test("requires a time when not clearing", () => {
+    expect(() => parseRemindArgs(["just do it"])).toThrow(/Say when/)
+    expect(() => parseRemindArgs([])).toThrow(/Say when/)
+  })
+
+  test("rejects unknown flags", () => {
+    expect(() => parseRemindArgs(["--in", "5m", "--wat"])).toThrow(/Unexpected argument/)
+  })
+
+  test("rejects a second positional", () => {
+    expect(() => parseRemindArgs(["--in", "5m", "one", "two"])).toThrow(/Unexpected argument/)
+  })
+
+  test("rejects a flag with a missing value", () => {
+    expect(() => parseRemindArgs(["--in"])).toThrow(/Missing value for --in/)
+    expect(() => parseRemindArgs(["--in", "5m", "--chat"])).toThrow(/Missing value for --chat/)
+  })
+})
+
+const INSTANCE: InstanceFile = {
+  port: 3210,
+  url: "http://127.0.0.1:3210",
+  token: "instance-token",
+  pid: 1234,
+  instance: "test-instance",
+  startedAt: NOW,
+}
+
+function createDeps(args: {
+  response?: { status?: number; body: unknown }
+  instance?: InstanceFile | null
+  env?: Record<string, string | undefined>
+} = {}) {
+  const logs: string[] = []
+  const warnings: string[] = []
+  const requests: Array<{ url: string; headers: Headers; body: unknown }> = []
+
+  const deps = {
+    log: (message: string) => logs.push(message),
+    warn: (message: string) => warnings.push(message),
+    cwd: () => "/repo",
+    env: args.env ?? {},
+    readInstance: async () => (args.instance === undefined ? INSTANCE : args.instance),
+    fetchImpl: (async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      requests.push({
+        url: String(url),
+        headers,
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      })
+      const status = args.response?.status ?? 200
+      return new Response(JSON.stringify(args.response?.body ?? { ok: true, dueAt: NOW, delayMs: 60_000 }), {
+        status,
+        headers: { "content-type": "application/json" },
+      })
+    }) as unknown as typeof fetch,
+  }
+
+  return { deps, logs, warnings, requests }
+}
+
+const SET_ARGS: RemindArgs = {
+  clear: false,
+  in: "30m",
+  at: null,
+  message: "check metrics",
+  chatId: null,
+}
+
+describe("runRemindCommand", () => {
+  test("posts to /set with the instance token and reports the schedule", async () => {
+    const { deps, logs, requests } = createDeps({
+      response: { body: { ok: true, dueAt: NOW, delayMs: 30 * 60_000, prompt: "check metrics" } },
+    })
+
+    const code = await runRemindCommand(SET_ARGS, deps)
+
+    expect(code).toBe(0)
+    expect(requests[0]?.url).toBe(`http://127.0.0.1:3210${REMINDERS_API_PATH_PREFIX}/set`)
+    expect(requests[0]?.headers.get(REMINDERS_API_TOKEN_HEADER)).toBe("instance-token")
+    expect(requests[0]?.body).toEqual({
+      cwd: "/repo",
+      chatId: null,
+      in: "30m",
+      at: null,
+      prompt: "check metrics",
+    })
+    expect(logs.join("\n")).toContain("in 30m")
+    // The line that stops the agent from sitting in a poll loop.
+    expect(logs.join("\n")).toContain("end your turn")
+  })
+
+  test("carries KANNA_CHAT_ID when the provider set it", async () => {
+    const { deps, requests } = createDeps({ env: { KANNA_CHAT_ID: "chat-env" } })
+    await runRemindCommand(SET_ARGS, deps)
+    expect(requests[0]?.body).toMatchObject({ chatId: "chat-env" })
+  })
+
+  test("an explicit --chat wins over the environment", async () => {
+    const { deps, requests } = createDeps({ env: { KANNA_CHAT_ID: "chat-env" } })
+    await runRemindCommand({ ...SET_ARGS, chatId: "chat-flag" }, deps)
+    expect(requests[0]?.body).toMatchObject({ chatId: "chat-flag" })
+  })
+
+  test("says so when a prompt-less reminder will only resurface the chat", async () => {
+    const { deps, logs } = createDeps({ response: { body: { ok: true, dueAt: NOW, delayMs: 60_000 } } })
+    await runRemindCommand({ ...SET_ARGS, message: null }, deps)
+    expect(logs.join("\n")).toContain("without starting a turn")
+  })
+
+  test("posts to /clear and says nothing about scheduling", async () => {
+    const { deps, logs, requests } = createDeps({ response: { body: { ok: true, cleared: true } } })
+
+    const code = await runRemindCommand(
+      { clear: true, in: null, at: null, message: null, chatId: null },
+      deps,
+    )
+
+    expect(code).toBe(0)
+    expect(requests[0]?.url).toEndWith("/clear")
+    expect(requests[0]?.body).toEqual({ cwd: "/repo", chatId: null })
+    expect(logs).toEqual(["Reminder cancelled."])
+  })
+
+  test("reports the server's error and exits 1", async () => {
+    const { deps, warnings } = createDeps({
+      response: { status: 400, body: { error: "A reminder has to be in the future." } },
+    })
+    const code = await runRemindCommand(SET_ARGS, deps)
+    expect(code).toBe(1)
+    expect(warnings).toEqual(["A reminder has to be in the future."])
+  })
+
+  test("exits 1 with guidance when no server is running", async () => {
+    const { deps, warnings } = createDeps({ instance: null })
+    const code = await runRemindCommand(SET_ARGS, deps)
+    expect(code).toBe(1)
+    expect(warnings[0]).toContain("instance.json")
+  })
+
+  test("exits 1 when the server cannot be reached", async () => {
+    const { deps, warnings } = createDeps()
+    const code = await runRemindCommand(SET_ARGS, {
+      ...deps,
+      fetchImpl: (async () => {
+        throw new Error("ECONNREFUSED")
+      }) as unknown as typeof fetch,
+    })
+    expect(code).toBe(1)
+    expect(warnings[0]).toContain("ECONNREFUSED")
+  })
+
+  test("an overridden KANNA_URL uses its own explicit token", async () => {
+    const { deps, requests } = createDeps({
+      env: { KANNA_URL: "http://127.0.0.1:9999", KANNA_TOKEN: "explicit" },
+    })
+    await runRemindCommand(SET_ARGS, deps)
+    expect(requests[0]?.url).toStartWith("http://127.0.0.1:9999")
+    expect(requests[0]?.headers.get(REMINDERS_API_TOKEN_HEADER)).toBe("explicit")
+  })
+
+  test("refuses to send the instance token to an overridden KANNA_URL", async () => {
+    const { deps, warnings, requests } = createDeps({
+      env: { KANNA_URL: "http://evil.example" },
+    })
+
+    const code = await runRemindCommand(SET_ARGS, deps)
+
+    expect(code).toBe(1)
+    expect(requests).toEqual([])
+    expect(warnings[0]).toContain("KANNA_TOKEN")
+  })
+})

--- a/src/server/remind-command.ts
+++ b/src/server/remind-command.ts
@@ -1,0 +1,188 @@
+/**
+ * `kanna remind` — the agent-facing half of chat reminders.
+ *
+ * Same shape as `link-pr`: a shell command, because a shell is the one
+ * affordance every provider shares, talking to the already-running server over
+ * the loopback API with the per-start instance token. A single round trip —
+ * the waiting happens server-side, in a schedule that outlives this process and
+ * the agent that ran it.
+ *
+ * The chat is identified by `KANNA_CHAT_ID` when the provider sets it, and
+ * otherwise inferred server-side from the working directory (see
+ * `resolveAskingChat`). `--chat` overrides both.
+ */
+
+import { CLI_COMMAND } from "../shared/branding"
+import {
+  formatReminderDelay,
+  REMINDERS_API_PATH_PREFIX,
+  REMINDERS_API_TOKEN_HEADER,
+} from "../shared/reminders"
+import { SECRET_CHAT_ID_ENV_VAR } from "../shared/secrets"
+import { readInstanceFile } from "./instance-file"
+
+export interface RemindArgs {
+  /** Cancel the pending reminder; ignores every other field. */
+  clear: boolean
+  /** A delay: `30m`, `2h`, `1h30m`, or a bare number of minutes. */
+  in: string | null
+  /** An absolute time, ISO 8601. */
+  at: string | null
+  /** Posted into the chat when it fires. Null resurfaces the chat silently. */
+  message: string | null
+  chatId: string | null
+}
+
+export interface RemindDeps {
+  log: (message: string) => void
+  warn: (message: string) => void
+  fetchImpl?: typeof fetch
+  cwd?: () => string
+  env?: Record<string, string | undefined>
+  readInstance?: typeof readInstanceFile
+}
+
+export function parseRemindArgs(argv: string[]): RemindArgs {
+  let clear = false
+  let inValue: string | null = null
+  let at: string | null = null
+  let message: string | null = null
+  let chatId: string | null = null
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--clear" || arg === "--cancel") {
+      clear = true
+      continue
+    }
+    if (arg === "--in" || arg === "--at" || arg === "--chat" || arg === "--message") {
+      const next = argv[index + 1]
+      if (!next) throw new Error(`Missing value for ${arg}`)
+      if (arg === "--in") inValue = next
+      else if (arg === "--at") at = next
+      else if (arg === "--chat") chatId = next
+      else message = next
+      index += 1
+      continue
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unexpected argument for ${CLI_COMMAND} remind: ${arg}`)
+    }
+    if (message === null) {
+      message = arg
+      continue
+    }
+    throw new Error(`Unexpected argument for ${CLI_COMMAND} remind: ${arg}`)
+  }
+
+  if (!clear && !inValue && !at) {
+    throw new Error(`Say when: ${CLI_COMMAND} remind --in 30m "<what to do then>"`)
+  }
+
+  return { clear, in: inValue, at, message, chatId }
+}
+
+interface RemindResponse {
+  ok?: boolean
+  cleared?: boolean
+  dueAt?: number
+  delayMs?: number
+  prompt?: string
+  error?: string
+}
+
+/** Exit codes: 0 scheduled/cleared, 1 error. */
+export async function runRemindCommand(args: RemindArgs, deps: RemindDeps): Promise<number> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const cwd = (deps.cwd ?? (() => process.cwd()))()
+  const env = deps.env ?? process.env
+
+  const instance = await (deps.readInstance ?? readInstanceFile)()
+  const overrideUrl = env.KANNA_URL?.trim() || null
+  const overrideToken = env.KANNA_TOKEN?.trim() || null
+
+  // Same rule as `ask-secret`: the instance token is only ever presented to the
+  // instance that minted it. An agent controls its own environment, so letting
+  // an overridden KANNA_URL borrow the token from ~/.kanna/instance.json would
+  // hand the capability to queue prompts into any chat to whatever endpoint the
+  // agent named.
+  const baseUrl = overrideUrl ?? instance?.url
+  const token = overrideUrl ? overrideToken : overrideToken ?? instance?.token
+
+  if (overrideUrl && !overrideToken) {
+    deps.warn(
+      "KANNA_URL is set without KANNA_TOKEN. The token from ~/.kanna/instance.json is not sent "
+      + "to an overridden URL — set KANNA_TOKEN explicitly if that endpoint is really yours.",
+    )
+    return 1
+  }
+
+  if (!baseUrl || !token) {
+    deps.warn(
+      `No running ${CLI_COMMAND} server found (looked for ~/.kanna/instance.json). `
+      + `Start ${CLI_COMMAND} and try again.`,
+    )
+    return 1
+  }
+
+  const endpoint = `${baseUrl.replace(/\/$/, "")}${REMINDERS_API_PATH_PREFIX}`
+  const chatId = args.chatId ?? env[SECRET_CHAT_ID_ENV_VAR] ?? null
+
+  let payload: RemindResponse
+  try {
+    const response = await fetchImpl(`${endpoint}/${args.clear ? "clear" : "set"}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [REMINDERS_API_TOKEN_HEADER]: token,
+      },
+      body: JSON.stringify({
+        cwd,
+        chatId,
+        ...(args.clear ? {} : { in: args.in, at: args.at, prompt: args.message }),
+      }),
+    })
+    payload = (await response.json()) as RemindResponse
+    if (!response.ok) {
+      deps.warn(payload.error ?? `Request failed with status ${response.status}`)
+      return 1
+    }
+  } catch (error) {
+    deps.warn(`Could not reach ${CLI_COMMAND}: ${(error as Error).message}`)
+    return 1
+  }
+
+  if (args.clear) {
+    deps.log("Reminder cancelled.")
+    return 0
+  }
+
+  const when = payload.dueAt ? new Date(payload.dueAt).toLocaleString() : "later"
+  const delay = payload.delayMs ? ` (in ${formatReminderDelay(payload.delayMs)})` : ""
+  deps.log(`Reminder set for ${when}${delay}.`)
+  if (payload.prompt) {
+    deps.log("")
+    deps.log("When it fires, this chat will be woken with:")
+    deps.log(`  ${payload.prompt}`)
+    deps.log("")
+    deps.log(
+      "You do not need to wait or poll for it — end your turn. Kanna will start a new turn "
+      + "in this chat at that time, even if it is restarted in the meantime.",
+    )
+  } else {
+    deps.log("The chat will be flagged unread then, without starting a turn.")
+  }
+  return 0
+}
+
+/** Shown by `kanna --help`. */
+export function remindHelpLines(): string[] {
+  return [
+    `  ${CLI_COMMAND} remind --in <delay> [<message>]`,
+    "                                 Wake this chat later with <message>",
+    "      --in <30m|2h|1h30m|1d>     How long to wait (a bare number means minutes)",
+    "      --at <iso-timestamp>       Absolute time instead of a delay",
+    "      --clear                    Cancel this chat's pending reminder",
+    "      --chat <id>                Target chat (default: $KANNA_CHAT_ID, else inferred from cwd)",
+  ]
+}

--- a/src/server/reminder-instructions.test.ts
+++ b/src/server/reminder-instructions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { CLI_COMMAND } from "../shared/branding"
+import { buildReminderInstructions, reminderInstructionsBlock } from "./reminder-instructions"
+
+describe("buildReminderInstructions", () => {
+  test("names the command and the fallback path", () => {
+    const block = buildReminderInstructions("/opt/kanna/bin/kanna")
+    expect(block).toContain(`${CLI_COMMAND} remind --in 30m`)
+    expect(block).toContain("/opt/kanna/bin/kanna")
+  })
+
+  test("bakes in --chat for providers that cannot carry KANNA_CHAT_ID", () => {
+    const block = buildReminderInstructions("/bin/kanna", "chat-42")
+    expect(block).toContain("--chat chat-42")
+  })
+
+  test("omits --chat when the chat id is not supplied", () => {
+    expect(buildReminderInstructions("/bin/kanna")).not.toContain("--chat")
+  })
+
+  test("tells the agent not to sleep or poll — the line the feature depends on", () => {
+    const block = buildReminderInstructions("/bin/kanna")
+    expect(block).toContain("Do not sleep, poll, or loop")
+    expect(block).toContain("survives a restart")
+  })
+
+  test("warns that the future message arrives without current context", () => {
+    expect(buildReminderInstructions("/bin/kanna")).toContain("none of your current context")
+  })
+
+  test("is always on — unlike pull requests, it has no global setting to gate", () => {
+    expect(reminderInstructionsBlock()).not.toBeNull()
+  })
+})

--- a/src/server/reminder-instructions.ts
+++ b/src/server/reminder-instructions.ts
@@ -1,0 +1,51 @@
+/**
+ * The system-prompt block that teaches an agent to schedule its own wake-ups.
+ *
+ * Appended for every provider — Claude via `systemPrompt.append`, codex via
+ * `developer_instructions`, pi via `appendSystemPrompt` — alongside the
+ * attribution, ask-secret and pull-request blocks.
+ *
+ * Kept short: it is paid for on every turn of every chat. The single most
+ * valuable line is the one telling the agent *not* to sleep in a loop, which is
+ * what it will otherwise reach for when the user says "check back in 30".
+ */
+
+import { CLI_COMMAND } from "../shared/branding"
+import { resolveCliFallbackPath } from "./secret-instructions"
+
+/**
+ * `chatId` is baked into the example command for providers that cannot carry a
+ * per-chat `KANNA_CHAT_ID`: codex shares one app-server process across every
+ * chat in a project, so the env var Claude gets is not available there. Without
+ * it the server has to infer the chat from the working directory, which is
+ * ambiguous the moment two chats in the same project are running at once.
+ */
+export function reminderInstructionsBlock(chatId?: string): string | null {
+  return buildReminderInstructions(resolveCliFallbackPath(), chatId)
+}
+
+export function buildReminderInstructions(
+  cliPath: string = resolveCliFallbackPath(),
+  chatId?: string,
+): string {
+  const chatFlag = chatId ? ` --chat ${chatId}` : ""
+  return [
+    "# Coming back to this later",
+    "",
+    "When something should happen after a wait — the user says \"check back in 30\", a deploy",
+    "needs time to settle, a rate limit resets in an hour — schedule it and end your turn:",
+    "",
+    `  ${CLI_COMMAND} remind --in 30m${chatFlag} "re-run the metrics query and compare to the numbers above"`,
+    `  ${CLI_COMMAND} remind --in 2h${chatFlag} "check whether the migration finished"`,
+    `  ${CLI_COMMAND} remind --clear${chatFlag}   # cancel the pending one`,
+    "",
+    "At that time Kanna starts a new turn in this chat with the message you gave, so write the",
+    "message to your future self: it arrives with none of your current context loaded, and what",
+    "you believe right now may be stale by then. Say what to do and what to compare against.",
+    "",
+    "- Do not sleep, poll, or loop waiting for a time to pass. It burns the turn and dies with",
+    "  the process. The schedule is persisted and survives a restart; your process will not.",
+    "- A chat has one pending reminder — scheduling another replaces it.",
+    `- If \`${CLI_COMMAND}\` is not on PATH, use \`${cliPath}\`.`,
+  ].join("\n")
+}

--- a/src/server/reminder-scheduler.test.ts
+++ b/src/server/reminder-scheduler.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test"
+import type { ChatReminder } from "../shared/reminders"
+import type { ChatRecord } from "./events"
+import { ReminderScheduler } from "./reminder-scheduler"
+
+const NOW = 1_700_000_000_000
+
+function chat(id: string): ChatRecord {
+  return {
+    id,
+    projectId: "project-1",
+    title: id,
+    createdAt: NOW - 1_000,
+    updatedAt: NOW - 1_000,
+    unread: false,
+    provider: null,
+    planMode: false,
+    autoPlan: false,
+    sessionToken: null,
+    lastTurnOutcome: null,
+  }
+}
+
+function createScheduler(args: {
+  reminders: Array<{ chat: ChatRecord; reminder: ChatReminder }>
+  now?: number
+  postPrompt?: (chatId: string, prompt: string) => Promise<void>
+  clearReminder?: (chatId: string) => Promise<void>
+}) {
+  const cleared: string[] = []
+  const unread: string[] = []
+  const posted: Array<{ chatId: string; prompt: string }> = []
+  const notices: Array<{ chatId: string; scheduledAt: number; createdBy: string; wokeAgent: boolean }> = []
+  /** Every side effect in fire order, so ordering can be asserted directly. */
+  const order: string[] = []
+  let changedCount = 0
+
+  const rows = [...args.reminders]
+
+  const scheduler = new ReminderScheduler({
+    // A fresh array per call, like `listChatsWithReminders` — clearing during
+    // a tick must not mutate the list that tick is iterating.
+    listReminders: () => [...rows],
+    clearReminder: async (chatId) => {
+      if (args.clearReminder) await args.clearReminder(chatId)
+      cleared.push(chatId)
+      order.push("clear")
+      // Mirror the store: a cleared reminder leaves the work list.
+      const index = rows.findIndex((row) => row.chat.id === chatId)
+      if (index >= 0) rows.splice(index, 1)
+    },
+    markUnread: async (chatId) => {
+      unread.push(chatId)
+      order.push("unread")
+    },
+    recordNotice: async (chatId, notice) => {
+      notices.push({ chatId, ...notice })
+      order.push("notice")
+    },
+    postPrompt: async (chatId, prompt) => {
+      order.push("prompt")
+      if (args.postPrompt) return args.postPrompt(chatId, prompt)
+      posted.push({ chatId, prompt })
+    },
+    onChanged: () => {
+      changedCount += 1
+    },
+    now: () => args.now ?? NOW,
+  })
+
+  return {
+    scheduler,
+    cleared,
+    unread,
+    posted,
+    notices,
+    order,
+    changed: () => changedCount,
+  }
+}
+
+describe("firing", () => {
+  test("fires a due reminder: clears it, marks unread, posts the prompt", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        reminder: { dueAt: NOW - 1, createdAt: NOW - 1_000, createdBy: "user", prompt: "check metrics" },
+      }],
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.cleared).toEqual(["chat-1"])
+    expect(harness.unread).toEqual(["chat-1"])
+    expect(harness.posted).toEqual([{ chatId: "chat-1", prompt: "check metrics" }])
+    expect(harness.changed()).toBe(1)
+    // The divider must land before the prompt it introduces, or the transcript
+    // reads as though the reminder answered the message.
+    expect(harness.order).toEqual(["clear", "unread", "notice", "prompt"])
+    expect(harness.notices).toEqual([{
+      chatId: "chat-1",
+      scheduledAt: NOW - 1_000,
+      createdBy: "user",
+      wokeAgent: true,
+    }])
+  })
+
+  test("a reminder with no prompt only resurfaces the chat", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        reminder: { dueAt: NOW - 1, createdAt: NOW - 1_000, createdBy: "agent" },
+      }],
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.unread).toEqual(["chat-1"])
+    expect(harness.posted).toEqual([])
+    // Still gets a divider — the chat resurfaced for a reason worth recording.
+    expect(harness.notices[0]).toMatchObject({ createdBy: "agent", wokeAgent: false })
+  })
+
+  test("leaves reminders that are not yet due alone", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        reminder: { dueAt: NOW + 60_000, createdAt: NOW, createdBy: "user", prompt: "later" },
+      }],
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.cleared).toEqual([])
+    expect(harness.posted).toEqual([])
+    expect(harness.changed()).toBe(0)
+  })
+
+  test("fires a reminder that came due while the server was down", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        // Set a week ago for six days ago: late, but not dropped.
+        reminder: {
+          dueAt: NOW - 6 * 86_400_000,
+          createdAt: NOW - 7 * 86_400_000,
+          createdBy: "user",
+          prompt: "still relevant",
+        },
+      }],
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.posted).toEqual([{ chatId: "chat-1", prompt: "still relevant" }])
+  })
+
+  test("fires several due reminders in one tick, broadcasting once", async () => {
+    const harness = createScheduler({
+      reminders: [
+        {
+          chat: chat("chat-1"),
+          reminder: { dueAt: NOW - 1, createdAt: NOW - 10, createdBy: "user", prompt: "one" },
+        },
+        {
+          chat: chat("chat-2"),
+          reminder: { dueAt: NOW - 2, createdAt: NOW - 10, createdBy: "agent", prompt: "two" },
+        },
+      ],
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.posted.map((entry) => entry.chatId)).toEqual(["chat-1", "chat-2"])
+    expect(harness.changed()).toBe(1)
+  })
+})
+
+describe("failure handling", () => {
+  test("a failed post still spends the reminder, so it cannot re-fire forever", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        reminder: { dueAt: NOW - 1, createdAt: NOW - 10, createdBy: "user", prompt: "boom" },
+      }],
+      postPrompt: async () => {
+        throw new Error("agent unavailable")
+      },
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.cleared).toEqual(["chat-1"])
+    // Second tick has nothing left to do.
+    await harness.scheduler.tick()
+    expect(harness.cleared).toEqual(["chat-1"])
+  })
+
+  test("a failure on one chat does not stop the others", async () => {
+    const harness = createScheduler({
+      reminders: [
+        {
+          chat: chat("chat-1"),
+          reminder: { dueAt: NOW - 1, createdAt: NOW - 10, createdBy: "user", prompt: "boom" },
+        },
+        {
+          chat: chat("chat-2"),
+          reminder: { dueAt: NOW - 1, createdAt: NOW - 10, createdBy: "user", prompt: "fine" },
+        },
+      ],
+      postPrompt: async (chatId, prompt) => {
+        if (chatId === "chat-1") throw new Error("nope")
+        expect(prompt).toBe("fine")
+      },
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.cleared).toEqual(["chat-1", "chat-2"])
+  })
+
+  test("a reminder that fails to clear is not posted", async () => {
+    const harness = createScheduler({
+      reminders: [{
+        chat: chat("chat-1"),
+        reminder: { dueAt: NOW - 1, createdAt: NOW - 10, createdBy: "user", prompt: "check" },
+      }],
+      clearReminder: async () => {
+        throw new Error("disk full")
+      },
+    })
+
+    await harness.scheduler.tick()
+
+    expect(harness.posted).toEqual([])
+    expect(harness.unread).toEqual([])
+    expect(harness.notices).toEqual([])
+  })
+})
+
+describe("lifecycle", () => {
+  test("start is idempotent and stop clears the timer", () => {
+    const harness = createScheduler({ reminders: [] })
+    harness.scheduler.start()
+    harness.scheduler.start()
+    harness.scheduler.stop()
+    harness.scheduler.stop()
+  })
+})

--- a/src/server/reminder-scheduler.ts
+++ b/src/server/reminder-scheduler.ts
@@ -1,0 +1,115 @@
+/**
+ * Fires chat reminders when they come due.
+ *
+ * One timer for the whole server, and no in-process schedule: every tick asks
+ * the store which chats have a pending reminder. That is what makes reminders
+ * survive a restart — the schedule lives in the event log, so a reminder set on
+ * Friday still fires on Monday even though the process that took it is long
+ * gone. Reminders that came due while the server was down fire on the first
+ * tick after it comes back, which is the behaviour you want from something the
+ * user described as "remind me": late is right, dropped is not.
+ *
+ * Firing is three things, in this order:
+ *   1. mark the chat unread, so it resurfaces in the sidebar
+ *   2. write a transcript divider saying a reminder fired
+ *   3. post the reminder's prompt, which starts (or queues) a turn
+ * The last is skipped for reminders with no prompt — those only resurface. The
+ * divider comes first so the transcript reads in order, and so the prompt below
+ * it is never mistaken for something the user typed.
+ */
+
+import { LOG_PREFIX } from "../shared/branding"
+import type { ChatReminder, ReminderSource } from "../shared/reminders"
+import type { ChatRecord } from "./events"
+
+/** How often the loop wakes to see whether anything is due. */
+const TICK_INTERVAL_MS = 15_000
+
+export interface ReminderSchedulerDeps {
+  listReminders: () => Array<{ chat: ChatRecord; reminder: ChatReminder }>
+  /** Consume the reminder. Called before anything is posted. */
+  clearReminder: (chatId: string) => Promise<void>
+  /** Bring the chat back in the sidebar. */
+  markUnread: (chatId: string) => Promise<void>
+  /**
+   * Write the transcript divider that explains the prompt about to appear.
+   * Posted before the prompt so the two land in reading order.
+   */
+  recordNotice: (chatId: string, notice: {
+    scheduledAt: number
+    createdBy: ReminderSource
+    wokeAgent: boolean
+  }) => Promise<void>
+  /** Post a prompt into the chat, starting or queueing a turn. */
+  postPrompt: (chatId: string, prompt: string) => Promise<void>
+  /** Something fired — re-push the sidebar. */
+  onChanged: () => void
+  now?: () => number
+}
+
+export class ReminderScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null
+  /** Chats mid-fire, so a slow post can't be entered twice. */
+  private readonly inFlight = new Set<string>()
+
+  constructor(private readonly deps: ReminderSchedulerDeps) {}
+
+  start() {
+    if (this.timer) return
+    this.timer = setInterval(() => {
+      void this.tick().catch((error: unknown) => {
+        console.warn(`${LOG_PREFIX} reminder tick failed:`, error)
+      })
+    }, TICK_INTERVAL_MS)
+    // Node/Bun keep the process alive for an interval; this one must not.
+    this.timer.unref?.()
+  }
+
+  stop() {
+    if (!this.timer) return
+    clearInterval(this.timer)
+    this.timer = null
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now()
+  }
+
+  /** Exposed for tests and for firing without waiting out the interval. */
+  async tick(): Promise<void> {
+    const now = this.now()
+    let fired = false
+
+    for (const { chat, reminder } of this.deps.listReminders()) {
+      if (reminder.dueAt > now) continue
+      if (this.inFlight.has(chat.id)) continue
+      this.inFlight.add(chat.id)
+      try {
+        // Clear first. If the post throws, the reminder is still spent rather
+        // than re-firing on every tick from here to the heat death of the
+        // universe — the one failure mode worth designing against.
+        await this.deps.clearReminder(chat.id)
+        fired = true
+        await this.deps.markUnread(chat.id)
+        await this.deps.recordNotice(chat.id, {
+          scheduledAt: reminder.createdAt,
+          createdBy: reminder.createdBy,
+          wokeAgent: Boolean(reminder.prompt),
+        })
+        if (reminder.prompt) {
+          await this.deps.postPrompt(chat.id, reminder.prompt)
+        }
+        console.log(
+          `${LOG_PREFIX} reminder fired for chat ${chat.id}`
+          + `${reminder.prompt ? "" : " (no prompt — resurfaced only)"}`,
+        )
+      } catch (error) {
+        console.warn(`${LOG_PREFIX} reminder failed to fire for chat ${chat.id}:`, error)
+      } finally {
+        this.inFlight.delete(chat.id)
+      }
+    }
+
+    if (fired) this.deps.onChanged()
+  }
+}

--- a/src/server/reminders-api.test.ts
+++ b/src/server/reminders-api.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test"
+import { REMINDERS_API_PATH_PREFIX, REMINDERS_API_TOKEN_HEADER } from "../shared/reminders"
+import { createRemindersApi } from "./reminders-api"
+
+const TOKEN = "correct-horse-battery-staple"
+const NOW = 1_700_000_000_000
+
+function createApi(args: {
+  resolveChat?: (args: { cwd: string; claimedChatId: string | null }) => string | null
+} = {}) {
+  const setCalls: Array<{ chatId: string; dueAt: number; prompt?: string }> = []
+  const clearCalls: string[] = []
+  let changedCount = 0
+
+  const handler = createRemindersApi({
+    token: TOKEN,
+    resolveChat: args.resolveChat ?? (({ claimedChatId }) => claimedChatId ?? "chat-1"),
+    setReminder: async (chatId, reminderArgs) => {
+      setCalls.push({ chatId, ...reminderArgs })
+    },
+    clearReminder: async (chatId) => {
+      clearCalls.push(chatId)
+    },
+    onChanged: () => {
+      changedCount += 1
+    },
+    now: () => NOW,
+  })
+
+  async function call(subPath: string, init: RequestInit & { token?: string | null } = {}) {
+    const url = new URL(`http://127.0.0.1:3210${REMINDERS_API_PATH_PREFIX}${subPath}`)
+    const headers = new Headers(init.headers)
+    headers.set("content-type", "application/json")
+    const token = init.token === undefined ? TOKEN : init.token
+    if (token !== null) headers.set(REMINDERS_API_TOKEN_HEADER, token)
+    const request = new Request(url, { method: init.method ?? "POST", headers, body: init.body })
+    return handler(request, url)
+  }
+
+  return { call, setCalls, clearCalls, changed: () => changedCount }
+}
+
+describe("routing", () => {
+  test("returns null for paths that are not ours, so routing falls through", async () => {
+    const { call } = createApi()
+    const url = new URL("http://127.0.0.1:3210/api/something")
+    const handler = createRemindersApi({
+      token: TOKEN,
+      resolveChat: () => "chat-1",
+      setReminder: async () => {},
+      clearReminder: async () => {},
+      onChanged: () => {},
+    })
+    expect(await handler(new Request(url), url)).toBeNull()
+    // Sanity: our own prefix does not return null.
+    expect(await call("/set", { body: JSON.stringify({ in: "30m" }) })).not.toBeNull()
+  })
+
+  test("404s an unknown sub-path", async () => {
+    const { call } = createApi()
+    const response = await call("/explode", { body: "{}" })
+    expect(response?.status).toBe(404)
+  })
+
+  test("405s a non-POST", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { method: "GET" })
+    expect(response?.status).toBe(405)
+  })
+})
+
+describe("auth", () => {
+  test("rejects a missing token", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { token: null, body: JSON.stringify({ in: "30m" }) })
+    expect(response?.status).toBe(401)
+  })
+
+  test("rejects a wrong token", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { token: "nope", body: JSON.stringify({ in: "30m" }) })
+    expect(response?.status).toBe(401)
+  })
+
+  test("rejects a token of a different length without throwing", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { token: "short", body: JSON.stringify({ in: "30m" }) })
+    expect(response?.status).toBe(401)
+  })
+})
+
+describe("setting a reminder", () => {
+  test("resolves a relative delay against the server clock", async () => {
+    const { call, setCalls, changed } = createApi()
+    const response = await call("/set", {
+      body: JSON.stringify({ in: "30m", prompt: "check metrics", chatId: "chat-7" }),
+    })
+
+    expect(response?.status).toBe(200)
+    expect(await response?.json()).toEqual({
+      ok: true,
+      dueAt: NOW + 30 * 60_000,
+      delayMs: 30 * 60_000,
+      prompt: "check metrics",
+    })
+    expect(setCalls).toEqual([{
+      chatId: "chat-7",
+      dueAt: NOW + 30 * 60_000,
+      prompt: "check metrics",
+    }])
+    expect(changed()).toBe(1)
+  })
+
+  test("accepts an absolute time", async () => {
+    const { call, setCalls } = createApi()
+    const at = new Date(NOW + 3_600_000).toISOString()
+    await call("/set", { body: JSON.stringify({ at }) })
+    expect(setCalls[0]?.dueAt).toBe(NOW + 3_600_000)
+  })
+
+  test("omits the prompt entirely when none is given", async () => {
+    const { call, setCalls } = createApi()
+    await call("/set", { body: JSON.stringify({ in: "1h" }) })
+    expect(setCalls[0]).toEqual({ chatId: "chat-1", dueAt: NOW + 3_600_000 })
+    expect("prompt" in (setCalls[0] ?? {})).toBe(false)
+  })
+
+  test("treats a whitespace-only prompt as no prompt", async () => {
+    const { call, setCalls } = createApi()
+    await call("/set", { body: JSON.stringify({ in: "1h", prompt: "   " }) })
+    expect("prompt" in (setCalls[0] ?? {})).toBe(false)
+  })
+
+  test("rejects a time in the past", async () => {
+    const { call, setCalls } = createApi()
+    const response = await call("/set", {
+      body: JSON.stringify({ at: new Date(NOW - 1_000).toISOString() }),
+    })
+    expect(response?.status).toBe(400)
+    expect(setCalls).toEqual([])
+  })
+
+  test("rejects an unreadable delay and says so", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { body: JSON.stringify({ in: "whenever" }) })
+    expect(response?.status).toBe(400)
+    expect((await response?.json())?.error).toContain("whenever")
+  })
+
+  test("rejects a body that is not JSON", async () => {
+    const { call } = createApi()
+    const response = await call("/set", { body: "not json" })
+    expect(response?.status).toBe(400)
+  })
+})
+
+describe("clearing a reminder", () => {
+  test("clears and broadcasts", async () => {
+    const { call, clearCalls, changed } = createApi()
+    const response = await call("/clear", { body: JSON.stringify({ chatId: "chat-3" }) })
+    expect(await response?.json()).toEqual({ ok: true, cleared: true })
+    expect(clearCalls).toEqual(["chat-3"])
+    expect(changed()).toBe(1)
+  })
+})
+
+describe("chat resolution", () => {
+  test("400s with guidance when the chat cannot be resolved", async () => {
+    const { call, setCalls } = createApi({ resolveChat: () => null })
+    const response = await call("/set", { body: JSON.stringify({ in: "30m" }) })
+    expect(response?.status).toBe(400)
+    expect((await response?.json())?.error).toContain("--chat")
+    expect(setCalls).toEqual([])
+  })
+
+  test("passes the claimed chat id and cwd through to the resolver", async () => {
+    const seen: Array<{ cwd: string; claimedChatId: string | null }> = []
+    const { call } = createApi({
+      resolveChat: (resolveArgs) => {
+        seen.push(resolveArgs)
+        return "chat-9"
+      },
+    })
+    await call("/set", { body: JSON.stringify({ in: "5m", cwd: "/repo", chatId: "chat-4" }) })
+    expect(seen).toEqual([{ cwd: "/repo", claimedChatId: "chat-4" }])
+  })
+
+  test("treats a blank claimed chat id as absent", async () => {
+    const seen: Array<{ cwd: string; claimedChatId: string | null }> = []
+    const { call } = createApi({
+      resolveChat: (resolveArgs) => {
+        seen.push(resolveArgs)
+        return "chat-9"
+      },
+    })
+    await call("/set", { body: JSON.stringify({ in: "5m", cwd: "/repo", chatId: "  " }) })
+    expect(seen[0]?.claimedChatId).toBeNull()
+  })
+})

--- a/src/server/reminders-api.ts
+++ b/src/server/reminders-api.ts
@@ -1,0 +1,117 @@
+/**
+ * Loopback HTTP surface for `kanna remind`.
+ *
+ * Mounted under `/__local/reminders` with the same guarantees as the secrets
+ * and pull-requests APIs: reachable only when the request class is `local`, and
+ * gated on the per-start instance token from `~/.kanna/instance.json`.
+ * Deliberately not under `/api/`, which is gated by the browser session cookie
+ * a CLI invocation does not have.
+ *
+ * Relative delays are resolved here rather than in the CLI. Both sides are the
+ * same machine over loopback, so it costs nothing and keeps one clock in play.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+import {
+  normalizeReminderPrompt,
+  REMINDERS_API_PATH_PREFIX,
+  REMINDERS_API_TOKEN_HEADER,
+  resolveReminderDueAt,
+} from "../shared/reminders"
+
+export interface RemindersApiDeps {
+  token: string
+  /** Which chat is asking — `resolveAskingChat`, shared with the secrets API. */
+  resolveChat: (args: { cwd: string; claimedChatId: string | null }) => string | null
+  setReminder: (chatId: string, args: { dueAt: number; prompt?: string }) => Promise<void>
+  clearReminder: (chatId: string) => Promise<void>
+  /** A reminder was scheduled or cancelled — re-push the sidebar. */
+  onChanged: () => void
+  now?: () => number
+}
+
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (!provided) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+function badRequest(message: string) {
+  return Response.json({ error: message }, { status: 400 })
+}
+
+export function createRemindersApi(deps: RemindersApiDeps) {
+  return async function handleRemindersRequest(req: Request, url: URL): Promise<Response | null> {
+    if (
+      url.pathname !== REMINDERS_API_PATH_PREFIX
+      && !url.pathname.startsWith(`${REMINDERS_API_PATH_PREFIX}/`)
+    ) {
+      return null
+    }
+
+    if (!tokenMatches(req.headers.get(REMINDERS_API_TOKEN_HEADER), deps.token)) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const subPath = url.pathname.slice(REMINDERS_API_PATH_PREFIX.length)
+    if (subPath !== "/set" && subPath !== "/clear") {
+      return Response.json({ error: "Not found" }, { status: 404 })
+    }
+    if (req.method !== "POST") {
+      return new Response(null, { status: 405, headers: { Allow: "POST" } })
+    }
+
+    let body: Record<string, unknown>
+    try {
+      body = (await req.json()) as Record<string, unknown>
+    } catch {
+      return badRequest("Body must be JSON")
+    }
+
+    const cwd = typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : process.cwd()
+    const claimedChatId = typeof body.chatId === "string" && body.chatId.trim()
+      ? body.chatId.trim()
+      : null
+    const chatId = deps.resolveChat({ cwd, claimedChatId })
+    if (!chatId) {
+      return badRequest(
+        "Could not tell which chat this belongs to. Pass --chat <id>, or run the command from "
+        + "inside the project directory of a running chat.",
+      )
+    }
+
+    if (subPath === "/clear") {
+      await deps.clearReminder(chatId)
+      deps.onChanged()
+      return Response.json({ ok: true, cleared: true })
+    }
+
+    const now = deps.now?.() ?? Date.now()
+    const resolved = resolveReminderDueAt({
+      now,
+      in: typeof body.in === "string" ? body.in : null,
+      at: typeof body.at === "string" || typeof body.at === "number" ? body.at : null,
+      dueAt: typeof body.dueAt === "number" ? body.dueAt : null,
+    })
+    if (!resolved.ok) return badRequest(resolved.error)
+
+    const prompt = normalizeReminderPrompt(
+      typeof body.prompt === "string" ? body.prompt : null,
+    )
+
+    await deps.setReminder(chatId, {
+      dueAt: resolved.dueAt,
+      ...(prompt ? { prompt } : {}),
+    })
+    deps.onChanged()
+
+    return Response.json({
+      ok: true,
+      dueAt: resolved.dueAt,
+      delayMs: resolved.dueAt - now,
+      ...(prompt ? { prompt } : {}),
+    })
+  }
+}

--- a/src/server/secret-instructions.test.ts
+++ b/src/server/secret-instructions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { buildAskSecretInstructions, resolveCliFallbackPath } from "./secret-instructions"
+
+const instructions = buildAskSecretInstructions("/opt/kanna/bin/kanna")
+
+describe("buildAskSecretInstructions", () => {
+  test("names the exact command an agent should run", () => {
+    expect(instructions).toContain('kanna ask-secret <NAME> --reason "<why you need it>"')
+  })
+
+  test("forbids the two ways an agent would otherwise leak the value", () => {
+    expect(instructions).toContain("never ask for it")
+    expect(instructions).toContain("Never cat, read, echo, grep or print")
+  })
+
+  test("explains the timeout is not a failure", () => {
+    expect(instructions).toContain("resumes the same wait")
+  })
+
+  test("documents the declined exit code so an agent stops retrying", () => {
+    expect(instructions).toContain("Exit code 3")
+  })
+
+  test("offers the absolute path for agents without kanna on PATH", () => {
+    expect(instructions).toContain("/opt/kanna/bin/kanna")
+  })
+
+  test("stays small enough to ride on every turn", () => {
+    // Rough token estimate, matching the bound attribution.test.ts applies.
+    expect(instructions.length / 3).toBeLessThan(400)
+  })
+})
+
+describe("resolveCliFallbackPath", () => {
+  test("points at the packaged bin", () => {
+    expect(resolveCliFallbackPath()).toEndWith("/bin/kanna")
+  })
+})

--- a/src/server/secret-instructions.ts
+++ b/src/server/secret-instructions.ts
@@ -1,0 +1,48 @@
+/**
+ * The system-prompt block that teaches an agent about ask-for-secret.
+ *
+ * Appended for every provider — Claude via `systemPrompt.append`, codex via
+ * `developer_instructions`, pi via `appendSystemPrompt` — because the CLI is
+ * the one affordance all three share. It rides alongside the git-attribution
+ * block (see attribution.ts) and is kept deliberately short: it is paid for
+ * on every single turn.
+ */
+
+import { fileURLToPath } from "node:url"
+import { CLI_COMMAND } from "../shared/branding"
+
+/**
+ * Absolute path to the bundled CLI, for the case where kanna was run from a
+ * source checkout and never installed onto PATH.
+ */
+export function resolveCliFallbackPath(): string {
+  try {
+    return fileURLToPath(new URL("../../bin/kanna", import.meta.url))
+  } catch {
+    return CLI_COMMAND
+  }
+}
+
+export function buildAskSecretInstructions(cliPath: string = resolveCliFallbackPath()): string {
+  return [
+    "# Secrets",
+    "",
+    "When you need a credential you do not have (API key, token, password), never ask for it",
+    "in chat — anything the user types there enters your context and the transcript. Instead run:",
+    "",
+    `  ${CLI_COMMAND} ask-secret <NAME> --reason "<why you need it>"`,
+    "",
+    "The user types the value into Kanna and chooses project or global scope. The command",
+    "prints a shell snippet that loads it, e.g. `set -a; . <path>/<NAME>.env; set +a` — run that",
+    "in the same shell command as the work that needs it, then use $<NAME>.",
+    "",
+    "- <NAME> must be a valid shell variable name, e.g. OPENAI_API_KEY.",
+    "- It waits up to 5 minutes, so give the command a generous timeout. If it times out the",
+    "  prompt is still open: re-running the same command resumes the same wait.",
+    "- Exit code 3 means the user declined. Do not ask again — continue without it or say what",
+    "  you cannot do.",
+    "- Never cat, read, echo, grep or print the .env file or the variable. The value is kept out",
+    "  of your context on purpose; reading it defeats the entire mechanism.",
+    `- If \`${CLI_COMMAND}\` is not on PATH, use \`${cliPath}\`.`,
+  ].join("\n")
+}

--- a/src/server/secret-requests.test.ts
+++ b/src/server/secret-requests.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test"
+import {
+  SECRET_REQUEST_TTL_MS,
+  SECRET_RESOLUTION_RETENTION_MS,
+  SecretRequestStore,
+} from "./secret-requests"
+import type { writeSecret } from "./secrets"
+
+function createStore(options: { now?: () => number } = {}) {
+  const written: Array<{ scope: string; name: string; value: string; projectPath?: string | null }> = []
+  const fakeWrite: typeof writeSecret = async (args) => {
+    written.push({ ...args })
+    return {
+      scope: args.scope,
+      name: args.name,
+      path: `/tmp/${args.name}.env`,
+      loadCommand: `set -a; . '/tmp/${args.name}.env'; set +a`,
+      gitignoreUpdated: args.scope === "project",
+    }
+  }
+
+  return {
+    written,
+    store: new SecretRequestStore({ writeSecret: fakeWrite, now: options.now }),
+  }
+}
+
+const baseArgs = {
+  name: "OPENAI_API_KEY",
+  reason: "call the API",
+  cwd: "/tmp/proj",
+  projectPath: "/tmp/proj",
+  projectTitle: "proj",
+  suggestedScope: null,
+}
+
+describe("create", () => {
+  test("registers a pending request the UI can render", () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+
+    expect(store.list()).toHaveLength(1)
+    expect(store.list()[0].id).toBe(request.id)
+    expect(store.resolutionFor(request.id).status).toBe("pending")
+  })
+
+  test("reuses the open prompt when the same ask is retried", () => {
+    const { store } = createStore()
+    const first = store.create(baseArgs)
+    const second = store.create({ ...baseArgs, reason: "retried" })
+
+    expect(second.id).toBe(first.id)
+    expect(store.list()).toHaveLength(1)
+  })
+
+  test("treats the same name in a different directory as a separate ask", () => {
+    const { store } = createStore()
+    store.create(baseArgs)
+    store.create({ ...baseArgs, cwd: "/tmp/other" })
+    expect(store.list()).toHaveLength(2)
+  })
+
+  test("truncates an over-long reason", () => {
+    const { store } = createStore()
+    const request = store.create({ ...baseArgs, reason: "x".repeat(900) })
+    expect(request.reason.length).toBe(500)
+  })
+})
+
+describe("submit", () => {
+  test("writes the secret and settles the request", async () => {
+    const { store, written } = createStore()
+    const request = store.create(baseArgs)
+
+    const resolution = await store.submit(request.id, { scope: "project", value: "sk-live" })
+
+    expect(resolution.status).toBe("saved")
+    expect(resolution.path).toBe("/tmp/OPENAI_API_KEY.env")
+    expect(resolution.gitignoreUpdated).toBe(true)
+    expect(written).toEqual([
+      { scope: "project", name: "OPENAI_API_KEY", value: "sk-live", projectPath: "/tmp/proj" },
+    ])
+  })
+
+  test("drops the request out of the pending list once answered", async () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+    await store.submit(request.id, { scope: "global", value: "v" })
+
+    expect(store.list()).toHaveLength(0)
+    expect(store.resolutionFor(request.id).status).toBe("saved")
+  })
+
+  test("never retains the value on the request itself", async () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+    await store.submit(request.id, { scope: "global", value: "super-secret" })
+
+    expect(JSON.stringify(store.get(request.id))).not.toContain("super-secret")
+    expect(JSON.stringify(store.resolutionFor(request.id))).not.toContain("super-secret")
+  })
+
+  test("rejects a second answer to the same request", async () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+    await store.submit(request.id, { scope: "global", value: "v" })
+
+    await expect(store.submit(request.id, { scope: "global", value: "v2" }))
+      .rejects.toThrow(/already been answered/)
+  })
+
+  test("rejects an unknown request", async () => {
+    const { store } = createStore()
+    await expect(store.submit("nope", { scope: "global", value: "v" }))
+      .rejects.toThrow(/no longer open/)
+  })
+
+  test("rejects project scope when the ask came from outside a project", async () => {
+    const { store } = createStore()
+    const request = store.create({ ...baseArgs, projectPath: null, projectTitle: null })
+
+    await expect(store.submit(request.id, { scope: "project", value: "v" }))
+      .rejects.toThrow(/saved globally/)
+  })
+})
+
+describe("cancel", () => {
+  test("settles the request as cancelled", () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+
+    expect(store.cancel(request.id)).toBe(true)
+    expect(store.resolutionFor(request.id).status).toBe("cancelled")
+    expect(store.list()).toHaveLength(0)
+  })
+
+  test("is a no-op for an unknown or already-settled request", () => {
+    const { store } = createStore()
+    const request = store.create(baseArgs)
+    store.cancel(request.id)
+
+    expect(store.cancel(request.id)).toBe(false)
+    expect(store.cancel("nope")).toBe(false)
+  })
+})
+
+describe("expiry and retention", () => {
+  test("a prompt nobody answers expires", () => {
+    let now = 1_000
+    const { store } = createStore({ now: () => now })
+    const request = store.create(baseArgs)
+
+    now += SECRET_REQUEST_TTL_MS - 1
+    expect(store.resolutionFor(request.id).status).toBe("pending")
+
+    now += 2
+    expect(store.resolutionFor(request.id).status).toBe("expired")
+    expect(store.list()).toHaveLength(0)
+  })
+
+  test("a settled result stays readable long enough for the CLI to poll it", async () => {
+    let now = 1_000
+    const { store } = createStore({ now: () => now })
+    const request = store.create(baseArgs)
+    await store.submit(request.id, { scope: "global", value: "v" })
+
+    now += SECRET_RESOLUTION_RETENTION_MS - 1
+    expect(store.resolutionFor(request.id).status).toBe("saved")
+
+    now += 2
+    expect(store.resolutionFor(request.id).status).toBe("expired")
+  })
+
+  test("an unknown id reads as expired, not pending, so the CLI stops waiting", () => {
+    const { store } = createStore()
+    expect(store.resolutionFor("never-existed").status).toBe("expired")
+  })
+})
+
+describe("onChange", () => {
+  test("fires for create, submit and cancel", async () => {
+    const { store } = createStore()
+    let calls = 0
+    const unsubscribe = store.onChange(() => {
+      calls += 1
+    })
+
+    const first = store.create(baseArgs)
+    await store.submit(first.id, { scope: "global", value: "v" })
+    const second = store.create({ ...baseArgs, cwd: "/tmp/two" })
+    store.cancel(second.id)
+
+    expect(calls).toBe(4)
+    unsubscribe()
+    store.create({ ...baseArgs, cwd: "/tmp/three" })
+    expect(calls).toBe(4)
+  })
+})

--- a/src/server/secret-requests.test.ts
+++ b/src/server/secret-requests.test.ts
@@ -7,6 +7,7 @@ import {
 import type { writeSecret } from "./secrets"
 
 function createStore(options: { now?: () => number } = {}) {
+  const settled: Array<{ chatId: string; name: string; outcome: string; scope?: string }> = []
   const written: Array<{ scope: string; name: string; value: string; projectPath?: string | null }> = []
   const fakeWrite: typeof writeSecret = async (args) => {
     written.push({ ...args })
@@ -21,7 +22,12 @@ function createStore(options: { now?: () => number } = {}) {
 
   return {
     written,
-    store: new SecretRequestStore({ writeSecret: fakeWrite, now: options.now }),
+    settled,
+    store: new SecretRequestStore({
+      writeSecret: fakeWrite,
+      now: options.now,
+      onSettled: (event) => settled.push({ ...event }),
+    }),
   }
 }
 
@@ -194,5 +200,68 @@ describe("onChange", () => {
     unsubscribe()
     store.create({ ...baseArgs, cwd: "/tmp/three" })
     expect(calls).toBe(4)
+  })
+})
+
+describe("settle notices", () => {
+  const chatArgs = { ...baseArgs, chatId: "chat-1" }
+
+  test("announces a save with the scope it landed in", async () => {
+    const { store, settled } = createStore()
+    const request = store.create(chatArgs)
+
+    await store.submit(request.id, { scope: "global", value: "sk-value" })
+
+    expect(settled).toEqual([
+      { chatId: "chat-1", name: "OPENAI_API_KEY", outcome: "saved", scope: "global" },
+    ])
+  })
+
+  test("announces a decline", () => {
+    const { store, settled } = createStore()
+    const request = store.create(chatArgs)
+
+    store.cancel(request.id)
+
+    expect(settled).toEqual([{ chatId: "chat-1", name: "OPENAI_API_KEY", outcome: "declined" }])
+  })
+
+  test("announces an expiry", () => {
+    let now = 1_000
+    const { store, settled } = createStore({ now: () => now })
+    store.create(chatArgs)
+
+    now += SECRET_REQUEST_TTL_MS
+    store.sweep()
+
+    expect(settled).toEqual([{ chatId: "chat-1", name: "OPENAI_API_KEY", outcome: "expired" }])
+  })
+
+  test("stays quiet when the request has no chat to announce into", async () => {
+    const { store, settled } = createStore()
+    const request = store.create(baseArgs)
+
+    await store.submit(request.id, { scope: "project", value: "sk-value" })
+
+    expect(settled).toEqual([])
+    expect(store.resolutionFor(request.id).status).toBe("saved")
+  })
+
+  test("announces once, not again on a repeat settle", () => {
+    const { store, settled } = createStore()
+    const request = store.create(chatArgs)
+
+    expect(store.cancel(request.id)).toBe(true)
+    expect(store.cancel(request.id)).toBe(false)
+    expect(settled).toHaveLength(1)
+  })
+
+  test("never carries the value", async () => {
+    const { store, settled } = createStore()
+    const request = store.create(chatArgs)
+
+    await store.submit(request.id, { scope: "project", value: "sk-super-secret" })
+
+    expect(JSON.stringify(settled)).not.toContain("sk-super-secret")
   })
 })

--- a/src/server/secret-requests.ts
+++ b/src/server/secret-requests.ts
@@ -40,11 +40,26 @@ export interface CreateSecretRequestArgs {
   projectPath: string | null
   projectTitle: string | null
   suggestedScope: SecretScope | null
+  chatId?: string | null
+}
+
+/** Emitted once per request when it settles, for the transcript notice. */
+export interface SecretSettledEvent {
+  chatId: string
+  name: string
+  outcome: "saved" | "declined" | "expired"
+  scope?: SecretScope
 }
 
 export interface SecretRequestStoreOptions {
   writeSecret?: typeof writeSecretToDisk
   now?: () => number
+  /**
+   * Called when a request settles and it belongs to a known chat. Failures
+   * are the caller's problem — a notice that cannot be written must never
+   * take down the save that just succeeded.
+   */
+  onSettled?: (event: SecretSettledEvent) => void
 }
 
 export class SecretRequestStore {
@@ -52,10 +67,18 @@ export class SecretRequestStore {
   private readonly listeners = new Set<() => void>()
   private readonly writeSecret: typeof writeSecretToDisk
   private readonly now: () => number
+  private readonly onSettled: (event: SecretSettledEvent) => void
 
   constructor(options: SecretRequestStoreOptions = {}) {
     this.writeSecret = options.writeSecret ?? writeSecretToDisk
     this.now = options.now ?? (() => Date.now())
+    this.onSettled = options.onSettled ?? (() => {})
+  }
+
+  /** No chat, no notice — the request still settles normally. */
+  private announce(request: PendingSecretRequest, event: Omit<SecretSettledEvent, "chatId" | "name">) {
+    if (!request.chatId) return
+    this.onSettled({ chatId: request.chatId, name: request.name, ...event })
   }
 
   onChange(listener: () => void): () => void {
@@ -90,6 +113,7 @@ export class SecretRequestStore {
       projectPath: args.projectPath,
       projectTitle: args.projectTitle,
       suggestedScope: args.suggestedScope,
+      chatId: args.chatId ?? null,
       createdAt: this.now(),
     }
 
@@ -155,6 +179,7 @@ export class SecretRequestStore {
       gitignoreUpdated: written.gitignoreUpdated,
     }
     tracked.settledAt = this.now()
+    this.announce(tracked.request, { outcome: "saved", scope: written.scope })
     this.emit()
     return tracked.resolution
   }
@@ -165,6 +190,7 @@ export class SecretRequestStore {
 
     tracked.resolution = { status: "cancelled" }
     tracked.settledAt = this.now()
+    this.announce(tracked.request, { outcome: "declined" })
     this.emit()
     return true
   }
@@ -179,6 +205,7 @@ export class SecretRequestStore {
         if (now - tracked.request.createdAt >= SECRET_REQUEST_TTL_MS) {
           tracked.resolution = { status: "expired" }
           tracked.settledAt = now
+          this.announce(tracked.request, { outcome: "expired" })
           changed = true
         }
         continue

--- a/src/server/secret-requests.ts
+++ b/src/server/secret-requests.ts
@@ -1,0 +1,198 @@
+/**
+ * The in-flight half of ask-for-secret: an agent's `kanna ask-secret` call
+ * parks here until someone answers it in the UI.
+ *
+ * The CLI polls by id rather than holding an open request, so a user who
+ * wanders off for ten minutes costs nothing and no socket times out. Resolved
+ * entries linger briefly so a poll that arrives just after the answer still
+ * sees it, then are swept.
+ *
+ * The secret value itself only ever exists here in the argument to `submit()`
+ * on its way to disk — it is never stored on the request, never snapshotted,
+ * and never returned to the CLI.
+ */
+
+import { randomUUID } from "node:crypto"
+import type {
+  PendingSecretRequest,
+  SecretRequestResolution,
+  SecretScope,
+} from "../shared/secrets"
+import { SECRET_REASON_MAX_LENGTH } from "../shared/secrets"
+import { writeSecret as writeSecretToDisk } from "./secrets"
+
+/** How long a prompt waits for the user before it gives up. */
+export const SECRET_REQUEST_TTL_MS = 15 * 60 * 1000
+/** How long a settled result stays readable by the polling CLI. */
+export const SECRET_RESOLUTION_RETENTION_MS = 5 * 60 * 1000
+
+interface TrackedRequest {
+  request: PendingSecretRequest
+  resolution: SecretRequestResolution
+  /** When a settled request becomes eligible for sweeping. */
+  settledAt: number | null
+}
+
+export interface CreateSecretRequestArgs {
+  name: string
+  reason: string
+  cwd: string
+  projectPath: string | null
+  projectTitle: string | null
+  suggestedScope: SecretScope | null
+}
+
+export interface SecretRequestStoreOptions {
+  writeSecret?: typeof writeSecretToDisk
+  now?: () => number
+}
+
+export class SecretRequestStore {
+  private readonly requests = new Map<string, TrackedRequest>()
+  private readonly listeners = new Set<() => void>()
+  private readonly writeSecret: typeof writeSecretToDisk
+  private readonly now: () => number
+
+  constructor(options: SecretRequestStoreOptions = {}) {
+    this.writeSecret = options.writeSecret ?? writeSecretToDisk
+    this.now = options.now ?? (() => Date.now())
+  }
+
+  onChange(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private emit() {
+    for (const listener of this.listeners) listener()
+  }
+
+  create(args: CreateSecretRequestArgs): PendingSecretRequest {
+    this.sweep()
+
+    // Re-running `ask-secret` is expected: the CLI gives up waiting long
+    // before a distracted user answers, and an agent's natural response is to
+    // run it again. Reuse the open prompt instead of stacking duplicates.
+    const open = [...this.requests.values()].find((tracked) => (
+      tracked.resolution.status === "pending"
+      && tracked.request.name === args.name
+      && tracked.request.cwd === args.cwd
+    ))
+    if (open) return open.request
+
+    const request: PendingSecretRequest = {
+      id: randomUUID(),
+      name: args.name,
+      reason: args.reason.slice(0, SECRET_REASON_MAX_LENGTH),
+      cwd: args.cwd,
+      projectPath: args.projectPath,
+      projectTitle: args.projectTitle,
+      suggestedScope: args.suggestedScope,
+      createdAt: this.now(),
+    }
+
+    this.requests.set(request.id, {
+      request,
+      resolution: { status: "pending" },
+      settledAt: null,
+    })
+    this.emit()
+    return request
+  }
+
+  /** Pending requests only — this is what the UI renders. */
+  list(): PendingSecretRequest[] {
+    this.sweep()
+    return [...this.requests.values()]
+      .filter((tracked) => tracked.resolution.status === "pending")
+      .map((tracked) => tracked.request)
+      .sort((a, b) => a.createdAt - b.createdAt)
+  }
+
+  get(id: string): PendingSecretRequest | null {
+    return this.requests.get(id)?.request ?? null
+  }
+
+  /** What the polling CLI reads. Unknown ids read as expired, not pending. */
+  resolutionFor(id: string): SecretRequestResolution {
+    this.sweep()
+    return this.requests.get(id)?.resolution ?? { status: "expired" }
+  }
+
+  /**
+   * Write the user's answer to disk and settle the request. The value is
+   * consumed here and deliberately not retained.
+   */
+  async submit(
+    id: string,
+    input: { scope: SecretScope; value: string },
+  ): Promise<SecretRequestResolution> {
+    const tracked = this.requests.get(id)
+    if (!tracked) {
+      throw new Error("That secret request is no longer open")
+    }
+    if (tracked.resolution.status !== "pending") {
+      throw new Error("That secret request has already been answered")
+    }
+    if (input.scope === "project" && !tracked.request.projectPath) {
+      throw new Error("This request did not come from a project, so it can only be saved globally")
+    }
+
+    const written = await this.writeSecret({
+      scope: input.scope,
+      name: tracked.request.name,
+      value: input.value,
+      projectPath: tracked.request.projectPath,
+    })
+
+    tracked.resolution = {
+      status: "saved",
+      path: written.path,
+      scope: written.scope,
+      loadCommand: written.loadCommand,
+      gitignoreUpdated: written.gitignoreUpdated,
+    }
+    tracked.settledAt = this.now()
+    this.emit()
+    return tracked.resolution
+  }
+
+  cancel(id: string): boolean {
+    const tracked = this.requests.get(id)
+    if (!tracked || tracked.resolution.status !== "pending") return false
+
+    tracked.resolution = { status: "cancelled" }
+    tracked.settledAt = this.now()
+    this.emit()
+    return true
+  }
+
+  /** Expire stale prompts and drop settled ones the CLI has had time to read. */
+  sweep(): void {
+    const now = this.now()
+    let changed = false
+
+    for (const [id, tracked] of this.requests) {
+      if (tracked.resolution.status === "pending") {
+        if (now - tracked.request.createdAt >= SECRET_REQUEST_TTL_MS) {
+          tracked.resolution = { status: "expired" }
+          tracked.settledAt = now
+          changed = true
+        }
+        continue
+      }
+      if (tracked.settledAt !== null && now - tracked.settledAt >= SECRET_RESOLUTION_RETENTION_MS) {
+        this.requests.delete(id)
+      }
+    }
+
+    if (changed) this.emit()
+  }
+
+  dispose(): void {
+    this.requests.clear()
+    this.listeners.clear()
+  }
+}

--- a/src/server/secrets-api.test.ts
+++ b/src/server/secrets-api.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { SECRETS_API_PATH_PREFIX, SECRETS_API_TOKEN_HEADER } from "../shared/secrets"
 import { SecretRequestStore } from "./secret-requests"
-import { createSecretsApi, resolveProjectFromCwd } from "./secrets-api"
+import { createSecretsApi, resolveAskingChat, resolveProjectFromCwd } from "./secrets-api"
 import { writeSecret } from "./secrets"
 
 const TOKEN = "test-token-0123456789"
@@ -241,5 +241,70 @@ describe("resolveProjectFromCwd", () => {
 
   test("returns null when nothing contains the cwd", () => {
     expect(resolveProjectFromCwd("/elsewhere", projects)).toBeNull()
+  })
+})
+
+describe("resolveAskingChat", () => {
+  const roots: Record<string, string> = {
+    "chat-outer": "/repos/outer",
+    "chat-nested": "/repos/outer/nested",
+    "chat-other": "/repos/other",
+  }
+  const chatLocalPath = (chatId: string) => roots[chatId] ?? null
+
+  test("a claimed chat id wins outright", () => {
+    expect(resolveAskingChat({
+      cwd: "/somewhere/unrelated",
+      claimedChatId: "chat-from-env",
+      runningChatIds: [],
+      chatLocalPath,
+    })).toBe("chat-from-env")
+  })
+
+  test("falls back to the running chat whose project contains the cwd", () => {
+    expect(resolveAskingChat({
+      cwd: "/repos/other/src",
+      claimedChatId: null,
+      runningChatIds: ["chat-outer", "chat-other"],
+      chatLocalPath,
+    })).toBe("chat-other")
+  })
+
+  test("prefers the deepest root when projects nest", () => {
+    expect(resolveAskingChat({
+      cwd: "/repos/outer/nested/src",
+      claimedChatId: null,
+      runningChatIds: ["chat-outer", "chat-nested"],
+      chatLocalPath,
+    })).toBe("chat-nested")
+  })
+
+  test("ignores chats that are not running", () => {
+    expect(resolveAskingChat({
+      cwd: "/repos/other/src",
+      claimedChatId: null,
+      runningChatIds: ["chat-outer"],
+      chatLocalPath,
+    })).toBeNull()
+  })
+
+  test("gives up rather than guess between two chats in the same project", () => {
+    expect(resolveAskingChat({
+      cwd: "/repos/outer/src",
+      claimedChatId: null,
+      runningChatIds: ["chat-outer", "chat-outer-twin"],
+      chatLocalPath: (chatId) => (
+        chatId === "chat-outer-twin" ? "/repos/outer" : chatLocalPath(chatId)
+      ),
+    })).toBeNull()
+  })
+
+  test("does not match a sibling with a shared prefix", () => {
+    expect(resolveAskingChat({
+      cwd: "/repos/outer-other/src",
+      claimedChatId: null,
+      runningChatIds: ["chat-outer"],
+      chatLocalPath,
+    })).toBeNull()
   })
 })

--- a/src/server/secrets-api.test.ts
+++ b/src/server/secrets-api.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { SECRETS_API_PATH_PREFIX, SECRETS_API_TOKEN_HEADER } from "../shared/secrets"
+import { SecretRequestStore } from "./secret-requests"
+import { createSecretsApi, resolveProjectFromCwd } from "./secrets-api"
+import { writeSecret } from "./secrets"
+
+const TOKEN = "test-token-0123456789"
+
+let project: string
+let requests: SecretRequestStore
+let handle: ReturnType<typeof createSecretsApi>
+
+beforeEach(async () => {
+  project = await mkdtemp(path.join(tmpdir(), "kanna-secrets-api-"))
+  requests = new SecretRequestStore()
+  handle = createSecretsApi({
+    requests,
+    token: TOKEN,
+    resolveProject: (cwd) => resolveProjectFromCwd(cwd, [{ path: project, title: "proj" }]),
+  })
+})
+
+afterEach(async () => {
+  requests.dispose()
+  await rm(project, { recursive: true, force: true })
+})
+
+function call(pathname: string, init: RequestInit & { token?: string | null } = {}) {
+  const { token = TOKEN, ...rest } = init
+  const url = new URL(`http://127.0.0.1:3000${pathname}`)
+  const headers = new Headers(rest.headers)
+  headers.set("content-type", "application/json")
+  if (token !== null) headers.set(SECRETS_API_TOKEN_HEADER, token)
+  return handle(new Request(url, { ...rest, headers }), url)
+}
+
+describe("routing and auth", () => {
+  test("ignores paths that are not ours so the caller can keep routing", async () => {
+    expect(await call("/api/projects")).toBeNull()
+    expect(await call("/")).toBeNull()
+  })
+
+  test("rejects a missing or wrong token", async () => {
+    const missing = await call(`${SECRETS_API_PATH_PREFIX}/list`, { token: null })
+    expect(missing?.status).toBe(401)
+
+    const wrong = await call(`${SECRETS_API_PATH_PREFIX}/list`, { token: "nope" })
+    expect(wrong?.status).toBe(401)
+  })
+
+  test("a token of the right length but wrong value still fails", async () => {
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/list`, {
+      token: "x".repeat(TOKEN.length),
+    })
+    expect(response?.status).toBe(401)
+  })
+
+  test("404s an unknown subpath under the prefix", async () => {
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/nonsense`)
+    expect(response?.status).toBe(404)
+  })
+})
+
+describe("POST /requests", () => {
+  test("queues a prompt and returns its id", async () => {
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "OPENAI_API_KEY", reason: "call the API", cwd: project }),
+    })
+
+    const body = await response!.json()
+    expect(body.status).toBe("pending")
+    expect(typeof body.requestId).toBe("string")
+
+    const pending = requests.list()
+    expect(pending).toHaveLength(1)
+    expect(pending[0].name).toBe("OPENAI_API_KEY")
+    expect(pending[0].projectPath).toBe(project)
+    expect(pending[0].projectTitle).toBe("proj")
+  })
+
+  test("resolves the project from a subdirectory", async () => {
+    await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: path.join(project, "src", "deep") }),
+    })
+    expect(requests.list()[0].projectPath).toBe(project)
+  })
+
+  test("records no project when the cwd is outside every known one", async () => {
+    await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: tmpdir() }),
+    })
+    expect(requests.list()[0].projectPath).toBeNull()
+  })
+
+  test("short-circuits when the secret is already stored", async () => {
+    const written = await writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "already-here",
+      projectPath: project,
+    })
+
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: project }),
+    })
+
+    const body = await response!.json()
+    expect(body.status).toBe("saved")
+    expect(body.existing).toBe(true)
+    expect(body.scope).toBe("project")
+    expect(body.path).toBe(written.path)
+    expect(body.loadCommand).toContain("set -a")
+    expect(JSON.stringify(body)).not.toContain("already-here")
+    expect(requests.list()).toHaveLength(0)
+  })
+
+  test("--force re-prompts even when one is stored", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "old", projectPath: project })
+
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: project, force: true }),
+    })
+
+    expect((await response!.json()).status).toBe("pending")
+    expect(requests.list()).toHaveLength(1)
+  })
+
+  test("carries the agent's suggested scope through to the prompt", async () => {
+    await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: project, scope: "global" }),
+    })
+    expect(requests.list()[0].suggestedScope).toBe("global")
+  })
+
+  test("rejects a name that is not shell-legal", async () => {
+    for (const name of ["../etc/passwd", "MY-KEY", "2FA", ""]) {
+      const response = await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+        method: "POST",
+        body: JSON.stringify({ name, cwd: project }),
+      })
+      expect(response?.status).toBe(400)
+    }
+    expect(requests.list()).toHaveLength(0)
+  })
+
+  test("rejects a non-JSON body", async () => {
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: "not json",
+    })
+    expect(response?.status).toBe(400)
+  })
+})
+
+describe("GET and DELETE /requests/:id", () => {
+  test("reports pending, then the settled result", async () => {
+    const created = await (await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: project }),
+    }))!.json()
+
+    const whilePending = await (await call(
+      `${SECRETS_API_PATH_PREFIX}/requests/${created.requestId}`,
+    ))!.json()
+    expect(whilePending.status).toBe("pending")
+
+    await requests.submit(created.requestId, { scope: "project", value: "sk-value" })
+
+    const settled = await (await call(
+      `${SECRETS_API_PATH_PREFIX}/requests/${created.requestId}`,
+    ))!.json()
+    expect(settled.status).toBe("saved")
+    expect(settled.loadCommand).toContain("TOKEN.env")
+    expect(JSON.stringify(settled)).not.toContain("sk-value")
+  })
+
+  test("DELETE cancels the prompt", async () => {
+    const created = await (await call(`${SECRETS_API_PATH_PREFIX}/requests`, {
+      method: "POST",
+      body: JSON.stringify({ name: "TOKEN", cwd: project }),
+    }))!.json()
+
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests/${created.requestId}`, {
+      method: "DELETE",
+    })
+    expect(response?.status).toBe(200)
+    expect(requests.resolutionFor(created.requestId).status).toBe("cancelled")
+  })
+
+  test("405s an unsupported method", async () => {
+    const response = await call(`${SECRETS_API_PATH_PREFIX}/requests/abc`, { method: "PUT" })
+    expect(response?.status).toBe(405)
+  })
+})
+
+describe("GET /list", () => {
+  test("returns names and scopes but no values", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "hunter2", projectPath: project })
+
+    const body = await (await call(
+      `${SECRETS_API_PATH_PREFIX}/list?cwd=${encodeURIComponent(project)}`,
+    ))!.json()
+
+    expect(body.secrets).toContainEqual({ scope: "project", name: "TOKEN" })
+    expect(JSON.stringify(body)).not.toContain("hunter2")
+  })
+})
+
+describe("resolveProjectFromCwd", () => {
+  const projects = [
+    { path: "/repos/outer", title: "outer" },
+    { path: "/repos/outer/nested", title: "nested" },
+    { path: "/repos/other", title: "other" },
+  ]
+
+  test("matches the project root itself", () => {
+    expect(resolveProjectFromCwd("/repos/other", projects)?.title).toBe("other")
+  })
+
+  test("matches from a subdirectory", () => {
+    expect(resolveProjectFromCwd("/repos/other/src/lib", projects)?.title).toBe("other")
+  })
+
+  test("prefers the deepest match when projects nest", () => {
+    expect(resolveProjectFromCwd("/repos/outer/nested/src", projects)?.title).toBe("nested")
+    expect(resolveProjectFromCwd("/repos/outer/src", projects)?.title).toBe("outer")
+  })
+
+  test("does not match a sibling with a shared prefix", () => {
+    expect(resolveProjectFromCwd("/repos/outer-other", projects)).toBeNull()
+  })
+
+  test("returns null when nothing contains the cwd", () => {
+    expect(resolveProjectFromCwd("/elsewhere", projects)).toBeNull()
+  })
+})

--- a/src/server/secrets-api.ts
+++ b/src/server/secrets-api.ts
@@ -34,6 +34,12 @@ export interface SecretsApiDeps {
   token: string
   /** Map the CLI's cwd onto a known Kanna project, if it sits inside one. */
   resolveProject: (cwd: string) => ResolvedProject | null
+  /**
+   * Which chat the asking agent belongs to, for the transcript notice.
+   * Returns null when it cannot be pinned down, in which case the secret is
+   * still saved — only the notice is skipped.
+   */
+  resolveChat?: (args: { cwd: string; claimedChatId: string | null }) => string | null
 }
 
 function tokenMatches(provided: string | null, expected: string): boolean {
@@ -69,6 +75,50 @@ export function resolveProjectFromCwd(
   }
 
   return best
+}
+
+/**
+ * Which chat raised an `ask-secret` prompt.
+ *
+ * Kanna sets `KANNA_CHAT_ID` on the environments it controls, and that claim
+ * wins outright — it comes from a process Kanna spawned, over a loopback
+ * surface that already required the instance token.
+ *
+ * Providers Kanna does not spawn with a per-chat environment fall back to the
+ * cwd: of the chats currently mid-turn, take the one whose project root
+ * contains it, deepest root first. Only an unambiguous single match counts —
+ * two chats running in the same project cannot be told apart this way, and
+ * guessing would file a notice in the wrong transcript.
+ */
+export function resolveAskingChat(args: {
+  cwd: string
+  claimedChatId: string | null
+  runningChatIds: string[]
+  chatLocalPath: (chatId: string) => string | null
+}): string | null {
+  if (args.claimedChatId) return args.claimedChatId
+
+  const resolved = path.resolve(args.cwd)
+  let best: { chatId: string; rootLength: number } | null = null
+  let bestIsAmbiguous = false
+
+  for (const chatId of args.runningChatIds) {
+    const localPath = args.chatLocalPath(chatId)
+    if (!localPath) continue
+
+    const root = path.resolve(localPath)
+    if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) continue
+
+    if (!best || root.length > best.rootLength) {
+      best = { chatId, rootLength: root.length }
+      bestIsAmbiguous = false
+      continue
+    }
+    if (root.length === best.rootLength) bestIsAmbiguous = true
+  }
+
+  if (!best || bestIsAmbiguous) return null
+  return best.chatId
 }
 
 /**
@@ -141,6 +191,7 @@ async function handleCreate(req: Request, deps: SecretsApiDeps): Promise<Respons
   const suggestedScope: SecretScope | null =
     body.scope === "project" || body.scope === "global" ? body.scope : null
 
+  const claimedChatId = typeof body.chatId === "string" && body.chatId.trim() ? body.chatId.trim() : null
   const project = deps.resolveProject(cwd)
 
   // Already stored? Hand back the load command without interrupting anyone —
@@ -165,6 +216,7 @@ async function handleCreate(req: Request, deps: SecretsApiDeps): Promise<Respons
     projectPath: project?.path ?? null,
     projectTitle: project?.title ?? null,
     suggestedScope,
+    chatId: deps.resolveChat?.({ cwd, claimedChatId }) ?? null,
   })
 
   return Response.json({ status: "pending", requestId: request.id })

--- a/src/server/secrets-api.ts
+++ b/src/server/secrets-api.ts
@@ -1,0 +1,171 @@
+/**
+ * Loopback HTTP surface for `kanna ask-secret`.
+ *
+ * Mounted under `/__local/secrets` and reachable only when the request class
+ * is `local` (see server.ts) — never through the kanna.sh proxy and never
+ * over the raw tunnel. On top of that it requires the per-start token from
+ * `~/.kanna/instance.json`, so another user's process on the same box cannot
+ * queue a prompt in your UI.
+ *
+ * Deliberately not under `/api/`: that prefix is gated by the browser session
+ * cookie, which a CLI invocation does not have.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+import path from "node:path"
+import {
+  buildSecretLoadCommand,
+  isValidSecretName,
+  SECRET_REASON_MAX_LENGTH,
+  SECRETS_API_PATH_PREFIX,
+  SECRETS_API_TOKEN_HEADER,
+  type SecretScope,
+} from "../shared/secrets"
+import { findExistingSecret, listSecrets } from "./secrets"
+import type { SecretRequestStore } from "./secret-requests"
+
+export interface ResolvedProject {
+  path: string
+  title: string
+}
+
+export interface SecretsApiDeps {
+  requests: SecretRequestStore
+  token: string
+  /** Map the CLI's cwd onto a known Kanna project, if it sits inside one. */
+  resolveProject: (cwd: string) => ResolvedProject | null
+}
+
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (!provided) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+function badRequest(message: string) {
+  return Response.json({ error: message }, { status: 400 })
+}
+
+/**
+ * Walk up from `cwd` so an agent working in a subdirectory still resolves to
+ * its project. Deepest match wins when projects are nested.
+ */
+export function resolveProjectFromCwd(
+  cwd: string,
+  projects: ResolvedProject[],
+): ResolvedProject | null {
+  const resolved = path.resolve(cwd)
+  let best: ResolvedProject | null = null
+
+  for (const project of projects) {
+    const root = path.resolve(project.path)
+    const inside = resolved === root || resolved.startsWith(`${root}${path.sep}`)
+    if (!inside) continue
+    if (!best || root.length > path.resolve(best.path).length) {
+      best = project
+    }
+  }
+
+  return best
+}
+
+/**
+ * Returns null when the path is not ours, so the caller can fall through to
+ * the rest of its routing table.
+ */
+export function createSecretsApi(deps: SecretsApiDeps) {
+  return async function handleSecretsRequest(req: Request, url: URL): Promise<Response | null> {
+    if (
+      url.pathname !== SECRETS_API_PATH_PREFIX
+      && !url.pathname.startsWith(`${SECRETS_API_PATH_PREFIX}/`)
+    ) {
+      return null
+    }
+
+    if (!tokenMatches(req.headers.get(SECRETS_API_TOKEN_HEADER), deps.token)) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const subPath = url.pathname.slice(SECRETS_API_PATH_PREFIX.length)
+
+    if (subPath === "/requests" && req.method === "POST") {
+      return handleCreate(req, deps)
+    }
+
+    const requestMatch = subPath.match(/^\/requests\/([^/]+)$/)
+    if (requestMatch) {
+      const id = decodeURIComponent(requestMatch[1])
+      if (req.method === "GET") {
+        return Response.json(deps.requests.resolutionFor(id))
+      }
+      if (req.method === "DELETE") {
+        deps.requests.cancel(id)
+        return Response.json({ ok: true })
+      }
+      return new Response(null, { status: 405, headers: { Allow: "GET, DELETE" } })
+    }
+
+    if (subPath === "/list" && req.method === "GET") {
+      const cwd = url.searchParams.get("cwd") ?? process.cwd()
+      const project = deps.resolveProject(cwd)
+      const secrets = await listSecrets(project?.path ?? null)
+      return Response.json({
+        secrets: secrets.map(({ scope, name }) => ({ scope, name })),
+      })
+    }
+
+    return Response.json({ error: "Not found" }, { status: 404 })
+  }
+}
+
+async function handleCreate(req: Request, deps: SecretsApiDeps): Promise<Response> {
+  let body: Record<string, unknown>
+  try {
+    body = (await req.json()) as Record<string, unknown>
+  } catch {
+    return badRequest("Body must be JSON")
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : ""
+  if (!isValidSecretName(name)) {
+    return badRequest(
+      "Invalid secret name — use letters, digits and underscores, starting with a letter or underscore (e.g. OPENAI_API_KEY)",
+    )
+  }
+
+  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, SECRET_REASON_MAX_LENGTH) : ""
+  const cwd = typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : process.cwd()
+  const force = body.force === true
+  const suggestedScope: SecretScope | null =
+    body.scope === "project" || body.scope === "global" ? body.scope : null
+
+  const project = deps.resolveProject(cwd)
+
+  // Already stored? Hand back the load command without interrupting anyone —
+  // an agent re-running the same ask on a later turn is the common case.
+  if (!force) {
+    const existing = await findExistingSecret(name, project?.path ?? null)
+    if (existing) {
+      return Response.json({
+        status: "saved",
+        existing: true,
+        scope: existing.scope,
+        path: existing.path,
+        loadCommand: buildSecretLoadCommand(existing.path),
+      })
+    }
+  }
+
+  const request = deps.requests.create({
+    name,
+    reason,
+    cwd,
+    projectPath: project?.path ?? null,
+    projectTitle: project?.title ?? null,
+    suggestedScope,
+  })
+
+  return Response.json({ status: "pending", requestId: request.id })
+}

--- a/src/server/secrets.test.ts
+++ b/src/server/secrets.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  deleteSecret,
+  ensureSecretsIgnored,
+  findExistingSecret,
+  getProjectSecretsDir,
+  listSecrets,
+  resolveSecretFilePath,
+  writeSecret,
+} from "./secrets"
+
+let project: string
+
+beforeEach(async () => {
+  project = await mkdtemp(path.join(tmpdir(), "kanna-secrets-"))
+})
+
+afterEach(async () => {
+  await rm(project, { recursive: true, force: true })
+})
+
+describe("writeSecret", () => {
+  test("writes a project secret under .kanna/secrets with 0600", async () => {
+    const result = await writeSecret({
+      scope: "project",
+      name: "OPENAI_API_KEY",
+      value: "sk-test",
+      projectPath: project,
+    })
+
+    expect(result.path).toBe(path.join(project, ".kanna", "secrets", "OPENAI_API_KEY.env"))
+    expect(await readFile(result.path, "utf8")).toContain("OPENAI_API_KEY='sk-test'")
+    expect((await stat(result.path)).mode & 0o777).toBe(0o600)
+    expect((await stat(getProjectSecretsDir(project))).mode & 0o777).toBe(0o700)
+  })
+
+  test("returns a load command pointing at the file it wrote", async () => {
+    const result = await writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "abc",
+      projectPath: project,
+    })
+    expect(result.loadCommand).toBe(`set -a; . '${result.path}'; set +a`)
+  })
+
+  test("overwrites an existing secret rather than appending", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "old", projectPath: project })
+    const result = await writeSecret({ scope: "project", name: "TOKEN", value: "new", projectPath: project })
+
+    const contents = await readFile(result.path, "utf8")
+    expect(contents).toContain("TOKEN='new'")
+    expect(contents).not.toContain("TOKEN='old'")
+  })
+
+  test("rejects names that are not shell-legal", async () => {
+    await expect(
+      writeSecret({ scope: "project", name: "../escape", value: "x", projectPath: project }),
+    ).rejects.toThrow(/Invalid secret name/)
+  })
+
+  test("rejects an empty value", async () => {
+    await expect(
+      writeSecret({ scope: "project", name: "TOKEN", value: "", projectPath: project }),
+    ).rejects.toThrow(/empty/)
+  })
+
+  test("requires a project path for project scope", async () => {
+    await expect(
+      writeSecret({ scope: "project", name: "TOKEN", value: "x", projectPath: null }),
+    ).rejects.toThrow(/project path is required/i)
+  })
+})
+
+describe("ensureSecretsIgnored", () => {
+  test("does nothing when the project is not a git repo", async () => {
+    expect(await ensureSecretsIgnored(project)).toBe(false)
+    await expect(stat(path.join(project, ".gitignore"))).rejects.toThrow()
+  })
+
+  test("creates .gitignore with the entry in a fresh repo", async () => {
+    await mkdir(path.join(project, ".git"))
+    expect(await ensureSecretsIgnored(project)).toBe(true)
+    expect(await readFile(path.join(project, ".gitignore"), "utf8")).toContain(".kanna/secrets/")
+  })
+
+  test("appends without clobbering existing rules, and only once", async () => {
+    await mkdir(path.join(project, ".git"))
+    await writeFile(path.join(project, ".gitignore"), "node_modules\n")
+
+    expect(await ensureSecretsIgnored(project)).toBe(true)
+    expect(await ensureSecretsIgnored(project)).toBe(false)
+
+    const contents = await readFile(path.join(project, ".gitignore"), "utf8")
+    expect(contents).toContain("node_modules")
+    expect(contents.match(/\.kanna\/secrets\//g)).toHaveLength(1)
+  })
+
+  test("adds a newline first when the file does not end in one", async () => {
+    await mkdir(path.join(project, ".git"))
+    await writeFile(path.join(project, ".gitignore"), "dist")
+
+    await ensureSecretsIgnored(project)
+    const lines = (await readFile(path.join(project, ".gitignore"), "utf8")).split("\n")
+    expect(lines[0]).toBe("dist")
+    expect(lines).toContain(".kanna/secrets/")
+  })
+
+  test("leaves repos that already ignore all of .kanna alone", async () => {
+    await mkdir(path.join(project, ".git"))
+    await writeFile(path.join(project, ".gitignore"), ".kanna/\n")
+    expect(await ensureSecretsIgnored(project)).toBe(false)
+  })
+
+  test("a .git file (worktree pointer) counts as a repo", async () => {
+    await writeFile(path.join(project, ".git"), "gitdir: /elsewhere\n")
+    expect(await ensureSecretsIgnored(project)).toBe(true)
+  })
+})
+
+describe("writeSecret gitignore integration", () => {
+  test("reports the gitignore edit it made", async () => {
+    await mkdir(path.join(project, ".git"))
+    const result = await writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "abc",
+      projectPath: project,
+    })
+    expect(result.gitignoreUpdated).toBe(true)
+    expect(await readFile(path.join(project, ".gitignore"), "utf8")).toContain(".kanna/secrets/")
+  })
+
+  test("never touches .gitignore for a non-repo", async () => {
+    const result = await writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "abc",
+      projectPath: project,
+    })
+    expect(result.gitignoreUpdated).toBe(false)
+  })
+})
+
+describe("findExistingSecret", () => {
+  test("returns null when nothing is stored", async () => {
+    expect(await findExistingSecret("NOPE", project)).toBeNull()
+  })
+
+  test("finds a project secret", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "abc", projectPath: project })
+    const found = await findExistingSecret("TOKEN", project)
+    expect(found?.scope).toBe("project")
+    expect(found?.path).toBe(resolveSecretFilePath("project", "TOKEN", project))
+  })
+
+  test("rejects an invalid name instead of probing the filesystem", async () => {
+    expect(await findExistingSecret("../etc/passwd", project)).toBeNull()
+  })
+})
+
+describe("listSecrets", () => {
+  test("lists names without reading values", async () => {
+    await writeSecret({ scope: "project", name: "BETA", value: "b", projectPath: project })
+    await writeSecret({ scope: "project", name: "ALPHA", value: "a", projectPath: project })
+
+    const listed = (await listSecrets(project)).filter((entry) => entry.scope === "project")
+    expect(listed.map((entry) => entry.name)).toEqual(["ALPHA", "BETA"])
+    expect(JSON.stringify(listed)).not.toContain("\"a\"")
+  })
+
+  test("tolerates a missing secrets directory", async () => {
+    const listed = await listSecrets(project)
+    expect(listed.every((entry) => entry.scope === "global")).toBe(true)
+  })
+
+  test("skips files that are not <NAME>.env", async () => {
+    await mkdir(getProjectSecretsDir(project), { recursive: true })
+    await writeFile(path.join(getProjectSecretsDir(project), "README.md"), "hi")
+    await writeFile(path.join(getProjectSecretsDir(project), "bad-name.env"), "x")
+
+    const listed = (await listSecrets(project)).filter((entry) => entry.scope === "project")
+    expect(listed).toHaveLength(0)
+  })
+})
+
+describe("deleteSecret", () => {
+  test("removes a stored secret and reports whether it existed", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "abc", projectPath: project })
+    expect(await deleteSecret("project", "TOKEN", project)).toBe(true)
+    expect(await deleteSecret("project", "TOKEN", project)).toBe(false)
+    expect(await findExistingSecret("TOKEN", project)).toBeNull()
+  })
+})

--- a/src/server/secrets.test.ts
+++ b/src/server/secrets.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import {
@@ -193,5 +193,53 @@ describe("deleteSecret", () => {
     expect(await deleteSecret("project", "TOKEN", project)).toBe(true)
     expect(await deleteSecret("project", "TOKEN", project)).toBe(false)
     expect(await findExistingSecret("TOKEN", project)).toBeNull()
+  })
+})
+
+describe("writeSecret symlink safety", () => {
+  test("refuses when the secrets directory is a symlink", async () => {
+    const elsewhere = path.join(project, "elsewhere")
+    await mkdir(elsewhere, { recursive: true })
+    await mkdir(path.join(project, ".kanna"), { recursive: true })
+    await symlink(elsewhere, getProjectSecretsDir(project))
+
+    await expect(writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "sk-live",
+      projectPath: project,
+    })).rejects.toThrow(/not a directory/)
+
+    // The redirect target must not have received the value.
+    await expect(readFile(path.join(elsewhere, "TOKEN.env"), "utf8")).rejects.toThrow()
+  })
+
+  test("refuses when the secret file itself is a symlink", async () => {
+    const victim = path.join(project, "victim.txt")
+    await writeFile(victim, "original", "utf8")
+
+    const dir = getProjectSecretsDir(project)
+    await mkdir(dir, { recursive: true })
+    await symlink(victim, path.join(dir, "TOKEN.env"))
+
+    await expect(writeSecret({
+      scope: "project",
+      name: "TOKEN",
+      value: "sk-live",
+      projectPath: project,
+    })).rejects.toThrow(/symbolic link/)
+
+    expect(await readFile(victim, "utf8")).toBe("original")
+  })
+
+  test("still overwrites a real file in place", async () => {
+    await writeSecret({ scope: "project", name: "TOKEN", value: "first", projectPath: project })
+    await writeSecret({ scope: "project", name: "TOKEN", value: "second", projectPath: project })
+
+    const filePath = resolveSecretFilePath("project", "TOKEN", project)
+    const contents = await readFile(filePath, "utf8")
+    expect(contents).toContain("second")
+    expect(contents).not.toContain("first")
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600)
   })
 })

--- a/src/server/secrets.ts
+++ b/src/server/secrets.ts
@@ -12,7 +12,7 @@
  */
 
 import { constants } from "node:fs"
-import { access, chmod, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { access, chmod, lstat, mkdir, open, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { getGlobalSecretsDir, PROJECT_SECRETS_DIR_RELATIVE } from "../shared/branding"
@@ -135,13 +135,46 @@ export async function writeSecret(args: WriteSecretArgs): Promise<WriteSecretRes
 
   const dir = getSecretsDir(scope, projectPath)
   await mkdir(dir, { recursive: true, mode: SECRET_DIR_MODE })
+
+  // `mkdir` is satisfied by a symlink that happens to point at a directory,
+  // so confirm what we actually got. Anything but a real directory here means
+  // someone pre-staged the path to redirect the write.
+  const dirStats = await lstat(dir)
+  if (!dirStats.isDirectory()) {
+    throw new Error(`Refusing to write a secret: ${dir} is not a directory`)
+  }
+
   // mkdir's mode is masked by umask on creation and skipped entirely when the
   // directory already exists, so the permissions are set explicitly.
   await chmod(dir, SECRET_DIR_MODE)
 
   const filePath = path.join(dir, secretFileName(name))
-  await writeFile(filePath, formatSecretEnvFile(name, value), { encoding: "utf8", mode: SECRET_FILE_MODE })
-  await chmod(filePath, SECRET_FILE_MODE)
+
+  // O_NOFOLLOW fails with ELOOP rather than following a symlink at the final
+  // component — otherwise a pre-created `<NAME>.env` link would send the
+  // credential wherever it pointed. Writing through the handle keeps the
+  // check and the write on the same file, with no window between them.
+  let handle
+  try {
+    handle = await open(
+      filePath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
+      SECRET_FILE_MODE,
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new Error(`Refusing to write a secret: ${filePath} is a symbolic link`)
+    }
+    throw error
+  }
+
+  try {
+    // An existing file keeps its old mode through O_CREAT, so set it here.
+    await handle.chmod(SECRET_FILE_MODE)
+    await handle.writeFile(formatSecretEnvFile(name, value), "utf8")
+  } finally {
+    await handle.close()
+  }
 
   const gitignoreUpdated = scope === "project" && projectPath
     ? await ensureSecretsIgnored(projectPath)

--- a/src/server/secrets.ts
+++ b/src/server/secrets.ts
@@ -1,0 +1,215 @@
+/**
+ * On-disk half of ask-for-secret (see `shared/secrets.ts` for the contract).
+ *
+ * One file per secret so an agent can source exactly the credential it needs
+ * and nothing else:
+ *   project scope → `<project>/.kanna/secrets/<NAME>.env`
+ *   global scope  → `~/.kanna/secrets/<NAME>.env`
+ *
+ * Files are 0600 and their directories 0700. Project scope also appends a
+ * single `.kanna/secrets/` line to `.gitignore`, which covers every secret
+ * the project will ever hold.
+ */
+
+import { constants } from "node:fs"
+import { access, chmod, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+import { getGlobalSecretsDir, PROJECT_SECRETS_DIR_RELATIVE } from "../shared/branding"
+import {
+  buildSecretLoadCommand,
+  coversSecretsDir,
+  formatSecretEnvFile,
+  isValidSecretName,
+  secretFileName,
+  SECRET_VALUE_MAX_BYTES,
+  SECRETS_GITIGNORE_ENTRY,
+  type SecretScope,
+} from "../shared/secrets"
+
+const SECRET_FILE_MODE = 0o600
+const SECRET_DIR_MODE = 0o700
+
+export interface SecretLocation {
+  scope: SecretScope
+  name: string
+  path: string
+}
+
+export interface WriteSecretArgs {
+  scope: SecretScope
+  name: string
+  value: string
+  /** Required for project scope; ignored for global. */
+  projectPath?: string | null
+}
+
+export interface WriteSecretResult extends SecretLocation {
+  loadCommand: string
+  gitignoreUpdated: boolean
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function getProjectSecretsDir(projectPath: string): string {
+  return path.join(projectPath, PROJECT_SECRETS_DIR_RELATIVE)
+}
+
+export function getSecretsDir(scope: SecretScope, projectPath?: string | null): string {
+  if (scope === "global") {
+    return getGlobalSecretsDir(homedir())
+  }
+  if (!projectPath) {
+    throw new Error("A project path is required for project-scoped secrets")
+  }
+  return getProjectSecretsDir(projectPath)
+}
+
+export function resolveSecretFilePath(
+  scope: SecretScope,
+  name: string,
+  projectPath?: string | null,
+): string {
+  if (!isValidSecretName(name)) {
+    throw new Error(
+      `Invalid secret name '${name}' — use letters, digits and underscores, starting with a letter or underscore`,
+    )
+  }
+  return path.join(getSecretsDir(scope, projectPath), secretFileName(name))
+}
+
+/**
+ * Add `.kanna/secrets/` to the project's `.gitignore`, unless git isn't in
+ * play or something already covers the directory. Returns true only when the
+ * file was actually changed.
+ */
+export async function ensureSecretsIgnored(projectPath: string): Promise<boolean> {
+  // No repo, nothing to leak into. A bare `.git` file (worktree/submodule
+  // pointer) counts just as much as a directory.
+  if (!(await pathExists(path.join(projectPath, ".git")))) {
+    return false
+  }
+
+  const gitignorePath = path.join(projectPath, ".gitignore")
+  let current = ""
+  try {
+    current = await readFile(gitignorePath, "utf8")
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+
+  if (current.split("\n").some(coversSecretsDir)) {
+    return false
+  }
+
+  const prefix = current.length === 0 || current.endsWith("\n") ? "" : "\n"
+  const block = `${prefix}\n# Kanna secrets — never commit\n${SECRETS_GITIGNORE_ENTRY}\n`
+  await writeFile(gitignorePath, `${current}${block}`, "utf8")
+  return true
+}
+
+export async function writeSecret(args: WriteSecretArgs): Promise<WriteSecretResult> {
+  const { scope, name, value, projectPath } = args
+
+  if (!isValidSecretName(name)) {
+    throw new Error(
+      `Invalid secret name '${name}' — use letters, digits and underscores, starting with a letter or underscore`,
+    )
+  }
+  if (value.length === 0) {
+    throw new Error("Secret value is empty")
+  }
+  if (Buffer.byteLength(value, "utf8") > SECRET_VALUE_MAX_BYTES) {
+    throw new Error("Secret value is too large")
+  }
+  if (scope === "project" && !projectPath) {
+    throw new Error("A project path is required for project-scoped secrets")
+  }
+
+  const dir = getSecretsDir(scope, projectPath)
+  await mkdir(dir, { recursive: true, mode: SECRET_DIR_MODE })
+  // mkdir's mode is masked by umask on creation and skipped entirely when the
+  // directory already exists, so the permissions are set explicitly.
+  await chmod(dir, SECRET_DIR_MODE)
+
+  const filePath = path.join(dir, secretFileName(name))
+  await writeFile(filePath, formatSecretEnvFile(name, value), { encoding: "utf8", mode: SECRET_FILE_MODE })
+  await chmod(filePath, SECRET_FILE_MODE)
+
+  const gitignoreUpdated = scope === "project" && projectPath
+    ? await ensureSecretsIgnored(projectPath)
+    : false
+
+  return {
+    scope,
+    name,
+    path: filePath,
+    loadCommand: buildSecretLoadCommand(filePath),
+    gitignoreUpdated,
+  }
+}
+
+/**
+ * Locate an already-stored secret. Project scope wins over global so a repo
+ * can override a machine-wide default with its own value.
+ */
+export async function findExistingSecret(
+  name: string,
+  projectPath?: string | null,
+): Promise<SecretLocation | null> {
+  if (!isValidSecretName(name)) return null
+
+  const candidates: SecretLocation[] = []
+  if (projectPath) {
+    candidates.push({ scope: "project", name, path: resolveSecretFilePath("project", name, projectPath) })
+  }
+  candidates.push({ scope: "global", name, path: resolveSecretFilePath("global", name) })
+
+  for (const candidate of candidates) {
+    if (await pathExists(candidate.path)) return candidate
+  }
+  return null
+}
+
+/** Names only — this never reads a secret's contents. */
+export async function listSecrets(projectPath?: string | null): Promise<SecretLocation[]> {
+  const found: SecretLocation[] = []
+
+  const scan = async (scope: SecretScope, dir: string) => {
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(".env")) continue
+      const name = entry.slice(0, -".env".length)
+      if (!isValidSecretName(name)) continue
+      found.push({ scope, name, path: path.join(dir, entry) })
+    }
+  }
+
+  if (projectPath) await scan("project", getProjectSecretsDir(projectPath))
+  await scan("global", getGlobalSecretsDir(homedir()))
+
+  return found.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope))
+}
+
+export async function deleteSecret(
+  scope: SecretScope,
+  name: string,
+  projectPath?: string | null,
+): Promise<boolean> {
+  const filePath = resolveSecretFilePath(scope, name, projectPath)
+  if (!(await pathExists(filePath))) return false
+  await rm(filePath, { force: true })
+  return true
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -39,6 +39,8 @@ import type { NightlyInstallResult } from "./nightly"
 import { createWsRouter, type ClientState } from "./ws-router"
 import { SecretRequestStore } from "./secret-requests"
 import { createSecretsApi, resolveAskingChat, resolveProjectFromCwd } from "./secrets-api"
+import { createRemindersApi } from "./reminders-api"
+import { ReminderScheduler } from "./reminder-scheduler"
 import { timestamped } from "./transcript"
 import { mintInstanceToken, removeInstanceFile, writeInstanceFile } from "./instance-file"
 import { instanceFingerprint } from "./instance"
@@ -300,6 +302,50 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     },
   })
 
+  // Chat reminders. The schedule lives in the store, so the scheduler holds no
+  // state of its own and a reminder outlives the process that took it.
+  // `router` is referenced lazily — it is assigned just below.
+  const reminderScheduler = new ReminderScheduler({
+    listReminders: () => store.listChatsWithReminders(),
+    clearReminder: (chatId) => store.clearChatReminder(chatId),
+    markUnread: (chatId) => store.setChatReadState(chatId, true),
+    // The divider that explains the prompt landing underneath it. Awaited (not
+    // best-effort like the secret notice): it must be in the transcript before
+    // the prompt it introduces, or it reads as a reply to it.
+    recordNotice: async (chatId, notice) => {
+      await store.appendMessage(chatId, timestamped({
+        kind: "reminder_notice",
+        scheduledAt: notice.scheduledAt,
+        createdBy: notice.createdBy,
+        wokeAgent: notice.wokeAgent,
+      }))
+    },
+    // Same entry point as a typed message, so a busy chat queues it rather
+    // than racing the running turn — and an archived one comes back.
+    postPrompt: async (chatId, content) => {
+      await agent.send({ type: "chat.send", chatId, content })
+    },
+    onChanged: () => router.scheduleBroadcast(),
+  })
+  const handleRemindersRequest = createRemindersApi({
+    token: instanceToken,
+    setReminder: (chatId, reminderArgs) =>
+      store.setChatReminder(chatId, { ...reminderArgs, createdBy: "agent" }),
+    clearReminder: (chatId) => store.clearChatReminder(chatId),
+    onChanged: () => router.scheduleBroadcast(),
+    resolveChat: ({ cwd, claimedChatId }) => resolveAskingChat({
+      cwd,
+      claimedChatId,
+      runningChatIds: [...agent.getActiveStatuses().keys()],
+      chatLocalPath: (chatId) => {
+        const chat = store.getChat(chatId)
+        if (!chat) return null
+        return store.getProject(chat.projectId)?.localPath ?? null
+      },
+    }),
+  })
+  reminderScheduler.start()
+
   router = createWsRouter({
     store,
     diffStore,
@@ -488,6 +534,8 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
           if (requestClass === "local") {
             const secretsResponse = await handleSecretsRequest(req, url)
             if (secretsResponse) return secretsResponse
+            const remindersResponse = await handleRemindersRequest(req, url)
+            if (remindersResponse) return remindersResponse
           }
 
           if (url.pathname === "/auth/status") {
@@ -681,6 +729,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     keybindings.dispose()
     terminals.closeAll()
     secretRequests.dispose()
+    reminderScheduler.stop()
     await removeInstanceFile()
     await store.compact()
     server.stop(true)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,7 +38,8 @@ import type { UpdateInstallAttemptResult } from "./cli-runtime"
 import type { NightlyInstallResult } from "./nightly"
 import { createWsRouter, type ClientState } from "./ws-router"
 import { SecretRequestStore } from "./secret-requests"
-import { createSecretsApi, resolveProjectFromCwd } from "./secrets-api"
+import { createSecretsApi, resolveAskingChat, resolveProjectFromCwd } from "./secrets-api"
+import { timestamped } from "./transcript"
 import { mintInstanceToken, removeInstanceFile, writeInstanceFile } from "./instance-file"
 import { instanceFingerprint } from "./instance"
 import { deleteProjectUpload, inferAttachmentContentType, inferProjectFileContentType, persistProjectUpload } from "./uploads"
@@ -193,7 +194,24 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
 
   // Ask-for-secret. The store holds prompts waiting on a human; the API is
   // the loopback-only door the `kanna ask-secret` CLI knocks on.
-  const secretRequests = new SecretRequestStore()
+  const secretRequests = new SecretRequestStore({
+    // A settled prompt leaves a note in the chat that raised it. Best-effort:
+    // the secret is already on disk by this point, so a failure here must not
+    // surface as a failed save.
+    onSettled: (event) => {
+      void store
+        .appendMessage(event.chatId, timestamped({
+          kind: "secret_notice",
+          secretName: event.name,
+          outcome: event.outcome,
+          ...(event.scope ? { scope: event.scope } : {}),
+        }))
+        .then(() => router.broadcastChatStateImmediately(event.chatId))
+        .catch((error: unknown) => {
+          console.warn(`${LOG_PREFIX} could not record secret notice: ${(error as Error).message}`)
+        })
+    },
+  })
   const instanceToken = mintInstanceToken()
   const handleSecretsRequest = createSecretsApi({
     requests: secretRequests,
@@ -202,6 +220,16 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
       cwd,
       store.listProjects().map((project) => ({ path: project.localPath, title: project.title })),
     ),
+    resolveChat: ({ cwd, claimedChatId }) => resolveAskingChat({
+      cwd,
+      claimedChatId,
+      runningChatIds: [...agent.getActiveStatuses().keys()],
+      chatLocalPath: (chatId) => {
+        const chat = store.getChat(chatId)
+        if (!chat) return null
+        return store.getProject(chat.projectId)?.localPath ?? null
+      },
+    }),
   })
   const keybindings = new KeybindingsManager()
   // Dev-box UI flag: the real thing is `kanna --cloud`; KANNA_DEVBOX_UI=1 is

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -37,6 +37,9 @@ import { UpdateManager } from "./update-manager"
 import type { UpdateInstallAttemptResult } from "./cli-runtime"
 import type { NightlyInstallResult } from "./nightly"
 import { createWsRouter, type ClientState } from "./ws-router"
+import { SecretRequestStore } from "./secret-requests"
+import { createSecretsApi, resolveProjectFromCwd } from "./secrets-api"
+import { mintInstanceToken, removeInstanceFile, writeInstanceFile } from "./instance-file"
 import { instanceFingerprint } from "./instance"
 import { deleteProjectUpload, inferAttachmentContentType, inferProjectFileContentType, persistProjectUpload } from "./uploads"
 import { getProjectUploadDir } from "./paths"
@@ -187,6 +190,19 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     void turnFiles.endTurn(chatId).finally(() => worktreeProbe.refreshForChat(chatId))
   }
   const terminals = new TerminalManager()
+
+  // Ask-for-secret. The store holds prompts waiting on a human; the API is
+  // the loopback-only door the `kanna ask-secret` CLI knocks on.
+  const secretRequests = new SecretRequestStore()
+  const instanceToken = mintInstanceToken()
+  const handleSecretsRequest = createSecretsApi({
+    requests: secretRequests,
+    token: instanceToken,
+    resolveProject: (cwd) => resolveProjectFromCwd(
+      cwd,
+      store.listProjects().map((project) => ({ path: project.localPath, title: project.title })),
+    ),
+  })
   const keybindings = new KeybindingsManager()
   // Dev-box UI flag: the real thing is `kanna --cloud`; KANNA_DEVBOX_UI=1 is
   // the dev-mode override (`bun run dev:cloud`) so the UI is developable
@@ -262,6 +278,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     worktreeProbe,
     agent,
     terminals,
+    secretRequests,
     keybindings,
     appSettings,
     analytics,
@@ -437,6 +454,14 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             return new Response("Not found", { status: 404 })
           }
 
+          // Ask-for-secret, before the password gate: the CLI presents the
+          // instance token instead of a browser session. Local requests only
+          // — never the proxy, never the raw tunnel.
+          if (requestClass === "local") {
+            const secretsResponse = await handleSecretsRequest(req, url)
+            if (secretsResponse) return secretsResponse
+          }
+
           if (url.pathname === "/auth/status") {
             return auth
               ? auth.handleStatus(req)
@@ -585,6 +610,20 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     }
   }
 
+  // Advertise where we are and how to authenticate, so `kanna ask-secret`
+  // (run by an agent, with no browser session) can find this process. 0600,
+  // and the token dies with the server.
+  void writeInstanceFile({
+    port: actualPort,
+    url: `http://127.0.0.1:${actualPort}`,
+    token: instanceToken,
+    pid: process.pid,
+    instance: instanceFingerprint(store.dataDir),
+    startedAt: Date.now(),
+  }).catch((error: unknown) => {
+    console.warn(`${LOG_PREFIX} could not write instance file: ${(error as Error).message}`)
+  })
+
   analytics.trackLaunch({
     port: actualPort,
     host: hostname,
@@ -613,6 +652,8 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     appSettings.dispose()
     keybindings.dispose()
     terminals.closeAll()
+    secretRequests.dispose()
+    await removeInstanceFile()
     await store.compact()
     server.stop(true)
   }

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -1350,6 +1350,172 @@ describe("ws-router", () => {
     })
   })
 
+  function createReminderRouterState() {
+    const state = createEmptyState()
+    state.projectsById.set("project-1", {
+      id: "project-1",
+      localPath: "/tmp/project",
+      title: "Project",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    state.projectIdsByPath.set("/tmp/project", "project-1")
+    state.chatsById.set("chat-1", {
+      id: "chat-1",
+      projectId: "project-1",
+      title: "Chat",
+      createdAt: 1,
+      updatedAt: 1,
+      unread: false,
+      provider: null,
+      planMode: false,
+      autoPlan: false,
+      sessionToken: null,
+      lastTurnOutcome: null,
+    })
+    return state
+  }
+
+  async function sendCommand(
+    router: ReturnType<typeof createTestRouter>,
+    ws: FakeWebSocket,
+    id: string,
+    command: unknown,
+  ) {
+    await router.handleMessage(ws as never, JSON.stringify({ v: 1, type: "command", id, command }))
+  }
+
+  test("sets the unread flag either way", async () => {
+    const state = createReminderRouterState()
+    const calls: Array<{ chatId: string; unread: boolean }> = []
+    const router = createTestRouter({
+      store: createFakeStore({
+        state,
+        async setChatReadState(chatId: string, unread: boolean) {
+          calls.push({ chatId, unread })
+          const chat = state.chatsById.get(chatId)
+          if (chat) chat.unread = unread
+        },
+      }),
+    })
+    const ws = new FakeWebSocket()
+    router.handleOpen(ws as never)
+
+    await sendCommand(router, ws, "unread-1", { type: "chat.setUnread", chatId: "chat-1", unread: true })
+    await sendCommand(router, ws, "unread-2", { type: "chat.setUnread", chatId: "chat-1", unread: false })
+
+    expect(calls).toEqual([
+      { chatId: "chat-1", unread: true },
+      { chatId: "chat-1", unread: false },
+    ])
+  })
+
+  test("schedules a reminder and puts its due time on the sidebar row", async () => {
+    const state = createReminderRouterState()
+    const calls: Array<Record<string, unknown>> = []
+    const router = createTestRouter({
+      store: createFakeStore({
+        state,
+        async setChatReminder(chatId: string, args: Record<string, unknown>) {
+          calls.push({ chatId, ...args })
+          const chat = state.chatsById.get(chatId)
+          if (chat) {
+            chat.reminder = {
+              dueAt: args.dueAt as number,
+              createdAt: 1,
+              createdBy: args.createdBy as "user" | "agent",
+              ...(args.prompt ? { prompt: args.prompt as string } : {}),
+            }
+          }
+        },
+      }),
+    })
+    const ws = new FakeWebSocket()
+    router.handleOpen(ws as never)
+    await router.handleMessage(ws as never, JSON.stringify({
+      v: 1, type: "subscribe", id: "sidebar", topic: { type: "sidebar" },
+    }))
+
+    const dueAt = Date.now() + 30 * 60_000
+    await sendCommand(router, ws, "remind-1", {
+      type: "chat.setReminder", chatId: "chat-1", dueAt, prompt: "  check metrics  ",
+    })
+
+    expect(calls).toEqual([{
+      chatId: "chat-1",
+      dueAt,
+      createdBy: "user",
+      prompt: "check metrics",
+    }])
+    const snapshot = ws.sent.at(-1) as { snapshot: { data: { projectGroups: Array<{ chats: Array<{ reminderAt?: number }> }> } } }
+    expect(snapshot.snapshot.data.projectGroups[0]?.chats[0]?.reminderAt).toBe(dueAt)
+  })
+
+  test("rejects a reminder in the past rather than scheduling one that never fires", async () => {
+    const state = createReminderRouterState()
+    const calls: unknown[] = []
+    const router = createTestRouter({
+      store: createFakeStore({
+        state,
+        async setChatReminder(...args: unknown[]) {
+          calls.push(args)
+        },
+      }),
+    })
+    const ws = new FakeWebSocket()
+    router.handleOpen(ws as never)
+
+    await sendCommand(router, ws, "remind-bad", {
+      type: "chat.setReminder", chatId: "chat-1", dueAt: Date.now() - 1_000,
+    })
+
+    expect(calls).toEqual([])
+    expect(ws.sent.at(-1)).toMatchObject({ type: "error", id: "remind-bad" })
+  })
+
+  test("omits the prompt when it is blank, so the reminder only resurfaces the chat", async () => {
+    const state = createReminderRouterState()
+    const calls: Array<Record<string, unknown>> = []
+    const router = createTestRouter({
+      store: createFakeStore({
+        state,
+        async setChatReminder(chatId: string, args: Record<string, unknown>) {
+          calls.push({ chatId, ...args })
+        },
+      }),
+    })
+    const ws = new FakeWebSocket()
+    router.handleOpen(ws as never)
+
+    await sendCommand(router, ws, "remind-2", {
+      type: "chat.setReminder", chatId: "chat-1", dueAt: Date.now() + 60_000, prompt: "   ",
+    })
+
+    expect(calls[0]).toEqual({ chatId: "chat-1", dueAt: calls[0]!.dueAt, createdBy: "user" })
+    expect("prompt" in calls[0]!).toBe(false)
+  })
+
+  test("clears a reminder", async () => {
+    const state = createReminderRouterState()
+    const cleared: string[] = []
+    const router = createTestRouter({
+      store: createFakeStore({
+        state,
+        async clearChatReminder(chatId: string) {
+          cleared.push(chatId)
+        },
+      }),
+    })
+    const ws = new FakeWebSocket()
+    router.handleOpen(ws as never)
+
+    await sendCommand(router, ws, "clear-1", { type: "chat.clearReminder", chatId: "chat-1" })
+
+    expect(cleared).toEqual(["chat-1"])
+    expect(ws.sent.some((message) => (message as { id?: string }).id === "clear-1"
+      && (message as { type?: string }).type === "ack")).toBe(true)
+  })
+
   test("marks chats read and rebroadcasts sidebar snapshots", async () => {
     const state = createEmptyState()
     state.projectsById.set("project-1", {

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1,6 +1,7 @@
 import type { ServerWebSocket } from "bun"
 import { homedir } from "node:os"
 import { PROTOCOL_VERSION } from "../shared/types"
+import { normalizeReminderPrompt, resolveReminderDueAt } from "../shared/reminders"
 import type { ClientEnvelope, ServerEnvelope, SubscriptionTopic } from "../shared/protocol"
 import { isClientEnvelope } from "../shared/protocol"
 import type { AgentCoordinator } from "./agent"
@@ -1288,6 +1289,31 @@ export function createWsRouter({
         }
         case "chat.markRead": {
           await store.setChatReadState(command.chatId, false)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "chat.setUnread": {
+          await store.setChatReadState(command.chatId, command.unread)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "chat.setReminder": {
+          const resolved = resolveReminderDueAt({ now: Date.now(), dueAt: command.dueAt })
+          if (!resolved.ok) throw new Error(resolved.error)
+          const prompt = normalizeReminderPrompt(command.prompt)
+          await store.setChatReminder(command.chatId, {
+            dueAt: resolved.dueAt,
+            createdBy: "user",
+            ...(prompt ? { prompt } : {}),
+          })
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          await broadcastChatAndSidebar(command.chatId)
+          return
+        }
+        case "chat.clearReminder": {
+          await store.clearChatReminder(command.chatId)
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
           await broadcastChatAndSidebar(command.chatId)
           return

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -22,6 +22,7 @@ import { writeStandaloneTranscriptExport } from "./standalone-export"
 import { TerminalManager } from "./terminal-manager"
 import type { WorktreeProbe } from "./worktree-probe"
 import type { ProviderAuthManager } from "./provider-auth"
+import type { SecretRequestStore } from "./secret-requests"
 import type { UpdateManager } from "./update-manager"
 import type { UsageLimitsManager } from "./usage-limits"
 import { deriveChatSnapshot, deriveChatTouchedFiles, deriveLocalProjectsSnapshot, deriveSidebarData } from "./read-models"
@@ -84,6 +85,7 @@ interface CreateWsRouterArgs {
     | "exchangeOpenRouterCode"
     | "onChange"
   > | null
+  secretRequests?: Pick<SecretRequestStore, "list" | "submit" | "cancel" | "onChange"> | null
 }
 
 interface SnapshotBroadcastFilter {
@@ -94,6 +96,7 @@ interface SnapshotBroadcastFilter {
   includeAppSettings?: boolean
   includeUsageLimits?: boolean
   includeProviderAuth?: boolean
+  includeSecretRequests?: boolean
   chatIds?: Set<string>
   projectIds?: Set<string>
   terminalIds?: Set<string>
@@ -161,6 +164,7 @@ export function createWsRouter({
   updateManager,
   usageLimits,
   providerAuth,
+  secretRequests,
 }: CreateWsRouterArgs) {
   const sockets = new Set<ServerWebSocket<ClientState>>()
   let pendingBroadcastTimer: ReturnType<typeof setTimeout> | null = null
@@ -249,6 +253,9 @@ export function createWsRouter({
     }
     if (topic.type === "provider-auth") {
       return Boolean(filter.includeProviderAuth)
+    }
+    if (topic.type === "secret-requests") {
+      return Boolean(filter.includeSecretRequests)
     }
     if (topic.type === "chat") {
       return filter.chatIds?.has(topic.chatId) ?? false
@@ -379,6 +386,18 @@ export function createWsRouter({
         snapshot: {
           type: "provider-auth",
           data: providerAuth?.getSnapshot() ?? { services: [] },
+        },
+      }
+    }
+
+    if (topic.type === "secret-requests") {
+      return {
+        v: PROTOCOL_VERSION,
+        type: "snapshot",
+        id,
+        snapshot: {
+          type: "secret-requests",
+          data: { requests: secretRequests?.list() ?? [] },
         },
       }
     }
@@ -759,6 +778,21 @@ export function createWsRouter({
       const snapshotSignatures = ensureSnapshotSignatures(ws)
       for (const [id, topic] of ws.data.subscriptions.entries()) {
         if (topic.type !== "provider-auth") continue
+        const envelope = createEnvelope(id, topic)
+        if (envelope.type !== "snapshot") continue
+        const signature = JSON.stringify(envelope.snapshot)
+        if (snapshotSignatures.get(id) === signature) continue
+        snapshotSignatures.set(id, signature)
+        send(ws, envelope)
+      }
+    }
+  }) ?? (() => {})
+
+  const disposeSecretRequestEvents = secretRequests?.onChange(() => {
+    for (const ws of sockets) {
+      const snapshotSignatures = ensureSnapshotSignatures(ws)
+      for (const [id, topic] of ws.data.subscriptions.entries()) {
+        if (topic.type !== "secret-requests") continue
         const envelope = createEnvelope(id, topic)
         if (envelope.type !== "snapshot") continue
         const signature = JSON.stringify(envelope.snapshot)
@@ -1546,6 +1580,38 @@ export function createWsRouter({
           pushTerminalSnapshot(command.terminalId, { force: true })
           return
         }
+
+        case "secret.submit": {
+          if (!secretRequests) {
+            throw new Error("Secret requests are not available")
+          }
+          // The value dies here: submit() writes it to disk and the ack
+          // carries only where it landed. Nothing about it is broadcast.
+          const resolution = await secretRequests.submit(command.requestId, {
+            scope: command.scope,
+            value: command.value,
+          })
+          send(ws, {
+            v: PROTOCOL_VERSION,
+            type: "ack",
+            id,
+            result: {
+              path: resolution.path,
+              scope: resolution.scope,
+              gitignoreUpdated: resolution.gitignoreUpdated ?? false,
+            },
+          })
+          return
+        }
+
+        case "secret.cancel": {
+          if (!secretRequests) {
+            throw new Error("Secret requests are not available")
+          }
+          secretRequests.cancel(command.requestId)
+          send(ws, { v: PROTOCOL_VERSION, type: "ack", id })
+          return
+        }
       }
     } catch (error) {
       const messageText = error instanceof Error ? error.message : String(error)
@@ -1639,6 +1705,7 @@ export function createWsRouter({
       disposeUpdateEvents()
       disposeUsageLimitsEvents()
       disposeProviderAuthEvents()
+      disposeSecretRequestEvents()
     },
   }
 }

--- a/src/shared/branding.ts
+++ b/src/shared/branding.ts
@@ -72,6 +72,26 @@ export function getCloudFilePathDisplay(env: RuntimeEnv = getRuntimeEnv()) {
   return `${getDataRootDirDisplay(env)}/cloud.json`
 }
 
+/** Global (cross-project) secrets, one `<NAME>.env` file each. */
+export function getGlobalSecretsDir(homeDir: string, env: RuntimeEnv = getRuntimeEnv()) {
+  return `${getDataRootDir(homeDir, env)}/secrets`
+}
+
+export function getGlobalSecretsDirDisplay(env: RuntimeEnv = getRuntimeEnv()) {
+  return `${getDataRootDirDisplay(env)}/secrets`
+}
+
+/**
+ * Where a running server advertises its port and loopback token so `kanna`
+ * subcommands (ask-secret) can find it without a session cookie.
+ */
+export function getInstanceFilePath(homeDir: string, env: RuntimeEnv = getRuntimeEnv()) {
+  return `${getDataRootDir(homeDir, env)}/instance.json`
+}
+
+/** Project-scoped secrets live beside uploads/exports under the repo's `.kanna/`. */
+export const PROJECT_SECRETS_DIR_RELATIVE = ".kanna/secrets"
+
 export function getCliInvocation(arg?: string) {
   return arg ? `${CLI_COMMAND} ${arg}` : CLI_COMMAND
 }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -178,6 +178,19 @@ export type ClientCommand =
    */
   | { type: "chat.touchedFiles"; chatId: string }
   | { type: "chat.markRead"; chatId: string }
+  /**
+   * Set the unread flag either way. `chat.markRead` stays for the automatic
+   * read-on-navigate-away path, which only ever clears; this is the deliberate
+   * one, and marking a chat *unread* is a thing only a person does.
+   */
+  | { type: "chat.setUnread"; chatId: string; unread: boolean }
+  /**
+   * Schedule a reminder for a chat, replacing any pending one. `prompt` is
+   * posted into the chat when it fires; without one the reminder just brings
+   * the chat back as unread.
+   */
+  | { type: "chat.setReminder"; chatId: string; dueAt: number; prompt?: string }
+  | { type: "chat.clearReminder"; chatId: string }
   | { type: "chat.setDone"; chatId: string; done: boolean }
   /**
    * Persist where the user left off reading. Sent on a throttle while

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -21,6 +21,8 @@ import type {
   EditorPreset,
 } from "./types"
 
+import type { SecretRequestsSnapshot, SecretScope } from "./secrets"
+
 export type { EditorPreset }
 
 export interface EditorOpenSettings {
@@ -52,6 +54,7 @@ export type SubscriptionTopic =
   | { type: "app-settings" }
   | { type: "usage-limits" }
   | { type: "provider-auth" }
+  | { type: "secret-requests" }
   | {
     type: "chat"
     chatId: string
@@ -286,6 +289,13 @@ export type ClientCommand =
   | { type: "terminal.input"; terminalId: string; data: string }
   | { type: "terminal.resize"; terminalId: string; cols: number; rows: number }
   | { type: "terminal.close"; terminalId: string }
+  /**
+   * Answer an agent's ask-for-secret prompt. `value` is the only place a
+   * secret crosses the socket: the server writes it straight to disk and it
+   * never appears in a snapshot, a transcript, or an ack.
+   */
+  | { type: "secret.submit"; requestId: string; scope: SecretScope; value: string }
+  | { type: "secret.cancel"; requestId: string }
 
 export type OpenExternalAction = Extract<ClientCommand, { type: "system.openExternal" }>["action"]
 
@@ -303,6 +313,7 @@ export type ServerSnapshot =
   | { type: "usage-limits"; data: UsageLimitsSnapshot }
   | { type: "provider-auth"; data: ProviderAuthSnapshot }
   | { type: "llm-provider"; data: LlmProviderSnapshot }
+  | { type: "secret-requests"; data: SecretRequestsSnapshot }
   | { type: "chat"; data: ChatSnapshot | null }
   | { type: "project-git"; data: ChatDiffSnapshot | null }
   | { type: "terminal"; data: TerminalSnapshot | null }

--- a/src/shared/reminders.test.ts
+++ b/src/shared/reminders.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import {
+  formatReminderDelay,
+  MAX_REMINDER_DELAY_MS,
+  MAX_REMINDER_PROMPT_LENGTH,
+  normalizeReminderPrompt,
+  parseReminderDelay,
+  resolveReminderDueAt,
+} from "./reminders"
+
+const NOW = 1_700_000_000_000
+
+describe("parseReminderDelay", () => {
+  test("reads a bare number as minutes", () => {
+    expect(parseReminderDelay("30")).toBe(30 * 60_000)
+    expect(parseReminderDelay(" 5 ")).toBe(5 * 60_000)
+  })
+
+  test("reads single units", () => {
+    expect(parseReminderDelay("45s")).toBe(45_000)
+    expect(parseReminderDelay("30m")).toBe(30 * 60_000)
+    expect(parseReminderDelay("2h")).toBe(2 * 3_600_000)
+    expect(parseReminderDelay("1d")).toBe(86_400_000)
+  })
+
+  test("reads compound units and ignores internal spacing", () => {
+    expect(parseReminderDelay("1h30m")).toBe(90 * 60_000)
+    expect(parseReminderDelay("1h 30m")).toBe(90 * 60_000)
+    expect(parseReminderDelay("1d2h")).toBe(86_400_000 + 2 * 3_600_000)
+  })
+
+  test("is case-insensitive", () => {
+    expect(parseReminderDelay("2H")).toBe(2 * 3_600_000)
+  })
+
+  test("rejects trailing junk rather than parsing the prefix", () => {
+    expect(parseReminderDelay("30mx")).toBeNull()
+    expect(parseReminderDelay("30 minutes")).toBeNull()
+  })
+
+  test("rejects what it cannot read", () => {
+    expect(parseReminderDelay("")).toBeNull()
+    expect(parseReminderDelay("soon")).toBeNull()
+    expect(parseReminderDelay("m")).toBeNull()
+  })
+})
+
+describe("formatReminderDelay", () => {
+  test("renders sub-minute delays in seconds", () => {
+    expect(formatReminderDelay(45_000)).toBe("45s")
+  })
+
+  test("renders compound delays", () => {
+    expect(formatReminderDelay(90 * 60_000)).toBe("1h 30m")
+    expect(formatReminderDelay(30 * 60_000)).toBe("30m")
+    expect(formatReminderDelay(2 * 3_600_000)).toBe("2h")
+    expect(formatReminderDelay(86_400_000)).toBe("1d")
+  })
+})
+
+describe("resolveReminderDueAt", () => {
+  test("resolves a relative delay against the caller's clock", () => {
+    const result = resolveReminderDueAt({ now: NOW, in: "30m" })
+    expect(result).toEqual({ ok: true, dueAt: NOW + 30 * 60_000 })
+  })
+
+  test("resolves an absolute ISO time", () => {
+    const at = new Date(NOW + 3_600_000).toISOString()
+    const result = resolveReminderDueAt({ now: NOW, at })
+    expect(result).toEqual({ ok: true, dueAt: NOW + 3_600_000 })
+  })
+
+  test("accepts a precomputed dueAt from a client that did its own arithmetic", () => {
+    const result = resolveReminderDueAt({ now: NOW, dueAt: NOW + 60_000 })
+    expect(result).toEqual({ ok: true, dueAt: NOW + 60_000 })
+  })
+
+  test("requires exactly one of in/at/dueAt", () => {
+    expect(resolveReminderDueAt({ now: NOW })).toEqual({
+      ok: false,
+      error: "Say when: --in <30m|2h|1d> or --at <time>.",
+    })
+    expect(resolveReminderDueAt({ now: NOW, in: "30m", at: "2030-01-01T00:00:00Z" })).toEqual({
+      ok: false,
+      error: "Pass only one of --in and --at.",
+    })
+  })
+
+  test("rejects times in the past — including a delay that rounds to zero", () => {
+    expect(resolveReminderDueAt({ now: NOW, dueAt: NOW - 1 }).ok).toBe(false)
+    expect(resolveReminderDueAt({ now: NOW, dueAt: NOW }).ok).toBe(false)
+    expect(resolveReminderDueAt({ now: NOW, in: "0m" }).ok).toBe(false)
+  })
+
+  test("rejects delays beyond the ceiling", () => {
+    const result = resolveReminderDueAt({ now: NOW, dueAt: NOW + MAX_REMINDER_DELAY_MS + 1 })
+    expect(result.ok).toBe(false)
+  })
+
+  test("allows a delay exactly at the ceiling", () => {
+    const result = resolveReminderDueAt({ now: NOW, dueAt: NOW + MAX_REMINDER_DELAY_MS })
+    expect(result.ok).toBe(true)
+  })
+
+  test("reports the input back when it cannot be read", () => {
+    const result = resolveReminderDueAt({ now: NOW, in: "sometime" })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("sometime")
+  })
+
+  test("rejects an unparseable absolute time", () => {
+    expect(resolveReminderDueAt({ now: NOW, at: "next tuesday" }).ok).toBe(false)
+  })
+})
+
+describe("normalizeReminderPrompt", () => {
+  test("trims and drops empty prompts", () => {
+    expect(normalizeReminderPrompt("  check metrics  ")).toBe("check metrics")
+    expect(normalizeReminderPrompt("   ")).toBeUndefined()
+    expect(normalizeReminderPrompt(null)).toBeUndefined()
+    expect(normalizeReminderPrompt(undefined)).toBeUndefined()
+  })
+
+  test("bounds an overlong prompt", () => {
+    const long = "x".repeat(MAX_REMINDER_PROMPT_LENGTH + 100)
+    expect(normalizeReminderPrompt(long)?.length).toBe(MAX_REMINDER_PROMPT_LENGTH)
+  })
+})

--- a/src/shared/reminders.ts
+++ b/src/shared/reminders.ts
@@ -1,0 +1,177 @@
+/**
+ * Chat reminders — "wake this chat up later", shared by client and server.
+ *
+ * A chat carries at most one pending reminder. When it comes due the server
+ * marks the chat unread and, if the reminder carries a prompt, posts that
+ * prompt into the chat — which starts (or queues) a turn exactly as if the
+ * user had typed it. Setting a second reminder replaces the first: "remind me
+ * about this chat" has one answer.
+ *
+ * Two ways in, one mechanism: the sidebar's right-click menu, and the agent
+ * itself via `kanna remind --in 30m "check the metrics again"`.
+ *
+ * No Bun/node imports here: this file is imported by both sides.
+ */
+
+/** Loopback-only HTTP surface for the `kanna remind` CLI. */
+export const REMINDERS_API_PATH_PREFIX = "/__local/reminders"
+
+/** The same per-start instance token the secrets and pull-requests APIs use. */
+export const REMINDERS_API_TOKEN_HEADER = "x-kanna-token"
+
+/**
+ * Furthest out a reminder may be set. Less a policy than a typo guard: `--in
+ * 1000d` is likelier to be a slip than an intention, and a scheduler that
+ * rebuilds its work list from the store on every tick has no business carrying
+ * items for years.
+ */
+export const MAX_REMINDER_DELAY_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Truncation point for the stored prompt. It becomes a chat message, so it is
+ * bounded for the same reason any other prompt is — but generously: an agent
+ * leaving itself a note wants room for the context it will have forgotten.
+ */
+export const MAX_REMINDER_PROMPT_LENGTH = 4_000
+
+/** Who set it. Only used for wording — the firing path is identical. */
+export type ReminderSource = "user" | "agent"
+
+/**
+ * What a reminder set from the sidebar posts when it fires.
+ *
+ * The menu's promise is "come back to this later and pick it up", so the
+ * default carries a prompt rather than only flagging the chat unread. It tells
+ * the agent to re-check state first because whatever it believed at the end of
+ * the last turn may be minutes or days stale by the time this arrives.
+ */
+export const DEFAULT_REMINDER_PROMPT =
+  "This is a scheduled reminder to pick this task back up. Check where things actually "
+  + "stand now before continuing — time has passed and the state may have moved. If it "
+  + "turns out everything here is already done, just say so instead of finding new work."
+
+export interface ChatReminder {
+  /** Epoch ms at which the reminder fires. */
+  dueAt: number
+  /**
+   * Posted into the chat when it fires, starting a turn. Absent means the
+   * reminder only resurfaces the chat (marks it unread) without waking the
+   * agent — what the sidebar's plain "Remind Me" does.
+   */
+  prompt?: string
+  createdAt: number
+  createdBy: ReminderSource
+}
+
+const UNIT_MS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+}
+
+/**
+ * Reads a human delay — `30m`, `2h`, `1h30m`, `1d` — into milliseconds.
+ *
+ * A bare number is minutes, because "remind me in 30" means thirty minutes to
+ * everyone who has ever said it out loud. Returns null for anything it cannot
+ * read, so callers can report the input back rather than silently guessing.
+ */
+export function parseReminderDelay(input: string): number | null {
+  const text = input.trim().toLowerCase().replace(/\s+/g, "")
+  if (!text) return null
+  if (/^\d+(?:\.\d+)?$/.test(text)) return Math.round(Number(text) * UNIT_MS.m)
+  // Anchored so trailing junk ("30mx") fails rather than parsing the prefix.
+  if (!/^(?:\d+(?:\.\d+)?[smhd])+$/.test(text)) return null
+  let total = 0
+  for (const [, value, unit] of text.matchAll(/(\d+(?:\.\d+)?)([smhd])/g)) {
+    total += Number(value) * (UNIT_MS[unit] ?? 0)
+  }
+  return Math.round(total)
+}
+
+/** `90m` → "1h 30m". For CLI confirmations and the sidebar's tooltip. */
+export function formatReminderDelay(ms: number): string {
+  if (ms < 60_000) return `${Math.max(1, Math.round(ms / 1_000))}s`
+  const totalMinutes = Math.round(ms / 60_000)
+  const days = Math.floor(totalMinutes / 1_440)
+  const hours = Math.floor((totalMinutes % 1_440) / 60)
+  const minutes = totalMinutes % 60
+  const parts: string[] = []
+  if (days) parts.push(`${days}d`)
+  if (hours) parts.push(`${hours}h`)
+  if (minutes) parts.push(`${minutes}m`)
+  return parts.join(" ")
+}
+
+export type ResolvedReminderDueAt =
+  | { ok: true; dueAt: number }
+  | { ok: false; error: string }
+
+/**
+ * Turns whichever of `--in` / `--at` / a raw timestamp the caller supplied into
+ * an absolute due time, with one set of rules for the CLI and the HTTP API.
+ *
+ * Both sides run on the same machine over loopback, so resolving relative
+ * delays against the server's clock rather than the caller's costs nothing and
+ * removes a class of skew from the picture entirely.
+ */
+export function resolveReminderDueAt(args: {
+  now: number
+  /** A delay in `parseReminderDelay` syntax. */
+  in?: string | null
+  /** An absolute time, ISO 8601 or epoch ms. */
+  at?: string | number | null
+  /** An already-absolute epoch ms, from a client that did its own arithmetic. */
+  dueAt?: number | null
+}): ResolvedReminderDueAt {
+  const provided = [args.in, args.at, args.dueAt].filter(
+    (value) => value !== null && value !== undefined && value !== "",
+  )
+  if (provided.length === 0) {
+    return { ok: false, error: "Say when: --in <30m|2h|1d> or --at <time>." }
+  }
+  if (provided.length > 1) {
+    return { ok: false, error: "Pass only one of --in and --at." }
+  }
+
+  let dueAt: number
+  if (args.in !== null && args.in !== undefined && args.in !== "") {
+    const delay = parseReminderDelay(args.in)
+    if (delay === null) {
+      return {
+        ok: false,
+        error: `Could not read '${args.in}' as a delay. Use 30m, 2h, 1h30m, 1d, or a plain number of minutes.`,
+      }
+    }
+    if (delay <= 0) return { ok: false, error: "A reminder has to be in the future." }
+    dueAt = args.now + delay
+  } else if (args.dueAt !== null && args.dueAt !== undefined) {
+    dueAt = args.dueAt
+  } else {
+    const at = args.at as string | number
+    dueAt = typeof at === "number" ? at : Date.parse(at)
+    if (!Number.isFinite(dueAt)) {
+      return { ok: false, error: `Could not read '${String(at)}' as a time. Use an ISO 8601 timestamp.` }
+    }
+  }
+
+  if (!Number.isFinite(dueAt)) return { ok: false, error: "Invalid reminder time." }
+  if (dueAt <= args.now) return { ok: false, error: "A reminder has to be in the future." }
+  if (dueAt - args.now > MAX_REMINDER_DELAY_MS) {
+    return {
+      ok: false,
+      error: `A reminder can be at most ${formatReminderDelay(MAX_REMINDER_DELAY_MS)} out.`,
+    }
+  }
+  return { ok: true, dueAt: Math.round(dueAt) }
+}
+
+/** Trims and bounds a prompt. Empty (or all-whitespace) becomes undefined. */
+export function normalizeReminderPrompt(prompt: string | null | undefined): string | undefined {
+  const text = prompt?.trim()
+  if (!text) return undefined
+  return text.length > MAX_REMINDER_PROMPT_LENGTH
+    ? text.slice(0, MAX_REMINDER_PROMPT_LENGTH)
+    : text
+}

--- a/src/shared/secrets.test.ts
+++ b/src/shared/secrets.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildSecretLoadCommand,
+  coversSecretsDir,
+  formatSecretEnvFile,
+  isValidSecretName,
+  secretFileName,
+  shellSingleQuote,
+} from "./secrets"
+
+describe("isValidSecretName", () => {
+  test("accepts shell-legal variable names", () => {
+    expect(isValidSecretName("OPENAI_API_KEY")).toBe(true)
+    expect(isValidSecretName("_private")).toBe(true)
+    expect(isValidSecretName("key2")).toBe(true)
+  })
+
+  test("rejects names that could not be sourced into a shell", () => {
+    expect(isValidSecretName("")).toBe(false)
+    expect(isValidSecretName("2FA_TOKEN")).toBe(false)
+    expect(isValidSecretName("MY-KEY")).toBe(false)
+    expect(isValidSecretName("MY KEY")).toBe(false)
+    expect(isValidSecretName("../escape")).toBe(false)
+    expect(isValidSecretName("a".repeat(129))).toBe(false)
+  })
+
+  test("rejects path separators, so a name can never escape the secrets dir", () => {
+    expect(isValidSecretName("a/b")).toBe(false)
+    expect(isValidSecretName("..")).toBe(false)
+    expect(secretFileName("OPENAI_API_KEY")).toBe("OPENAI_API_KEY.env")
+  })
+})
+
+describe("shellSingleQuote", () => {
+  test("wraps plain values", () => {
+    expect(shellSingleQuote("sk-abc123")).toBe("'sk-abc123'")
+  })
+
+  test("escapes embedded single quotes with the POSIX close/escape/reopen dance", () => {
+    expect(shellSingleQuote("it's")).toBe("'it'\\''s'")
+  })
+
+  test("leaves shell metacharacters inert", () => {
+    expect(shellSingleQuote("$(rm -rf /)")).toBe("'$(rm -rf /)'")
+    expect(shellSingleQuote("a\nb")).toBe("'a\nb'")
+    expect(shellSingleQuote('back`tick`')).toBe("'back`tick`'")
+  })
+})
+
+describe("formatSecretEnvFile", () => {
+  test("emits a bare assignment that both sh and dotenv can read", () => {
+    const file = formatSecretEnvFile("TOKEN", "abc123")
+    expect(file).toContain("TOKEN='abc123'")
+    expect(file.endsWith("\n")).toBe(true)
+  })
+
+  test("warns against committing or printing the file", () => {
+    const file = formatSecretEnvFile("TOKEN", "abc123")
+    expect(file).toContain("Do not commit")
+    expect(file.split("\n")[0].startsWith("#")).toBe(true)
+  })
+
+  test("a value containing a quote survives the round trip", () => {
+    const file = formatSecretEnvFile("TOKEN", "pa'ss")
+    expect(file).toContain("TOKEN='pa'\\''ss'")
+  })
+})
+
+describe("buildSecretLoadCommand", () => {
+  test("exports the variable without printing it", () => {
+    const command = buildSecretLoadCommand("/tmp/proj/.kanna/secrets/TOKEN.env")
+    expect(command).toBe("set -a; . '/tmp/proj/.kanna/secrets/TOKEN.env'; set +a")
+    expect(command).not.toContain("cat")
+    expect(command).not.toContain("echo")
+  })
+
+  test("quotes paths containing spaces", () => {
+    expect(buildSecretLoadCommand("/tmp/my proj/TOKEN.env"))
+      .toBe("set -a; . '/tmp/my proj/TOKEN.env'; set +a")
+  })
+})
+
+describe("coversSecretsDir", () => {
+  test("recognises patterns that already ignore the secrets dir", () => {
+    expect(coversSecretsDir(".kanna/secrets/")).toBe(true)
+    expect(coversSecretsDir(".kanna/secrets")).toBe(true)
+    expect(coversSecretsDir("/.kanna/")).toBe(true)
+    expect(coversSecretsDir(".kanna")).toBe(true)
+    expect(coversSecretsDir(".kanna/*")).toBe(true)
+    expect(coversSecretsDir("  .kanna/secrets/  ")).toBe(true)
+  })
+
+  test("ignores comments, blanks and unrelated entries", () => {
+    expect(coversSecretsDir("# .kanna/secrets/")).toBe(false)
+    expect(coversSecretsDir("")).toBe(false)
+    expect(coversSecretsDir("node_modules")).toBe(false)
+    expect(coversSecretsDir(".kanna/uploads")).toBe(false)
+  })
+})

--- a/src/shared/secrets.ts
+++ b/src/shared/secrets.ts
@@ -1,0 +1,119 @@
+/**
+ * Ask-for-secret: the agent asks Kanna for a credential by name, the user
+ * types it into Kanna's UI, and it lands in a file the agent sources into a
+ * shell. The value never travels through the agent's context — not in the
+ * tool call, not in the tool result, not in the transcript.
+ *
+ * This module is the wire contract shared by client, server, and the CLI, so
+ * it stays free of Bun/node imports (see CLAUDE.md).
+ */
+
+export type SecretScope = "project" | "global"
+
+/**
+ * Secrets are sourced into a shell, so a name has to be a valid POSIX
+ * variable name — anything else would produce a file that `.` cannot read.
+ */
+export const SECRET_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+export const SECRET_NAME_MAX_LENGTH = 128
+/** Generous enough for a PEM private key, small enough to bound a stray paste. */
+export const SECRET_VALUE_MAX_BYTES = 64 * 1024
+export const SECRET_REASON_MAX_LENGTH = 500
+
+/** Path prefix for the loopback-only HTTP API the CLI talks to. */
+export const SECRETS_API_PATH_PREFIX = "/__local/secrets"
+/** Header carrying the instance token minted at server start. */
+export const SECRETS_API_TOKEN_HEADER = "x-kanna-token"
+
+export interface PendingSecretRequest {
+  id: string
+  name: string
+  /** Why the agent needs it — shown to the user verbatim. */
+  reason: string
+  /** Absolute project root, when the CLI's cwd resolved to a known project. */
+  projectPath: string | null
+  projectTitle: string | null
+  /** Directory the agent ran the CLI from. */
+  cwd: string
+  /** The agent's suggestion; the user still picks in the dialog. */
+  suggestedScope: SecretScope | null
+  createdAt: number
+}
+
+export interface SecretRequestsSnapshot {
+  requests: PendingSecretRequest[]
+}
+
+/** Terminal states for one ask. `pending` means the dialog is still open. */
+export type SecretRequestStatus = "pending" | "saved" | "cancelled" | "expired"
+
+export interface SecretRequestResolution {
+  status: SecretRequestStatus
+  /** Absolute path of the written file. Present only when `saved`. */
+  path?: string
+  scope?: SecretScope
+  /** Shell snippet that loads the secret. Present only when `saved`. */
+  loadCommand?: string
+  /** True when the user's answer also added a `.gitignore` entry. */
+  gitignoreUpdated?: boolean
+}
+
+export function isValidSecretName(name: string): boolean {
+  return (
+    name.length > 0
+    && name.length <= SECRET_NAME_MAX_LENGTH
+    && SECRET_NAME_PATTERN.test(name)
+  )
+}
+
+/** The single file that holds one secret, e.g. `OPENAI_API_KEY.env`. */
+export function secretFileName(name: string): string {
+  return `${name}.env`
+}
+
+/**
+ * Wrap a value in single quotes for `sh`. The only character that cannot
+ * appear inside a single-quoted string is `'` itself, which is closed,
+ * escaped, and reopened — the standard POSIX dance.
+ */
+export function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+/**
+ * Body of a `<NAME>.env` file. Deliberately a bare `NAME=value` assignment
+ * rather than `export NAME=value`: it stays readable by dotenv-style loaders,
+ * and `set -a` around the `.` handles exporting.
+ */
+export function formatSecretEnvFile(name: string, value: string): string {
+  return [
+    `# Written by Kanna — holds the secret ${name}.`,
+    "# Do not commit this file, and do not print or cat it.",
+    `${name}=${shellSingleQuote(value)}`,
+    "",
+  ].join("\n")
+}
+
+/** The shell snippet handed back to the agent. Exports the name, prints nothing. */
+export function buildSecretLoadCommand(filePath: string): string {
+  return `set -a; . ${shellSingleQuote(filePath)}; set +a`
+}
+
+/** The one `.gitignore` line that covers every project-scoped secret. */
+export const SECRETS_GITIGNORE_ENTRY = ".kanna/secrets/"
+
+/**
+ * Patterns that already keep `.kanna/secrets/` out of git. Checked before
+ * appending so repos that ignore all of `.kanna/` are left alone.
+ */
+export function coversSecretsDir(gitignoreLine: string): boolean {
+  const trimmed = gitignoreLine.trim()
+  if (!trimmed || trimmed.startsWith("#")) return false
+  const normalized = trimmed.replace(/^\/+/, "").replace(/\/+$/, "")
+  return (
+    normalized === ".kanna"
+    || normalized === ".kanna/*"
+    || normalized === ".kanna/secrets"
+    || normalized === ".kanna/secrets/*"
+  )
+}

--- a/src/shared/secrets.ts
+++ b/src/shared/secrets.ts
@@ -24,6 +24,13 @@ export const SECRET_REASON_MAX_LENGTH = 500
 export const SECRETS_API_PATH_PREFIX = "/__local/secrets"
 /** Header carrying the instance token minted at server start. */
 export const SECRETS_API_TOKEN_HEADER = "x-kanna-token"
+/**
+ * Set on the environment of a spawned harness so `ask-secret` can name the
+ * chat it was run from. Absent for providers Kanna does not spawn with a
+ * per-chat environment, where the server falls back to matching the running
+ * turn against the CLI's cwd.
+ */
+export const SECRET_CHAT_ID_ENV_VAR = "KANNA_CHAT_ID"
 
 export interface PendingSecretRequest {
   id: string
@@ -35,6 +42,11 @@ export interface PendingSecretRequest {
   projectTitle: string | null
   /** Directory the agent ran the CLI from. */
   cwd: string
+  /**
+   * Chat the asking agent is running in, when it could be determined. Drives
+   * the transcript notice written when the prompt settles.
+   */
+  chatId: string | null
   /** The agent's suggestion; the user still picks in the dialog. */
   suggestedScope: SecretScope | null
   createdAt: number

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -862,11 +862,12 @@ export interface SidebarChatRow {
   status: KannaStatus
   unread: boolean
   /**
-   * The GitHub pull request this chat references, with the latest watched
-   * state. Absent unless someone linked one; the sidebar draws a status badge
-   * from it, left of the trailing detail label.
+   * When this chat's pending reminder fires. Absent unless one is scheduled.
+   * Only the time rides the wire — the prompt behind it can be long, is read
+   * by nothing in the sidebar, and would put a chat message into a snapshot
+   * that fans out to every socket.
    */
-  linkedPullRequest?: LinkedPullRequest
+  reminderAt?: number
   /** User marked the chat done (board Done column). Cleared when a new turn starts. */
   done?: boolean
   /** When the chat was marked done. Set iff `done` is true. */
@@ -1798,6 +1799,24 @@ export interface SecretNoticeEntry extends TranscriptEntryBase {
   scope?: "project" | "global"
 }
 
+/**
+ * A reminder came due and woke this chat.
+ *
+ * Written when it *fires*, not when it is scheduled: a pending reminder is
+ * live state (the composer shows it, and it can still be cancelled), while a
+ * fired one is history. It earns its place in the transcript because firing
+ * posts a prompt the user never typed — without this marker that prompt is
+ * inexplicable.
+ */
+export interface ReminderNoticeEntry extends TranscriptEntryBase {
+  kind: "reminder_notice"
+  /** When the reminder was set, so the notice can say how long ago that was. */
+  scheduledAt: number
+  createdBy: "user" | "agent"
+  /** False for a reminder that only resurfaced the chat without a prompt. */
+  wokeAgent: boolean
+}
+
 export interface InterruptedEntry extends TranscriptEntryBase {
   kind: "interrupted"
 }
@@ -1847,6 +1866,7 @@ export type TranscriptEntry =
   | CompactSummaryEntry
   | ContextClearedEntry
   | SecretNoticeEntry
+  | ReminderNoticeEntry
   | InterruptedEntry
   | HandoffBoundaryEntry
   | SessionRestoredEntry
@@ -1960,6 +1980,7 @@ export type HydratedTranscriptMessage =
   | ({ kind: "compact_summary"; summary: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "context_cleared"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "secret_notice"; secretName: string; outcome: SecretNoticeEntry["outcome"]; scope?: SecretNoticeEntry["scope"]; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "reminder_notice"; scheduledAt: number; createdBy: ReminderNoticeEntry["createdBy"]; wokeAgent: boolean; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "handoff_boundary"; fromProvider: AgentProvider; toProvider: AgentProvider; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "session_restored"; provider: AgentProvider; stats?: HandoffBoundaryEntry["stats"]; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "interrupted"; id: string; messageId?: string; timestamp: string; hidden?: boolean })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -861,6 +861,12 @@ export interface SidebarChatRow {
   title: string
   status: KannaStatus
   unread: boolean
+  /**
+   * The GitHub pull request this chat references, with the latest watched
+   * state. Absent unless someone linked one; the sidebar draws a status badge
+   * from it, left of the trailing detail label.
+   */
+  linkedPullRequest?: LinkedPullRequest
   /** User marked the chat done (board Done column). Cleared when a new turn starts. */
   done?: boolean
   /** When the chat was marked done. Set iff `done` is true. */
@@ -1780,6 +1786,18 @@ export interface ContextClearedEntry extends TranscriptEntryBase {
   kind: "context_cleared"
 }
 
+/**
+ * How an agent's ask-for-secret prompt ended. Records the name and outcome
+ * only — never the value, which is the whole point of the mechanism.
+ */
+export interface SecretNoticeEntry extends TranscriptEntryBase {
+  kind: "secret_notice"
+  secretName: string
+  outcome: "saved" | "declined" | "expired"
+  /** Present only when saved. */
+  scope?: "project" | "global"
+}
+
 export interface InterruptedEntry extends TranscriptEntryBase {
   kind: "interrupted"
 }
@@ -1828,6 +1846,7 @@ export type TranscriptEntry =
   | CompactBoundaryEntry
   | CompactSummaryEntry
   | ContextClearedEntry
+  | SecretNoticeEntry
   | InterruptedEntry
   | HandoffBoundaryEntry
   | SessionRestoredEntry
@@ -1940,6 +1959,7 @@ export type HydratedTranscriptMessage =
   | ({ kind: "compact_boundary"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "compact_summary"; summary: string; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "context_cleared"; id: string; messageId?: string; timestamp: string; hidden?: boolean })
+  | ({ kind: "secret_notice"; secretName: string; outcome: SecretNoticeEntry["outcome"]; scope?: SecretNoticeEntry["scope"]; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "handoff_boundary"; fromProvider: AgentProvider; toProvider: AgentProvider; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "session_restored"; provider: AgentProvider; stats?: HandoffBoundaryEntry["stats"]; id: string; messageId?: string; timestamp: string; hidden?: boolean })
   | ({ kind: "interrupted"; id: string; messageId?: string; timestamp: string; hidden?: boolean })


### PR DESCRIPTION
Two related ways to make a chat come back to you.

> **Stacked on #97.** This branch sits on top of the ask-for-secret work, so the diff currently also shows those 3 commits. They drop out once #97 merges. Only the `reminder`/`unread` files below are new here.

## Mark as unread

Right-click a chat row → **Mark as Unread**. This flips the flag the sidebar already renders, so no new badge was needed.

One wrinkle worth calling out: the existing effect clears `unread` when you navigate *away* from a chat, not when you open it. That would have undone a deliberate mark the instant you left the chat you just marked. A mark now suppresses exactly one such clear — leaving consumes it, so the next visit reads and clears as normal.

## Reminders

Right-click → **Remind Me** → a preset (or set a time). The chat resurfaces when it comes due, optionally with a prompt that starts a turn.

- **The schedule lives in the event log, not in timers**, so a reminder survives a restart — including one that came due while the server was down.
- One `unref()`'d interval sweeps the work list, mirroring the PR watcher's single-timer shape rather than holding a timer per chat.
- `chat_reminder_set` deliberately **does not bump `updatedAt`**: scheduling something for later is not activity, and an old chat should not climb the sidebar because you asked to be reminded of it.
- The three GC sweeps (prune / auto-archive / delete) skip chats with a pending reminder — otherwise they would prune, archive, or delete the reminder out from under itself.
- Firing clears the reminder *before* posting, so a failed post spends it rather than re-firing on every tick forever.

## Agent-facing: `kanna remind`

Agents reach the same mechanism through a CLI subcommand over the loopback API, following `ask-for-secret` exactly — a shell is the one entry point every provider has, so this works for Claude, Codex, Cursor, and Pi alike.

That makes "check the metrics again in 30 minutes" something the agent schedules itself, and unlike a harness-native wakeup it is not session-scoped: it is on disk and survives a restart.

## In-chat UI

A pending reminder shows as a quiet dock card above the composer — live countdown, cancel control. It is live state rather than a transcript entry because it can still be cancelled and its countdown changes.

Firing writes a `reminder_notice` divider to the transcript instead. That one is history, and it earns its place because **the prompt underneath it was posted by the schedule, not typed by the user** — without the divider that prompt is inexplicable. It is also carried across a provider handoff for the same reason.

## Testing

`bun run check` clean (typecheck + both production builds); `bun test` 1792 pass / 0 fail. New coverage for the scheduler (including fire ordering, restart-late firing, and the failure paths), the reminder presets, the parser and API, and the dock card's countdown wording.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus`.