### PR TITLE
Fix uploads failing when Kanna is opened over plain http

### DIFF
--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "../ui/button"
 import { Textarea } from "../ui/textarea"
 import { ScrollArea } from "../ui/scroll-area"
-import { cn } from "../../lib/utils"
+import { cn, generateUUID } from "../../lib/utils"
 import { useComposer } from "../../hooks/useComposer"
 import { useIsStandalone } from "../../hooks/useIsStandalone"
 import { useVoiceRecorder } from "../../hooks/useVoiceRecorder"
@@ -540,7 +540,10 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
       if (!file) break
 
       activeUploadsRef.current += 1
-      const tempId = crypto.randomUUID()
+      // Not crypto.randomUUID(): that is secure-context only, so it is
+      // undefined when Kanna is opened over plain http on a LAN/Tailscale
+      // hostname, and every upload would throw before it started.
+      const tempId = generateUUID()
       const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined
       const generation = uploadGenerationRef.current
 

--- a/src/client/lib/chat-navigation.ts
+++ b/src/client/lib/chat-navigation.ts
@@ -1,3 +1,5 @@
+import { generateUUID } from "./utils"
+
 /**
  * The router-state contract for opening a chat *at a message*.
  *
@@ -29,7 +31,9 @@ export interface ChatJumpLocationState {
 }
 
 export function buildChatJumpLocationState(role: ChatJumpRole): ChatJumpLocationState {
-  return { jumpToRole: role, jumpRequestId: crypto.randomUUID() }
+  // generateUUID, not crypto.randomUUID: the latter is secure-context only and
+  // is undefined over plain http on a LAN/Tailscale hostname.
+  return { jumpToRole: role, jumpRequestId: generateUUID() }
 }
 
 /** Reads the jump out of an opaque `useLocation().state`, or null if absent. */


### PR DESCRIPTION
Image and file uploads silently do nothing when Kanna is opened over a LAN or Tailscale hostname (e.g. `http://host.ts.net:5174`). Nothing appears in the composer, no error banner renders, and no request reaches the server.

## Cause

`crypto.randomUUID()` is a [secure-context-only API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID). It exists on `https://` origins and on `localhost`/`127.0.0.1`, and nowhere else — so on a plain-http hostname it is `undefined`.

The upload queue called it directly, on the first line of per-file work:

```ts
activeUploadsRef.current += 1
const tempId = crypto.randomUUID()   // TypeError, over http on a hostname
```

That throws synchronously, before the attachment placeholder is added and before the `fetch`. It sits outside the `try/catch` that populates `uploadError`, so the failure is completely invisible. It also leaks `activeUploadsRef` — incremented on the line above, only decremented in the `finally` of the async block below it — so after `MAX_CONCURRENT_UPLOADS` (3) attempts the queue wedges until reload.

Everything works on localhost, which is why this only shows up over the network. The server side is not involved: `handleProjectUpload` has no origin check, and without `--password` there is no auth gate on `/api/`.

## Fix

Use `generateUUID()` from `lib/utils`, which already exists for exactly this and falls back to a `Math.random` UUID when `crypto.randomUUID` is missing. Both ids are composer-local temporaries and router request tokens, so a non-cryptographic fallback is fine.

`buildChatJumpLocationState` in `lib/chat-navigation.ts` had the identical bug, which broke jump-to-message from the sidebar and minimap on the same page. Fixed alongside.

Serving over HTTPS (`tailscale serve` issues a real cert for the hostname) is still the better setup — it restores `crypto.randomUUID`, the async Clipboard API, and anything else secure-context-gated. This just stops uploads breaking without it.

## Testing

- `bunx tsc --noEmit` clean
- `bun test src/client` — 722 pass, 0 fail

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus[1m]`.