### PR TITLE
Add isolated RC runtime and chat history imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,50 @@ kanna --no-open        # don't open browser
 kanna --password <secret>      # require a password before loading the app
 kanna --share                # create a public quick tunnel + terminal QR
 kanna --cloudflared <token>  # run a named Cloudflare tunnel from a token
+kanna-rc                     # production build on port 3211 with isolated data
 ```
 
 Default URL: `http://localhost:3210`
+
+### Release-candidate instance
+
+`kanna-rc` runs the same production build as `kanna`, but defaults to
+`http://localhost:3211` and stores its state under `~/.kanna-rc/`. It can run
+alongside production without sharing chat history, settings, credentials, or
+cloud pairing state.
+
+```bash
+kanna-rc
+kanna-rc --no-open
+```
+
+To build the current checkout and run it as RC without replacing your globally
+installed production command:
+
+```bash
+bun run rc
+bun run rc -- --no-open
+```
+
+This rebuilds the production client, disables package self-updates for the
+local run, and launches the normal supervised server on port `3211`.
+
+### Import chat history
+
+Import all live chats from another environment into the command's environment:
+
+```bash
+kanna import-chats dev       # dev → production
+kanna import-chats rc        # RC → production
+kanna-rc import-chats prd    # production → RC
+bun run dev:import-chats rc  # RC → dev
+```
+
+Stop both the source and destination instances before importing. Imports are additive:
+destination-only chats remain, while a chat previously imported from the same
+source is updated in place on the next import. Projects are matched by local
+path, and transcripts, tool payloads, queued messages, and transcript media are
+copied with each chat. `prod` is also accepted as an alias for `prd`.
 
 ### Network access (Tailscale / LAN)
 
@@ -212,6 +253,8 @@ bun run dev:server   # http://localhost:5175
 | `bun run dev`        | Run client + server together |
 | `bun run dev:client` | Vite dev server only         |
 | `bun run dev:server` | Bun backend only             |
+| `bun run dev:import-chats <env>` | Import chats into dev        |
+| `bun run rc`         | Build and run an isolated local RC |
 | `bun run start`      | Start production server      |
 | `bun test`           | Unit/integration tests       |
 | `bun run test:e2e`   | Playwright browser smoke suite |
@@ -255,7 +298,8 @@ e2e/                 Playwright smoke suite (boots the real server)
 
 ## Data Storage
 
-All state is stored locally at `~/.kanna/data/`:
+Production state is stored locally at `~/.kanna/data/`. Dev uses
+`~/.kanna-dev/data/`, and RC uses `~/.kanna-rc/data/`:
 
 | File             | Purpose                                   |
 | ---------------- | ----------------------------------------- |

--- a/bin/kanna-rc
+++ b/bin/kanna-rc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+import process from "node:process"
+import { CLI_CHILD_MODE, CLI_CHILD_MODE_ENV_VAR } from "../src/server/restart"
+
+process.env.KANNA_RUNTIME_PROFILE = "rc"
+
+if (process.env[CLI_CHILD_MODE_ENV_VAR] === CLI_CHILD_MODE) {
+  await import("../src/server/cli.ts")
+} else {
+  await import("../src/server/cli-supervisor.ts")
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "git+https://github.com/jakemor/kanna.git"
   },
   "bin": {
-    "kanna": "./bin/kanna"
+    "kanna": "./bin/kanna",
+    "kanna-rc": "./bin/kanna-rc"
   },
   "packageManager": "bun@1.3.5",
   "files": [
@@ -43,6 +44,8 @@
     "dev:cloud": "KANNA_DEVBOX_UI=1 bun run ./scripts/dev.ts",
     "dev:client": "vite --host 0.0.0.0 --port 5174",
     "dev:server": "bun run ./scripts/dev-server.ts --no-open --port 5175",
+    "dev:import-chats": "bun run ./scripts/dev-import-chats.ts",
+    "rc": "bun run build && bun run ./scripts/rc.ts",
     "install:dev": "bun install && bun run build && bun install -g .",
     "start": "bun run ./src/server/cli.ts",
     "test": "bun test",

--- a/scripts/dev-import-chats.ts
+++ b/scripts/dev-import-chats.ts
@@ -1,0 +1,7 @@
+import process from "node:process"
+
+process.env.KANNA_RUNTIME_PROFILE = "dev"
+process.env.KANNA_DISABLE_SELF_UPDATE = "1"
+process.argv.splice(2, 0, "import-chats")
+
+await import("../src/server/cli")

--- a/scripts/rc.ts
+++ b/scripts/rc.ts
@@ -1,0 +1,17 @@
+import process from "node:process"
+import path from "node:path"
+import {
+  CLI_CHILD_ARGS_ENV_VAR,
+  CLI_CHILD_COMMAND_ENV_VAR,
+} from "../src/server/restart"
+
+// Run the checked-out RC entrypoint through the normal supervisor so restart
+// behavior works without requiring a globally installed `kanna-rc` binary.
+process.env.KANNA_RUNTIME_PROFILE = "rc"
+process.env.KANNA_DISABLE_SELF_UPDATE = "1"
+process.env[CLI_CHILD_COMMAND_ENV_VAR] = process.execPath
+process.env[CLI_CHILD_ARGS_ENV_VAR] = JSON.stringify([
+  path.resolve(import.meta.dir, "../bin/kanna-rc"),
+])
+
+await import("../src/server/cli-supervisor")

--- a/src/server/chat-import.test.ts
+++ b/src/server/chat-import.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EventStore } from "./event-store"
+import { getProfileDataDir, importChats, parseChatImportProfile } from "./chat-import"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("chat imports", () => {
+  test("accepts the public environment names", () => {
+    expect(parseChatImportProfile("dev")).toBe("dev")
+    expect(parseChatImportProfile("rc")).toBe("rc")
+    expect(parseChatImportProfile("prd")).toBe("prod")
+    expect(parseChatImportProfile("prod")).toBe("prod")
+    expect(parseChatImportProfile("staging")).toBeNull()
+  })
+
+  test("adds chats, remaps matching projects, and updates on re-import", async () => {
+    const homeDir = await mkdtemp(path.join(tmpdir(), "kanna-chat-import-test-"))
+    tempDirs.push(homeDir)
+    const projectPath = path.join(homeDir, "project")
+    const source = new EventStore(getProfileDataDir("dev", homeDir))
+    const target = new EventStore(getProfileDataDir("rc", homeDir))
+    await source.initialize()
+    await target.initialize()
+
+    const sourceProject = await source.openProject(projectPath, "Source title")
+    const targetProject = await target.openProject(projectPath, "Target title")
+    const chat = await source.createChat(sourceProject.id)
+    await source.renameChat(chat.id, "First title")
+    await source.appendMessage(chat.id, {
+      _id: "prompt-1",
+      kind: "user_prompt",
+      content: "hello from dev",
+      createdAt: 100,
+    })
+
+    expect(await importChats({ sourceProfile: "dev", targetProfile: "rc", homeDir })).toEqual({
+      added: 1,
+      updated: 0,
+      projectsAdded: 0,
+    })
+
+    let imported = new EventStore(getProfileDataDir("rc", homeDir))
+    await imported.initialize()
+    expect(imported.state.chatsById.get(chat.id)?.projectId).toBe(targetProject.id)
+    expect(imported.state.chatsById.get(chat.id)?.title).toBe("First title")
+    expect(imported.getMessages(chat.id).map((entry) => entry._id)).toEqual(["prompt-1"])
+
+    await source.renameChat(chat.id, "Updated title")
+    expect(await importChats({ sourceProfile: "dev", targetProfile: "rc", homeDir })).toMatchObject({
+      added: 0,
+      updated: 1,
+    })
+    imported = new EventStore(getProfileDataDir("rc", homeDir))
+    await imported.initialize()
+    expect(imported.state.chatsById.get(chat.id)?.title).toBe("Updated title")
+    expect(await readFile(imported.getTranscriptPath(chat.id), "utf8")).toContain("hello from dev")
+  })
+})

