### PR TITLE
Rename a chat after its first turn when the title is too generic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ React client (src/client)
 - Provider adapters normalize three different wire protocols into
   `HarnessEvent`s (`harness-types.ts`). Claude runs through the Agent SDK in
   `agent.ts` directly; codex/cursor/pi produce `HarnessTurn`s.
+- Chat titles are generated twice: once from the opening message
+  (`generate-title.ts`, optimistic fallback first), then once more after the
+  first turn finishes (`refine-title.ts`), where a small model may replace a
+  title too generic to find the chat by. `ChatRecord.titleSource` gates the
+  second pass — a rename with no source is a person typing, and nothing
+  automatic touches the title again.
 - Transcripts are append-only JSONL per chat (`transcripts/<chatId>.jsonl`)
   with a small LRU cache in the EventStore. `debugRaw` (raw provider JSON) is
   stamped only on `system_init` — the one entry with a raw JSON view. Tool

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -13,8 +13,53 @@ import {
 } from "./agent"
 import type { HarnessTurn } from "./harness-types"
 import type { ChatAttachment, TranscriptEntry } from "../shared/types"
+import type { RefineChatTitleArgs } from "./refine-title"
 import type { SessionArtifactStatus } from "./session-artifacts"
 import { timestamped } from "./transcript"
