### PR TITLE
Add a key-gated remote REST API behind --api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,14 @@ React client (src/client)
   a connected browser straight away. It deliberately does *not* reuse
   ws-router's `handleCommand`, which is bound to a socket — when you change
   the semantics of `chat.send`, `chat.delete` or `project.open` there, check
-  whether the matching route needs the same change.
+  whether the matching route needs the same change — including the analytics
+  event, which the routes emit to the same reporter.
+- Anything a request can name that the harness looks up later must be
+  validated at the route. `provider` in particular: an unknown one only
+  surfaces when the turn is set up, and for a queued prompt that is after the
+  202, in `dequeueAndStartQueuedMessage` — which removes the queued message
+  before the catalog lookup throws, so the prompt would be acknowledged and
+  then silently dropped.
 - Prompts are async: `POST /chats/:id/messages` answers 202 and the caller
   polls `GET /chats/:id`. A turn runs far longer than any HTTP client will
   wait. `queued: true` means it landed behind a running turn.
@@ -98,6 +105,10 @@ React client (src/client)
   every other `/api/` route still needs the cookie. Raw cloud-tunnel traffic
   (`requestClass === "untrusted"`) still sees nothing but `/health` and `/ws`,
   so the API is not reachable through a paired machine's tunnel by design.
+- `/health` reports `api`, so a second `kanna --api` against an already-running
+  instance can tell that its flags will not take effect: it exits 1 asking for
+  a restart when that instance has no API, and warns that this run's keys were
+  not applied when it does.
 
 ## Cloud contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,30 @@ React client (src/client)
   chat). When a bug report or request does not say which one it is about,
   ask before touching code. A fix on the wrong platform is wasted work.
 
+## Remote REST API (`src/server/api/`)
+
+- Off by default. `kanna --api --api-key=<k1,k2>` (or `--api-key-file=<path>`,
+  one key per line) mounts `/api/v1`. Pair with the existing `--remote` to
+  reach it off-loopback. `--api` without keys is a startup error — the API
+  has no session, origin check or login in front of it, so an unkeyed one
+  would be wide open.
+- `routes.ts` calls the same `EventStore` and `AgentCoordinator` the socket
+  does, then `broadcastSnapshots()`, so a chat created over HTTP shows up in
+  a connected browser straight away. It deliberately does *not* reuse
+  ws-router's `handleCommand`, which is bound to a socket — when you change
+  the semantics of `chat.send`, `chat.delete` or `project.open` there, check
+  whether the matching route needs the same change.
+- Prompts are async: `POST /chats/:id/messages` answers 202 and the caller
+  polls `GET /chats/:id`. A turn runs far longer than any HTTP client will
+  wait. `queued: true` means it landed behind a running turn.
+- The route claims `/api/v1` even when the API is unmounted, answering a JSON
+  404 — otherwise the SPA fallback returns index.html with a 200 and a client
+  cannot tell the API is off (same reason `/__cloud` 404s explicitly).
+- A valid key substitutes for the `--password` session on `/api/v1` only;
+  every other `/api/` route still needs the cookie. Raw cloud-tunnel traffic
+  (`requestClass === "untrusted"`) still sees nothing but `/health` and `/ws`,
+  so the API is not reachable through a paired machine's tunnel by design.
+
 ## Cloud contract
 
 - `src/shared/cloud-api.ts` is the wire contract with the hosted control

