### PR TITLE
Fix opening URL-encoded local file links

### DIFF
--- a/src/client/lib/pathUtils.test.ts
+++ b/src/client/lib/pathUtils.test.ts
@@ -32,6 +32,64 @@ describe("parseLocalFileLink", () => {
     })
   })
 
+  test("decodes a percent-encoded absolute file path", () => {
+    expect(parseLocalFileLink("/Users/example/My%20Project/report.xlsx")).toEqual({
+      path: "/Users/example/My Project/report.xlsx",
+    })
+  })
+
+  test("decodes the path without disturbing line selectors", () => {
+    expect(parseLocalFileLink("/Users/example/My%20Project/app.ts#L12")).toEqual({
+      path: "/Users/example/My Project/app.ts",
+      line: 12,
+      column: undefined,
+    })
+    expect(parseLocalFileLink("/Users/example/My%20Project/app.ts:12:3")).toEqual({
+      path: "/Users/example/My Project/app.ts",
+      line: 12,
+      column: 3,
+    })
+  })
+
+  test("does not treat encoded selector characters as line selectors", () => {
+    expect(parseLocalFileLink("/tmp/report%23L12.ts")).toEqual({
+      path: "/tmp/report#L12.ts",
+    })
+    expect(parseLocalFileLink("/tmp/report%3A12")).toEqual({
+      path: "/tmp/report:12",
+    })
+  })
+
+  test("decodes percent encoding only once", () => {
+    expect(parseLocalFileLink("/tmp/percent%2520name.txt")).toEqual({
+      path: "/tmp/percent%20name.txt",
+    })
+  })
+
+  test("preserves a path with malformed percent encoding", () => {
+    expect(parseLocalFileLink("/tmp/100%done.txt")).toEqual({
+      path: "/tmp/100%done.txt",
+    })
+  })
+
+  test("preserves encoded separators and NUL bytes", () => {
+    expect(parseLocalFileLink("/tmp/encoded%2Fslash.txt")).toEqual({
+      path: "/tmp/encoded%2Fslash.txt",
+    })
+    expect(parseLocalFileLink("/tmp/encoded%5Cbackslash.txt")).toEqual({
+      path: "/tmp/encoded%5Cbackslash.txt",
+    })
+    expect(parseLocalFileLink("/tmp/encoded%00nul.txt")).toEqual({
+      path: "/tmp/encoded%00nul.txt",
+    })
+  })
+
+  test("decodes a percent-encoded Unicode file name", () => {
+    expect(parseLocalFileLink("/tmp/caf%C3%A9.txt")).toEqual({
+      path: "/tmp/café.txt",
+    })
+  })
+
   test("parses an absolute file path with a line suffix", () => {
     expect(parseLocalFileLink("/Users/jake/Kanna/superwall-agent/scripts/e2b-proxy.mjs:1")).toEqual({
       path: "/Users/jake/Kanna/superwall-agent/scripts/e2b-proxy.mjs",
@@ -48,7 +106,7 @@ describe("parseLocalFileLink", () => {
     })
   })
 
-  test("parses same-origin absolute file urls with a line suffix", () => {
+  test("parses same-origin absolute file urls", () => {
     const originalWindow = globalThis.window
     Object.defineProperty(globalThis, "window", {
       value: {
@@ -65,6 +123,9 @@ describe("parseLocalFileLink", () => {
         line: 1,
         column: undefined,
       })
+      expect(parseLocalFileLink("http://localhost:9000/Users/example/My%20Project/report.xlsx")).toEqual({
+        path: "/Users/example/My Project/report.xlsx",
+      })
     } finally {
       Object.defineProperty(globalThis, "window", {
         value: originalWindow,
@@ -75,6 +136,7 @@ describe("parseLocalFileLink", () => {
 
   test("does not treat web links as local file links", () => {
     expect(parseLocalFileLink("https://example.com")).toBeNull()
+    expect(parseLocalFileLink("https://example.com/My%20Project/report.xlsx")).toBeNull()
   })
 })
 

--- a/src/client/lib/pathUtils.ts
+++ b/src/client/lib/pathUtils.ts
@@ -41,11 +41,21 @@ function toPositiveInteger(value: string | undefined) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function decodeLocalFilePath(filePath: string) {
+  // Keep separator and NUL escapes encoded while decoding the rest once.
+  const pathWithProtectedEscapes = filePath.replace(/%(2f|5c|00)/gi, "%25$1")
+  try {
+    return decodeURIComponent(pathWithProtectedEscapes)
+  } catch {
+    return filePath
+  }
+}
+
 function parseAbsoluteFileTarget(target: string): ParsedFileTarget | null {
   const hashMatch = /^(?<path>\/.+?)#L(?<line>\d+)(?:C(?<column>\d+))?$/.exec(target)
   if (hashMatch?.groups?.path) {
     return {
-      path: hashMatch.groups.path,
+      path: decodeLocalFilePath(hashMatch.groups.path),
       line: toPositiveInteger(hashMatch.groups.line),
       column: toPositiveInteger(hashMatch.groups.column),
     }
@@ -54,14 +64,14 @@ function parseAbsoluteFileTarget(target: string): ParsedFileTarget | null {
   const suffixMatch = /^(?<path>\/.+?):(?<line>\d+)(?::(?<column>\d+))?$/.exec(target)
   if (suffixMatch?.groups?.path) {
     return {
-      path: suffixMatch.groups.path,
+      path: decodeLocalFilePath(suffixMatch.groups.path),
       line: toPositiveInteger(suffixMatch.groups.line),
       column: toPositiveInteger(suffixMatch.groups.column),
     }
   }
 
   if (target.startsWith("/")) {
-    return { path: target }
+    return { path: decodeLocalFilePath(target) }
   }
 
   return null


### PR DESCRIPTION
## Summary

- Decode percent-encoded filesystem paths parsed from local Markdown links.
- Add regression coverage for paths containing spaces and one-pass decoding.

### ELI5

Browsers write a space in a link as `%20`. Kanna forgot to translate that shorthand back, so it asked the computer for a file inside `My%20Project` even though the real folder was `My Project`. Because spaces are common in folder names, otherwise valid local links could not open. We now translate the local path back exactly once, at the URL-to-filesystem boundary, while keeping line references and unsafe encoded separators intact.

## Root cause

`react-markdown` supplies an encoded href such as `My%20Project`, while `parseLocalFileLink` forwarded that value unchanged to `system.openExternal`. The backend consequently looked for a path containing the literal `%20`.

## Why this layer

Decoding belongs at the URL-to-filesystem boundary. `resolveLocalPath` also handles raw filesystem input and should not reinterpret percent sequences globally. Line selectors are separated before decoding, malformed encoding is preserved, and encoded separators or NUL bytes remain encoded.

## Before / After

- Before: `/Users/example/My%20Project/report.xlsx` reached `stat()` unchanged and failed.
- After: the parser passes `/Users/example/My Project/report.xlsx` to `system.openExternal`.

## Verification

- `bun test src/client/lib/pathUtils.test.ts` — 18 passed.
- `bun run check` — passed (typecheck and both production builds).
- `bun test src/server/auth.test.ts src/server/uploads.test.ts` — 23 passed.
- `bun test` — 1,699 passed; unrelated parallel server-test failures were also reproduced on `origin/main`, which likewise passed 1,699 tests.
- Normal Chrome smoke test with a temporary `.xlsx` file in a directory containing a space — the default-open command received the decoded existing path, with no `Path not found` error.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `codex/gpt-5.6-sol`.