+
+/** A codex manager whose turn says one thing and finishes — enough to title. */
+function createTitleTurnCodexManager(assistantText: string) {
+  return {
+    async startSession() {},
+    async startTurn(): Promise<HarnessTurn> {
+      async function* stream() {
+        yield {
+          type: "transcript" as const,
+          entry: timestamped({
+            kind: "system_init",
+            provider: "codex",
+            model: "gpt-5.4",
+            tools: [],
+            agents: [],
+            slashCommands: [],
+            mcpServers: [],
+          }),
+        }
+        yield {
+          type: "transcript" as const,
+          entry: timestamped({ kind: "assistant_text", text: assistantText }),
+        }
+        yield {
+          type: "transcript" as const,
+          entry: timestamped({
+            kind: "result",
+            subtype: "success",
+            isError: false,
+            durationMs: 0,
+            result: "",
+          }),
+        }
+      }
+
+      return {
+        provider: "codex",
+        stream: stream(),
+        interrupt: async () => {},
+        close: () => {},
+      }
+    },
+  }
+}
 
 async function waitFor(condition: () => boolean, timeoutMs = 2000) {
   const start = Date.now()
@@ -370,6 +415,7 @@ describe("AgentCoordinator codex integration", () => {
           failureMessage: null,
         }
       },
+      refineTitle: async () => ({ title: null, failureMessage: null }),
     })
 
     await coordinator.send({
@@ -441,6 +487,7 @@ describe("AgentCoordinator codex integration", () => {
           failureMessage: null,
         }
       },
+      refineTitle: async () => ({ title: null, failureMessage: null }),
     })
 
     await coordinator.send({
@@ -526,6 +573,140 @@ describe("AgentCoordinator codex integration", () => {
     expect(backgroundErrors).toEqual([
       "[title-generation] chat chat-1 failed provider title generation: claude failed conversation title generation: Not authenticated",
     ])
+  })
+
+  test("renames a generic auto title once the first turn shows what the chat is about", async () => {
+    const store = createFakeStore()
+    const refineCalls: RefineChatTitleArgs[] = []
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: createTitleTurnCodexManager("The web SDK never fires the paywall event.") as never,
+      generateTitle: async () => ({
+        title: "Investigate Slack Thread",
+        usedFallback: false,
+        failureMessage: null,
+      }),
+      refineTitle: async (args) => {
+        refineCalls.push(args)
+        return { title: "Web SDK paywall event", failureMessage: null }
+      },
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "look at this slack thread",
+      model: "gpt-5.4",
+    })
+
+    await waitFor(() => store.chat.title === "Web SDK paywall event")
+    expect(store.chat.titleSource).toBe("refined")
+    // It judges the generated title, not the optimistic first-message one.
+    expect(refineCalls[0]?.currentTitle).toBe("Investigate Slack Thread")
+    expect(refineCalls[0]?.digest).toContain("look at this slack thread")
+    expect(refineCalls[0]?.digest).toContain("The web SDK never fires the paywall event.")
+  })
+
+  test("keeps the auto title when the refiner says it is already specific", async () => {
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: createTitleTurnCodexManager("Fixed it.") as never,
+      generateTitle: async () => ({
+        title: "Web SDK paywall event",
+        usedFallback: false,
+        failureMessage: null,
+      }),
+      refineTitle: async () => ({ title: null, failureMessage: null }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "the paywall event never fires",
+      model: "gpt-5.4",
+    })
+
+    await waitFor(() => store.turnFinishedCount === 1)
+    expect(store.chat.title).toBe("Web SDK paywall event")
+    expect(store.chat.titleSource).toBe("auto")
+  })
+
+  test("never refines a title the user typed", async () => {
+    const store = createFakeStore()
+    let refineCalls = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: createTitleTurnCodexManager("Done.") as never,
+      generateTitle: async () => ({
+        title: "Investigate Slack Thread",
+        usedFallback: false,
+        failureMessage: null,
+      }),
+      refineTitle: async () => {
+        refineCalls += 1
+        return { title: "Web SDK paywall event", failureMessage: null }
+      },
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "look at this slack thread",
+      model: "gpt-5.4",
+    })
+    await store.renameChat("chat-1", "Manual title")
+
+    await waitFor(() => store.turnFinishedCount === 1)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(store.chat.title).toBe("Manual title")
+    expect(refineCalls).toBe(0)
+  })
+
+  test("only refines the first turn of a chat", async () => {
+    const store = createFakeStore()
+    let refineCalls = 0
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      codexManager: createTitleTurnCodexManager("Done.") as never,
+      generateTitle: async () => ({
+        title: "Investigate Slack Thread",
+        usedFallback: false,
+        failureMessage: null,
+      }),
+      refineTitle: async () => {
+        refineCalls += 1
+        return { title: null, failureMessage: null }
+      },
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "look at this slack thread",
+      model: "gpt-5.4",
+    })
+    await waitFor(() => refineCalls === 1)
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "codex",
+      content: "and now fix it",
+      model: "gpt-5.4",
+    })
+    await waitFor(() => store.turnFinishedCount === 2)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(refineCalls).toBe(1)
   })
 
   test("binds codex provider and reuses the session token on later turns", async () => {
@@ -2378,6 +2559,8 @@ function createFakeChat(id: string, projectId: string, title = "New Chat") {
     id,
     projectId,
     title,
+    titleSource: undefined as "auto" | "refined" | undefined,
+    turnCount: 0,
     provider: null as "claude" | "codex" | null,
     planMode: false,
     autoPlan: false,
@@ -2427,13 +2610,20 @@ function createFakeStore(options?: {
     async setAutoPlan(chatId: string, autoPlan: boolean) {
       requireChat(chatId).autoPlan = autoPlan
     },
-    async renameChat(chatId: string, title: string) {
-      requireChat(chatId).title = title
+    async renameChat(chatId: string, title: string, options?: { source?: "auto" | "refined" }) {
+      const target = requireChat(chatId)
+      target.title = title
+      target.titleSource = options?.source
     },
     async appendMessage(_chatId: string, entry: TranscriptEntry) {
       this.messages.push(entry)
     },
-    async recordTurnStarted() {},
+    getTranscriptHeaders() {
+      return this.messages
+    },
+    async recordTurnStarted(chatId: string) {
+      requireChat(chatId).turnCount += 1
+    },
     async recordTurnFinished() {
       this.turnFinishedCount += 1
     },

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -25,6 +25,12 @@ import { CodexAppServerManager } from "./codex-app-server"
 import { CursorCliManager } from "./cursor-cli"
 import { PiAgentManager, resolvePiConnection } from "./pi-agent"
 import { type GenerateChatTitleResult, generateTitleForChatDetailed } from "./generate-title"
+import {
+  type RefineChatTitleArgs,
+  type RefineChatTitleResult,
+  buildTurnDigest,
+  refineChatTitleDetailed,
+} from "./refine-title"
 import type { ClaudeRateLimitInfoRaw, ClaudeUsageRaw } from "./usage-limits"
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
 import {
@@ -193,6 +199,7 @@ interface AgentCoordinatorArgs {
   piManager?: PiAgentManager
   resolvePiConnection?: () => Promise<import("./pi-agent").PiConnection | null>
   generateTitle?: (messageContent: string, cwd: string) => Promise<GenerateChatTitleResult>
+  refineTitle?: (args: RefineChatTitleArgs) => Promise<RefineChatTitleResult>
   startClaudeSession?: (args: {
     localPath: string
     model: string
@@ -853,11 +860,16 @@ export class AgentCoordinator {
   private readonly piManager: PiAgentManager
   private readonly resolvePiConnection: () => Promise<import("./pi-agent").PiConnection | null>
   private readonly generateTitle: (messageContent: string, cwd: string) => Promise<GenerateChatTitleResult>
+  private readonly refineTitle: (args: RefineChatTitleArgs) => Promise<RefineChatTitleResult>
   private readonly startClaudeSessionFn: NonNullable<AgentCoordinatorArgs["startClaudeSession"]>
   private readonly checkSessionArtifactFn: NonNullable<AgentCoordinatorArgs["checkSessionArtifact"]>
   private reportBackgroundError: ((message: string) => void) | null = null
   private onClaudeRateLimit: ((info: ClaudeRateLimitInfoRaw) => void) | null = null
   private cursorModelCatalogApplied = false
+  /** First-message title generation still in flight, keyed by chat. */
+  private readonly pendingTitleGeneration = new Map<string, Promise<void>>()
+  /** Chats the post-turn title refiner has already looked at this process. */
+  private readonly refinedTitles = new Set<string>()
   readonly activeTurns = new Map<string, ActiveTurn>()
   readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
   readonly claudeSessions = new Map<string, ClaudeSessionState>()
@@ -871,6 +883,7 @@ export class AgentCoordinator {
     this.piManager = args.piManager ?? new PiAgentManager()
     this.resolvePiConnection = args.resolvePiConnection ?? resolvePiConnection
     this.generateTitle = args.generateTitle ?? generateTitleForChatDetailed
+    this.refineTitle = args.refineTitle ?? refineChatTitleDetailed
     this.startClaudeSessionFn = args.startClaudeSession ?? startClaudeSession
     this.checkSessionArtifactFn = args.checkSessionArtifact ?? checkSessionArtifact
   }
@@ -1286,7 +1299,7 @@ export class AgentCoordinator {
     const optimisticTitle = shouldGenerateTitle ? fallbackTitleFromMessage(args.content) : null
 
     if (optimisticTitle) {
-      await this.store.renameChat(args.chatId, optimisticTitle)
+      await this.store.renameChat(args.chatId, optimisticTitle, { source: "auto" })
     }
 
     const project = this.store.getProject(chat.projectId)
@@ -1333,7 +1346,20 @@ export class AgentCoordinator {
     await this.store.recordTurnStarted(args.chatId, args.model)
 
     if (shouldGenerateTitle) {
-      void this.generateTitleInBackground(args.chatId, args.content, project.localPath, optimisticTitle ?? "New Chat")
+      // Held so the post-turn refiner judges the generated title rather than
+      // racing it — the two run against the same first turn.
+      const generation = this.generateTitleInBackground(
+        args.chatId,
+        args.content,
+        project.localPath,
+        optimisticTitle ?? "New Chat"
+      )
+      this.pendingTitleGeneration.set(args.chatId, generation)
+      void generation.finally(() => {
+        if (this.pendingTitleGeneration.get(args.chatId) === generation) {
+          this.pendingTitleGeneration.delete(args.chatId)
+        }
+      })
     }
 
     const onToolRequest = async (request: HarnessToolRequest): Promise<unknown> => {
@@ -1979,6 +2005,7 @@ export class AgentCoordinator {
             await this.store.recordTurnFailed(session.chatId, event.entry.result || "Turn failed")
           } else if (!active.cancelRequested) {
             await this.store.recordTurnFinished(session.chatId)
+            void this.maybeRefineTitleAfterTurn(session.chatId)
           }
           this.activeTurns.delete(session.chatId)
           if (!active.cancelRequested) {
@@ -2037,12 +2064,66 @@ export class AgentCoordinator {
       const chat = this.store.requireChat(chatId)
       if (chat.title !== expectedCurrentTitle) return
 
-      await this.store.renameChat(chatId, result.title)
+      await this.store.renameChat(chatId, result.title, { source: "auto" })
       this.emitStateChange(chatId)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.reportBackgroundError?.(
         `[title-generation] chat ${chatId} failed background title generation: ${message}`
+      )
+    }
+  }
+
+  /**
+   * Second look at the title once the chat's first turn has landed.
+   *
+   * The original is generated from the opening message alone, so it names
+   * whatever the user opened with ("Investigate Slack thread") rather than what
+   * the chat turned out to be about (the web SDK bug in that thread). Now that
+   * there's a turn to read, give a small model the chance to say the title is
+   * too generic to find later and replace it — most of the time it keeps it.
+   *
+   * Only ever fires on the first successful turn of a chat whose title we
+   * generated ourselves: a hand-typed name is never touched.
+   */
+  private async maybeRefineTitleAfterTurn(chatId: string) {
+    if (this.refinedTitles.has(chatId)) return
+    try {
+      // Judge the generated title, not the placeholder it replaces.
+      await this.pendingTitleGeneration.get(chatId)
+
+      const chat = this.store.getChat(chatId)
+      if (!chat || chat.titleSource !== "auto") return
+      if ((chat.turnCount ?? 0) !== 1) return
+      const project = this.store.getProject(chat.projectId)
+      if (!project) return
+
+      const digest = buildTurnDigest(this.store.getTranscriptHeaders(chatId))
+      if (!digest) return
+
+      this.refinedTitles.add(chatId)
+      const result = await this.refineTitle({
+        currentTitle: chat.title,
+        digest,
+        cwd: project.localPath,
+      })
+      if (result.failureMessage) {
+        this.reportBackgroundError?.(
+          `[title-refinement] chat ${chatId} failed provider title refinement: ${result.failureMessage}`
+        )
+      }
+      if (!result.title) return
+
+      // The user may have renamed it while we were thinking; their name wins.
+      const current = this.store.getChat(chatId)
+      if (!current || current.titleSource !== "auto" || current.title !== chat.title) return
+
+      await this.store.renameChat(chatId, result.title, { source: "refined" })
+      this.emitStateChange(chatId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.reportBackgroundError?.(
+        `[title-refinement] chat ${chatId} failed background title refinement: ${message}`
       )
     }
   }
@@ -2080,6 +2161,7 @@ export class AgentCoordinator {
             await this.store.recordTurnFailed(active.chatId, event.entry.result || "Turn failed")
           } else if (!active.cancelRequested) {
             await this.store.recordTurnFinished(active.chatId)
+            void this.maybeRefineTitleAfterTurn(active.chatId)
           }
           // Remove from activeTurns as soon as the result arrives so the UI
           // transitions to idle immediately. The stream may still be open

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -216,6 +216,36 @@ describe("EventStore", () => {
     expect(reloaded.getChat(chat.id)?.unread).toBe(true)
   })
 
+  test("records who named a chat, and forgets automation once a person renames it", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+
+    const project = await store.openProject("/tmp/project")
+    const chat = await store.createChat(project.id)
+    expect(store.getChat(chat.id)?.titleSource).toBeUndefined()
+
+    await store.renameChat(chat.id, "Investigate Slack thread", { source: "auto" })
+    expect(store.getChat(chat.id)?.titleSource).toBe("auto")
+
+    await store.renameChat(chat.id, "Web SDK paywall event", { source: "refined" })
+    expect(store.getChat(chat.id)?.titleSource).toBe("refined")
+
+    await store.compact()
+    const reloaded = new EventStore(dataDir)
+    await reloaded.initialize()
+    expect(reloaded.getChat(chat.id)?.titleSource).toBe("refined")
+
+    await reloaded.renameChat(chat.id, "My name for it")
+    expect(reloaded.getChat(chat.id)?.titleSource).toBeUndefined()
+
+    // Same text, now hand-typed: the source has to change even though the
+    // title did not, or automation would still think it owns the name.
+    await reloaded.renameChat(chat.id, "Auto name", { source: "auto" })
+    await reloaded.renameChat(chat.id, "Auto name")
+    expect(reloaded.getChat(chat.id)?.titleSource).toBeUndefined()
+  })
+
   test("stores and resolves a read anchor across restart", async () => {
     const dataDir = await createTempDataDir()
     const store = new EventStore(dataDir)

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -691,6 +691,13 @@ export class EventStore {
         const chat = this.state.chatsById.get(event.chatId)
         if (!chat) break
         chat.title = event.title
+        // A rename with no source is a person typing, and it takes the title
+        // out of automation's hands for good.
+        if (event.source) {
+          chat.titleSource = event.source
+        } else {
+          delete chat.titleSource
+        }
         chat.updatedAt = event.timestamp
         break
       }
@@ -1229,17 +1236,23 @@ export class EventStore {
     return this.state.chatsById.get(chatId)!
   }
 
-  async renameChat(chatId: string, title: string) {
+  /**
+   * `source` records who named the chat: omit it for a user rename, which is
+   * final, or pass "auto"/"refined" for a generated one, which the post-turn
+   * refiner is still allowed to revisit.
+   */
+  async renameChat(chatId: string, title: string, options?: { source?: "auto" | "refined" }) {
     const trimmed = title.trim()
     if (!trimmed) return
     const chat = this.requireChat(chatId)
-    if (chat.title === trimmed) return
+    if (chat.title === trimmed && chat.titleSource === options?.source) return
     const event: ChatEvent = {
       v: STORE_VERSION,
       type: "chat_renamed",
       timestamp: Date.now(),
       chatId,
       title: trimmed,
+      ...(options?.source ? { source: options.source } : {}),
     }
     await this.append(this.chatsLogPath, event)
   }
@@ -1888,6 +1901,15 @@ export class EventStore {
     return entries.map((entry) => entry.trimmed
       ? mergeTranscriptPayload({ ...entry }, payloads.get(entry._id))
       : { ...entry })
+  }
+
+  /**
+   * The transcript in header form — tool bodies left in the sidecar. For
+   * readers that only need to know *what* happened (titles, summaries), not
+   * what the tools returned.
+   */
+  getTranscriptHeaders(chatId: string) {
+    return cloneTranscriptEntries(this.getTranscriptEntries(chatId))
   }
 
   getQueuedMessages(chatId: string) {

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -33,6 +33,13 @@ export interface ChatRecord {
   id: string
   projectId: string
   title: string
+  /**
+   * Where the current title came from. "auto" — generated from the opening
+   * message before any work happened, so the post-turn refiner is allowed to
+   * replace it. "refined" — the refiner has already had its look. Absent means
+   * a person named it (or a fork inherited it), and nothing renames it again.
+   */
+  titleSource?: "auto" | "refined"
   createdAt: number
   updatedAt: number
   deletedAt?: number
@@ -212,6 +219,12 @@ export type ChatEvent =
       timestamp: number
       chatId: string
       title: string
+      /**
+       * Who named it. Absent means the user did, which is the only answer old
+       * logs can give and the one that keeps automation off a hand-typed name.
+       * See `ChatRecord.titleSource`.
+       */
+      source?: "auto" | "refined"
     }
   | {
       v: 2

--- a/src/server/generate-title.ts
+++ b/src/server/generate-title.ts
@@ -9,7 +9,7 @@ const TITLE_SCHEMA = {
   additionalProperties: false,
 } as const
 
-function normalizeGeneratedTitle(value: unknown): string | null {
+export function normalizeGeneratedTitle(value: unknown): string | null {
   if (typeof value !== "string") return null
   const normalized = value.replace(/\s+/g, " ").trim().slice(0, 80)
   if (!normalized || normalized === "New Chat") return null

--- a/src/server/refine-title.test.ts
+++ b/src/server/refine-title.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import { QuickResponseAdapter } from "./quick-response"
+import { buildTurnDigest, refineChatTitleDetailed } from "./refine-title"
+import { timestamped } from "./transcript"
+
+let nextId = 0
+function entry<T extends Parameters<typeof timestamped>[0]>(partial: T) {
+  nextId += 1
+  return timestamped(partial, nextId)
+}
+
+function disabledLlmProvider() {
+  return {
+    provider: "openai" as const,
+    apiKey: "",
+    model: "",
+    baseUrl: "",
+    resolvedBaseUrl: "https://api.openai.com/v1",
+    faveModels: [],
+    enabled: false,
+    warning: null,
+    filePathDisplay: "~/.kanna/llm-provider.json",
+  }
+}
+
+function adapterReturning(value: unknown, calls?: { prompts: string[] }) {
+  return new QuickResponseAdapter({
+    readLlmProvider: async () => disabledLlmProvider(),
+    runClaudeStructured: async (args) => {
+      calls?.prompts.push(args.prompt)
+      return value
+    },
+    runCodexStructured: async () => null,
+  })
+}
+
+describe("buildTurnDigest", () => {
+  test("names the prompt, the work, and how the turn ended", () => {
+    const digest = buildTurnDigest([
+      entry({ kind: "user_prompt", content: "Look at   this slack thread please" }),
+      entry({
+        kind: "tool_call",
+        tool: { kind: "tool", toolKind: "edit_file", toolName: "Edit", toolId: "t1", input: { filePath: "src/web-sdk/paywall.ts" } },
+      }),
+      entry({
+        kind: "tool_call",
+        tool: { kind: "tool", toolKind: "bash", toolName: "Bash", toolId: "t2", input: { command: "bun test", description: "Run the suite" } },
+      }),
+      entry({ kind: "assistant_text", text: "The web SDK dropped the paywall event." }),
+    ])
+
+    expect(digest).toContain("Look at this slack thread please")
+    expect(digest).toContain("edited src/web-sdk/paywall.ts")
+    expect(digest).toContain("ran Run the suite")
+    expect(digest).toContain("The web SDK dropped the paywall event.")
+  })
+
+  test("collapses repeated tool calls and keeps the closing assistant text", () => {
+    const digest = buildTurnDigest([
+      entry({ kind: "assistant_text", text: "Let me look." }),
+      ...Array.from({ length: 4 }, () => entry({
+        kind: "tool_call",
+        tool: { kind: "tool", toolKind: "read_file", toolName: "Read", toolId: "t", input: { filePath: "/repo/src/a.ts" } },
+      })),
+      entry({ kind: "assistant_text", text: "Done." }),
+    ])
+
+    expect(digest.match(/read a\.ts/g)).toHaveLength(1)
+    expect(digest).toContain("Done.")
+  })
+
+  test("is empty for a transcript with nothing to summarize", () => {
+    expect(buildTurnDigest([])).toBe("")
+    expect(buildTurnDigest([
+      entry({ kind: "system_init", provider: "claude", model: "opus", tools: [], agents: [], slashCommands: [], mcpServers: [] }),
+    ])).toBe("")
+  })
+})
+
+describe("refineChatTitleDetailed", () => {
+  const args = {
+    currentTitle: "Investigate Slack Thread",
+    digest: "The user asked:\nlook at this thread",
+    cwd: "/tmp/project",
+  }
+
+  test("returns the proposed title when the model asks for a rename", async () => {
+    const result = await refineChatTitleDetailed(
+      args,
+      adapterReturning({ rename: true, title: "  Web SDK\npaywall event drop  " })
+    )
+
+    expect(result.title).toBe("Web SDK paywall event drop")
+    expect(result.failureMessage).toBeNull()
+  })
+
+  test("keeps the current title when the model declines", async () => {
+    const result = await refineChatTitleDetailed(args, adapterReturning({ rename: false, title: "" }))
+
+    expect(result.title).toBeNull()
+    expect(result.failureMessage).toBeNull()
+  })
+
+  test("keeps the current title when the rename only restates it", async () => {
+    const result = await refineChatTitleDetailed(
+      args,
+      adapterReturning({ rename: true, title: "investigate slack thread" })
+    )
+
+    expect(result.title).toBeNull()
+  })
+
+  test("does not call a provider when there is nothing to judge", async () => {
+    const calls = { prompts: [] as string[] }
+    const result = await refineChatTitleDetailed(
+      { ...args, digest: "   " },
+      adapterReturning({ rename: true, title: "Never asked" }, calls)
+    )
+
+    expect(result.title).toBeNull()
+    expect(calls.prompts).toHaveLength(0)
+  })
+
+  test("passes the current title and the digest to the provider", async () => {
+    const calls = { prompts: [] as string[] }
+    await refineChatTitleDetailed(args, adapterReturning({ rename: false, title: "" }, calls))
+
+    expect(calls.prompts[0]).toContain("Investigate Slack Thread")
+    expect(calls.prompts[0]).toContain("look at this thread")
+  })
+
+  test("reports the failure when no provider answers", async () => {
+    const result = await refineChatTitleDetailed(args, new QuickResponseAdapter({
+      readLlmProvider: async () => disabledLlmProvider(),
+      runClaudeStructured: async () => {
+        throw new Error("not authenticated")
+      },
+      runCodexStructured: async () => null,
+    }))
+
+    expect(result.title).toBeNull()
+    expect(result.failureMessage).toContain("not authenticated")
+  })
+})

--- a/src/server/refine-title.ts
+++ b/src/server/refine-title.ts
@@ -1,0 +1,172 @@
+import path from "node:path"
+import type { NormalizedToolCall, TranscriptEntry } from "../shared/types"
+import { normalizeGeneratedTitle } from "./generate-title"
+import { getSharedQuickResponseAdapter } from "./quick-response"
+
+const REFINED_TITLE_SCHEMA = {
+  type: "object",
+  properties: {
+    rename: { type: "boolean" },
+    title: { type: "string" },
+  },
+  required: ["rename", "title"],
+  additionalProperties: false,
+} as const
+
+const MAX_PROMPT_CHARS = 600
+const MAX_ASSISTANT_TEXTS = 3
+const MAX_ASSISTANT_CHARS = 500
+const MAX_WORK_LINES = 12
+
+function condense(value: string, maxLength: number) {
+  const normalized = value.replace(/\s+/g, " ").trim()
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, maxLength).trimEnd()}...`
+}
+
+/**
+ * One line naming what a tool call did — the specific noun (a path, a pattern,
+ * a command) rather than the tool's name, since the point of the digest is to
+ * tell the refiner *what* the turn was about.
+ */
+function describeToolCall(tool: NormalizedToolCall): string | null {
+  switch (tool.toolKind) {
+    case "read_file":
+      return `read ${path.basename(tool.input.filePath)}`
+    case "write_file":
+      return `wrote ${tool.input.filePath}`
+    case "edit_file":
+      return `edited ${tool.input.filePath}`
+    case "delete_file":
+      return `deleted ${tool.input.filePath}`
+    case "bash":
+      return `ran ${condense(tool.input.description || tool.input.command, 80)}`
+    case "grep":
+      return `searched for ${condense(tool.input.pattern, 60)}`
+    case "glob":
+      return `globbed ${condense(tool.input.pattern, 60)}`
+    case "web_search":
+      return `web search: ${condense(tool.input.query, 60)}`
+    case "skill":
+      return `used the ${tool.input.skill} skill`
+    case "subagent_task":
+      return tool.input.subagentType ? `ran the ${tool.input.subagentType} agent` : null
+    case "mcp_generic":
+      return `called ${tool.input.server}/${tool.input.tool}`
+    default:
+      return null
+  }
+}
+
+/**
+ * What the turn was actually about, in a few hundred characters: the prompt
+ * that opened it, the agent's closing words, and the files and commands it
+ * touched. Built from header-form entries only — no tool bodies — so it stays
+ * cheap and stays inside a small model's attention.
+ */
+export function buildTurnDigest(entries: TranscriptEntry[]): string {
+  const sections: string[] = []
+
+  const prompt = entries.find((entry) => entry.kind === "user_prompt" && !entry.hidden)
+  if (prompt?.kind === "user_prompt" && prompt.content.trim()) {
+    sections.push(`The user asked:\n${condense(prompt.content, MAX_PROMPT_CHARS)}`)
+  }
+
+  const work: string[] = []
+  for (const entry of entries) {
+    if (entry.kind !== "tool_call") continue
+    const line = describeToolCall(entry.tool)
+    if (line && !work.includes(line)) work.push(line)
+  }
+  if (work.length > 0) {
+    sections.push(`The agent:\n${work.slice(0, MAX_WORK_LINES).map((line) => `- ${line}`).join("\n")}`)
+  }
+
+  // The last few assistant messages, not the first: an agent opens by restating
+  // the prompt and closes by naming what it found, and the close is the part
+  // the title is missing.
+  const assistantTexts = entries
+    .filter((entry) => entry.kind === "assistant_text" && entry.text.trim())
+    .slice(-MAX_ASSISTANT_TEXTS)
+    .map((entry) => condense((entry as { text: string }).text, MAX_ASSISTANT_CHARS))
+  if (assistantTexts.length > 0) {
+    sections.push(`The agent concluded:\n${assistantTexts.join("\n")}`)
+  }
+
+  return sections.join("\n\n")
+}
+
+export interface RefineChatTitleResult {
+  /** The better title, or null when the current one should stand. */
+  title: string | null
+  failureMessage: string | null
+}
+
+function summarizeFailures(failures: Array<{ provider: "openai" | "claude" | "codex"; reason: string }>) {
+  if (failures.length === 0) return null
+  return failures.map((failure) => failure.reason).join("; ")
+}
+
+export interface RefineChatTitleArgs {
+  currentTitle: string
+  digest: string
+  cwd: string
+}
+
+/**
+ * Second look at a chat's title once its first turn has run.
+ *
+ * The first title is generated from the opening message alone, before any work
+ * has happened, so it often names the action and not the subject ("Investigate
+ * Slack thread" for a chat that turned out to be about the web SDK). This asks
+ * a small model to replace it — but only when the current title would fail to
+ * find the chat later. A title that already names the specific thing is left
+ * exactly as it is.
+ */
+export async function refineChatTitleDetailed(
+  args: RefineChatTitleArgs,
+  adapter = getSharedQuickResponseAdapter()
+): Promise<RefineChatTitleResult> {
+  if (!args.digest.trim()) {
+    return { title: null, failureMessage: null }
+  }
+
+  const result = await adapter.generateStructuredWithDiagnostics<{ title: string | null }>({
+    cwd: args.cwd,
+    task: "conversation title refinement",
+    prompt: [
+      `A chat in a coding tool is titled "${args.currentTitle}".`,
+      "That title was generated from the user's opening message alone, before any of the work below had happened.",
+      "",
+      "Here is what the conversation turned out to be about:",
+      "",
+      args.digest,
+      "",
+      "Decide whether the title should change.",
+      "Rename it only when it would be hard to find this chat by that title later — it names a generic action"
+        + " (\"Investigate thread\", \"Fix bug\", \"Update code\") without naming the specific subject, or the work"
+        + " turned out to be about something the title never mentions.",
+      "Keep the title when it already names the specific thing that was worked on, even if you could phrase it better.",
+      "",
+      "When renaming, write a title under 40 characters that names the specific subject — the feature, component,"
+        + " file, or product area — and what was done to it. No quotes, no trailing punctuation.",
+      "When keeping the title, set rename to false and title to an empty string.",
+    ].join("\n"),
+    schema: REFINED_TITLE_SCHEMA,
+    parse: (value) => {
+      const output = value && typeof value === "object" ? value as { rename?: unknown; title?: unknown } : {}
+      if (output.rename !== true) return { title: null }
+      const title = normalizeGeneratedTitle(output.title)
+      // A provider that asked for a rename but named nothing usable hasn't
+      // answered: fall through to the next one rather than keeping quiet.
+      if (!title) return null
+      if (title.toLowerCase() === args.currentTitle.trim().toLowerCase()) return { title: null }
+      return { title }
+    },
+  })
+
+  return {
+    title: result.value?.title ?? null,
+    failureMessage: summarizeFailures(result.failures),
+  }
+}


### PR DESCRIPTION
Chat titles are generated from the opening message alone, before any work has happened. That means a chat often ends up named after whatever you opened with rather than what it turned out to be about — "Investigate Slack Thread" for a chat that was really a web SDK bug in that thread. By the time you go looking for it in the sidebar, the useful name is the one nobody wrote.

This adds a second look once the first turn finishes.

## How it works

`refine-title.ts` builds a digest of the finished turn — the opening prompt, the files/commands/searches the agent touched, and its closing words — and hands it plus the current title to the same small-model quick-response stack titles already use (`{ rename, title }` schema). The prompt is deliberately conservative: rename only when the title names a generic action without its subject, or the work turned out to be about something the title never mentions. Otherwise keep it. Most of the time it keeps it.

The digest is built from header-form transcript entries via a new `EventStore.getTranscriptHeaders()`, so it never reads the tool payload sidecar.

## What it will not touch

A new `ChatRecord.titleSource` (`"auto"` / `"refined"` / absent) records who named the chat. `renameChat()` takes an optional `source`; a rename without one is a person typing, and that permanently takes the name out of automation's hands — forks included, since they inherit their title from a `chat_created` event with no source. The refiner runs only when all of:

- `titleSource === "auto"`
- it is the chat's first turn (`turnCount === 1`)
- the turn succeeded — not cancelled, not failed
- the title has not changed since the digest was built (re-checked after the model returns, so a rename mid-flight still wins)

It also awaits any in-flight first-message title generation first, so it judges the generated title rather than racing it, and one chat is only ever reconsidered once per process.

## Tests

- `refine-title.test.ts` — digest building (dedupes repeated tool calls, keeps the closing assistant text, empty for a transcript with nothing in it) and the refiner (renames, declines, rejects a rename that only restates the title, skips the provider call entirely when there is nothing to judge, reports provider failure).
- `agent.test.ts` — renames a generic auto title after the first turn, keeps a specific one, never refines a user-typed name, only fires on the first turn.
- `event-store.test.ts` — `titleSource` survives compaction and is cleared by a manual rename, including a manual rename to the same text.

`bun run check` is clean. `bun test` shows the same 5 failures (`cli-runtime` ×4, `password auth` ×1) as pristine `main` on this machine; nothing new.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus[1m]`.