--- a/src/server/api/keys.test.ts
+++ b/src/server/api/keys.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  createApiKeyVerifier,
+  extractApiKey,
+  parseApiKeyFile,
+  parseApiKeyList,
+  readApiKeyFile,
+} from "./keys"
+
+describe("parseApiKeyList", () => {
+  test("splits on commas and trims", () => {
+    expect(parseApiKeyList("a, b ,c")).toEqual(["a", "b", "c"])
+  })
+
+  test("drops empties and duplicates", () => {
+    expect(parseApiKeyList("a,,a, ,b")).toEqual(["a", "b"])
+  })
+
+  test("returns nothing for a blank value", () => {
+    expect(parseApiKeyList("   ")).toEqual([])
+  })
+
+  test("rejects a key past the length cap", () => {
+    expect(parseApiKeyList("x".repeat(513))).toEqual([])
+    expect(parseApiKeyList("x".repeat(512))).toHaveLength(1)
+  })
+})
+
+describe("parseApiKeyFile", () => {
+  test("reads one key per line", () => {
+    expect(parseApiKeyFile("alpha\nbravo\ncharlie")).toEqual(["alpha", "bravo", "charlie"])
+  })
+
+  test("skips blank lines and comments", () => {
+    expect(parseApiKeyFile("# for CI\nalpha\n\n  # laptop\nbravo\n")).toEqual(["alpha", "bravo"])
+  })
+
+  test("handles CRLF, since key files travel between machines", () => {
+    expect(parseApiKeyFile("alpha\r\nbravo\r\n")).toEqual(["alpha", "bravo"])
+  })
+
+  test("dedupes", () => {
+    expect(parseApiKeyFile("alpha\nalpha\n")).toEqual(["alpha"])
+  })
+})
+
+describe("readApiKeyFile", () => {
+  test("reads keys from disk", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-keys-"))
+    try {
+      const file = path.join(dir, "keys.txt")
+      await writeFile(file, "alpha\n# note\nbravo\n", "utf8")
+      expect(await readApiKeyFile(file)).toEqual(["alpha", "bravo"])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("names the missing file so the operator can fix it", async () => {
+    const missing = path.join(tmpdir(), `kanna-missing-${crypto.randomUUID()}.txt`)
+    await expect(readApiKeyFile(missing)).rejects.toThrow(missing)
+  })
+})
+
+describe("createApiKeyVerifier", () => {
+  test("accepts a configured key and rejects everything else", () => {
+    const verifier = createApiKeyVerifier(["alpha", "bravo"])
+    expect(verifier.isValid("alpha")).toBe(true)
+    expect(verifier.isValid("bravo")).toBe(true)
+    expect(verifier.isValid("charlie")).toBe(false)
+  })
+
+  test("rejects a prefix of a real key", () => {
+    const verifier = createApiKeyVerifier(["alphabet"])
+    expect(verifier.isValid("alpha")).toBe(false)
+    expect(verifier.isValid("alphabet")).toBe(true)
+  })
+
+  test("rejects empty and absent candidates", () => {
+    const verifier = createApiKeyVerifier(["alpha"])
+    expect(verifier.isValid(null)).toBe(false)
+    expect(verifier.isValid(undefined)).toBe(false)
+    expect(verifier.isValid("")).toBe(false)
+  })
+
+  test("an empty key list accepts nothing", () => {
+    const verifier = createApiKeyVerifier([])
+    expect(verifier.count).toBe(0)
+    expect(verifier.isValid("alpha")).toBe(false)
+  })
+
+  test("counts distinct usable keys", () => {
+    expect(createApiKeyVerifier(["alpha", "alpha", "", "bravo"]).count).toBe(2)
+  })
+
+  test("an oversized candidate is rejected without comparing", () => {
+    expect(createApiKeyVerifier(["alpha"]).isValid("x".repeat(513))).toBe(false)
+  })
+})
+
+describe("extractApiKey", () => {
+  const request = (headers: Record<string, string>) => new Request("http://localhost/api/v1", { headers })
+
+  test("reads a bearer token", () => {
+    expect(extractApiKey(request({ authorization: "Bearer alpha" }))).toBe("alpha")
+  })
+
+  test("accepts any case for the scheme", () => {
+    expect(extractApiKey(request({ authorization: "bearer alpha" }))).toBe("alpha")
+  })
+
+  test("reads X-Api-Key", () => {
+    expect(extractApiKey(request({ "x-api-key": "alpha" }))).toBe("alpha")
+  })
+
+  test("prefers the Authorization header when both are present", () => {
+    expect(extractApiKey(request({ authorization: "Bearer alpha", "x-api-key": "bravo" }))).toBe("alpha")
+  })
+
+  test("ignores other auth schemes", () => {
+    expect(extractApiKey(request({ authorization: "Basic alpha" }))).toBeNull()
+  })
+
+  test("returns null with no credential", () => {
+    expect(extractApiKey(request({}))).toBeNull()
+  })
+})

--- a/src/server/api/keys.ts
+++ b/src/server/api/keys.ts
@@ -1,0 +1,117 @@
+/**
+ * API keys for the remote REST API (`kanna --api`).
+ *
+ * Keys arrive either inline (`--api-key=a,b,c`) or from a file
+ * (`--api-key-file=path`, one key per line). Both forms end up as the same
+ * flat list, which the verifier compares against in constant time.
+ *
+ * The API key is the *only* credential on these routes — a caller with a key
+ * skips the `--password` session gate — so verification must not leak which
+ * prefix of a candidate matched.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+
+/** Longest key we will accept, so a huge header can't be used to burn CPU. */
+const MAX_KEY_LENGTH = 512
+
+function isUsableKey(value: string) {
+  return value.length > 0 && value.length <= MAX_KEY_LENGTH
+}
+
+function dedupe(keys: string[]) {
+  return [...new Set(keys)]
+}
+
+/**
+ * `--api-key=a,b,c` — comma separated. Whitespace around each key is trimmed,
+ * so `--api-key="a, b"` works as typed.
+ */
+export function parseApiKeyList(value: string): string[] {
+  return dedupe(
+    value
+      .split(",")
+      .map((key) => key.trim())
+      .filter(isUsableKey)
+  )
+}
+
+/**
+ * `--api-key-file` contents — one key per line. Blank lines are skipped and so
+ * are `#` comments, so a key file can be annotated with who each key is for.
+ * Handles CRLF, since a key file may well be edited on another machine.
+ */
+export function parseApiKeyFile(contents: string): string[] {
+  return dedupe(
+    contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => !line.startsWith("#"))
+      .filter(isUsableKey)
+  )
+}
+
+export async function readApiKeyFile(filePath: string): Promise<string[]> {
+  const file = Bun.file(filePath)
+  if (!(await file.exists())) {
+    throw new Error(`API key file not found: ${filePath}`)
+  }
+  return parseApiKeyFile(await file.text())
+}
+
+/**
+ * Compare without leaking length or content through timing.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so both sides are hashed to a
+ * fixed 32 bytes first. That also bounds the comparison cost for a candidate
+ * of any length.
+ */
+function constantTimeEquals(a: string, b: string) {
+  const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest()
+  return timingSafeEqual(hash(a), hash(b))
+}
+
+export interface ApiKeyVerifier {
+  /** How many keys are configured. Zero means the API must not be mounted. */
+  readonly count: number
+  isValid(candidate: string | null | undefined): boolean
+}
+
+export function createApiKeyVerifier(keys: string[]): ApiKeyVerifier {
+  const configured = dedupe(keys.filter(isUsableKey))
+
+  return {
+    get count() {
+      return configured.length
+    },
+    isValid(candidate) {
+      if (!candidate || candidate.length > MAX_KEY_LENGTH) return false
+      // No early return: every configured key is compared on every call, so a
+      // hit and a miss cost the same.
+      let matched = false
+      for (const key of configured) {
+        if (constantTimeEquals(candidate, key)) {
+          matched = true
+        }
+      }
+      return matched
+    },
+  }
+}
+
+/**
+ * The credential on an incoming request: `Authorization: Bearer <key>`, or
+ * `X-Api-Key: <key>` for callers that can't set an Authorization header.
+ */
+export function extractApiKey(req: Request): string | null {
+  const authorization = req.headers.get("authorization")
+  if (authorization) {
+    const [scheme, ...rest] = authorization.trim().split(/\s+/)
+    if (scheme?.toLowerCase() === "bearer" && rest.length > 0) {
+      return rest.join(" ")
+    }
+  }
+
+  const headerKey = req.headers.get("x-api-key")
+  return headerKey?.trim() || null
+}

--- a/src/server/api/routes.test.ts
+++ b/src/server/api/routes.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import type { AppSettingsSnapshot, KannaStatus } from "../../shared/types"
+import type { ClientCommand } from "../../shared/protocol"
+import { createEmptyState, type ChatRecord, type ProjectRecord } from "../events"
+import { createApiKeyVerifier } from "./keys"
+import { handleApiRequest, type ApiRouteDeps } from "./routes"
+
+const KEY = "test-key"
+
+function chatRecord(overrides: Partial<ChatRecord> & Pick<ChatRecord, "id" | "projectId">): ChatRecord {
+  return {
+    title: "Chat",
+    createdAt: 1,
+    updatedAt: 1,
+    unread: false,
+    provider: null,
+    planMode: false,
+    autoPlan: false,
+    sessionToken: null,
+    ...overrides,
+  } as ChatRecord
+}
+
+interface Calls {
+  sends: Array<Extract<ClientCommand, { type: "chat.send" }>>
+  cancels: string[]
+  closes: string[]
+  deletes: string[]
+  broadcasts: number
+}
+
+function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {}) {
+  const state = createEmptyState()
+  state.projectsById.set("project-1", {
+    id: "project-1",
+    localPath: "/tmp/project-1",
+    title: "Project One",
+    createdAt: 1,
+    updatedAt: 5,
+  } as ProjectRecord)
+  state.projectIdsByPath.set("/tmp/project-1", "project-1")
+  state.chatsById.set("chat-1", chatRecord({ id: "chat-1", projectId: "project-1", lastMessageAt: 10, hasMessages: true }))
+  state.chatsById.set("chat-2", chatRecord({ id: "chat-2", projectId: "project-1", lastMessageAt: 20 }))
+  state.chatsById.set("chat-archived", chatRecord({ id: "chat-archived", projectId: "project-1", archivedAt: 3 }))
+  state.chatsById.set("chat-deleted", chatRecord({ id: "chat-deleted", projectId: "project-1", deletedAt: 4 }))
+
+  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0 }
+  let created = 0
+
+  const store = {
+    state,
+    getChat: (chatId: string) => state.chatsById.get(chatId) ?? null,
+    getProject: (projectId: string) => state.projectsById.get(projectId) ?? null,
+    getClientTranscript: () => ({ messages: [], startIndex: 0, readAnchor: null }),
+    getInitialTranscriptWindowStart: () => 0,
+    openProject: async (localPath: string, title?: string) => {
+      const existingId = state.projectIdsByPath.get(localPath)
+      if (existingId) return state.projectsById.get(existingId)!
+      const project = {
+        id: `project-${state.projectsById.size + 1}`,
+        localPath,
+        title: title ?? path.basename(localPath),
+        createdAt: 1,
+        updatedAt: 1,
+      } as ProjectRecord
+      state.projectsById.set(project.id, project)
+      state.projectIdsByPath.set(localPath, project.id)
+      return project
+    },
+    createChat: async (projectId: string) => {
+      created += 1
+      const chat = chatRecord({ id: `new-chat-${created}`, projectId })
+      state.chatsById.set(chat.id, chat)
+      return chat
+    },
+    deleteChat: async (chatId: string) => {
+      calls.deletes.push(chatId)
+      const chat = state.chatsById.get(chatId)
+      if (chat) chat.deletedAt = Date.now()
+    },
+  }
+
+  const agent = {
+    getActiveStatuses: () => options.activeStatuses ?? new Map<string, KannaStatus>(),
+    getDrainingChatIds: () => new Set<string>(),
+    send: async (command: Extract<ClientCommand, { type: "chat.send" }>) => {
+      calls.sends.push(command)
+      if (command.chatId) return { chatId: command.chatId }
+      const chat = await store.createChat(command.projectId!)
+      return { chatId: chat.id }
+    },
+    cancel: async (chatId: string) => {
+      calls.cancels.push(chatId)
+    },
+    closeChat: async (chatId: string) => {
+      calls.closes.push(chatId)
+    },
+  }
+
+  const deps = {
+    store,
+    agent,
+    appSettings: {
+      getSnapshot: () => ({ transcript: { windowAssistantMessages: 50 } } as unknown as AppSettingsSnapshot),
+    },
+    verifier: createApiKeyVerifier([KEY]),
+    broadcast: () => {
+      calls.broadcasts += 1
+    },
+    version: "1.2.3",
+  } as unknown as ApiRouteDeps
+
+  return { deps, calls, state }
+}
+
+function call(
+  deps: ApiRouteDeps,
+  pathname: string,
+  init: { method?: string; body?: unknown; key?: string | null } = {}
+) {
+  const url = new URL(`http://localhost${pathname}`)
+  const headers: Record<string, string> = {}
+  const key = init.key === undefined ? KEY : init.key
+  if (key) headers.authorization = `Bearer ${key}`
+  if (init.body !== undefined) headers["content-type"] = "application/json"
+  const req = new Request(url, {
+    method: init.method ?? "GET",
+    headers,
+    body: init.body === undefined ? undefined : typeof init.body === "string" ? init.body : JSON.stringify(init.body),
+  })
+  return handleApiRequest(req, url, deps)
+}
+
+/** Test-local: response bodies are asserted field by field, not typed. */
+async function json(response: Response | null): Promise<Record<string, any>> {
+  expect(response).not.toBeNull()
+  return (await response!.json()) as Record<string, any>
+}
+
+describe("routing", () => {
+  test("ignores requests outside the API prefix", async () => {
+    const { deps } = createDeps()
+    expect(await call(deps, "/api/chats/chat-1/window")).toBeNull()
+    expect(await call(deps, "/")).toBeNull()
+  })
+
+  test("claims the prefix even for an unknown path", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/nope")
+    expect(response?.status).toBe(404)
+  })
+
+  test("reports version and capabilities at the root", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1")
+    expect(response?.status).toBe(200)
+    expect(await json(response)).toMatchObject({ name: "kanna", version: "1.2.3", api: 1 })
+  })
+
+  test("answers 405 with an Allow header on the wrong method", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "GET" })
+    expect(response?.status).toBe(405)
+    expect(response?.headers.get("Allow")).toBe("POST")
+  })
+
+  test("never caches a response", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats")
+    expect(response?.headers.get("Cache-Control")).toBe("no-store")
+  })
+})
+
+describe("authentication", () => {
+  test("rejects a request with no key", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { key: null })
+    expect(response?.status).toBe(401)
+    expect(response?.headers.get("WWW-Authenticate")).toContain("Bearer")
+  })
+
+  test("rejects a wrong key", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats", { key: "nope" }))?.status).toBe(401)
+  })
+
+  test("accepts X-Api-Key as well as Bearer", async () => {
+    const { deps } = createDeps()
+    const url = new URL("http://localhost/api/v1/chats")
+    const req = new Request(url, { headers: { "x-api-key": KEY } })
+    expect((await handleApiRequest(req, url, deps))?.status).toBe(200)
+  })
+
+  test("checks the key before doing any work", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" }, key: null })
+    expect(calls.sends).toHaveLength(0)
+  })
+})
+
+describe("projects", () => {
+  test("lists projects with a live chat count", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/projects"))
+    expect(body.projects).toHaveLength(1)
+    // chat-1 and chat-2 only: archived and deleted chats don't count.
+    expect(body.projects[0]).toMatchObject({ id: "project-1", localPath: "/tmp/project-1", chatCount: 2 })
+  })
+
+  test("adds an existing directory as a project", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await Bun.write(path.join(dir, "README.md"), "# existing\n")
+      const response = await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir, title: "Added" } })
+      expect(response?.status).toBe(201)
+      const body = await json(response)
+      expect(body.project).toMatchObject({ localPath: dir, title: "Added" })
+      expect(calls.broadcasts).toBe(1)
+      // A directory with content is adopted as-is, not turned into a repo.
+      expect(await Bun.file(path.join(dir, ".git", "HEAD")).exists()).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("creates and git-inits a directory that does not exist yet", async () => {
+    const { deps } = createDeps()
+    const parent = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    const target = path.join(parent, "fresh")
+    try {
+      const response = await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: target } })
+      expect(response?.status).toBe(201)
+      expect(await Bun.file(path.join(target, ".git", "HEAD")).exists()).toBe(true)
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects a path that is a file, not a directory", async () => {
+    const { deps } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    const file = path.join(dir, "not-a-dir.txt")
+    try {
+      await Bun.write(file, "hello")
+      expect((await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: file } }))?.status).toBe(400)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("re-adding the same path returns the project already open there", async () => {
+    const { deps } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      const first = await json(await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } }))
+      const second = await json(await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } }))
+      expect(second.project.id).toBe(first.project.id)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("requires localPath", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/projects", { method: "POST", body: {} })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("localPath")
+  })
+
+  test("rejects a body that is not JSON", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/projects", { method: "POST", body: "{" }))?.status).toBe(400)
+  })
+})
+
+describe("listing chats", () => {
+  test("hides archived and deleted chats by default, newest first", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats"))
+    expect(body.chats.map((chat: { id: string }) => chat.id)).toEqual(["chat-2", "chat-1"])
+    expect(body.total).toBe(2)
+  })
+
+  test("includes archived chats on request, still never deleted ones", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats?includeArchived=true"))
+    const ids = body.chats.map((chat: { id: string }) => chat.id)
+    expect(ids).toContain("chat-archived")
+    expect(ids).not.toContain("chat-deleted")
+  })
+
+  test("filters by project", async () => {
+    const { deps, state } = createDeps()
+    state.projectsById.set("project-2", { id: "project-2", localPath: "/tmp/p2", title: "Two", createdAt: 1, updatedAt: 1 } as ProjectRecord)
+    state.chatsById.set("chat-other", chatRecord({ id: "chat-other", projectId: "project-2" }))
+    const body = await json(await call(deps, "/api/v1/chats?projectId=project-2"))
+    expect(body.chats.map((chat: { id: string }) => chat.id)).toEqual(["chat-other"])
+  })
+
+  test("404s an unknown project rather than returning an empty list", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats?projectId=nope"))?.status).toBe(404)
+  })
+
+  test("honours limit and reports the untruncated total", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats?limit=1"))
+    expect(body.chats).toHaveLength(1)
+    expect(body.total).toBe(2)
+  })
+
+  test("rejects a nonsense limit", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats?limit=0"))?.status).toBe(400)
+    expect((await call(deps, "/api/v1/chats?limit=abc"))?.status).toBe(400)
+  })
+
+  test("reports the live turn status", async () => {
+    const { deps } = createDeps({ activeStatuses: new Map([["chat-1", "running" as KannaStatus]]) })
+    const body = await json(await call(deps, "/api/v1/chats"))
+    const chat = body.chats.find((entry: { id: string }) => entry.id === "chat-1")
+    expect(chat).toMatchObject({ status: "running" })
+  })
+})
+
+describe("creating chats", () => {
+  test("creates an empty chat", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1" } })
+    expect(response?.status).toBe(201)
+    expect((await json(response)).chat).toMatchObject({ projectId: "project-1" })
+    expect(calls.sends).toHaveLength(0)
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("creates and prompts in one call when content is given", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "build it", model: "opus", planMode: true },
+    })
+    expect(response?.status).toBe(202)
+    expect(calls.sends).toEqual([
+      {
+        type: "chat.send",
+        projectId: "project-1",
+        content: "build it",
+        provider: undefined,
+        model: "opus",
+        effort: undefined,
+        modelOptions: undefined,
+        planMode: true,
+        autoPlan: undefined,
+      },
+    ])
+  })
+
+  test("treats whitespace-only content as no content", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1", content: "   " } })
+    expect(response?.status).toBe(201)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("404s an unknown project", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "nope" } }))?.status).toBe(404)
+  })
+})
+
+describe("reading a chat", () => {
+  test("returns the chat with its transcript window", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats/chat-1"))
+    expect(body.chat).toMatchObject({ id: "chat-1", projectId: "project-1" })
+    expect(body.messages).toEqual([])
+    expect(body.runtime).toBeDefined()
+  })
+
+  test("404s an unknown chat", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope"))?.status).toBe(404)
+  })
+
+  test("404s a deleted chat", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats/chat-deleted"))?.status).toBe(404)
+  })
+})
+
+describe("sending a prompt", () => {
+  test("accepts the prompt and answers 202 without waiting for the turn", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hello" } })
+    expect(response?.status).toBe(202)
+    expect(await json(response)).toMatchObject({ chatId: "chat-1", queued: false })
+    expect(calls.sends[0]).toMatchObject({ type: "chat.send", chatId: "chat-1", content: "hello" })
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("reports a prompt that landed behind a running turn", async () => {
+    const { deps } = createDeps()
+    deps.agent.send = async () => ({ chatId: "chat-1", queued: true as const, queuedMessageId: "queued-1" })
+    const body = await json(await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hello" } }))
+    expect(body).toMatchObject({ queued: true, queuedMessageId: "queued-1" })
+  })
+
+  test("requires content", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: {} })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("content")
+  })
+
+  test("rejects a non-object modelOptions", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", modelOptions: "nope" },
+    })
+    expect(response?.status).toBe(400)
+  })
+
+  test("404s an unknown chat before sending", async () => {
+    const { deps, calls } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope/messages", { method: "POST", body: { content: "hi" } }))?.status).toBe(404)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("surfaces an agent failure as 500", async () => {
+    const { deps } = createDeps()
+    deps.agent.send = async () => {
+      throw new Error("provider is not configured")
+    }
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
+    expect(response?.status).toBe(500)
+    expect((await json(response)).error).toBe("provider is not configured")
+  })
+})
+
+describe("cancel and delete", () => {
+  test("cancels a running turn", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/cancel", { method: "POST" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("deletes a chat, stopping its turn first", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.closes).toEqual(["chat-1"])
+    expect(calls.deletes).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("404s deleting an unknown chat", async () => {
+    const { deps, calls } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope", { method: "DELETE" }))?.status).toBe(404)
+    expect(calls.deletes).toHaveLength(0)
+  })
+})

--- a/src/server/api/routes.test.ts
+++ b/src/server/api/routes.test.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import type { AppSettingsSnapshot, KannaStatus } from "../../shared/types"
 import type { ClientCommand } from "../../shared/protocol"
 import { createEmptyState, type ChatRecord, type ProjectRecord } from "../events"
+import { SERVER_PROVIDERS } from "../provider-catalog"
 import { createApiKeyVerifier } from "./keys"
 import { handleApiRequest, type ApiRouteDeps } from "./routes"
 
@@ -30,6 +31,7 @@ interface Calls {
   closes: string[]
   deletes: string[]
   broadcasts: number
+  events: string[]
 }
 
 function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {}) {
@@ -47,7 +49,7 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
   state.chatsById.set("chat-archived", chatRecord({ id: "chat-archived", projectId: "project-1", archivedAt: 3 }))
   state.chatsById.set("chat-deleted", chatRecord({ id: "chat-deleted", projectId: "project-1", deletedAt: 4 }))
 
-  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0 }
+  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0, events: [] }
   let created = 0
 
   const store = {
@@ -109,6 +111,11 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
     verifier: createApiKeyVerifier([KEY]),
     broadcast: () => {
       calls.broadcasts += 1
+    },
+    analytics: {
+      track: (eventName: string) => {
+        calls.events.push(eventName)
+      },
     },
     version: "1.2.3",
   } as unknown as ApiRouteDeps