--- a/src/server/chat-import.ts
+++ b/src/server/chat-import.ts
@@ -1,0 +1,197 @@
+import { existsSync } from "node:fs"
+import { cp, copyFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+import { getDataDir, type RuntimeProfile } from "../shared/branding"
+import { STORE_VERSION } from "../shared/types"
+import type { ChatRecord, ProjectRecord, SnapshotFile } from "./events"
+import { EventStore } from "./event-store"
+
+export type ChatImportProfile = RuntimeProfile
+
+export interface ChatImportStats {
+  added: number
+  updated: number
+  projectsAdded: number
+}
+
+export function parseChatImportProfile(value: string): ChatImportProfile | null {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === "dev" || normalized === "rc") return normalized
+  if (normalized === "prd" || normalized === "prod") return "prod"
+  return null
+}
+
+export function chatImportProfileLabel(profile: ChatImportProfile) {
+  return profile === "prod" ? "prd" : profile
+}
+
+export function getProfileDataDir(profile: ChatImportProfile, homeDir = homedir()) {
+  return getDataDir(homeDir, { KANNA_RUNTIME_PROFILE: profile })
+}
+
+async function copyFileAtomically(sourcePath: string, destinationPath: string) {
+  await mkdir(path.dirname(destinationPath), { recursive: true })
+  const tempPath = `${destinationPath}.import-${crypto.randomUUID()}.tmp`
+  await copyFile(sourcePath, tempPath)
+  await rename(tempPath, destinationPath)
+}
+
+async function replaceOptionalFile(sourcePath: string, destinationPath: string) {
+  if (existsSync(sourcePath)) {
+    await copyFileAtomically(sourcePath, destinationPath)
+  } else {
+    await rm(destinationPath, { force: true })
+  }
+}
+
+/**
+ * Import every live chat from one profile into another.
+ *
+ * Chat ids are stable across imports. Re-importing therefore updates the
+ * destination copy instead of duplicating it, while destination-only chats
+ * remain untouched. For an id present in both stores, the selected source is
+ * authoritative, including its transcript and media.
+ */
+export async function importChats(args: {
+  sourceProfile: ChatImportProfile
+  targetProfile: ChatImportProfile
+  homeDir?: string
+}): Promise<ChatImportStats> {
+  if (args.sourceProfile === args.targetProfile) {
+    throw new Error("Source and destination environments must be different")
+  }
+
+  const homeDir = args.homeDir ?? homedir()
+  const sourceDataDir = getProfileDataDir(args.sourceProfile, homeDir)
+  const targetDataDir = getProfileDataDir(args.targetProfile, homeDir)
+  if (!existsSync(sourceDataDir)) {
+    throw new Error(`Source chat history does not exist at ${sourceDataDir}`)
+  }
+
+  // Work from a copy. This keeps source initialization and any legacy
+  // migration away from the real source store. The CLI guards both profiles'
+  // standard ports so the copied files form a consistent point in time.
+  await mkdir(path.dirname(targetDataDir), { recursive: true })
+  const tempRoot = await mkdtemp(path.join(path.dirname(targetDataDir), ".chat-import-"))
+  const sourceCopyDir = path.join(tempRoot, "source")
+  const targetCopyDir = path.join(tempRoot, "target")
+
+  try {
+    await cp(sourceDataDir, sourceCopyDir, { recursive: true })
+    if (existsSync(targetDataDir)) {
+      await cp(targetDataDir, targetCopyDir, { recursive: true })
+    } else {
+      await mkdir(targetCopyDir, { recursive: true })
+    }
+
+    const source = new EventStore(sourceCopyDir)
+    await source.initialize()
+    await source.migrateLegacyTranscripts()
+
+    const target = new EventStore(targetCopyDir)
+    await target.initialize()
+    await target.migrateLegacyTranscripts()
+    // Fold the destination log tail into a snapshot before replacing it.
+    await target.compact()
+
+    const targetSnapshotPath = path.join(targetCopyDir, "snapshot.json")
+    const targetSnapshot = JSON.parse(await readFile(targetSnapshotPath, "utf8")) as SnapshotFile
+    const projects = new Map(targetSnapshot.projects.map((project) => [project.id, project]))
+    const projectIdByPath = new Map(targetSnapshot.projects.map((project) => [project.localPath, project.id]))
+    const chats = new Map(targetSnapshot.chats.map((chat) => [chat.id, chat]))
+    const queuedMessages = new Map((targetSnapshot.queuedMessages ?? []).map((entry) => [entry.chatId, entry]))
+    const sourceChats = [...source.state.chatsById.values()].filter((chat) => !chat.deletedAt)
+    const sourceProjectIds = new Set(sourceChats.map((chat) => chat.projectId))
+    const projectIdMap = new Map<string, string>()
+    let projectsAdded = 0
+
+    for (const sourceProjectId of sourceProjectIds) {
+      const sourceProject = source.state.projectsById.get(sourceProjectId)
+      if (!sourceProject) continue
+      const existingId = projectIdByPath.get(sourceProject.localPath)
+      if (existingId) {
+        projectIdMap.set(sourceProjectId, existingId)
+        continue
+      }
+
+      let importedId = sourceProject.id
+      if (projects.has(importedId)) importedId = crypto.randomUUID()
+      const importedProject: ProjectRecord = { ...sourceProject, id: importedId }
+      projects.set(importedId, importedProject)
+      projectIdByPath.set(importedProject.localPath, importedId)
+      projectIdMap.set(sourceProjectId, importedId)
+      projectsAdded += 1
+    }
+
+    let added = 0
+    let updated = 0
+    for (const sourceChat of sourceChats) {
+      const projectId = projectIdMap.get(sourceChat.projectId)
+      if (!projectId) continue
+      if (chats.has(sourceChat.id)) updated += 1
+      else added += 1
+
+      const importedChat: ChatRecord = { ...sourceChat, projectId }
+      chats.set(importedChat.id, importedChat)
+
+      const sourceQueue = source.state.queuedMessagesByChatId.get(sourceChat.id)
+      if (sourceQueue?.length) {
+        queuedMessages.set(sourceChat.id, {
+          chatId: sourceChat.id,
+          entries: sourceQueue.map((entry) => ({ ...entry, attachments: [...entry.attachments] })),
+        })
+      } else {
+        queuedMessages.delete(sourceChat.id)
+      }
+
+      const sourceTranscriptDir = path.join(sourceCopyDir, "transcripts")
+      const targetTranscriptDir = path.join(targetCopyDir, "transcripts")
+      await replaceOptionalFile(
+        path.join(sourceTranscriptDir, `${sourceChat.id}.jsonl`),
+        path.join(targetTranscriptDir, `${sourceChat.id}.jsonl`)
+      )
+      await replaceOptionalFile(
+        path.join(sourceTranscriptDir, `${sourceChat.id}.payloads.jsonl`),
+        path.join(targetTranscriptDir, `${sourceChat.id}.payloads.jsonl`)
+      )
+
+      const sourceMediaDir = path.join(sourceCopyDir, "media", sourceChat.id)
+      const targetMediaDir = path.join(targetCopyDir, "media", sourceChat.id)
+      await rm(targetMediaDir, { recursive: true, force: true })
+      if (existsSync(sourceMediaDir)) {
+        await mkdir(path.dirname(targetMediaDir), { recursive: true })
+        await cp(sourceMediaDir, targetMediaDir, { recursive: true })
+      }
+    }
+
+    const mergedSnapshot: SnapshotFile = {
+      v: STORE_VERSION,
+      generatedAt: Date.now(),
+      projects: [...projects.values()],
+      chats: [...chats.values()],
+      sidebarProjectOrder: targetSnapshot.sidebarProjectOrder,
+      queuedMessages: [...queuedMessages.values()],
+    }
+    const tempSnapshotPath = `${targetSnapshotPath}.import-${crypto.randomUUID()}.tmp`
+    await writeFile(tempSnapshotPath, JSON.stringify(mergedSnapshot, null, 2), "utf8")
+    await rename(tempSnapshotPath, targetSnapshotPath)
+
+    // The whole destination is staged first, so an error above leaves the
+    // real store untouched. Swap directories only after every chat is ready.
+    const backupDir = path.join(path.dirname(targetDataDir), `.data-before-import-${crypto.randomUUID()}`)
+    const hadTarget = existsSync(targetDataDir)
+    if (hadTarget) await rename(targetDataDir, backupDir)
+    try {
+      await rename(targetCopyDir, targetDataDir)
+    } catch (error) {
+      if (hadTarget) await rename(backupDir, targetDataDir)
+      throw error
+    }
+    if (hadTarget) await rm(backupDir, { recursive: true, force: true })
+
+    return { added, updated, projectsAdded }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+}

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -316,6 +316,36 @@ describe("compareVersions", () => {
     expect(compareVersions("0.3.0", "0.3.1")).toBe(-1)
     expect(compareVersions("1.0.0", "0.9.9")).toBe(1)
   })
+
+  test("orders release candidates", () => {
+    expect(compareVersions("0.66.0-rc.1", "0.66.0-rc.2")).toBe(-1)
+    expect(compareVersions("0.66.0-rc.2", "0.66.0-rc.1")).toBe(1)
+    expect(compareVersions("0.66.0-rc.1", "0.66.0-rc.1")).toBe(0)
+    // Numerically, so rc.10 is newer than rc.9 rather than sorting as a string.
+    expect(compareVersions("0.66.0-rc.9", "0.66.0-rc.10")).toBe(-1)
+    // The release part still dominates the prerelease tag.
+    expect(compareVersions("0.66.0-rc.9", "0.66.1-rc.1")).toBe(-1)
+  })
+
+  test("ranks a prerelease below the release it leads up to", () => {
+    expect(compareVersions("0.66.0-rc.1", "0.66.0")).toBe(-1)
+    expect(compareVersions("0.66.0", "0.66.0-rc.1")).toBe(1)
+    // Fewer identifiers sort lower.
+    expect(compareVersions("0.66.0-rc.1", "0.66.0-rc.1.1")).toBe(-1)
+  })
+
+  test("keeps nightly builds level with their base version", () => {
+    // A nightly is cut from main *after* its base shipped. Ranking it below
+    // the base (as semver would) would make the stable updater reinstall over
+    // it on every launch; it should hold until a later release supersedes it.
+    expect(compareVersions("0.66.0-nightly.abc1234", "0.66.0")).toBe(0)
+    expect(compareVersions("0.66.0-nightly.abc1234", "0.66.1")).toBe(-1)
+    expect(compareVersions("0.66.0-nightly.abc1234", "0.65.9")).toBe(1)
+  })
+
+  test("ignores build metadata", () => {
+    expect(compareVersions("0.66.0+build.5", "0.66.0")).toBe(0)
+  })
 })
 
 describe("classifyInstallVersionFailure", () => {

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -151,6 +151,18 @@ describe("parseArgs", () => {
     })
   })
 
