### PR TITLE
Add optional machine hostname to sidebar header

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -318,6 +318,9 @@ function KannaLayout() {
   // snapshot, which moved on every streamed token.
   const sidebarElement = (
     <KannaSidebar
+      machineName={state.appSettings?.showMachineName === true
+        ? state.localProjects?.machine.hostname ?? null
+        : null}
       activeChatId={state.activeChatId}
       connectionStatus={state.connectionStatus}
       ready={state.sidebarReady}

--- a/src/client/app/KannaSidebar.tsx
+++ b/src/client/app/KannaSidebar.tsx
@@ -69,6 +69,7 @@ function readStoredSidebarView(): SidebarView {
 }
 
 interface KannaSidebarProps {
+  machineName: string | null
   activeChatId: string | null
   connectionStatus: SocketStatus
   ready: boolean
@@ -104,6 +105,7 @@ interface KannaSidebarProps {
 }
 
 function KannaSidebarImpl({
+  machineName,
   activeChatId,
   connectionStatus,
   ready,
@@ -540,7 +542,7 @@ function KannaSidebarImpl({
               <Settings className="h-5 w-5" />
             </Button>
           </div>
-          <div className="flex items-center justify-self-center gap-2 md:justify-self-auto">
+          <div className="flex min-w-0 items-center justify-self-center gap-2 md:justify-self-auto">
             <button
               type="button"
               onClick={onCollapse}
@@ -551,7 +553,15 @@ function KannaSidebarImpl({
               <PanelLeft className="absolute inset-0 h-4 w-4 sm:h-6 sm:w-6 text-slate-500 dark:text-slate-400 transition-all duration-200 ease-out opacity-0 scale-0 group-hover/sidebar-collapse:opacity-100 group-hover/sidebar-collapse:scale-80 hover:opacity-50" />
             </button>
             <Flower className="h-5 w-5 sm:h-6 sm:w-6 text-logo md:hidden" />
-            <span className="font-logo text-base uppercase sm:text-md text-slate-600 dark:text-slate-100">{APP_NAME}</span>
+            <span className="shrink-0 font-logo text-base uppercase sm:text-md text-slate-600 dark:text-slate-100">{APP_NAME}</span>
+            {machineName ? (
+              <>
+                <span className="shrink-0 text-xs text-muted-foreground/50" aria-hidden>·</span>
+                <span className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={machineName}>
+                  {machineName}
+                </span>
+              </>
+            ) : null}
           </div>
           <div className="flex items-center justify-self-end md:justify-self-auto">
             {!newSidebarEnabled ? (

--- a/src/client/app/settings/GeneralSection.tsx
+++ b/src/client/app/settings/GeneralSection.tsx
@@ -233,11 +233,21 @@ export function GeneralSection({
     }
   }
 
+  async function handleMachineNamePreferenceChange(nextValue: "enabled" | "disabled") {
+    try {
+      setAppSettingsError(null)
+      await handleWriteAppSettings({ showMachineName: nextValue === "enabled" })
+    } catch (error) {
+      setAppSettingsError(error instanceof Error ? error.message : "Unable to save the machine name setting.")
+    }
+  }
+
   const customEditorPreview = editorCommandDraft
     .replaceAll("{path}", "/Users/jake/Projects/kanna/src/client/app/App.tsx")
     .replaceAll("{line}", "12")
     .replaceAll("{column}", "1")
   const analyticsSettingValue = appSettings?.analyticsEnabled === false ? "disabled" : "enabled"
+  const machineNameSettingValue = appSettings?.showMachineName === true ? "enabled" : "disabled"
 
   return (
     <>
@@ -276,6 +286,17 @@ export function GeneralSection({
             value={theme}
             onValueChange={handleThemeChange}
             options={themeOptions}
+            size="sm"
+          />
+        </SettingsRow>
+
+        <SettingsRow def={SETTINGS_ROWS.machineName}>
+          <SegmentedControl
+            value={machineNameSettingValue}
+            onValueChange={(value) => {
+              void handleMachineNamePreferenceChange(value)
+            }}
+            options={ENABLED_DISABLED_OPTIONS}
             size="sm"
           />
         </SettingsRow>

--- a/src/client/app/settings/registry.ts
+++ b/src/client/app/settings/registry.ts
@@ -92,6 +92,12 @@ export const SETTINGS_ROWS = defineRows({
     description: "Choose between light, dark, or system appearance",
     keywords: ["appearance", "dark mode", "light mode"],
   },
+  machineName: {
+    sectionId: "general",
+    title: "Machine Name",
+    description: "Show this device's hostname beside Kanna at the top of the sidebar",
+    keywords: ["hostname", "computer", "device", "sidebar"],
+  },
   chatSounds: {
     sectionId: "general",
     title: "Chat Sounds",

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -23,6 +23,7 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
     devbox: false,
     analyticsEnabled: true,
     browserSettingsMigrated: false,
+    showMachineName: false,
     setupShown: false,
     setupCompleted: false,
     setupDismissed: false,
@@ -166,6 +167,27 @@ describe("readAppSettingsSnapshot", () => {
     } finally {
       manager.dispose()
     }
+  })
+
+  test("showMachineName defaults off, persists, and rejects invalid values", async () => {
+    const filePath = await createTempFilePath()
+    const manager = new AppSettingsManager(filePath)
+    await manager.initialize()
+    try {
+      expect(manager.getSnapshot().showMachineName).toBe(false)
+
+      const enabled = await manager.writePatch({ showMachineName: true })
+      expect(enabled.showMachineName).toBe(true)
+      const raw = JSON.parse(await readFile(filePath, "utf8")) as { showMachineName: boolean }
+      expect(raw.showMachineName).toBe(true)
+    } finally {
+      manager.dispose()
+    }
+
+    await writeFile(filePath, JSON.stringify({ showMachineName: "yes" }), "utf8")
+    const invalid = await readAppSettingsSnapshot(filePath)
+    expect(invalid.showMachineName).toBe(false)
+    expect(invalid.warning).toContain("showMachineName")
   })
 })
 

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -52,6 +52,7 @@ interface AppSettingsFile {
     cursor?: ProviderPreferenceInput
     pi?: ProviderPreferenceInput
   }
+  showMachineName?: unknown
   newSidebarEnabled?: unknown
   newProjectsDirectory?: unknown
   setupShown?: unknown
@@ -160,6 +161,7 @@ function toFilePayload(state: AppSettingsState) {
     transcript: state.transcript,
     defaultProvider: state.defaultProvider,
     providerDefaults: state.providerDefaults,
+    showMachineName: state.showMachineName,
     newSidebarEnabled: state.newSidebarEnabled,
     newProjectsDirectory: state.newProjectsDirectory,
     setupShown: state.setupShown,
@@ -181,6 +183,7 @@ function toSnapshot(state: AppSettingsState, devbox = false): AppSettingsSnapsho
     transcript: state.transcript,
     defaultProvider: state.defaultProvider,
     providerDefaults: state.providerDefaults,
+    showMachineName: state.showMachineName,
     newSidebarEnabled: state.newSidebarEnabled,
     newProjectsDirectory: state.newProjectsDirectory,
     setupShown: state.setupShown,
@@ -226,6 +229,13 @@ function normalizeAppSettings(
     warnings.push("newSidebarEnabled must be a boolean")
   }
 
+  const showMachineName = typeof source?.showMachineName === "boolean"
+    ? source.showMachineName
+    : false
+  if (source?.showMachineName !== undefined && typeof source.showMachineName !== "boolean") {
+    warnings.push("showMachineName must be a boolean")
+  }
+
   const rawNewProjectsDirectory = typeof source?.newProjectsDirectory === "string"
     ? source.newProjectsDirectory.trim()
     : ""
@@ -261,6 +271,7 @@ function normalizeAppSettings(
     },
     defaultProvider: normalizeDefaultProvider(source?.defaultProvider),
     providerDefaults: normalizeProviderDefaults(source?.providerDefaults),
+    showMachineName,
     newSidebarEnabled,
     newProjectsDirectory,
     // Onboarding markers default to false so a machine that has never run the
@@ -297,6 +308,7 @@ function toComparablePayload(source: AppSettingsFile) {
     transcript: source.transcript,
     defaultProvider: source.defaultProvider,
     providerDefaults: source.providerDefaults,
+    showMachineName: source.showMachineName,
     newSidebarEnabled: source.newSidebarEnabled,
     newProjectsDirectory: typeof source.newProjectsDirectory === "string"
       ? source.newProjectsDirectory.trim()

--- a/src/server/machine-name.test.ts
+++ b/src/server/machine-name.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
-import { getMachineDisplayName, readDevboxSubdomain, readMachineNameOverride } from "./machine-name"
+import { getMachineDisplayName, normalizeMachineHostname, readDevboxSubdomain, readMachineNameOverride } from "./machine-name"
 
 let tempDir: string | null = null
 const MISSING = "/nonexistent/never-here"
@@ -30,6 +30,17 @@ describe("machine-name override file", () => {
   test("missing or blank override files fall through", () => {
     expect(readMachineNameOverride(MISSING)).toBeNull()
     expect(readMachineNameOverride(tempFile("machine-name", "\n \n"))).toBeNull()
+  })
+})
+
+describe("machine hostname", () => {
+  test("normalizes local network suffixes", () => {
+    expect(normalizeMachineHostname("arpanet.local\n")).toBe("arpanet")
+    expect(normalizeMachineHostname("workstation.lan")).toBe("workstation")
+  })
+
+  test("falls back when the hostname is blank", () => {
+    expect(normalizeMachineHostname("  ")).toBe("This Machine")
   })
 })
 

--- a/src/server/machine-name.ts
+++ b/src/server/machine-name.ts
@@ -16,6 +16,14 @@ export function getMachineNameOverridePath() {
   return path.join(homedir(), ".kanna", "machine-name")
 }
 
+export function normalizeMachineHostname(rawHostname: string) {
+  return rawHostname.trim().replace(/\.local$|\.lan$/i, "") || "This Machine"
+}
+
+export function getMachineHostname() {
+  return normalizeMachineHostname(hostname())
+}
+
 /**
  * ~/.kanna/machine-name — explicit display-name override (first non-empty
  * line). Written by environments whose hostname is meaningless, e.g. deploy
@@ -66,6 +74,5 @@ export function getMachineDisplayName(identityPath?: string, overridePath?: stri
     }
   }
 
-  const rawHostname = hostname().trim()
-  return rawHostname.replace(/\.local$|\.lan$/i, "") || "This Machine"
+  return getMachineHostname()
 }

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -20,8 +20,9 @@ describe("read models", () => {
         localPath: projectDir,
         title: "Project",
         modifiedAt: 1,
-      }], "Machine")
+      }], "Friendly Machine", "arpanet")
 
+      expect(snapshot.machine).toMatchObject({ displayName: "Friendly Machine", hostname: "arpanet" })
       expect(snapshot.projects[0]?.folderModifiedAt).toBe(modifiedAt.getTime())
     } finally {
       rmSync(tempRoot, { recursive: true, force: true })

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -346,7 +346,8 @@ export function isCodexScratchWorkspacePath(localPath: string) {
 export function deriveLocalProjectsSnapshot(
   state: StoreState,
   discoveredProjects: Array<{ localPath: string; title: string; modifiedAt: number }>,
-  machineName: string
+  machineName: string,
+  machineHostname = machineName
 ): LocalProjectsSnapshot {
   const projects = new Map<string, LocalProjectsSnapshot["projects"][number]>()
 
@@ -385,6 +386,7 @@ export function deriveLocalProjectsSnapshot(
     machine: {
       id: "local",
       displayName: machineName,
+      hostname: machineHostname,
       platform: process.platform,
     },
     projects: [...projects.values()].sort((a, b) => (b.lastOpenedAt ?? 0) - (a.lastOpenedAt ?? 0)),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -32,7 +32,7 @@ import { handleTranscribe } from "./transcribe"
 import { applyPiFaveModels } from "./provider-catalog"
 import { createProcessAuthDeps, ProviderAuthManager } from "./provider-auth"
 import { fetchLatestPackageVersion } from "./cli-runtime"
-import { getMachineDisplayName } from "./machine-name"
+import { getMachineDisplayName, getMachineHostname } from "./machine-name"
 import { TerminalManager } from "./terminal-manager"
 import { UpdateManager } from "./update-manager"
 import type { UpdateInstallAttemptResult } from "./cli-runtime"
@@ -142,6 +142,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const store = new EventStore(options.dataDir)
   const diffStore = new DiffStore(store.dataDir)
   const machineDisplayName = getMachineDisplayName()
+  const machineHostname = getMachineHostname()
   // Mutable: device-code pairing can attach a cloud runtime mid-flight, and
   // every request path below reads the current value.
   let cloud: CloudRuntime | null = options.cloud ?? null
@@ -289,6 +290,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     refreshDiscovery,
     getDiscoveredProjects: () => discoveredProjects,
     machineDisplayName,
+    machineHostname,
     updateManager,
     providerAuth,
   })

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -78,6 +78,7 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
   devbox: false,
   analyticsEnabled: true,
   browserSettingsMigrated: false,
+  showMachineName: false,
   setupShown: false,
   setupCompleted: false,
   setupDismissed: false,

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -85,6 +85,7 @@ interface CreateWsRouterArgs {
   refreshDiscovery: () => Promise<DiscoveredProject[]>
   getDiscoveredProjects: () => DiscoveredProject[]
   machineDisplayName: string
+  machineHostname?: string
   updateManager: UpdateManager | null
   usageLimits?: Pick<UsageLimitsManager, "getSnapshot" | "refresh" | "onChange"> | null
   providerAuth?: Pick<
@@ -174,6 +175,7 @@ export function createWsRouter({
   refreshDiscovery,
   getDiscoveredProjects,
   machineDisplayName,
+  machineHostname,
   updateManager,
   usageLimits,
   providerAuth,
@@ -337,7 +339,12 @@ export function createWsRouter({
 
     if (topic.type === "local-projects") {
       const discoveredProjects = getDiscoveredProjects()
-      const data = deriveLocalProjectsSnapshot(store.state, discoveredProjects, machineDisplayName)
+      const data = deriveLocalProjectsSnapshot(
+        store.state,
+        discoveredProjects,
+        machineDisplayName,
+        machineHostname
+      )
 
       return {
         v: PROTOCOL_VERSION,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1027,6 +1027,7 @@ export interface LocalProjectsSnapshot {
   machine: {
     id: "local"
     displayName: string
+    hostname: string
     platform: NodeJS.Platform
   }
   projects: LocalProjectSummary[]
@@ -1106,6 +1107,8 @@ export interface AppSettingsSnapshot {
   }
   defaultProvider: DefaultProviderPreference
   providerDefaults: ChatProviderPreferences
+  /** Show this machine's hostname beside the Kanna wordmark in the sidebar header. */
+  showMachineName: boolean
   /** Labs: the tabbed Chats/Projects "New Sidebar". On by default; false opts back into the legacy sidebar. */
   newSidebarEnabled: boolean
   /** Base directory where cloned and newly created projects are placed. */
@@ -1134,6 +1137,7 @@ export interface AppSettingsPatch {
   theme?: AppThemePreference
   chatSoundPreference?: ChatSoundPreference
   chatSoundId?: ChatSoundId
+  showMachineName?: boolean
   newSidebarEnabled?: boolean
   newProjectsDirectory?: string
   setupShown?: boolean


### PR DESCRIPTION
## Summary

- detect and normalize the local machine hostname separately from its friendly cloud display name
- show the hostname beside the Kanna wordmark with responsive truncation
- add a persisted General setting that defaults to Off and controls hostname visibility

## Testing

- bunx tsc --noEmit
- bun test src/server/machine-name.test.ts src/server/read-models.test.ts src/server/app-settings.test.ts src/server/ws-router.test.ts src/client/app/SettingsPage.test.tsx src/client/app/App.test.tsx
- bun run build

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `codex/gpt-5.6-sol`.