@@ -439,6 +446,128 @@ describe("sending a prompt", () => {
     const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
     expect(response?.status).toBe(500)
     expect((await json(response)).error).toBe("provider is not configured")
+  })
+})
+
+describe("provider validation", () => {
+  // An unknown provider is only noticed when the turn is set up. For a prompt
+  // that queues behind a running turn that happens after the 202, in
+  // dequeueAndStartQueuedMessage, which removes the queued message before the
+  // catalog lookup throws — so an accepted prompt would vanish.
+  test("rejects an unknown provider instead of accepting the prompt", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", provider: "bogus" },
+    })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("bogus")
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("names the providers it will accept", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", provider: "bogus" },
+    }))
+    expect(body.error).toContain("claude")
+  })
+
+  test("rejects an unknown provider on create-and-prompt too", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "hi", provider: "bogus" },
+    })
+    expect(response?.status).toBe(400)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("accepts every provider the server has a catalog entry for", async () => {
+    for (const provider of SERVER_PROVIDERS.map((entry) => entry.id)) {
+      const { deps, calls } = createDeps()
+      const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+        method: "POST",
+        body: { content: "hi", provider },
+      })
+      expect(response?.status).toBe(202)
+      expect(calls.sends[0]).toMatchObject({ provider })
+    }
+  })
+
+  test("a missing provider stays undefined so the chat's own is used", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
+    expect(calls.sends[0]?.provider).toBeUndefined()
+  })
+})
+
+describe("malformed paths", () => {
+  test("answers 400, not 500, on bad percent-encoding", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/%ZZ")
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("percent-encoding")
+  })
+
+  test("still decodes a legitimately encoded id", async () => {
+    const { deps, state } = createDeps()
+    state.chatsById.set("chat/with slash", chatRecord({ id: "chat/with slash", projectId: "project-1" }))
+    const response = await call(deps, `/api/v1/chats/${encodeURIComponent("chat/with slash")}`)
+    expect(response?.status).toBe(200)
+  })
+})
+
+describe("analytics", () => {
+  test("creating a chat reports chat_created", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1" } })
+    expect(calls.events).toEqual(["chat_created"])
+  })
+
+  test("create-and-prompt leaves the event to agent.send, so it is not doubled", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1", content: "hi" } })
+    expect(calls.events).toEqual([])
+  })
+
+  test("deleting a chat reports chat_deleted", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
+    expect(calls.events).toEqual(["chat_deleted"])
+  })
+
+  test("adding a new project reports project_opened", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      expect(calls.events).toEqual(["project_opened"])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("re-adding an already-open project reports nothing", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      calls.events.length = 0
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      expect(calls.events).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("reads report nothing", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats")
+    await call(deps, "/api/v1/projects")
+    await call(deps, "/api/v1/chats/chat-1")
+    expect(calls.events).toEqual([])
   })
 })
 