+  test("uses the isolated rc default port", () => {
+    process.env.KANNA_RUNTIME_PROFILE = "rc"
+
+    expect(parseArgs([])).toMatchObject({ kind: "run", options: { port: 3211 } })
+  })
+
+  test("parses chat import environments", () => {
+    expect(parseArgs(["import-chats", "dev"])).toEqual({ kind: "import-chats", source: "dev" })
+    expect(parseArgs(["import-chats", "rc"])).toEqual({ kind: "import-chats", source: "rc" })
+    expect(parseArgs(["import-chats", "prd"])).toEqual({ kind: "import-chats", source: "prod" })
+  })
+
   test("parses strict port mode", () => {
     expect(parseArgs(["--strict-port"])).toEqual({
       kind: "run",
@@ -364,6 +376,49 @@ describe("runCli", () => {
     await runCli(["--port", "4000", "--no-open"], deps)
 
     expect(calls.log).toContain("[kanna] data dir: ~/.kanna-dev/data")
+  })
+
+  test("imports chats into the active environment", async () => {
+    process.env.KANNA_RUNTIME_PROFILE = "rc"
+    const imports: unknown[] = []
+    const probedPorts: number[] = []
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async (port) => {
+        probedPorts.push(port)
+        return null
+      },
+      importChatsImpl: async (options) => {
+        imports.push(options)
+        return { added: 3, updated: 2, projectsAdded: 1 }
+      },
+    })
+
+    const result = await runCli(["import-chats", "dev"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 0 })
+    expect(probedPorts).toEqual([3211, 5175])
+    expect(imports).toEqual([{ sourceProfile: "dev", targetProfile: "rc" }])
+    expect(calls.log).toContain("[kanna] imported chats dev → rc: 3 added, 2 updated, 1 projects added")
+    expect(calls.fetchLatestVersion).toEqual([])
+    expect(calls.startServer).toEqual([])
+  })
+
+  test("refuses to import while the destination is running", async () => {
+    process.env.KANNA_RUNTIME_PROFILE = "dev"
+    let imported = false
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async (port) => ({ localUrl: `http://localhost:${port}`, port }),
+      importChatsImpl: async () => {
+        imported = true
+        return { added: 0, updated: 0, projectsAdded: 0 }
+      },
+    })
+
+    const result = await runCli(["import-chats", "prd"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 1 })
+    expect(imported).toBe(false)
+    expect(calls.warn.some((line) => line.includes("http://localhost:5175"))).toBe(true)
   })
 
   test("fails fast on unsupported Bun versions", async () => {
@@ -865,4 +920,3 @@ describe("runCli single-instance guard + hosted open", () => {
     if (result.kind === "started") await result.stop()
   })
 })
