### PR TITLE
Add GPT-6 Astra to the Codex model picker

### DIFF
--- a/src/client/components/chat-ui/ChatPreferenceControls.test.tsx
+++ b/src/client/components/chat-ui/ChatPreferenceControls.test.tsx
@@ -61,6 +61,25 @@ describe("ChatPreferenceControls", () => {
     expect(html).toContain("Ultra")
   })
 
+  test("renders Astra with its Codex reasoning and fast-mode controls", () => {
+    const html = renderToStaticMarkup(
+      <ChatPreferenceControls
+        availableProviders={PROVIDERS}
+        selectedProvider="codex"
+        model="gpt-6-astra"
+        modelOptions={{ reasoningEffort: "ultra", fastMode: true }}
+        onProviderChange={() => {}}
+        onModelChange={() => {}}
+        onModelOptionChange={() => {}}
+        includeMode={false}
+      />
+    )
+
+    expect(html).toContain("GPT-6 Astra")
+    expect(html).toContain("Ultra")
+    expect(html).toContain("Fast Mode")
+  })
+
   test("renders claude plan mode controls when enabled", () => {
     const html = renderToStaticMarkup(
       <ChatPreferenceControls

--- a/src/server/app-settings.test.ts
+++ b/src/server/app-settings.test.ts
@@ -281,7 +281,7 @@ describe("AppSettingsManager", () => {
     manager.dispose()
   })
 
-  test("normalizes GPT-5.6 reasoning levels when settings are written", async () => {
+  test("normalizes current Codex reasoning levels when settings are written", async () => {
     const filePath = await createTempFilePath()
     const manager = new AppSettingsManager(filePath)
     await manager.initialize()
@@ -315,6 +315,16 @@ describe("AppSettingsManager", () => {
     expect(legacy.providerDefaults.codex).toMatchObject({
       model: "gpt-5.5",
       modelOptions: { reasoningEffort: "xhigh", fastMode: false },
+    })
+
+    const astra = await manager.writePatch({
+      providerDefaults: {
+        codex: { model: "gpt-6-astra", modelOptions: { reasoningEffort: "ultra", fastMode: true } },
+      },
+    })
+    expect(astra.providerDefaults.codex).toMatchObject({
+      model: "gpt-6-astra",
+      modelOptions: { reasoningEffort: "ultra", fastMode: true },
     })
 
     manager.dispose()

--- a/src/server/provider-catalog.test.ts
+++ b/src/server/provider-catalog.test.ts
@@ -103,6 +103,13 @@ describe("provider catalog normalization", () => {
       fastMode: false,
     })
 
+    expect(normalizeCodexModelOptions("gpt-6-astra", {
+      codex: { reasoningEffort: "ultra", fastMode: true },
+    })).toEqual({
+      reasoningEffort: "ultra",
+      fastMode: true,
+    })
+
     const normalized = normalizeCodexModelOptions("gpt-5.6-terra", {
       codex: {
         reasoningEffort: "xhigh",
@@ -223,6 +230,7 @@ describe("provider catalog normalization", () => {
 
   test("normalizes server model ids through the shared alias catalog", () => {
     expect(normalizeServerModel("codex")).toBe("gpt-5.6-sol")
+    expect(normalizeServerModel("codex", "gpt-6-astra")).toBe("gpt-6-astra")
     expect(normalizeServerModel("claude", "fable")).toBe("fable")
     expect(normalizeServerModel("claude", "opus")).toBe("opus")
     // Version-pinned ids persisted by older Kanna versions fold into the alias.

--- a/src/server/provider-catalog.ts
+++ b/src/server/provider-catalog.ts
@@ -289,7 +289,7 @@ export function normalizeCodexModelOptions(
       isCodexReasoningEffort(reasoningEffort) ? reasoningEffort : legacyEffort,
     ),
     // Spawn-time gating: fast mode only reaches models that support it
-    // (per Codex docs: GPT-5.6/5.5/5.4 — not 5.3 Codex or Spark).
+    // (per Codex docs: Astra and GPT-5.6/5.5/5.4 — not 5.3 Codex or Spark).
     fastMode: supportsProviderFastMode("codex", model) && modelOptions?.codex?.fastMode === true,
   }
 }

--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -296,6 +296,7 @@ describe("read models", () => {
     expect(chat?.queuedMessages.map((message) => message.content)).toEqual(["follow up"])
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
+      "gpt-6-astra",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",

--- a/src/shared/types.test.ts
+++ b/src/shared/types.test.ts
@@ -59,6 +59,7 @@ describe("shared model normalization", () => {
 
   test("normalizes legacy Codex aliases and defaults to the latest catalog model", () => {
     expect(normalizeCodexModelId()).toBe("gpt-5.6-sol")
+    expect(normalizeCodexModelId("gpt-6-astra")).toBe("gpt-6-astra")
     expect(normalizeCodexModelId("gpt-5.6")).toBe("gpt-5.6-sol")
     expect(normalizeCodexModelId("gpt-5.6-terra")).toBe("gpt-5.6-terra")
     expect(normalizeCodexModelId("gpt-5.6-luna")).toBe("gpt-5.6-luna")
@@ -66,7 +67,10 @@ describe("shared model normalization", () => {
     expect(normalizeCodexModelId("not-a-real-model")).toBe("gpt-5.6-sol")
   })
 
-  test("exposes model-specific GPT-5.6 reasoning efforts", () => {
+  test("exposes model-specific current Codex reasoning efforts", () => {
+    expect(getCodexReasoningOptions("gpt-6-astra").map((option) => option.id)).toEqual([
+      "low", "medium", "high", "xhigh", "max", "ultra",
+    ])
     expect(getCodexReasoningOptions("gpt-5.6-sol").map((option) => option.id)).toEqual([
       "low", "medium", "high", "xhigh", "max", "ultra",
     ])

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -381,6 +381,7 @@ const LEGACY_CODEX_REASONING_OPTIONS = [
   ...CODEX_REASONING_OPTIONS.filter((option) => option.id !== "max" && option.id !== "ultra"),
 ] as const satisfies readonly ProviderEffortOption[]
 
+const GPT_6_ASTRA_REASONING_OPTIONS = [...CODEX_REASONING_OPTIONS]
 const GPT_5_6_REASONING_OPTIONS = [...CODEX_REASONING_OPTIONS]
 const GPT_5_6_LUNA_REASONING_OPTIONS = CODEX_REASONING_OPTIONS.filter((option) => option.id !== "ultra")
 
@@ -569,6 +570,14 @@ export const PROVIDERS: ProviderCatalogEntry[] = [
     supportsAutoPlanMode: false,
     models: [
       {
+        id: "gpt-6-astra",
+        label: "GPT-6 Astra",
+        supportsEffort: true,
+        supportedReasoningEfforts: GPT_6_ASTRA_REASONING_OPTIONS,
+        defaultReasoningEffort: "medium",
+        supportsFastMode: true,
+      },
+      {
         id: "gpt-5.6-sol",
         label: "GPT-5.6 Sol",
         supportsEffort: true,
@@ -616,7 +625,7 @@ export const PROVIDERS: ProviderCatalogEntry[] = [
         aliases: ["gpt-5-codex"],
         supportedReasoningEfforts: LEGACY_CODEX_REASONING_OPTIONS,
         defaultReasoningEffort: "high",
-        // Fast mode supports GPT-5.6/5.5/5.4 only (docs: /codex/speed).
+        // Fast mode supports Astra and GPT-5.6/5.5/5.4 (docs: /codex/speed).
         supportsFastMode: false,
       },
       {


### PR DESCRIPTION
Adds `gpt-6-astra` to the Codex model picker with the parameters reported by the current Codex catalog: Medium by default, Low through Ultra reasoning, and Fast mode support. GPT-5.6 Sol remains the default model.

Tests cover picker rendering, model normalization, settings persistence, and the provider catalog.

Validation: `bun test src/shared/types.test.ts src/server/provider-catalog.test.ts src/server/app-settings.test.ts src/server/read-models.test.ts src/client/lib/composer.test.ts src/client/components/chat-ui/ChatPreferenceControls.test.tsx` (100 passed), plus `bunx tsc --noEmit`.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `codex/gpt-5.6-sol`.