--- a/src/server/api/routes.ts
+++ b/src/server/api/routes.ts
@@ -16,7 +16,9 @@ import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../
 import type { ClientCommand } from "../../shared/protocol"
 import type { ChatRecord, ProjectRecord } from "../events"
 import type { EventStore } from "../event-store"
+import type { AnalyticsReporter } from "../analytics"
 import { initializeProjectDirectory } from "../paths"
+import { SERVER_PROVIDERS } from "../provider-catalog"
 import { deriveChatSnapshot, deriveStatus } from "../read-models"
 import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
 import { extractApiKey, type ApiKeyVerifier } from "./keys"
@@ -38,6 +40,12 @@ export interface ApiRouteDeps extends ChatWindowRouteDeps {
   verifier: ApiKeyVerifier
   /** Push fresh snapshots to connected sockets after a write. */
   broadcast: () => Promise<void> | void
+  /**
+   * Same reporter the socket uses. API writes emit the same events as the
+   * equivalent `ClientCommand`, so metrics don't silently miss whatever is
+   * driven over HTTP.
+   */
+  analytics: Pick<AnalyticsReporter, "track">
   version: string
 }
 
@@ -125,6 +133,28 @@ function serializeChat(chat: ChatRecord, status: KannaStatus) {
 }
 
 /**
+ * Reject a provider the server has no catalog entry for.
+ *
+ * This has to happen before `agent.send`. A bad provider is only discovered
+ * when the turn is set up — and for a prompt that lands behind a running turn
+ * that is long after the 202, in `dequeueAndStartQueuedMessage`, which removes
+ * the queued message *before* the catalog lookup throws. The prompt would be
+ * acknowledged and then silently dropped. Validating against SERVER_PROVIDERS
+ * (rather than a hand-written list) keeps this in step with what
+ * `getProviderSettings` will actually accept.
+ */
+function readProvider(body: Record<string, unknown>): AgentProvider | undefined {
+  const value = optionalString(body, "provider")
+  if (value === undefined) return undefined
+  const entry = SERVER_PROVIDERS.find((candidate) => candidate.id === value)
+  if (!entry) {
+    const known = SERVER_PROVIDERS.map((candidate) => candidate.id).join(", ")
+    throw new ApiError(400, `Unknown provider "${value}". Expected one of: ${known}`)
+  }
+  return entry.id
+}
+
+/**
  * The prompt fields shared by "create a chat and send" and "send to an
  * existing chat". Kept in one place so the two routes can't drift.
  */
@@ -134,7 +164,7 @@ function readPromptFields(body: Record<string, unknown>) {
     throw new ApiError(400, '"modelOptions" must be an object')
   }
   return {
-    provider: optionalString(body, "provider") as AgentProvider | undefined,
+    provider: readProvider(body),
     model: optionalString(body, "model"),
     effort: optionalString(body, "effort"),
     modelOptions: modelOptions as ModelOptions | undefined,
@@ -206,7 +236,11 @@ async function handleCreateProject(req: Request, deps: ApiRouteDeps) {
     throw new ApiError(400, error instanceof Error ? error.message : "Could not open project directory")
   }
 
+  // Mirrors ws-router's `project.open`: only a path that wasn't already open
+  // counts as opening a project.
+  const alreadyOpen = deps.store.state.projectIdsByPath.get(resolvedPath)
   const project = await deps.store.openProject(resolvedPath, title)
+  if (!alreadyOpen) deps.analytics.track("project_opened")
   await deps.broadcast()
   return json({ project: serializeProject(project, 0) }, 201)
 }
@@ -259,7 +293,10 @@ async function handleCreateChat(req: Request, deps: ApiRouteDeps) {
     return json({ chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false }, 202)
   }
 
+  // `agent.send` tracks this itself on the prompt path above, so it is only
+  // emitted here, where the chat is created on its own.
   const chat = await deps.store.createChat(projectId)
+  deps.analytics.track("chat_created")
   await deps.broadcast()
   return json({ chat: serializeChat(chat, chatStatus(deps, chat)) }, 201)
 }
@@ -320,6 +357,7 @@ async function handleDeleteChat(chatId: string, deps: ApiRouteDeps) {
   await deps.agent.cancel(chatId)
   await deps.agent.closeChat(chatId)
   await deps.store.deleteChat(chatId)
+  deps.analytics.track("chat_deleted")
   await deps.broadcast()
   return json({ chatId, deleted: true })
 }