-

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -321,29 +321,85 @@ function getProfileServerPort(profile: RuntimeProfile) {
   return profile === "dev" ? DEV_SERVER_PORT : getDefaultServerPort(profile)
 }
 
+/**
+ * Semver precedence: numeric release parts first, then prerelease tags, so
+ * "0.66.0-rc.1" < "0.66.0-rc.2" < "0.66.0". Release candidates depend on that
+ * ordering — comparing only the release part makes every candidate for a base
+ * version equal, so an RC would never see a newer RC as an update.
+ *
+ * Nightly builds are the deliberate exception. "<base>-nightly.<sha>" is cut
+ * from main *after* <base> shipped, so ranking it below <base> (as semver
+ * would) makes the stable updater reinstall over it on every launch. Treating
+ * a nightly as its base version keeps it in place until a later release
+ * genuinely supersedes it — the behavior nightly.ts already documents.
+ */
 export function compareVersions(currentVersion: string, latestVersion: string) {
-  const currentParts = normalizeVersion(currentVersion)
-  const latestParts = normalizeVersion(latestVersion)
-  const length = Math.max(currentParts.length, latestParts.length)
+  const current = parseVersion(currentVersion)
+  const latest = parseVersion(latestVersion)
+  const length = Math.max(current.release.length, latest.release.length)
 
   for (let index = 0; index < length; index += 1) {
-    const current = currentParts[index] ?? 0
-    const latest = latestParts[index] ?? 0
-    if (current === latest) continue
-    return current < latest ? -1 : 1
+    const currentPart = current.release[index] ?? 0
+    const latestPart = latest.release[index] ?? 0
+    if (currentPart === latestPart) continue
+    return currentPart < latestPart ? -1 : 1
   }
 
-  return 0
+  return comparePrerelease(current.prerelease, latest.prerelease)
 }
 
