### PR TITLE
Allow forking a chat while its turn is still running

### DIFF
--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1835,9 +1835,6 @@ export class AgentCoordinator {
 
   async forkChat(chatId: string) {
     const chat = this.store.requireChat(chatId)
-    if (this.activeTurns.has(chatId) || this.drainingStreams.has(chatId)) {
-      throw new Error("Chat must be idle before forking")
-    }
     if (!chat.provider) {
       throw new Error("Chat must have a provider before forking")
     }
@@ -1845,7 +1842,12 @@ export class AgentCoordinator {
       throw new Error("Chat has no session to fork")
     }
 
-    const forked = await this.store.forkChat(chatId)
+    // A running chat is forkable: the fork branches from the last completed
+    // turn, leaving the turn in flight out of the copy so it never inherits
+    // tool calls whose results have not arrived. Nothing here touches the
+    // source's turn — it keeps running.
+    const running = this.activeTurns.has(chatId) || this.drainingStreams.has(chatId)
+    const forked = await this.store.forkChat(chatId, { atLastCompletedTurn: running })
     this.analytics.track("chat_created")
     return { chatId: forked.id }
   }

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -26,10 +26,24 @@ async function createTempDataDir() {
   return dir
 }
 
-function entry(kind: "user_prompt" | "assistant_text", createdAt: number, extra: Record<string, unknown> = {}): TranscriptEntry {
+function entry(
+  kind: "user_prompt" | "assistant_text" | "result",
+  createdAt: number,
+  extra: Record<string, unknown> = {},
+): TranscriptEntry {
   const base = { _id: `${kind}-${createdAt}`, createdAt }
   if (kind === "user_prompt") {
     return { ...base, kind, content: String(extra.content ?? "") }
+  }
+  if (kind === "result") {
+    return {
+      ...base,
+      kind,
+      subtype: "success",
+      isError: false,
+      durationMs: Number(extra.durationMs ?? 0),
+      result: String(extra.result ?? ""),
+    }
   }
   return { ...base, kind, text: String(extra.content ?? extra.text ?? "") }
 }
@@ -837,6 +851,65 @@ describe("EventStore", () => {
     expect(forked.lastMessageAt).toBe(source.createdAt + 2)
     expect(forked.hasMessages).toBe(true)
     expect(store.getMessages(forked.id)).toEqual(store.getMessages(source.id))
+  })
+
+  test("forking mid-turn branches from the last completed turn", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const source = await store.createChat(project.id)
+    await store.setChatProvider(source.id, "claude")
+    await store.setSessionToken(source.id, "session-1")
+
+    // A turn that finished.
+    await store.recordTurnStarted(source.id)
+    await store.appendMessage(source.id, entry("user_prompt", 1_000, { content: "analyze this" }))
+    await store.appendMessage(source.id, entry("assistant_text", 2_000, { text: "analysis done" }))
+    await store.appendMessage(source.id, entry("result", 3_000, { result: "ok", durationMs: 5 }))
+    await store.recordTurnFinished(source.id)
+
+    // …and one still running: a prompt and a reply whose tool results haven't landed.
+    await store.recordTurnStarted(source.id)
+    await store.appendMessage(source.id, entry("user_prompt", 4_000, { content: "now refactor it" }))
+    await store.appendMessage(source.id, entry("assistant_text", 5_000, { text: "starting the refactor" }))
+
+    const forked = await store.forkChat(source.id, { atLastCompletedTurn: true })
+
+    // The copy stops at the completed turn's result — the in-flight prompt and
+    // its half-written reply stay behind with the source.
+    expect(store.getMessages(forked.id)).toEqual(store.getMessages(source.id).slice(0, 3))
+    expect(forked.lastMessageAt).toBe(3_000)
+    // Previews describe the branch point, not the turn the fork left behind.
+    expect(forked.lastUserMessagePreview).toBe("analyze this")
+    expect(forked.lastAgentMessagePreview).toBe("analysis done")
+    expect(forked.lastAgentMessageAt).toBe(3_000)
+    expect(forked.turnCount).toBe(1)
+    // The source is untouched: its turn is still running.
+    expect(store.getMessages(source.id)).toHaveLength(5)
+
+    const reloaded = new EventStore(dataDir)
+    await reloaded.initialize()
+    expect(reloaded.getMessages(forked.id)).toHaveLength(3)
+  })
+
+  test("refuses a mid-turn fork when no turn has completed yet", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const source = await store.createChat(project.id)
+    await store.setChatProvider(source.id, "claude")
+    await store.setSessionToken(source.id, "session-1")
+    await store.recordTurnStarted(source.id)
+    await store.appendMessage(source.id, entry("user_prompt", 1_000, { content: "first ever prompt" }))
+
+    const chatsBefore = store.listChatsByProject(project.id).length
+    await expect(store.forkChat(source.id, { atLastCompletedTurn: true })).rejects.toThrow(/no completed turn/)
+    // The refusal happens before anything is written — no half-built fork.
+    expect(store.listChatsByProject(project.id).length).toBe(chatsBefore)
   })
 
   test("lastAgentMessageAt tracks agent entries mid-turn, ignoring user prompts", async () => {

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -152,6 +152,56 @@ function isAgentAuthoredEntry(entry: TranscriptEntry) {
     || entry.kind === "result"
 }
 
+/**
+ * Index just past the last completed turn in a transcript, or 0 when no turn
+ * has finished yet. A turn closes with a `result` entry, or with `interrupted`
+ * when it was cancelled (Claude emits that instead of a result), so everything
+ * after the last of those belongs to a turn still in flight.
+ *
+ * Used to fork a chat mid-turn: the fork branches from the last settled point
+ * rather than inheriting a turn whose tool calls have no results yet.
+ */
+export function findLastCompletedTurnEnd(entries: TranscriptEntry[]) {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const kind = entries[index]!.kind
+    if (kind === "result" || kind === "interrupted") return index + 1
+  }
+  return 0
+}
+
+/**
+ * Re-derive the sidebar preview fields from a fork's copied transcript. Forks
+ * of an idle chat inherit these from the source record instead (it is the same
+ * conversation), but a fork taken mid-turn drops the running turn, so the
+ * source's fields would advertise a prompt the fork does not contain.
+ *
+ * Mirrors `applyMessageMetadata`, which derives the same fields on append.
+ */
+function summarizeForkedTranscript(entries: TranscriptEntry[]) {
+  const summary: {
+    lastUserMessagePreview?: string
+    lastAgentMessagePreview?: string
+    lastAgentMessagePreviewAt?: number
+    lastAgentMessageAt?: number
+  } = {}
+  for (const entry of entries) {
+    if (entry.kind === "user_prompt" && !entry.hidden) {
+      const preview = buildChatMessagePreview(entry.content)
+      if (preview) summary.lastUserMessagePreview = preview
+    } else if (entry.kind === "assistant_text" && !entry.hidden) {
+      const preview = buildChatMessagePreview(entry.text)
+      if (preview) {
+        summary.lastAgentMessagePreview = preview
+        summary.lastAgentMessagePreviewAt = entry.createdAt
+      }
+    }
+    if (isAgentAuthoredEntry(entry)) {
+      summary.lastAgentMessageAt = Math.max(summary.lastAgentMessageAt ?? 0, entry.createdAt)
+    }
+  }
+  return summary
+}
+
 function normalizeSidebarProjectOrder(value: unknown) {
   if (!Array.isArray(value)) {
     return []
@@ -1145,12 +1195,48 @@ export class EventStore {
     return this.state.chatsById.get(chatId)!
   }
 
-  async forkChat(sourceChatId: string) {
+  /**
+   * Copy a chat into a new one that resumes the same native session.
+   *
+   * `atLastCompletedTurn` trims the copied transcript to the last settled turn.
+   * That is how a chat with a turn in flight is forked: the fork starts from a
+   * conversation whose tool calls all have their results, and the source keeps
+   * running undisturbed.
+   */
+  async forkChat(sourceChatId: string, options?: { atLastCompletedTurn?: boolean }) {
     const sourceChat = this.requireChat(sourceChatId)
     const sourceSessionToken = sourceChat.sessionToken ?? sourceChat.pendingForkSessionToken ?? null
     if (!sourceChat.provider || !sourceSessionToken) {
       throw new Error("Chat cannot be forked")
     }
+
+    // Resolved before anything is written: a mid-turn fork of a chat whose
+    // first turn is still running has no settled branch point, and refusing
+    // here means it leaves no half-built chat behind.
+    const allEntries = this.getMessages(sourceChatId)
+    const branchPoint = options?.atLastCompletedTurn
+      ? findLastCompletedTurnEnd(allEntries)
+      : allEntries.length
+    if (branchPoint === 0 && allEntries.length > 0) {
+      throw new Error("Chat has no completed turn to fork from yet")
+    }
+    const droppedRunningTurn = branchPoint < allEntries.length
+
+    // A fork of an idle chat inherits these from the source record — same
+    // conversation, so the same counts and previews. A fork taken mid-turn left
+    // that turn behind, so its numbers come from the copied transcript instead.
+    const inherited = droppedRunningTurn
+      ? {
+          turnCount: Math.max(0, (sourceChat.turnCount ?? 0) - 1),
+          ...summarizeForkedTranscript(allEntries.slice(0, branchPoint)),
+        }
+      : {
+          turnCount: sourceChat.turnCount,
+          lastUserMessagePreview: sourceChat.lastUserMessagePreview,
+          lastAgentMessagePreview: sourceChat.lastAgentMessagePreview,
+          lastAgentMessagePreviewAt: sourceChat.lastAgentMessagePreviewAt,
+          lastAgentMessageAt: sourceChat.lastAgentMessageAt,
+        }
 
     const chatId = crypto.randomUUID()
     const createdAt = Date.now()
@@ -1182,7 +1268,8 @@ export class EventStore {
 
     // The fork gets its own copy of any images, and its entries point at
     // that copy, so deleting the source later does not blank its screenshots.
-    const sourceEntries = this.getMessages(sourceChatId)
+    const sourceEntries = allEntries
+      .slice(0, branchPoint)
       .map((entry) => retargetEntryMediaUrls(entry, sourceChatId, chatId))
     if (sourceEntries.length > 0) {
       const transcriptPath = this.transcriptPath(chatId)
@@ -1201,16 +1288,16 @@ export class EventStore {
           // The fork's conversation *is* the source's, so it inherits its turns
           // too — a fork of a twenty-turn chat has twenty turns behind it, and
           // starting the count from zero would read as a fresh chat.
-          if (sourceChat.turnCount) chat.turnCount = sourceChat.turnCount
-          if (sourceChat.lastUserMessagePreview) chat.lastUserMessagePreview = sourceChat.lastUserMessagePreview
-          if (sourceChat.lastAgentMessagePreview) {
-            chat.lastAgentMessagePreview = sourceChat.lastAgentMessagePreview
-            chat.lastAgentMessagePreviewAt = sourceChat.lastAgentMessagePreviewAt
+          if (inherited.turnCount) chat.turnCount = inherited.turnCount
+          if (inherited.lastUserMessagePreview) chat.lastUserMessagePreview = inherited.lastUserMessagePreview
+          if (inherited.lastAgentMessagePreview) {
+            chat.lastAgentMessagePreview = inherited.lastAgentMessagePreview
+            chat.lastAgentMessagePreviewAt = inherited.lastAgentMessagePreviewAt
           }
           // Same transcript, so the same last-agent-activity timestamp a
           // reload would derive from it.
-          if (sourceChat.lastAgentMessageAt != null) {
-            chat.lastAgentMessageAt = Math.max(chat.lastAgentMessageAt ?? 0, sourceChat.lastAgentMessageAt)
+          if (inherited.lastAgentMessageAt != null) {
+            chat.lastAgentMessageAt = Math.max(chat.lastAgentMessageAt ?? 0, inherited.lastAgentMessageAt)
           }
         }
         this.setCachedTranscript(chatId, cloneTranscriptEntries(sourceEntries))

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -556,7 +556,7 @@ describe("read models", () => {
     expect(sidebar.projectGroups[0]?.olderChats.map((chat) => chat.chatId)).toEqual([])
   })
 
-  test("disables forking for active and draining chats, but allows pending fork chats", () => {
+  test("forks a busy chat only once it has a completed turn to branch from", () => {
     const state = createEmptyState()
     state.projectsById.set("project-1", {
       id: "project-1",
@@ -619,14 +619,31 @@ describe("read models", () => {
       sessionToken: "cursor-session",
       lastTurnOutcome: null,
     })
+    // Busy, but with a settled turn behind it — the fork branches from there.
+    state.chatsById.set("chat-active-again", {
+      id: "chat-active-again",
+      projectId: "project-1",
+      title: "Active again",
+      createdAt: 5,
+      updatedAt: 5,
+      unread: false,
+      provider: "claude",
+      planMode: false,
+      autoPlan: false,
+      sessionToken: "session-active-again",
+      lastTurnEndedAt: 4,
+      lastTurnOutcome: "success",
+    })
 
     const sidebar = deriveSidebarData(
       state,
-      new Map([["chat-active", "running"]]),
+      new Map([["chat-active", "running"], ["chat-active-again", "running"]]),
       { drainingChatIds: new Set(["chat-draining"]) }
     )
 
+    // Still inside its first turn: nothing settled to branch from.
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-active")?.canFork).toBeUndefined()
+    expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-active-again")?.canFork).toBe(true)
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-pending")?.canFork).toBe(true)
     expect(sidebar.projectGroups[0]?.chats.find((chat) => chat.chatId === "chat-draining")?.canFork).toBeUndefined()
     // Cursor has no fork primitive, so forking is disabled even with a live session.

--- a/src/server/read-models.ts
+++ b/src/server/read-models.ts
@@ -72,8 +72,11 @@ function canForkChat(
   // Cursor has no fork/branch primitive, so forking would silently start a fresh session.
   if (chat.provider === "cursor") return false
   if (!chat.sessionToken && !chat.pendingForkSessionToken) return false
-  if (activeStatuses.has(chat.id)) return false
-  if (drainingChatIds.has(chat.id)) return false
+  // A chat with a turn in flight forks from its last completed turn, so it
+  // needs one: a chat still inside its very first turn has no branch point.
+  if (activeStatuses.has(chat.id) || drainingChatIds.has(chat.id)) {
+    return chat.lastTurnEndedAt != null
+  }
   return true
 }
 


### PR DESCRIPTION
Forking required an idle chat, so branching off a long-running turn meant waiting for it or interrupting it. A running chat is now forkable: the fork branches from the **last completed turn**, and the source keeps running untouched.

### Why not copy the in-flight turn

Copying it verbatim would hand the fork a conversation head whose tool calls have no results yet. So `EventStore.forkChat` takes `atLastCompletedTurn` and trims the copy at the last `result` entry — or `interrupted`, which is what Claude emits for a cancelled turn.

- `agent.ts` — the `"Chat must be idle before forking"` throw is gone; it passes `atLastCompletedTurn` when the chat has an active or draining turn.
- `event-store.ts` — new `findLastCompletedTurnEnd`; entry resolution moved above the first write, so a refused fork leaves no half-built chat behind. Sidebar previews are re-derived from the trimmed copy via `summarizeForkedTranscript` (inheriting them from the source record would advertise the prompt the fork deliberately left behind), and the turn count drops the turn in flight.
- `read-models.ts` — `canForkChat` allows busy chats that have a `lastTurnEndedAt`. A chat still inside its very first turn has no settled branch point and stays unforkable.

Composes with the existing media-URL retargeting on copy.

### Known gap

The native session fork still happens when the fork is **first prompted**, not when it is created — `pendingForkSessionToken` is consumed then. A fork prompted after the source's turn lands therefore resumes a session that contains that turn: the fork's visible transcript stops at the branch point, but the harness's context won't. Pinning the branch point needs Claude's `resumeSessionAt` (our entries already carry the message uuid in `messageId`); codex's `thread/fork` takes only a thread id, so it would be Claude-only. Left for a follow-up.

### Testing

`bun run check` clean. Full `bun test` green (1704 tests). New coverage: a mid-turn fork trims the copy and survives a reload; a first-turn fork is refused without creating a chat; the sidebar affordance appears for a busy chat only once a turn has completed.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus`.