@@ -343,7 +381,14 @@ export function hasValidApiKey(req: Request, verifier: ApiKeyVerifier | null) {
 
 async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response> {
   const rest = url.pathname.slice(API_ROUTE_PREFIX.length).replace(/^\/+|\/+$/g, "")
-  const segments = rest ? rest.split("/").map(decodeURIComponent) : []
+  let segments: string[]
+  try {
+    segments = rest ? rest.split("/").map(decodeURIComponent) : []
+  } catch {
+    // decodeURIComponent throws URIError on malformed input like `%ZZ`. That
+    // is a bad request, not a server fault, so it must not reach the 500 path.
+    throw new ApiError(400, "Malformed percent-encoding in path")
+  }
 
   if (segments.length === 0) {
     if (req.method !== "GET") return methodNotAllowed("GET")

--- a/src/server/api/routes.ts
+++ b/src/server/api/routes.ts
@@ -1,0 +1,416 @@
+/**
+ * `/api/v1/*` — the remote REST API, mounted only when the server is started
+ * with `--api` (see cli-runtime.ts).
+ *
+ * Everything here goes through the same EventStore and AgentCoordinator the
+ * WebSocket uses, so a chat created over HTTP shows up in a connected browser
+ * immediately and is written to the normal data dir. After any write the
+ * caller-supplied `broadcast` pushes fresh snapshots to connected sockets.
+ *
+ * Prompts are asynchronous: a send returns 202 with the chat id, and the
+ * caller polls `GET /api/v1/chats/:id` for status and new messages. A turn can
+ * run for many minutes, which no HTTP client or proxy would sit through.
+ */
+
+import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../../shared/types"
+import type { ClientCommand } from "../../shared/protocol"
+import type { ChatRecord, ProjectRecord } from "../events"
+import type { EventStore } from "../event-store"
+import { initializeProjectDirectory } from "../paths"
+import { deriveChatSnapshot, deriveStatus } from "../read-models"
+import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
+import { extractApiKey, type ApiKeyVerifier } from "./keys"
+
+export const API_ROUTE_PREFIX = "/api/v1"
+
+/** Cap on `GET /chats` so one call can't serialize an entire history. */
+const DEFAULT_CHAT_LIMIT = 50
+const MAX_CHAT_LIMIT = 200
+
+export interface ApiRouteDeps extends ChatWindowRouteDeps {
+  store: ChatWindowRouteDeps["store"] &
+    Pick<EventStore, "getProject" | "openProject" | "createChat" | "deleteChat">
+  agent: ChatWindowRouteDeps["agent"] & {
+    send: (command: Extract<ClientCommand, { type: "chat.send" }>) => Promise<{ chatId: string; queuedMessageId?: string; queued?: true }>
+    cancel: (chatId: string) => Promise<void>
+    closeChat: (chatId: string) => Promise<void>
+  }
+  verifier: ApiKeyVerifier
+  /** Push fresh snapshots to connected sockets after a write. */
+  broadcast: () => Promise<void> | void
+  version: string
+}
+
+class ApiError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message)
+  }
+}
+
+function json(body: unknown, status = 200) {
+  return Response.json(body, { status, headers: { "Cache-Control": "no-store" } })
+}
+
+function methodNotAllowed(allow: string) {
+  return new Response(null, { status: 405, headers: { Allow: allow, "Cache-Control": "no-store" } })
+}
+
+async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
+  const raw = await req.text()
+  if (!raw.trim()) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new ApiError(400, "Body must be valid JSON")
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ApiError(400, "Body must be a JSON object")
+  }
+  return parsed as Record<string, unknown>
+}
+
+function requireString(body: Record<string, unknown>, field: string): string {
+  const value = body[field]
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ApiError(400, `Missing or empty "${field}"`)
+  }
+  return value
+}
+
+function optionalString(body: Record<string, unknown>, field: string): string | undefined {
+  const value = body[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "string") throw new ApiError(400, `"${field}" must be a string`)
+  return value
+}
+
+function optionalBoolean(body: Record<string, unknown>, field: string): boolean | undefined {
+  const value = body[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "boolean") throw new ApiError(400, `"${field}" must be a boolean`)
+  return value
+}
+
+function isTruthyParam(value: string | null) {
+  return value === "" || value === "1" || value === "true"
+}
+
+function serializeProject(project: ProjectRecord, chatCount: number) {
+  return {
+    id: project.id,
+    title: project.sidebarTitle ?? project.title,
+    localPath: project.localPath,
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+    chatCount,
+  }
+}
+
+function serializeChat(chat: ChatRecord, status: KannaStatus) {
+  return {
+    id: chat.id,
+    projectId: chat.projectId,
+    title: chat.title,
+    status,
+    provider: chat.provider,
+    createdAt: chat.createdAt,
+    updatedAt: chat.updatedAt,
+    lastMessageAt: chat.lastMessageAt ?? null,
+    lastModel: chat.lastModel ?? null,
+    hasMessages: Boolean(chat.hasMessages),
+    unread: chat.unread,
+    archived: Boolean(chat.archivedAt),
+  }
+}
+
+/**
+ * The prompt fields shared by "create a chat and send" and "send to an
+ * existing chat". Kept in one place so the two routes can't drift.
+ */
+function readPromptFields(body: Record<string, unknown>) {
+  const modelOptions = body.modelOptions
+  if (modelOptions !== undefined && (typeof modelOptions !== "object" || modelOptions === null || Array.isArray(modelOptions))) {
+    throw new ApiError(400, '"modelOptions" must be an object')
+  }
+  return {
+    provider: optionalString(body, "provider") as AgentProvider | undefined,
+    model: optionalString(body, "model"),
+    effort: optionalString(body, "effort"),
+    modelOptions: modelOptions as ModelOptions | undefined,
+    planMode: optionalBoolean(body, "planMode"),
+    autoPlan: optionalBoolean(body, "autoPlan"),
+  }
+}
+
+function chatStatus(deps: ApiRouteDeps, chat: ChatRecord): KannaStatus {
+  return deriveStatus(chat, deps.agent.getActiveStatuses().get(chat.id))
+}
+
+function liveChats(deps: ApiRouteDeps) {
+  return [...deps.store.state.chatsById.values()].filter((chat) => !chat.deletedAt)
+}
+
+function requireChat(deps: ApiRouteDeps, chatId: string): ChatRecord {
+  const chat = deps.store.getChat(chatId)
+  if (!chat || chat.deletedAt) throw new ApiError(404, "Chat not found")
+  return chat
+}
+
+function readFullChatSnapshot(chatId: string, deps: ApiRouteDeps): ChatSnapshot | null {
+  return deriveChatSnapshot(
+    deps.store.state,
+    deps.agent.getActiveStatuses(),
+    deps.agent.getDrainingChatIds(),
+    chatId,
+    (id) => deps.store.getClientTranscript(id)
+  )
+}
+
+// --- routes ---------------------------------------------------------------
+
+function handleRoot(deps: ApiRouteDeps) {
+  return json({
+    name: "kanna",
+    version: deps.version,
+    api: 1,
+    capabilities: ["projects", "chats", "messages", "cancel"],
+  })
+}
+
+function handleListProjects(deps: ApiRouteDeps) {
+  const chatCounts = new Map<string, number>()
+  for (const chat of liveChats(deps)) {
+    if (chat.archivedAt) continue
+    chatCounts.set(chat.projectId, (chatCounts.get(chat.projectId) ?? 0) + 1)
+  }
+  const projects = [...deps.store.state.projectsById.values()]
+    .filter((project) => !project.deletedAt)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((project) => serializeProject(project, chatCounts.get(project.id) ?? 0))
+  return json({ projects })
+}
+
+async function handleCreateProject(req: Request, deps: ApiRouteDeps) {
+  const body = await readJsonBody(req)
+  const localPath = requireString(body, "localPath")
+  const title = optionalString(body, "title")
+
+  // Same call the UI's "new project" flow makes: create the directory if it is
+  // missing, and `git init` it when it is empty so chats there get diffs. An
+  // existing non-empty directory is left exactly as it is.
+  let resolvedPath: string
+  try {
+    resolvedPath = await initializeProjectDirectory(localPath)
+  } catch (error) {
+    throw new ApiError(400, error instanceof Error ? error.message : "Could not open project directory")
+  }
+
+  const project = await deps.store.openProject(resolvedPath, title)
+  await deps.broadcast()
+  return json({ project: serializeProject(project, 0) }, 201)
+}
+
+function handleListChats(url: URL, deps: ApiRouteDeps) {
+  const projectId = url.searchParams.get("projectId")
+  if (projectId && !deps.store.getProject(projectId)) {
+    throw new ApiError(404, "Project not found")
+  }
+  const includeArchived = isTruthyParam(url.searchParams.get("includeArchived"))
+
+  const rawLimit = url.searchParams.get("limit")
+  let limit = DEFAULT_CHAT_LIMIT
+  if (rawLimit !== null) {
+    const parsed = Number(rawLimit)
+    if (!Number.isInteger(parsed) || parsed < 1) throw new ApiError(400, '"limit" must be a positive integer')
+    limit = Math.min(parsed, MAX_CHAT_LIMIT)
+  }
+
+  const matching = liveChats(deps)
+    .filter((chat) => (projectId ? chat.projectId === projectId : true))
+    .filter((chat) => (includeArchived ? true : !chat.archivedAt))
+    .sort((a, b) => (b.lastMessageAt ?? b.updatedAt) - (a.lastMessageAt ?? a.updatedAt))
+
+  return json({
+    chats: matching.slice(0, limit).map((chat) => serializeChat(chat, chatStatus(deps, chat))),
+    total: matching.length,
+  })
+}
+
+async function handleCreateChat(req: Request, deps: ApiRouteDeps) {
+  const body = await readJsonBody(req)
+  const projectId = requireString(body, "projectId")
+  if (!deps.store.getProject(projectId)) throw new ApiError(404, "Project not found")
+
+  const content = optionalString(body, "content")
+
+  // With `content`, hand the whole thing to agent.send: it creates the chat
+  // and starts the first turn in one step, exactly as the composer does when
+  // you type into a project with no chat open.
+  if (content?.trim()) {
+    const result = await deps.agent.send({
+      type: "chat.send",
+      projectId,
+      content,
+      ...readPromptFields(body),
+    })
+    await deps.broadcast()
+    const chat = requireChat(deps, result.chatId)
+    return json({ chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false }, 202)
+  }
+
+  const chat = await deps.store.createChat(projectId)
+  await deps.broadcast()
+  return json({ chat: serializeChat(chat, chatStatus(deps, chat)) }, 201)
+}
+
+function handleGetChat(url: URL, chatId: string, deps: ApiRouteDeps) {
+  const chat = requireChat(deps, chatId)
+  const full = isTruthyParam(url.searchParams.get("full"))
+  const snapshot = full ? readFullChatSnapshot(chatId, deps) : readChatWindow(chatId, deps)
+  if (!snapshot) throw new ApiError(404, "Chat not found")
+  return json({
+    chat: serializeChat(chat, chatStatus(deps, chat)),
+    runtime: snapshot.runtime,
+    queuedMessages: snapshot.queuedMessages,
+    messages: snapshot.messages,
+    startIndex: snapshot.startIndex,
+  })
+}
+
+async function handleSendMessage(req: Request, chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  const body = await readJsonBody(req)
+  const content = requireString(body, "content")
+
+  const result = await deps.agent.send({
+    type: "chat.send",
+    chatId,
+    content,
+    ...readPromptFields(body),
+  })
+  await deps.broadcast()
+
+  const chat = requireChat(deps, result.chatId)
+  return json(
+    {
+      chatId: result.chatId,
+      // True when a turn was already running: the prompt was queued behind it
+      // rather than starting one, and will run when the current turn ends.
+      queued: result.queued ?? false,
+      queuedMessageId: result.queuedMessageId ?? null,
+      status: chatStatus(deps, chat),
+    },
+    202
+  )
+}
+
+async function handleCancelChat(chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  await deps.agent.cancel(chatId)
+  await deps.broadcast()
+  const chat = requireChat(deps, chatId)
+  return json({ chatId, status: chatStatus(deps, chat) })
+}
+
+async function handleDeleteChat(chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  // Same order as the UI's chat.delete: stop the turn, release the harness
+  // session, then tombstone the record.
+  await deps.agent.cancel(chatId)
+  await deps.agent.closeChat(chatId)
+  await deps.store.deleteChat(chatId)
+  await deps.broadcast()
+  return json({ chatId, deleted: true })
+}
+
+// --- dispatch -------------------------------------------------------------
+
+/** True when this request is for the REST API, whoever it turns out to be. */
+export function isApiRoute(url: URL) {
+  return url.pathname === API_ROUTE_PREFIX || url.pathname.startsWith(`${API_ROUTE_PREFIX}/`)
+}
+
+/**
+ * True when the request carries a key valid for this server. `server.ts` uses
+ * this to let an API caller past the `--password` session gate, which exists
+ * for browsers and which an API client has no way to satisfy.
+ */
+export function hasValidApiKey(req: Request, verifier: ApiKeyVerifier | null) {
+  if (!verifier || verifier.count === 0) return false
+  return verifier.isValid(extractApiKey(req))
+}
+
+async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response> {
+  const rest = url.pathname.slice(API_ROUTE_PREFIX.length).replace(/^\/+|\/+$/g, "")
+  const segments = rest ? rest.split("/").map(decodeURIComponent) : []
+
+  if (segments.length === 0) {
+    if (req.method !== "GET") return methodNotAllowed("GET")
+    return handleRoot(deps)
+  }
+
+  if (segments[0] === "projects" && segments.length === 1) {
+    if (req.method === "GET") return handleListProjects(deps)
+    if (req.method === "POST") return await handleCreateProject(req, deps)
+    return methodNotAllowed("GET, POST")
+  }
+
+  if (segments[0] === "chats") {
+    if (segments.length === 1) {
+      if (req.method === "GET") return handleListChats(url, deps)
+      if (req.method === "POST") return await handleCreateChat(req, deps)
+      return methodNotAllowed("GET, POST")
+    }
+
+    const chatId = segments[1]!
+    if (segments.length === 2) {
+      if (req.method === "GET") return handleGetChat(url, chatId, deps)
+      if (req.method === "DELETE") return await handleDeleteChat(chatId, deps)
+      return methodNotAllowed("GET, DELETE")
+    }
+
+    if (segments.length === 3 && segments[2] === "messages") {
+      if (req.method !== "POST") return methodNotAllowed("POST")
+      return await handleSendMessage(req, chatId, deps)
+    }
+
+    if (segments.length === 3 && segments[2] === "cancel") {
+      if (req.method !== "POST") return methodNotAllowed("POST")
+      return await handleCancelChat(chatId, deps)
+    }
+  }
+
+  return json({ error: "Not found" }, 404)
+}
+
+/**
+ * Returns null when the request is not for the API, so `server.ts` can keep
+ * this in its chain of fall-through handlers.
+ */
+export async function handleApiRequest(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response | null> {
+  if (!isApiRoute(url)) return null
+
+  if (!hasValidApiKey(req, deps.verifier)) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "WWW-Authenticate": 'Bearer realm="kanna"',
+      },
+    })
+  }
+
+  try {
+    return await route(req, url, deps)
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return json({ error: error.message }, error.status)
+    }
+    // Store and agent failures surface as 500 with their message: this API is
+    // key-gated and operator-facing, so the detail is useful, not a leak.
+    const message = error instanceof Error ? error.message : "Internal error"
+    return json({ error: message }, 500)
+  }
+}

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -147,6 +147,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -163,6 +166,9 @@ describe("parseArgs", () => {
         strictPort: true,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -179,6 +185,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -195,6 +204,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -211,6 +223,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -227,6 +242,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -253,6 +271,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -269,6 +290,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -631,6 +655,64 @@ describe("parseArgs pair subcommand", () => {
     expect(() => parseArgs(["--cloud", "--cloudflared", "tok"])).toThrow("--cloudflared")
     expect(() => parseArgs(["--cloud", "--host", "10.0.0.5"])).toThrow("--host")
     expect(() => parseArgs(["--cloud", "--remote"])).toThrow("--remote")
+  })
+
+  test("--api collects inline keys in either flag form", () => {
+    const equals = parseArgs(["--api", "--api-key=alpha,bravo"])
+    expect(equals).toMatchObject({ kind: "run", options: { api: true, apiKeys: ["alpha", "bravo"], apiKeyFile: null } })
+
+    const spaced = parseArgs(["--api", "--api-key", "alpha,bravo"])
+    expect(spaced).toMatchObject({ kind: "run", options: { api: true, apiKeys: ["alpha", "bravo"] } })
+  })
+
+  test("repeating --api-key accumulates without duplicates", () => {
+    expect(parseArgs(["--api", "--api-key=alpha", "--api-key=bravo,alpha"])).toMatchObject({
+      kind: "run",
+      options: { apiKeys: ["alpha", "bravo"] },
+    })
+  })
+
+  test("--api-key-file is recorded for startup to read", () => {
+    expect(parseArgs(["--api", "--api-key-file=/tmp/keys.txt"])).toMatchObject({
+      kind: "run",
+      options: { api: true, apiKeys: [], apiKeyFile: "/tmp/keys.txt" },
+    })
+    expect(parseArgs(["--api", "--api-key-file", "/tmp/keys.txt"])).toMatchObject({
+      kind: "run",
+      options: { apiKeyFile: "/tmp/keys.txt" },
+    })
+  })
+
+  test("--api-key-file is not swallowed by --api-key", () => {
+    const parsed = parseArgs(["--api", "--api-key-file=/tmp/keys.txt"])
+    expect(parsed).toMatchObject({ kind: "run", options: { apiKeys: [], apiKeyFile: "/tmp/keys.txt" } })
+  })
+
+  test("--api without any key flag is refused", () => {
+    expect(() => parseArgs(["--api"])).toThrow("--api-key")
+  })
+
+  test("key flags without --api are refused", () => {
+    expect(() => parseArgs(["--api-key=alpha"])).toThrow("--api")
+    expect(() => parseArgs(["--api-key-file=/tmp/keys.txt"])).toThrow("--api")
+  })
+
+  test("key flags need a value", () => {
+    expect(() => parseArgs(["--api", "--api-key="])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key"])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key", "--no-open"])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key-file"])).toThrow("Missing value for --api-key-file")
+  })
+
+  test("--api composes with --remote", () => {
+    expect(parseArgs(["--remote", "--api", "--api-key=alpha"])).toMatchObject({
+      kind: "run",
+      options: { host: "0.0.0.0", api: true, apiKeys: ["alpha"] },
+    })
+  })
+
+  test("a blank inline key list is treated as no keys", () => {
+    expect(() => parseArgs(["--api", "--api-key= , "])).toThrow("--api-key")
   })
 })
 

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -913,6 +913,52 @@ describe("runCli single-instance guard + hosted open", () => {
     expect(calls.openUrl).toEqual([])
   })
 