-function normalizeVersion(version: string) {
-  return version
-    .trim()
-    .replace(/^v/i, "")
-    .split("-")[0]
+interface ParsedVersion {
+  release: number[]
+  /** null for a plain release, and for nightly builds (see compareVersions). */
+  prerelease: string[] | null
+}
+
+function parseVersion(version: string): ParsedVersion {
+  // Build metadata ("+<sha>") never participates in precedence.
+  const withoutBuild = version.trim().replace(/^v/i, "").split("+")[0] ?? ""
+  const separator = withoutBuild.indexOf("-")
+  const releasePart = separator === -1 ? withoutBuild : withoutBuild.slice(0, separator)
+  const prereleasePart = separator === -1 ? "" : withoutBuild.slice(separator + 1)
+
+  const release = releasePart
     .split(".")
     .map((part) => Number.parseInt(part, 10))
     .filter((part) => Number.isFinite(part))
+  const identifiers = prereleasePart ? prereleasePart.split(".") : []
+
+  return {
+    release,
+    prerelease: identifiers.length === 0 || identifiers[0] === "nightly" ? null : identifiers,
+  }
+}
+
+function comparePrerelease(current: string[] | null, latest: string[] | null) {
+  if (current === null && latest === null) return 0
+  // A prerelease sorts below the release it leads up to.
+  if (current === null) return 1
+  if (latest === null) return -1
+
+  const length = Math.max(current.length, latest.length)
+  for (let index = 0; index < length; index += 1) {
+    const currentPart = current[index]
+    const latestPart = latest[index]
+    // A shorter identifier list sorts lower ("rc.1" < "rc.1.1").
+    if (currentPart === undefined) return -1
+    if (latestPart === undefined) return 1
+    if (currentPart === latestPart) continue
+
+    const currentNumeric = /^\d+$/.test(currentPart)
+    const latestNumeric = /^\d+$/.test(latestPart)
+    // Numeric identifiers compare numerically and rank below alphanumeric ones.
+    if (currentNumeric && latestNumeric) {
+      return Number(currentPart) < Number(latestPart) ? -1 : 1
+    }
+    if (currentNumeric) return -1
+    if (latestNumeric) return 1
+    return currentPart < latestPart ? -1 : 1
+  }
+
+  return 0
 }
 
 async function maybeSelfUpdate(_argv: string[], deps: CliRuntimeDeps) {

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -1,12 +1,13 @@
 import process from "node:process"
 import { spawnSync } from "node:child_process"
 import { hasCommand, spawnDetached } from "./process-utils"
-import { APP_NAME, CLI_COMMAND, getDataDirDisplay, LOG_PREFIX, PACKAGE_NAME } from "../shared/branding"
+import { APP_NAME, getCliCommand, getDataDirDisplay, getRuntimeProfile, LOG_PREFIX, PACKAGE_NAME } from "../shared/branding"
+import type { RuntimeProfile } from "../shared/branding"
 import type { ShareMode } from "../shared/share"
 import { assertNoHostOverride, getShareCliFlag, isShareEnabled, isTokenShareMode } from "../shared/share"
 import type { UpdateInstallErrorCode } from "../shared/types"
 import { repairBunGlobalManifest, type NightlyInstallResult } from "./nightly"
-import { PROD_SERVER_PORT } from "../shared/ports"
+import { DEV_SERVER_PORT, PROD_SERVER_PORT, RC_SERVER_PORT } from "../shared/ports"
 import { CLI_SUPPRESS_OPEN_ONCE_ENV_VAR } from "./restart"
 import { logShareDetails, renderTerminalQr, startShareTunnel, type StartedShareTunnel } from "./share"
 import { probeExistingInstance, type ExistingInstance } from "./instance"
@@ -83,6 +84,7 @@ export interface CliRuntimeDeps {
   createCloudRuntimeImpl?: (identity: CloudIdentity) => CloudRuntime
   probeExistingInstanceImpl?: (port: number) => Promise<ExistingInstance | null>
   slimTranscriptsImpl?: (log: (message: string) => void) => Promise<SlimTranscriptsStats>
+  importChatsImpl?: typeof import("./chat-import").importChats
 }
 
 export interface UpdateInstallAttemptResult {
@@ -96,6 +98,7 @@ type ParsedArgs =
   | { kind: "run"; options: CliOptions }
   | { kind: "pair"; args: PairCommandArgs }
   | { kind: "slim-transcripts" }
+  | { kind: "import-chats"; source: RuntimeProfile }
   | { kind: "help" }
   | { kind: "version" }
 
@@ -126,18 +129,22 @@ function throwShareConflict(share: Exclude<ShareMode, false>, hostFlag: "--host"
 }
 
 function printHelp() {
+  const command = getCliCommand()
+  const defaultPort = getDefaultServerPort()
   console.log(`${APP_NAME} — local-only project chat UI
 
 Usage:
-  ${CLI_COMMAND} [options]
-  ${CLI_COMMAND} pair          Claim this machine on kanna.sh (prints a link + QR) and start
-  ${CLI_COMMAND} pair <code>   Same, using a code from https://kanna.sh/machines
-  ${CLI_COMMAND} pair --status|--disable|--enable|--remove
-  ${CLI_COMMAND} slim-transcripts
-                       Rewrite stored transcripts without raw tool payloads (stop ${CLI_COMMAND} first)
+  ${command} [options]
+  ${command} pair          Claim this machine on kanna.sh (prints a link + QR) and start
+  ${command} pair <code>   Same, using a code from https://kanna.sh/machines
+  ${command} pair --status|--disable|--enable|--remove
+  ${command} slim-transcripts
+                       Rewrite stored transcripts without raw tool payloads (stop ${command} first)
+  ${command} import-chats <dev|rc|prd>
+                       Import/sync chats from another environment (stop ${command} first)
 
 Options:
-  --port <number>      Port to listen on (default: ${PROD_SERVER_PORT})
+  --port <number>      Port to listen on (default: ${defaultPort})
   --host <host>        Bind to a specific host or IP
   --remote             Shortcut for --host 0.0.0.0
   --share              Create a public Cloudflare quick tunnel with terminal QR
@@ -168,7 +175,7 @@ function parsePairArgs(argv: string[]): ParsedArgs {
     } else if (!arg.startsWith("-") && pairingCode === null) {
       pairingCode = arg
     } else {
-      throw new Error(`Unexpected argument for ${CLI_COMMAND} pair: ${arg}`)
+      throw new Error(`Unexpected argument for ${getCliCommand()} pair: ${arg}`)
     }
   }
 
@@ -183,11 +190,23 @@ export function parseArgs(argv: string[]): ParsedArgs {
     return parsePairArgs(argv.slice(1))
   }
   if (argv[0] === "slim-transcripts") {
-    if (argv.length > 1) throw new Error(`Unexpected argument for ${CLI_COMMAND} slim-transcripts: ${argv[1]}`)
+    if (argv.length > 1) throw new Error(`Unexpected argument for ${getCliCommand()} slim-transcripts: ${argv[1]}`)
     return { kind: "slim-transcripts" }
   }
+  if (argv[0] === "import-chats") {
+    if (argv.length !== 2) throw new Error(`Usage: ${getCliCommand()} import-chats <dev|rc|prd>`)
+    const value = argv[1]!
+    const normalized = value.trim().toLowerCase()
+    const source = normalized === "prd" || normalized === "prod"
+      ? "prod"
+      : normalized === "dev" || normalized === "rc"
+        ? normalized
+        : null
+    if (!source) throw new Error(`Unknown chat environment: ${value} (expected dev, rc, or prd)`)
+    return { kind: "import-chats", source }
+  }
 
-  let port = PROD_SERVER_PORT
+  let port = getDefaultServerPort()
   let host = "127.0.0.1"
   let openBrowser = true
   let share: ShareMode = false
@@ -294,6 +313,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 }
 
+export function getDefaultServerPort(profile = getRuntimeProfile()) {
+  return profile === "rc" ? RC_SERVER_PORT : PROD_SERVER_PORT
+}
+
+function getProfileServerPort(profile: RuntimeProfile) {
+  return profile === "dev" ? DEV_SERVER_PORT : getDefaultServerPort(profile)
+}
+
 export function compareVersions(currentVersion: string, latestVersion: string) {
   const currentParts = normalizeVersion(currentVersion)
   const latestParts = normalizeVersion(latestVersion)
@@ -378,7 +405,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     // Successful pairing flows straight into a normal run — the machine
     // comes online immediately and the hosted URL opens once the tunnel
     // connects. From then on any plain `kanna` does the same (sticky).
-    deps.log(`${LOG_PREFIX} starting ${CLI_COMMAND}…`)
+    deps.log(`${LOG_PREFIX} starting ${getCliCommand()}…`)
     parsedArgs = parseArgs([])
   }
 
@@ -387,9 +414,9 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     // Its own boot sweep already covered this data dir, so refusing costs
     // nothing; the check only sees the default port, so a dev instance on
     // another port is on the user.
-    const running = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(PROD_SERVER_PORT)
+    const running = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(getDefaultServerPort())
     if (running) {
-      deps.warn(`${LOG_PREFIX} ${CLI_COMMAND} is running at ${running.localUrl}; stop it before slimming transcripts`)
+      deps.warn(`${LOG_PREFIX} ${getCliCommand()} is running at ${running.localUrl}; stop it before slimming transcripts`)
       return { kind: "exited", code: 1 }
     }
     const stats = await (deps.slimTranscriptsImpl ?? slimTranscripts)(deps.log)
@@ -400,6 +427,36 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
         : `${LOG_PREFIX} ${stats.chats} transcripts checked, nothing to slim`
     )
     return { kind: "exited", code: 0 }
+  }
+
+  if (parsedArgs.kind === "import-chats") {
+    const targetProfile = getRuntimeProfile()
+    if (parsedArgs.source === targetProfile) {
+      deps.warn(`${LOG_PREFIX} source and destination environments are both ${targetProfile === "prod" ? "prd" : targetProfile}`)
+      return { kind: "exited", code: 1 }
+    }
+    const running = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(getProfileServerPort(targetProfile))
+    if (running) {
+      deps.warn(`${LOG_PREFIX} ${getCliCommand()} is running at ${running.localUrl}; stop it before importing chats`)
+      return { kind: "exited", code: 1 }
+    }
+    const sourceRunning = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(getProfileServerPort(parsedArgs.source))
+    if (sourceRunning) {
+      const sourceLabel = parsedArgs.source === "prod" ? "prd" : parsedArgs.source
+      deps.warn(`${LOG_PREFIX} source environment ${sourceLabel} is running at ${sourceRunning.localUrl}; stop it before importing chats`)
+      return { kind: "exited", code: 1 }
+    }
+    try {
+      const importChatsImpl = deps.importChatsImpl ?? (await import("./chat-import")).importChats
+      const stats = await importChatsImpl({ sourceProfile: parsedArgs.source, targetProfile })
+      const sourceLabel = parsedArgs.source === "prod" ? "prd" : parsedArgs.source
+      const targetLabel = targetProfile === "prod" ? "prd" : targetProfile
+      deps.log(`${LOG_PREFIX} imported chats ${sourceLabel} → ${targetLabel}: ${stats.added} added, ${stats.updated} updated, ${stats.projectsAdded} projects added`)
+      return { kind: "exited", code: 0 }
+    } catch (error) {
+      deps.warn(`${LOG_PREFIX} chat import failed: ${error instanceof Error ? error.message : String(error)}`)
+      return { kind: "exited", code: 1 }
+    }
   }
 
   if (parsedArgs.kind !== "run") {
@@ -441,7 +498,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     const hostedUrl = identity?.enabled ? identity.appOrigin : null
     deps.log(`${LOG_PREFIX} kanna is already running at ${existing.localUrl}${hostedUrl ? ` (and ${hostedUrl})` : ""}`)
     if (hostedUrl) {
-      deps.log(`${LOG_PREFIX} if the hosted URL shows offline, restart the running ${CLI_COMMAND} to pick up the pairing`)
+      deps.log(`${LOG_PREFIX} if the hosted URL shows offline, restart the running ${getCliCommand()} to pick up the pairing`)
     }
     if (runOptions.openBrowser && !suppressOpenBrowser) {
       deps.openUrl(hostedUrl ?? existing.localUrl)
@@ -475,7 +532,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
       installVersion: deps.installVersion,
       installNightly: deps.installNightly,
       argv,
-      command: CLI_COMMAND,
+      command: getCliCommand(),
     },
   })
   const { port, stop } = started
@@ -534,7 +591,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     })
     // The supervisor logs `cloud: connected (…)` when the tunnel is live —
     // that's also when the browser opens.
-    deps.log(`${LOG_PREFIX} cloud: waiting for ${runtime.identity.appOrigin} to come online… (disable with \`${CLI_COMMAND} pair --disable\`)`)
+    deps.log(`${LOG_PREFIX} cloud: waiting for ${runtime.identity.appOrigin} to come online… (disable with \`${getCliCommand()} pair --disable\`)`)
   }
 
   if (runOptions.openBrowser && !isShareEnabled(runOptions.share) && !suppressOpenBrowser && !cloudRuntime) {

--- a/src/server/cli-supervisor.ts
+++ b/src/server/cli-supervisor.ts
@@ -1,6 +1,6 @@
 import process from "node:process"
 import { spawn } from "node:child_process"
-import { CLI_COMMAND, LOG_PREFIX } from "../shared/branding"
+import { getCliCommand, LOG_PREFIX } from "../shared/branding"
 import {
   CLI_CHILD_ARGS_ENV_VAR,
   CLI_CHILD_COMMAND_ENV_VAR,
@@ -20,7 +20,7 @@ interface ChildExit {
 }
 
 function getChildProcessSpec() {
-  const command = process.env[CLI_CHILD_COMMAND_ENV_VAR] || CLI_COMMAND
+  const command = process.env[CLI_CHILD_COMMAND_ENV_VAR] || getCliCommand()
   const args = parseChildArgsEnv(process.env[CLI_CHILD_ARGS_ENV_VAR])
   return { command, args }
 }
@@ -99,7 +99,7 @@ while (true) {
     }
 
     suppressOpenOnNextChild = isUiUpdateRestart(result.code, result.signal)
-    console.log(`${LOG_PREFIX} supervisor restarting ${CLI_COMMAND} in the same terminal session`)
+    console.log(`${LOG_PREFIX} supervisor restarting ${getCliCommand()} in the same terminal session`)
     continue
   }
 

--- a/src/shared/branding.test.ts
+++ b/src/shared/branding.test.ts
@@ -3,6 +3,7 @@ import {
   getDataDir,
   getDataDirDisplay,
   getDataRootName,
+  getCliCommand,
   getKeybindingsFilePath,
   getKeybindingsFilePathDisplay,
   getRuntimeProfile,
@@ -27,5 +28,17 @@ describe("runtime profile helpers", () => {
     expect(getDataDirDisplay(env)).toBe("~/.kanna-dev/data")
     expect(getKeybindingsFilePath("/tmp/home", env)).toBe("/tmp/home/.kanna-dev/keybindings.json")
     expect(getKeybindingsFilePathDisplay(env)).toBe("~/.kanna-dev/keybindings.json")
+  })
+
+  test("switches to isolated paths and command name for the rc profile", () => {
+    const env = { KANNA_RUNTIME_PROFILE: "rc" }
+
+    expect(getRuntimeProfile(env)).toBe("rc")
+    expect(getDataRootName(env)).toBe(".kanna-rc")
+    expect(getDataDir("/tmp/home", env)).toBe("/tmp/home/.kanna-rc/data")
+    expect(getDataDirDisplay(env)).toBe("~/.kanna-rc/data")
+    expect(getKeybindingsFilePath("/tmp/home", env)).toBe("/tmp/home/.kanna-rc/keybindings.json")
+    expect(getKeybindingsFilePathDisplay(env)).toBe("~/.kanna-rc/keybindings.json")
+    expect(getCliCommand(env)).toBe("kanna-rc")
   })
 })

--- a/src/shared/branding.ts
+++ b/src/shared/branding.ts
@@ -2,6 +2,7 @@ export const APP_NAME = "Kanna"
 export const CLI_COMMAND = "kanna"
 export const DATA_ROOT_NAME = ".kanna"
 export const DEV_DATA_ROOT_NAME = ".kanna-dev"
+export const RC_DATA_ROOT_NAME = ".kanna-rc"
 export const PACKAGE_NAME = "kanna-code"
 export const RUNTIME_PROFILE_ENV_VAR = "KANNA_RUNTIME_PROFILE"
 // Read version from package.json — JSON import works in both Bun and Vite
@@ -11,7 +12,7 @@ export const SDK_CLIENT_APP = `kanna/${pkg.version}`
 export const LOG_PREFIX = "[kanna]"
 export const DEFAULT_NEW_PROJECT_ROOT = `~/${APP_NAME}`
 
-export type RuntimeProfile = "dev" | "prod"
+export type RuntimeProfile = "dev" | "rc" | "prod"
 
 type RuntimeEnv = Record<string, string | undefined> | undefined
 
@@ -25,11 +26,20 @@ function getRuntimeEnv(): RuntimeEnv {
 }
 
 export function getRuntimeProfile(env: RuntimeEnv = getRuntimeEnv()): RuntimeProfile {
-  return env?.[RUNTIME_PROFILE_ENV_VAR]?.trim().toLowerCase() === "dev" ? "dev" : "prod"
+  const profile = env?.[RUNTIME_PROFILE_ENV_VAR]?.trim().toLowerCase()
+  if (profile === "dev" || profile === "rc") return profile
+  return "prod"
 }
 
 export function getDataRootName(env: RuntimeEnv = getRuntimeEnv()) {
-  return getRuntimeProfile(env) === "dev" ? DEV_DATA_ROOT_NAME : DATA_ROOT_NAME
+  const profile = getRuntimeProfile(env)
+  if (profile === "dev") return DEV_DATA_ROOT_NAME
+  if (profile === "rc") return RC_DATA_ROOT_NAME
+  return DATA_ROOT_NAME
+}
+
+export function getCliCommand(env: RuntimeEnv = getRuntimeEnv()) {
+  return getRuntimeProfile(env) === "rc" ? "kanna-rc" : CLI_COMMAND
 }
 
 export function getDataRootDir(homeDir: string, env: RuntimeEnv = getRuntimeEnv()) {
@@ -73,5 +83,6 @@ export function getCloudFilePathDisplay(env: RuntimeEnv = getRuntimeEnv()) {
 }
 
 export function getCliInvocation(arg?: string) {
-  return arg ? `${CLI_COMMAND} ${arg}` : CLI_COMMAND
+  const command = getCliCommand()
+  return arg ? `${command} ${arg}` : command
 }

--- a/src/shared/ports.ts
+++ b/src/shared/ports.ts
@@ -1,2 +1,4 @@
 export const PROD_SERVER_PORT = 3210
+export const RC_SERVER_PORT = 3211
 export const DEV_CLIENT_PORT = 5174
+export const DEV_SERVER_PORT = 5175


### PR DESCRIPTION
## Summary

- add a `kanna-rc` production runtime on port 3211 with isolated data under `~/.kanna-rc`
- add additive, repeatable chat imports between dev, RC, and production, including transcripts, payloads, queued messages, and media
- add `bun run rc` for building and launching the current checkout without replacing a global production install
- document RC usage and cross-environment import commands
- order prerelease versions in `compareVersions` so `-rc.N` builds compare as newer than each other, keeping nightly builds level with their base version as before

## Testing

- `bun run check`
- `bun test` (1716 passed)
- `bun run rc -- --help`

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `codex/gpt-5.6-sol`.
