### PR TITLE
feat(composer): choose whether Enter queues or steers while a turn runs

### DIFF
--- a/src/client/app/settings/GeneralSection.tsx
+++ b/src/client/app/settings/GeneralSection.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { Monitor, Moon, Sun } from "lucide-react"
 import { ANALYTICS_STATIC_EVENT_NAMES, ANALYTICS_STATIC_PROPERTY_NAMES } from "../../../shared/analytics"
 import type { EditorPreset } from "../../../shared/protocol"
-import { DEFAULT_NEW_PROJECTS_DIRECTORY } from "../../../shared/types"
+import { DEFAULT_NEW_PROJECTS_DIRECTORY, type SubmitWhileRunning } from "../../../shared/types"
 import { EDITOR_OPTIONS, EditorIcon } from "../../components/editor-icons"
 import { Button } from "../../components/ui/button"
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogTitle } from "../../components/ui/dialog"
@@ -86,6 +86,7 @@ export function GeneralSection({
   const [editorCommandDraft, setEditorCommandDraft] = useState(editorCommandTemplate)
   const newProjectsDirectory = appSettings?.newProjectsDirectory ?? DEFAULT_NEW_PROJECTS_DIRECTORY
   const [newProjectsDirectoryDraft, setNewProjectsDirectoryDraft] = useState(newProjectsDirectory)
+  const submitWhileRunning = appSettings?.submitWhileRunning ?? "queue"
   const transcriptWindow = appSettings?.transcript?.windowAssistantMessages ?? DEFAULT_TRANSCRIPT_WINDOW_ASSISTANT_MESSAGES
   const [transcriptWindowDraft, setTranscriptWindowDraft] = useState(String(transcriptWindow))
   const [appSettingsError, setAppSettingsError] = useState<string | null>(null)
@@ -315,6 +316,27 @@ export function GeneralSection({
                     {option.label}
                   </SelectItem>
                 ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+
+        <SettingsRow def={SETTINGS_ROWS.submitWhileRunning}>
+          <Select
+            value={submitWhileRunning}
+            onValueChange={(value) => {
+              void handleWriteAppSettings({ submitWhileRunning: value as SubmitWhileRunning }).catch((error) => {
+                setAppSettingsError(error instanceof Error ? error.message : "Unable to save composer settings.")
+              })
+            }}
+          >
+            <SelectTrigger className="min-w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="queue">Queue message</SelectItem>
+                <SelectItem value="steer">Steer now</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>

--- a/src/client/app/settings/registry.ts
+++ b/src/client/app/settings/registry.ts
@@ -104,6 +104,12 @@ export const SETTINGS_ROWS = defineRows({
     description: "The bundled sound used for chat notification playback and previews",
     keywords: ["notifications", "audio"],
   },
+  submitWhileRunning: {
+    sectionId: "general",
+    title: "Enter While Running",
+    description: "What Enter does while an agent is working. ⌘Enter always does the other one",
+    keywords: ["queue", "steer", "interrupt", "enter", "send", "composer"],
+  },
   defaultEditor: {
     sectionId: "general",
     title: "Default Editor",

--- a/src/client/app/useSendMessage.ts
+++ b/src/client/app/useSendMessage.ts
@@ -61,7 +61,7 @@ export function useSendMessage(params: {
 
   const handleSend = useCallback(async (
     content: string,
-    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean; autoPlan?: boolean; attachments?: ChatAttachment[] }
+    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean; autoPlan?: boolean; attachments?: ChatAttachment[]; steer?: boolean }
   ) => {
     const { isProcessing, optimisticUserPrompts, serverTranscriptEntries, selectedProjectId, fallbackLocalProjectPath } = sendContextRef.current
     const attachments = options?.attachments ?? []
@@ -77,6 +77,9 @@ export function useSendMessage(params: {
           modelOptions: options?.modelOptions,
           planMode: options?.planMode,
           autoPlan: options?.autoPlan,
+          // Only meaningful here: off a running turn there is nothing to
+          // interrupt, and the message starts immediately either way.
+          steer: options?.steer,
         })
         setCommandError(null)
         return

--- a/src/client/components/chat-ui/ChatInput.tsx
+++ b/src/client/components/chat-ui/ChatInput.tsx
@@ -27,6 +27,8 @@ import { abbreviatePathHead, formatPathWithTilde } from "../../lib/pathUtils"
 import { copyTextToClipboard } from "../../lib/clipboard"
 import { buildUploadErrorReport, simpleUploadError, type UploadErrorReport } from "../../lib/uploadError"
 import { useUnauthenticatedHarnesses } from "../../stores/providerAuthStore"
+import { useAppSettingsStore } from "../../stores/appSettingsStore"
+import { shouldSteerSubmit } from "../../../shared/submit-mode"
 import { SignInDialog } from "../auth/SignInDialog"
 import { ChatPreferenceControls } from "./ChatPreferenceControls"
 import { ContextWindowMeter } from "./ContextWindowMeter"
@@ -168,7 +170,7 @@ interface ComposerAttachment extends ChatAttachment {
 interface Props {
   onSubmit: (
     value: string,
-    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean; autoPlan?: boolean; attachments?: ChatAttachment[] }
+    options?: { provider?: AgentProvider; model?: string; modelOptions?: ModelOptions; planMode?: boolean; autoPlan?: boolean; attachments?: ChatAttachment[]; steer?: boolean }
   ) => Promise<void>
   onLayoutChange?: () => void
   onCancel?: () => void
@@ -244,6 +246,8 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   const { composerChatId, providerSwitchPending, selectedProvider } = composer
   const providerPrefs = composer.effectiveState
   const showModePicker = composer.supportsPlanMode
+  // What Enter does while a turn is running; ⌘/Ctrl+Enter does the other.
+  const submitWhileRunning = useAppSettingsStore((store) => store.settings?.submitWhileRunning) ?? "queue"
   // Switching to a harness that isn't signed in is blocked: the pick is
   // stashed here, a sign-in dialog opens, and the switch applies
   // automatically once the auth store reports the service signed in.
@@ -684,7 +688,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
   }, [])
 
   /** The composer's current prefs, the way a send carries them. */
-  function buildSubmitOptions(attachmentsForSubmit: ChatAttachment[]) {
+  function buildSubmitOptions(attachmentsForSubmit: ChatAttachment[], steer = shouldSteerSubmit(submitWhileRunning, false)) {
     let modelOptions: ModelOptions
     if (providerPrefs.provider === "claude") {
       modelOptions = { claude: { ...providerPrefs.modelOptions } }
@@ -696,6 +700,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
       modelOptions = { codex: { ...providerPrefs.modelOptions } }
     }
     return {
+      steer,
       provider: selectedProvider,
       model: providerPrefs.model,
       modelOptions,
@@ -705,7 +710,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     }
   }
 
-  async function handleSubmit() {
+  async function handleSubmit(options?: { withModifier?: boolean }) {
     if (!canSubmit || hasPendingUploads) return
 
     const nextValue = value
@@ -713,7 +718,10 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     const previousSelectedAttachmentId = selectedAttachmentId
     const previousUploadError = uploadError
     const attachmentsForSubmit = uploadedAttachments.map(({ previewUrl: _previewUrl, status: _status, ...attachment }) => attachment)
-    const submitOptions = buildSubmitOptions(attachmentsForSubmit)
+    const submitOptions = buildSubmitOptions(
+      attachmentsForSubmit,
+      shouldSteerSubmit(submitWhileRunning, options?.withModifier === true)
+    )
     setValue("")
     if (chatId) clearDraft(chatId)
     if (textareaRef.current) textareaRef.current.style.height = "auto"
@@ -833,7 +841,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
     const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0
     if (event.key === "Enter" && !event.shiftKey && !isTouchDevice && !disabled && canSubmit && !hasPendingUploads) {
       event.preventDefault()
-      void handleSubmit()
+      void handleSubmit({ withModifier: event.metaKey || event.ctrlKey })
     }
   }
 
@@ -1061,7 +1069,7 @@ const ChatInputInner = forwardRef<ChatInputHandle, Props>(function ChatInput({
                 // cancel, so a file-only message queues instead of stopping
                 // the running turn.
                 if (!disabled && canSubmit && !hasPendingUploads) {
-                  void handleSubmit()
+                  void handleSubmit({ withModifier: event.metaKey || event.ctrlKey })
                 } else if (canCancel) {
                   onCancel?.()
                 }

--- a/src/server/agent.test.ts
+++ b/src/server/agent.test.ts
@@ -1784,6 +1784,104 @@ describe("AgentCoordinator claude integration", () => {
     events.close()
   })
 
+  test("enqueue with steer goes through the same path as Send now on a queued message", async () => {
+    const events = new AsyncEventQueue<any>()
+    const prompts: string[] = []
+    const store = createFakeStore()
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        sendPrompt: async (content: string) => {
+          prompts.push(content)
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "first prompt",
+      model: "claude-opus-4-1",
+    })
+    await coordinator.enqueue({
+      type: "message.enqueue",
+      chatId: "chat-1",
+      content: "actually, do this instead",
+      steer: true,
+    })
+
+    // Interrupted and re-prompted straight away, with the steer block —
+    // exactly what steer() does, because it is steer().
+    expect(prompts).toHaveLength(2)
+    expect(prompts[1]).toContain("actually, do this instead")
+    expect(prompts[1]).toContain("<system-message>")
+    expect(store.messages.some((entry) => entry.kind === "interrupted")).toBe(true)
+    expect(store.getQueuedMessages()).toEqual([])
+
+    events.close()
+  })
+
+  test("enqueue with steer is not an error when the queue drained first", async () => {
+    // The race the flag exists for: the turn ends while the message is being
+    // queued, the drain starts it, and steer() finds nothing to steer. The
+    // message is running — which is what was asked for — so that is success.
+    const events = new AsyncEventQueue<any>()
+    const prompts: string[] = []
+    const store = createFakeStore()
+    // Simulate the drain: the message is gone by the time steer() looks.
+    const enqueueMessage = store.enqueueMessage.bind(store)
+    store.enqueueMessage = async (chatId: string, message: any) => {
+      const queued = await enqueueMessage(chatId, message)
+      await store.removeQueuedMessage(chatId, queued.id)
+      return queued
+    }
+    const coordinator = new AgentCoordinator({
+      store: store as never,
+      onStateChange: () => {},
+      startClaudeSession: async () => ({
+        provider: "claude",
+        stream: events,
+        getAccountInfo: async () => null,
+        interrupt: async () => {},
+        close: () => {},
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        sendPrompt: async (content: string) => {
+          prompts.push(content)
+        },
+      }),
+    })
+
+    await coordinator.send({
+      type: "chat.send",
+      chatId: "chat-1",
+      provider: "claude",
+      content: "first prompt",
+      model: "claude-opus-4-1",
+    })
+    await expect(coordinator.enqueue({
+      type: "message.enqueue",
+      chatId: "chat-1",
+      content: "late steer",
+      steer: true,
+    })).resolves.toEqual({ queuedMessageId: expect.any(String) })
+
+    // Nothing was double-sent and the running turn was left alone.
+    expect(prompts).toEqual(["first prompt"])
+    expect(store.messages.some((entry) => entry.kind === "interrupted")).toBe(false)
+
+    events.close()
+  })
+
   test("escape mid-turn does not surface the SDK's interrupt error result", async () => {
     const events = new AsyncEventQueue<any>()
     const store = createFakeStore()

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1694,6 +1694,19 @@ export class AgentCoordinator {
       planMode: command.planMode,
       autoPlan: command.autoPlan,
     })
+    if (command.steer) {
+      // The same path as "Send now" on a queued message, so the two can't
+      // drift. One thing it has to absorb: the turn can end while the message
+      // was being queued, in which case the drain has already started it —
+      // the outcome steering wanted, just not by this call.
+      try {
+        await this.steer({ type: "message.steer", chatId: command.chatId, queuedMessageId: queuedMessage.id })
+      } catch (error) {
+        const drained = !this.store.getQueuedMessage(command.chatId, queuedMessage.id)
+          && this.activeTurns.has(command.chatId)
+        if (!drained) throw error
+      }
+    }
     return { queuedMessageId: queuedMessage.id }
   }
 

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -302,6 +302,23 @@ describe("AppSettingsManager", () => {
     manager.dispose()
   })
 
+  test("does not rewrite a settings file that already carries the composer default", async () => {
+    // Every field the file payload has must be in the comparison too, or the
+    // file is rewritten on every launch for no change.
+    const filePath = await createTempFilePath()
+    const first = new AppSettingsManager(filePath)
+    await first.initialize()
+    await first.writePatch({ submitWhileRunning: "steer" })
+    first.dispose()
+    const written = await readFile(filePath, "utf8")
+
+    const second = new AppSettingsManager(filePath)
+    await second.initialize()
+    second.dispose()
+
+    expect(await readFile(filePath, "utf8")).toBe(written)
+  })
+
   test("normalizes GPT-5.6 reasoning levels when settings are written", async () => {
     const filePath = await createTempFilePath()
     const manager = new AppSettingsManager(filePath)

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -29,6 +29,7 @@ function expectedSettingsSnapshot(filePath: string, overrides: Partial<AppSettin
     theme: "system",
     chatSoundPreference: "always",
     chatSoundId: "funk",
+    submitWhileRunning: "queue",
     terminal: {
       scrollbackLines: 1_000,
       minColumnWidth: 450,
@@ -277,6 +278,26 @@ describe("AppSettingsManager", () => {
     expect(nextPayload.analyticsUserId).toBe(initialPayload.analyticsUserId)
     expect(nextPayload.theme).toBe("dark")
     expect(nextPayload.chatSoundId).toBe("glass")
+
+    manager.dispose()
+  })
+
+  test("persists the composer's queue-or-steer default, and ignores junk", async () => {
+    const filePath = await createTempFilePath()
+    const manager = new AppSettingsManager(filePath)
+    await manager.initialize()
+
+    expect(manager.getSnapshot().submitWhileRunning).toBe("queue")
+    expect((await manager.writePatch({ submitWhileRunning: "steer" })).submitWhileRunning).toBe("steer")
+
+    const payload = JSON.parse(await readFile(filePath, "utf8")) as { submitWhileRunning: string }
+    expect(payload.submitWhileRunning).toBe("steer")
+
+    // Anything unrecognised falls back to queueing rather than to the more
+    // disruptive action.
+    await writeFile(filePath, JSON.stringify({ submitWhileRunning: "yolo" }), "utf8")
+    await manager.reload()
+    expect(manager.getSnapshot().submitWhileRunning).toBe("queue")
 
     manager.dispose()
   })

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -24,6 +24,7 @@ import {
   type ChatSoundPreference,
   type DefaultProviderPreference,
   type EditorPreset,
+  type SubmitWhileRunning,
 } from "../shared/types"
 
 interface AppSettingsFile {
@@ -33,6 +34,7 @@ interface AppSettingsFile {
   theme?: unknown
   chatSoundPreference?: unknown
   chatSoundId?: unknown
+  submitWhileRunning?: unknown
   terminal?: {
     scrollbackLines?: unknown
     minColumnWidth?: unknown
@@ -79,6 +81,9 @@ const MAX_TERMINAL_MIN_COLUMN_WIDTH = 900
 const DEFAULT_EDITOR_PRESET: EditorPreset = "cursor"
 const DEFAULT_CHAT_SOUND_PREFERENCE: ChatSoundPreference = "always"
 const DEFAULT_CHAT_SOUND_ID: ChatSoundId = "funk"
+// Queue by default: interrupting a running turn is the rarer, more disruptive
+// intent, so it is the one you reach for deliberately.
+const DEFAULT_SUBMIT_WHILE_RUNNING: SubmitWhileRunning = "queue"
 
 function createAnalyticsUserId() {
   return `anon_${randomUUID()}`
@@ -130,6 +135,10 @@ function normalizeChatSoundId(value: unknown): ChatSoundId {
   }
 }
 
+function normalizeSubmitWhileRunning(value: unknown): SubmitWhileRunning {
+  return value === "steer" ? "steer" : DEFAULT_SUBMIT_WHILE_RUNNING
+}
+
 function normalizeDefaultProvider(value: unknown): DefaultProviderPreference {
   return value === "claude" || value === "codex" || value === "cursor" || value === "pi" || value === "last_used"
     ? value
@@ -155,6 +164,7 @@ function toFilePayload(state: AppSettingsState) {
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    submitWhileRunning: state.submitWhileRunning,
     terminal: state.terminal,
     editor: state.editor,
     transcript: state.transcript,
@@ -176,6 +186,7 @@ function toSnapshot(state: AppSettingsState, devbox = false): AppSettingsSnapsho
     theme: state.theme,
     chatSoundPreference: state.chatSoundPreference,
     chatSoundId: state.chatSoundId,
+    submitWhileRunning: state.submitWhileRunning,
     terminal: state.terminal,
     editor: state.editor,
     transcript: state.transcript,
@@ -242,6 +253,7 @@ function normalizeAppSettings(
     theme: normalizeTheme(source?.theme),
     chatSoundPreference: normalizeChatSoundPreference(source?.chatSoundPreference),
     chatSoundId: normalizeChatSoundId(source?.chatSoundId),
+    submitWhileRunning: normalizeSubmitWhileRunning(source?.submitWhileRunning),
     terminal: {
       scrollbackLines: clampNumber(source?.terminal?.scrollbackLines, DEFAULT_TERMINAL_SCROLLBACK, MIN_TERMINAL_SCROLLBACK, MAX_TERMINAL_SCROLLBACK),
       minColumnWidth: clampNumber(source?.terminal?.minColumnWidth, DEFAULT_TERMINAL_MIN_COLUMN_WIDTH, MIN_TERMINAL_MIN_COLUMN_WIDTH, MAX_TERMINAL_MIN_COLUMN_WIDTH),

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -304,6 +304,7 @@ function toComparablePayload(source: AppSettingsFile) {
     theme: source.theme,
     chatSoundPreference: source.chatSoundPreference,
     chatSoundId: source.chatSoundId,
+    submitWhileRunning: source.submitWhileRunning,
     terminal: source.terminal,
     editor: source.editor,
     transcript: source.transcript,

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -4,6 +4,7 @@ import { CLI_SUPPRESS_OPEN_ONCE_ENV_VAR } from "./restart"
 
 const originalRuntimeProfile = process.env.KANNA_RUNTIME_PROFILE
 const originalSuppressOpen = process.env[CLI_SUPPRESS_OPEN_ONCE_ENV_VAR]
+const originalDisableSelfUpdate = process.env.KANNA_DISABLE_SELF_UPDATE
 
 beforeEach(() => {
   // Every test assumes the open-once suppression flag is unset; the parent
@@ -11,6 +12,10 @@ beforeEach(() => {
   // Kanna-managed terminal after a self-restart). Tests that need it set it
   // themselves; afterEach restores the inherited value for other suites.
   delete process.env[CLI_SUPPRESS_OPEN_ONCE_ENV_VAR]
+  // Likewise for the self-update opt-out: anyone running Kanna from a checkout
+  // exports it in their shell, and leaving it set would silently skip the
+  // update path these tests are here to cover.
+  delete process.env.KANNA_DISABLE_SELF_UPDATE
 })
 
 afterEach(() => {
@@ -18,6 +23,11 @@ afterEach(() => {
     delete process.env.KANNA_RUNTIME_PROFILE
   } else {
     process.env.KANNA_RUNTIME_PROFILE = originalRuntimeProfile
+  }
+  if (originalDisableSelfUpdate === undefined) {
+    delete process.env.KANNA_DISABLE_SELF_UPDATE
+  } else {
+    process.env.KANNA_DISABLE_SELF_UPDATE = originalDisableSelfUpdate
   }
   if (originalSuppressOpen === undefined) {
     delete process.env[CLI_SUPPRESS_OPEN_ONCE_ENV_VAR]

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -84,6 +84,7 @@ const DEFAULT_APP_SETTINGS_SNAPSHOT: AppSettingsSnapshot = {
   theme: "system",
   chatSoundPreference: "always",
   chatSoundId: "funk",
+  submitWhileRunning: "queue",
   terminal: {
     scrollbackLines: 1_000,
     minColumnWidth: 450,
@@ -816,6 +817,54 @@ describe("ws-router", () => {
     } finally {
       await rm(projectPath, { recursive: true, force: true })
     }
+  })
+
+  test("message.enqueue steers the message it just queued when asked", async () => {
+    // One command, not enqueue-then-steer from the client: between the two the
+    // turn could end and drain the queue, leaving the steer nothing to find.
+    const steered: Array<{ chatId: string; queuedMessageId: string }> = []
+    const router = createTestRouter({
+      agent: {
+        enqueue: async () => ({ queuedMessageId: "queued-7" }),
+        steer: async (command: { chatId: string; queuedMessageId: string }) => {
+          steered.push({ chatId: command.chatId, queuedMessageId: command.queuedMessageId })
+        },
+        getActiveStatuses: () => new Map(),
+        getDrainingChatIds: () => new Set(),
+      } as never,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(ws as never, JSON.stringify({
+      v: 1,
+      type: "command",
+      id: "enqueue-steer-1",
+      command: { type: "message.enqueue", chatId: "chat-1", content: "actually, stop", steer: true },
+    }))
+
+    expect(steered).toEqual([{ chatId: "chat-1", queuedMessageId: "queued-7" }])
+  })
+
+  test("message.enqueue leaves the message queued by default", async () => {
+    let steerCalls = 0
+    const router = createTestRouter({
+      agent: {
+        enqueue: async () => ({ queuedMessageId: "queued-8" }),
+        steer: async () => { steerCalls += 1 },
+        getActiveStatuses: () => new Map(),
+        getDrainingChatIds: () => new Set(),
+      } as never,
+    })
+    const ws = new FakeWebSocket()
+
+    await router.handleMessage(ws as never, JSON.stringify({
+      v: 1,
+      type: "command",
+      id: "enqueue-plain-1",
+      command: { type: "message.enqueue", chatId: "chat-1", content: "after you're done" },
+    }))
+
+    expect(steerCalls).toBe(0)
   })
 
   test("project.create initializes the directory, acks the resolved path, and tracks analytics", async () => {

--- a/src/server/ws-router.test.ts
+++ b/src/server/ws-router.test.ts
@@ -819,54 +819,6 @@ describe("ws-router", () => {
     }
   })
 
-  test("message.enqueue steers the message it just queued when asked", async () => {
-    // One command, not enqueue-then-steer from the client: between the two the
-    // turn could end and drain the queue, leaving the steer nothing to find.
-    const steered: Array<{ chatId: string; queuedMessageId: string }> = []
-    const router = createTestRouter({
-      agent: {
-        enqueue: async () => ({ queuedMessageId: "queued-7" }),
-        steer: async (command: { chatId: string; queuedMessageId: string }) => {
-          steered.push({ chatId: command.chatId, queuedMessageId: command.queuedMessageId })
-        },
-        getActiveStatuses: () => new Map(),
-        getDrainingChatIds: () => new Set(),
-      } as never,
-    })
-    const ws = new FakeWebSocket()
-
-    await router.handleMessage(ws as never, JSON.stringify({
-      v: 1,
-      type: "command",
-      id: "enqueue-steer-1",
-      command: { type: "message.enqueue", chatId: "chat-1", content: "actually, stop", steer: true },
-    }))
-
-    expect(steered).toEqual([{ chatId: "chat-1", queuedMessageId: "queued-7" }])
-  })
-
-  test("message.enqueue leaves the message queued by default", async () => {
-    let steerCalls = 0
-    const router = createTestRouter({
-      agent: {
-        enqueue: async () => ({ queuedMessageId: "queued-8" }),
-        steer: async () => { steerCalls += 1 },
-        getActiveStatuses: () => new Map(),
-        getDrainingChatIds: () => new Set(),
-      } as never,
-    })
-    const ws = new FakeWebSocket()
-
-    await router.handleMessage(ws as never, JSON.stringify({
-      v: 1,
-      type: "command",
-      id: "enqueue-plain-1",
-      command: { type: "message.enqueue", chatId: "chat-1", content: "after you're done" },
-    }))
-
-    expect(steerCalls).toBe(0)
-  })
-
   test("project.create initializes the directory, acks the resolved path, and tracks analytics", async () => {
     const analyticsEvents: string[] = []
     const state = createEmptyState()

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1693,6 +1693,13 @@ export function createWsRouter({
         }
         case "message.enqueue": {
           const result = await agent.enqueue(command)
+          if (command.steer) {
+            await agent.steer({
+              type: "message.steer",
+              chatId: command.chatId,
+              queuedMessageId: result.queuedMessageId,
+            })
+          }
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
           await broadcastChatAndSidebar(command.chatId)
           return

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -1693,13 +1693,6 @@ export function createWsRouter({
         }
         case "message.enqueue": {
           const result = await agent.enqueue(command)
-          if (command.steer) {
-            await agent.steer({
-              type: "message.steer",
-              chatId: command.chatId,
-              queuedMessageId: result.queuedMessageId,
-            })
-          }
           send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
           await broadcastChatAndSidebar(command.chatId)
           return

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -300,9 +300,9 @@ export type ClientCommand =
       autoPlan?: boolean
       /**
        * Interrupt the running turn and deliver this message now, instead of
-       * leaving it queued. Done here rather than as a follow-up `message.steer`
-       * so the turn can't finish and drain the queue in between, which would
-       * leave the steer with nothing to find.
+       * leaving it queued — the same as "Send now" on a queued message, folded
+       * into one command so the coordinator can absorb the turn ending in
+       * between (in which case the message has already started).
        */
       steer?: boolean
     }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -298,6 +298,13 @@ export type ClientCommand =
       modelOptions?: ModelOptions
       planMode?: boolean
       autoPlan?: boolean
+      /**
+       * Interrupt the running turn and deliver this message now, instead of
+       * leaving it queued. Done here rather than as a follow-up `message.steer`
+       * so the turn can't finish and drain the queue in between, which would
+       * leave the steer with nothing to find.
+       */
+      steer?: boolean
     }
   | {
       type: "message.steer"

--- a/src/shared/submit-mode.test.ts
+++ b/src/shared/submit-mode.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { shouldSteerSubmit } from "./submit-mode"
+
+describe("shouldSteerSubmit", () => {
+  test("queues on a bare Enter and steers with the modifier", () => {
+    expect(shouldSteerSubmit("queue", false)).toBe(false)
+    expect(shouldSteerSubmit("queue", true)).toBe(true)
+  })
+
+  test("inverts once the default is steer", () => {
+    // The point of the setting: whichever action you use most is the bare
+    // keystroke, and the other stays reachable rather than disappearing.
+    expect(shouldSteerSubmit("steer", false)).toBe(true)
+    expect(shouldSteerSubmit("steer", true)).toBe(false)
+  })
+})

--- a/src/shared/submit-mode.ts
+++ b/src/shared/submit-mode.ts
@@ -1,0 +1,13 @@
+import type { SubmitWhileRunning } from "./types"
+
+/**
+ * Whether a send should interrupt the running turn rather than queue behind it.
+ *
+ * The setting decides what a bare Enter does, and the modifier (⌘/Ctrl+Enter,
+ * or a modified click on the send button) always asks for the other one — so
+ * whichever way the default is set, both actions stay one keystroke away and
+ * neither becomes unreachable.
+ */
+export function shouldSteerSubmit(mode: SubmitWhileRunning, withModifier: boolean) {
+  return (mode === "steer") !== withModifier
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,12 @@ export type AppThemePreference = "light" | "dark" | "system"
 export type ChatSoundPreference = "never" | "unfocused" | "always"
 export type ChatSoundId = "blow" | "bottle" | "frog" | "funk" | "glass" | "ping" | "pop" | "purr" | "tink"
 export type DefaultProviderPreference = "last_used" | AgentProvider
+/**
+ * What pressing Enter does while a turn is running: hold the message until the
+ * turn ends, or interrupt and deliver it now. The modifier (⌘/Ctrl+Enter) always
+ * does the other one, so either is one keystroke away whatever the default.
+ */
+export type SubmitWhileRunning = "queue" | "steer"
 export type EditorPreset = "cursor" | "vscode" | "xcode" | "windsurf" | "custom"
 export const DEFAULT_OPENAI_SDK_MODEL = "gpt-5.4-mini"
 export const DEFAULT_OPENROUTER_SDK_MODEL = "moonshotai/kimi-k2.5:nitro"
@@ -1105,6 +1111,8 @@ export interface AppSettingsSnapshot {
     windowAssistantMessages: number
   }
   defaultProvider: DefaultProviderPreference
+  /** Default action for Enter while a turn is running. ⌘Enter does the other. */
+  submitWhileRunning: SubmitWhileRunning
   providerDefaults: ChatProviderPreferences
   /** Labs: the tabbed Chats/Projects "New Sidebar". On by default; false opts back into the legacy sidebar. */
   newSidebarEnabled: boolean
@@ -1134,6 +1142,7 @@ export interface AppSettingsPatch {
   theme?: AppThemePreference
   chatSoundPreference?: ChatSoundPreference
   chatSoundId?: ChatSoundId
+  submitWhileRunning?: SubmitWhileRunning
   newSidebarEnabled?: boolean
   newProjectsDirectory?: string
   setupShown?: boolean


### PR DESCRIPTION
Enter always queued behind the running turn; steering meant finding the queued message and clicking Send now. Which one you want by default depends on how you work, so it's a setting — **Settings → General → Enter While Running**, defaulting to queue.

⌘/Ctrl+Enter always does the other one, so neither action becomes unreachable whichever way it's set. Same for a modified click on the send button.

`message.enqueue` gained an optional `steer` flag instead of the client chaining enqueue → steer: between those two the turn can end and drain the queue, leaving the steer with nothing to find.

Also fixes four `cli-runtime` tests that fail on any machine exporting `KANNA_DISABLE_SELF_UPDATE` — the suite already guards another env var the same way.

Tested by hand in both modes; full suite, typecheck and both builds pass.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus[1m]`.