+  // This run starts no server, so its --api flags cannot take effect. Exiting
+  // 0 would tell a script the API is up when the running instance has no
+  // /api/v1 at all.
+  test("--api against an instance without the API → exit 1, say to restart", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: false }),
+    })
+
+    const result = await runCli(["--api", "--api-key=alpha"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 1 })
+    expect(calls.startServer).toEqual([])
+    expect(calls.openUrl).toEqual([])
+    expect(calls.warn.some((line) => line.includes("without the API"))).toBe(true)
+    expect(calls.warn.some((line) => line.includes("--api"))).toBe(true)
+  })
+
+  test("an instance predating the health field is treated as having no API", async () => {
+    const { deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210 }),
+    })
+
+    expect(await runCli(["--api", "--api-key=alpha"], deps)).toEqual({ kind: "exited", code: 1 })
+  })
+
+  test("--api against an instance already serving it → exit 0, but say the keys were not applied", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: true }),
+    })
+
+    const result = await runCli(["--api", "--api-key=alpha", "--no-open"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 0 })
+    expect(calls.startServer).toEqual([])
+    expect(calls.warn.some((line) => line.includes("was not applied"))).toBe(true)
+  })
+
+  test("without --api an existing instance is unaffected by the new check", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: false }),
+    })
+
+    expect(await runCli(["--no-open"], deps)).toEqual({ kind: "exited", code: 0 })
+    expect(calls.warn).toEqual([])
+  })
+
   test("paired start opens the hosted URL when the tunnel connects (not localhost)", async () => {
     const fake = createFakeCloudRuntime()
     let capturedOnTunnelUp: ((kind: "started" | "recovered") => void) | undefined

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -526,6 +526,21 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
   // fingerprint (e.g. dev profile) keeps the try-next-port behavior.
   const existing = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(runOptions.port)
   if (existing) {
+    // This run is not going to start a server, so its --api flags cannot take
+    // effect. Saying nothing would exit 0 and leave the caller believing the
+    // API is up: a script would go straight on to a /api/v1 request and get a
+    // 404 from an instance that never had the API mounted.
+    if (runOptions.api) {
+      if (!existing.api) {
+        deps.warn(`${LOG_PREFIX} kanna is already running at ${existing.localUrl} without the API`)
+        deps.warn(`${LOG_PREFIX} restart that instance with --api to serve ${API_ROUTE_PREFIX}`)
+        return { kind: "exited", code: 1 }
+      }
+      // It does serve the API, but with the key set it was started with —
+      // this run's keys were never loaded, so don't imply otherwise.
+      deps.warn(`${LOG_PREFIX} kanna is already running with the API enabled; it kept its own keys, and this run's --api-key was not applied`)
+    }
+
     const hostedUrl = identity?.enabled ? identity.appOrigin : null
     deps.log(`${LOG_PREFIX} kanna is already running at ${existing.localUrl}${hostedUrl ? ` (and ${hostedUrl})` : ""}`)
     if (hostedUrl) {

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -14,6 +14,8 @@ import type { AnalyticsReporter } from "./analytics"
 import { createCloudRuntime, type CloudRuntime } from "./cloud"
 import { readCloudIdentity, type CloudIdentity } from "./cloud/identity"
 import { runPairCommand, type PairCommandArgs, type PairAction } from "./cloud/pair-command"
+import { parseApiKeyList, readApiKeyFile } from "./api/keys"
+import { API_ROUTE_PREFIX } from "./api/routes"
 
 export interface CliOptions {
   port: number
@@ -31,6 +33,12 @@ export interface CliOptions {
    * ingress can reach the server. Hook for future dev-box-only features.
    */
   directCloud: boolean
+  /** Mount the remote REST API at /api/v1 (`--api`). Always needs keys. */
+  api: boolean
+  /** Keys given inline with `--api-key`. Merged with `apiKeyFile` at startup. */
+  apiKeys: string[]
+  /** Path from `--api-key-file`; read at startup, one key per line. */
+  apiKeyFile: string | null
 }
 
 export interface CliUpdateOptions {
@@ -83,6 +91,7 @@ export interface CliRuntimeDeps {
   createCloudRuntimeImpl?: (identity: CloudIdentity) => CloudRuntime
   probeExistingInstanceImpl?: (port: number) => Promise<ExistingInstance | null>
   slimTranscriptsImpl?: (log: (message: string) => void) => Promise<SlimTranscriptsStats>
+  readApiKeyFileImpl?: (filePath: string) => Promise<string[]>
 }
 
 export interface UpdateInstallAttemptResult {
@@ -125,6 +134,29 @@ function throwShareConflict(share: Exclude<ShareMode, false>, hostFlag: "--host"
   throw new Error(`${getShareCliFlag(share)} cannot be used with ${hostFlag}`)
 }
 
+/**
+ * Read `--flag=value` or `--flag value`. Every other flag here takes the
+ * space-separated form only; the API key flags accept both because `=` is what
+ * you reach for when the value is a secret being pasted in.
+ *
+ * Returns the value plus how many argv entries it consumed.
+ */
+function readFlagValue(argv: string[], index: number, flag: string): { value: string; consumed: number } {
+  const arg = argv[index]!
+  if (arg.startsWith(`${flag}=`)) {
+    const value = arg.slice(flag.length + 1)
+    if (!value) throw new Error(`Missing value for ${flag}`)
+    return { value, consumed: 0 }
+  }
+  const next = argv[index + 1]
+  if (!next || next.startsWith("-")) throw new Error(`Missing value for ${flag}`)
+  return { value: next, consumed: 1 }
+}
+
+function matchesFlag(arg: string, flag: string) {
+  return arg === flag || arg.startsWith(`${flag}=`)
+}
+
 function printHelp() {
   console.log(`${APP_NAME} — local-only project chat UI
 
@@ -144,6 +176,10 @@ Options:
   --cloudflared <token>
                        Run a named Cloudflare tunnel from a token
   --password <secret>  Require a password before loading the app
+  --api                Serve the remote REST API at /api/v1 (needs a key flag)
+  --api-key=<k1,k2>    API keys, comma separated
+  --api-key-file=<path>
+                       Read API keys from a file, one per line
   --strict-port        Fail instead of trying another port
   --no-open            Don't open browser automatically
   --no-cloud           Skip bringing a paired machine online for this run
@@ -197,6 +233,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let strictPort = false
   let noCloud = false
   let directCloud = false
+  let api = false
+  let apiKeys: string[] = []
+  let apiKeyFile: string | null = null
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -268,7 +307,34 @@ export function parseArgs(argv: string[]): ParsedArgs {
       strictPort = true
       continue
     }
+    if (arg === "--api") {
+      api = true
+      continue
+    }
+    if (matchesFlag(arg, "--api-key-file")) {
+      const { value, consumed } = readFlagValue(argv, index, "--api-key-file")
+      apiKeyFile = value
+      index += consumed
+      continue
+    }
+    if (matchesFlag(arg, "--api-key")) {
+      const { value, consumed } = readFlagValue(argv, index, "--api-key")
+      // Repeating the flag adds to the set rather than replacing it.
+      apiKeys = [...new Set([...apiKeys, ...parseApiKeyList(value)])]
+      index += consumed
+      continue
+    }
     if (!arg.startsWith("-")) throw new Error(`Unexpected positional argument: ${arg}`)
+  }
+
+  // The API is credential-only — there is no session, origin check or browser
+  // login in front of it — so refuse to mount it without keys rather than
+  // quietly serving an open one.
+  if (api && apiKeys.length === 0 && !apiKeyFile) {
+    throw new Error("--api requires --api-key=<key[,key]> or --api-key-file=<path>")
+  }
+  if (!api && (apiKeys.length > 0 || apiKeyFile)) {
+    throw new Error("--api-key and --api-key-file require --api")
   }
 
   if (directCloud) {
@@ -290,6 +356,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       strictPort,
       noCloud,
       directCloud,
+      api,
+      apiKeys,
+      apiKeyFile,
     },
   }
 }
@@ -413,6 +482,25 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     return { kind: "exited", code: 1 }
   }
 
+  // Resolve API keys before anything slow: a bad key file is a config error
+  // and should fail on the spot, not after a self-update round trip.
+  let apiKeys = runOptions.apiKeys
+  if (runOptions.api) {
+    if (runOptions.apiKeyFile) {
+      try {
+        const fromFile = await (deps.readApiKeyFileImpl ?? readApiKeyFile)(runOptions.apiKeyFile)
+        apiKeys = [...new Set([...apiKeys, ...fromFile])]
+      } catch (error) {
+        deps.warn(`${LOG_PREFIX} ${error instanceof Error ? error.message : String(error)}`)
+        return { kind: "exited", code: 1 }
+      }
+    }
+    if (apiKeys.length === 0) {
+      deps.warn(`${LOG_PREFIX} --api needs at least one key; none were found`)
+      return { kind: "exited", code: 1 }
+    }
+  }
+
   const shouldRestart = await maybeSelfUpdate(argv, deps)
   if (shouldRestart !== null) {
     return { kind: "restarting", reason: shouldRestart }
@@ -463,6 +551,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   const started = await deps.startServer({
     ...runOptions,
+    apiKeys,
     trustProxy: isShareEnabled(runOptions.share) || cloudRuntime !== null,
     cloud: cloudRuntime,
     // Unpaired but cloud-capable: the sidebar can claim this machine in one
@@ -486,6 +575,16 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   deps.log(`${LOG_PREFIX} listening on http://${bindHost}:${port}`)
   deps.log(`${LOG_PREFIX} data dir: ${getDataDirDisplay()}`)
+
+  if (runOptions.api) {
+    const keyCount = `${apiKeys.length} key${apiKeys.length === 1 ? "" : "s"}`
+    deps.log(`${LOG_PREFIX} REST API on http://${bindHost}:${port}${API_ROUTE_PREFIX} (${keyCount})`)
+    if (bindHost !== "127.0.0.1") {
+      // Worth saying out loud: bound off loopback, the only thing between the
+      // network and full read/write on every chat is the key.
+      deps.warn(`${LOG_PREFIX} the API is reachable from the network — the API key is its only protection`)
+    }
+  }
 
   if (isShareEnabled(runOptions.share)) {
     try {

--- a/src/server/instance.test.ts
+++ b/src/server/instance.test.ts
@@ -31,7 +31,8 @@ describe("probeExistingInstance", () => {
     stops.push(server.stop)
 
     const match = await probeExistingInstance(server.port, dataDir)
-    expect(match).toEqual({ localUrl: `http://localhost:${server.port}`, port: server.port })
+    // `api` is false: this server was started without --api.
+    expect(match).toEqual({ localUrl: `http://localhost:${server.port}`, port: server.port, api: false })
 
     // Same server, different expected data dir (e.g. dev profile) → no match.
     const mismatch = await probeExistingInstance(server.port, "/somewhere/else")

--- a/src/server/instance.ts
+++ b/src/server/instance.ts
@@ -22,6 +22,12 @@ export function instanceFingerprint(dataDir: string = getDataDir(homedir())) {
 export interface ExistingInstance {
   localUrl: string
   port: number
+  /**
+   * Whether that instance serves the REST API. Absent from an instance older
+   * than this field, which is indistinguishable from "no API" here — either
+   * way `--api` cannot take effect without restarting it.
+   */
+  api?: boolean
 }
 
 /**
@@ -39,10 +45,10 @@ export async function probeExistingInstance(
       signal: AbortSignal.timeout(700),
     })
     if (!response.ok) return null
-    const payload = await response.json() as { ok?: unknown; instance?: unknown }
+    const payload = await response.json() as { ok?: unknown; instance?: unknown; api?: unknown }
     if (payload.ok !== true || typeof payload.instance !== "string") return null
     if (payload.instance !== instanceFingerprint(dataDir)) return null
-    return { localUrl: `http://localhost:${port}`, port }
+    return { localUrl: `http://localhost:${port}`, port, api: payload.api === true }
   } catch {
     return null
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,6 +30,8 @@ import { clearGitHubRepoCache } from "./github"
 import { readLlmProviderSnapshot, validateLlmProviderCredentials, writeLlmProviderSnapshot } from "./llm-provider"
 import { handleTranscribe } from "./transcribe"
 import { handleChatWindow } from "./chat-window-route"
+import { createApiKeyVerifier } from "./api/keys"
+import { handleApiRequest, hasValidApiKey, isApiRoute } from "./api/routes"
 import { applyPiFaveModels } from "./provider-catalog"
 import { createProcessAuthDeps, ProviderAuthManager } from "./provider-auth"
 import { fetchLatestPackageVersion } from "./cli-runtime"
@@ -125,6 +127,13 @@ export interface StartKannaServerOptions {
    * through the app-settings snapshot to unlock dev-box-only UI.
    */
   directCloud?: boolean
+  /**
+   * Mount the remote REST API at /api/v1 (`kanna --api`). Requires `apiKeys`;
+   * with an empty list the API stays unmounted rather than serving openly.
+   */
+  api?: boolean
+  /** Keys accepted on /api/v1 as `Authorization: Bearer` or `X-Api-Key`. */
+  apiKeys?: string[]
   onMigrationProgress?: (message: string) => void
   update?: {
     version: string
@@ -140,6 +149,11 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const strictPort = options.strictPort ?? false
   const runtimeProfile = getRuntimeProfile()
   const auth = options.password ? createAuthManager(options.password, { trustProxy: options.trustProxy ?? false }) : null
+  // Null unless --api was passed with at least one key. Every /api/v1 request
+  // is checked against it, and nothing else on the server consults it.
+  const apiKeyVerifier = options.api && (options.apiKeys?.length ?? 0) > 0
+    ? createApiKeyVerifier(options.apiKeys ?? [])
+    : null
   const store = new EventStore(options.dataDir)
   const diffStore = new DiffStore(store.dataDir)
   const machineDisplayName = getMachineDisplayName()
@@ -505,7 +519,14 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
                   return withOriginAgentCluster(new Response("Unauthorized", { status: 401 }))
                 }
               }
-            } else if (url.pathname.startsWith("/api/") && !auth.isAuthenticated(req)) {
+            } else if (
+              url.pathname.startsWith("/api/") &&
+              !auth.isAuthenticated(req) &&
+              // A valid API key stands in for the browser session on /api/v1.
+              // The password gate is a cookie flow an API client cannot do,
+              // and the key is the stronger credential of the two.
+              !(isApiRoute(url) && hasValidApiKey(req, apiKeyVerifier))
+            ) {
               return withOriginAgentCluster(Response.json({ error: "Unauthorized" }, { status: 401 }))
             }
           }
@@ -565,6 +586,29 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             }
             const payload: CloudWsEndpointResponse = { wsUrl: null }
             return withOriginAgentCluster(Response.json(payload, { headers: { "Cache-Control": "no-store" } }))
+          }
+
+          if (isApiRoute(url)) {
+            // Claim the prefix whether or not the API is mounted: without
+            // this, an unmounted /api/v1 falls through to the SPA and answers
+            // index.html with a 200, which a client reads as success.
+            if (!apiKeyVerifier) {
+              return withOriginAgentCluster(Response.json({ error: "Not found" }, { status: 404 }))
+            }
+            const apiResponse = await handleApiRequest(req, url, {
+              store,
+              agent,
+              appSettings,
+              verifier: apiKeyVerifier,
+              // API writes are rare next to socket traffic, so a full
+              // broadcast is the safe choice: every topic an API call can
+              // touch gets refreshed without enumerating them here.
+              broadcast: () => router.broadcastSnapshots(),
+              version: options.update?.version ?? "0.0.0",
+            })
+            if (apiResponse) {
+              return withOriginAgentCluster(apiResponse)
+            }
           }
 
           const uploadResponse = await handleProjectUpload(req, url, store)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -540,7 +540,16 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             // data dir is already being served (single-instance guard). Only
             // exposed on local/proxied requests — the raw-tunnel /health
             // above stays minimal.
-            return withOriginAgentCluster(Response.json({ ok: true, port: actualPort, instance: instanceFingerprint(store.dataDir) }))
+            // `api` lets a second `kanna --api` invocation see whether the
+            // instance already running on this data dir serves /api/v1, so it
+            // can report that the flag needs a restart instead of exiting as
+            // though it had taken effect.
+            return withOriginAgentCluster(Response.json({
+              ok: true,
+              port: actualPort,
+              instance: instanceFingerprint(store.dataDir),
+              api: apiKeyVerifier !== null,
+            }))
           }
 
           if (url.pathname === CLOUD_PAIR_SESSION_PATH) {
@@ -604,6 +613,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
               // broadcast is the safe choice: every topic an API call can
               // touch gets refreshed without enumerating them here.
               broadcast: () => router.broadcastSnapshots(),
+              analytics,
               version: options.update?.version ?? "0.0.0",
             })
             if (apiResponse) {


### PR DESCRIPTION
Kanna could only be driven by a browser over the WebSocket. This adds an HTTP API so a session can be created, read, prompted and cancelled from another machine or a script.

```bash
kanna --remote --api --api-key=k1,k2
kanna --remote --api --api-key-file=~/.kanna/api-keys.txt
```

`--remote` keeps its existing meaning (bind `0.0.0.0`); `--api` mounts `/api/v1` and requires keys. Both flag forms (`--api-key=v` and `--api-key v`) work, repeating the flag accumulates, and a key file takes one key per line with `#` comments.

## Routes

All key-gated via `Authorization: Bearer <key>` or `X-Api-Key`.

| Method | Route | |
|---|---|---|
| GET | `/api/v1` | version + capabilities |
| GET / POST | `/api/v1/projects` | list / add |
| GET / POST | `/api/v1/chats` | list / create (optional `content` creates *and* prompts) |
| GET / DELETE | `/api/v1/chats/:id` | read (`?full=1` for whole transcript) / delete |
| POST | `/api/v1/chats/:id/messages` | prompt → **202** |
| POST | `/api/v1/chats/:id/cancel` | interrupt a running turn |

Everything routes through the same `EventStore` and `AgentCoordinator` the socket uses, then broadcasts — so an API-created chat is written to the normal data dir and appears in a connected browser immediately.

Prompts are **asynchronous**: a send answers 202 and the caller polls the chat. A turn runs far longer than any HTTP client or proxy will wait. `queued: true` means it landed behind a running turn.

## Security surface

- **`--api` without keys is a startup error.** The API has no session, origin check or login in front of it, so an unkeyed one would be wide open. Keys are compared in constant time against every configured key, and the boot log warns when bound off loopback.
- **The route claims `/api/v1` even when unmounted**, answering a JSON 404. Otherwise the SPA fallback returns `index.html` with a 200 and a client cannot tell the API is off — the same reason `/__cloud` 404s explicitly.
- **A valid key substitutes for the `--password` session on `/api/v1` only**; every other `/api/` route still needs the cookie.
- **Raw cloud-tunnel traffic still sees only `/health` and `/ws`**, so the API is deliberately *not* reachable through a paired machine's tunnel. Happy to open that up if wanted.

## Testing

- **70 new tests** across `keys.test.ts`, `routes.test.ts` and the CLI flag parser. On this base, `cli-runtime.test.ts` goes 49 pass → 119 pass with no new failures.
- `bun run check` clean (typecheck + both production builds).
- Verified end-to-end against a real `startKannaServer`: full project → chat → read → cancel → delete lifecycle; and the `--password` interaction (valid key 200; no key, wrong key, and a valid key on other `/api/` routes all 401).

Pre-existing on `main` and untouched by this PR: 4 `runCli` self-update tests fail, and `auth.test.ts` needs a built `dist/client`.

## Maintenance note

`routes.ts` deliberately does **not** reuse ws-router's `handleCommand`, which is bound to a socket. When the semantics of `chat.send`, `chat.delete` or `project.open` change there, the matching route needs the same change. `CLAUDE.md` records this.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus[1m]`.