### PR TITLE
Give Claude and Codex sessions tools for Kanna itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,27 +77,48 @@ React client (src/client)
 
 ## Remote REST API (`src/server/api/`)
 
-- Off by default. `kanna --api --api-key=<k1,k2>` (or `--api-key-file=<path>`,
-  one key per line) mounts `/api/v1`. Pair with the existing `--remote` to
-  reach it off-loopback. `--api` without keys is a startup error — the API
-  has no session, origin check or login in front of it, so an unkeyed one
-  would be wide open.
-- `routes.ts` calls the same `EventStore` and `AgentCoordinator` the socket
-  does, then `broadcastSnapshots()`, so a chat created over HTTP shows up in
-  a connected browser straight away. It deliberately does *not* reuse
-  ws-router's `handleCommand`, which is bound to a socket — when you change
-  the semantics of `chat.send`, `chat.delete` or `project.open` there, check
-  whether the matching route needs the same change — including the analytics
-  event, which the routes emit to the same reporter.
+- Off by default *for people*. `kanna --api --api-key=<k1,k2>` (or
+  `--api-key-file=<path>`, one key per line) is what lets a human client use
+  `/api/v1`; pair with `--remote` to reach it off-loopback. `--api` without
+  keys is a startup error — the API has no session, origin check or login in
+  front of it, so an unkeyed one would be wide open.
+- The routes are *always* mounted for one caller: Kanna's own agent bridge,
+  holding a per-run key minted at startup (`kanna-mcp-bridge.ts`). That key is
+  accepted only on requests that came straight off loopback with no forwarding
+  headers (`api/local-request.ts`). Peer address alone is not enough —
+  cloudflared runs on this machine under `--share`, so every tunnelled request
+  looks like loopback; and `requestClass` alone is not enough either, since it
+  reports "local" for a LAN peer when no cloud runtime is attached. Without
+  `--api`, anything relayed still gets the JSON 404 as before.
+- `control.ts` holds the operations; `routes.ts` and the agent-facing MCP
+  tools are both thin shells over it, so HTTP and tools cannot drift. It calls
+  the same `EventStore` and `AgentCoordinator` the socket does, then
+  `broadcastSnapshots()`, so a chat created either way shows up in a connected
+  browser straight away. It deliberately does *not* reuse ws-router's
+  `handleCommand`, which is bound to a socket — when you change the semantics
+  of `chat.send`, `chat.delete` or `project.open` there, check whether
+  `control.ts` needs the same change.
 - Anything a request can name that the harness looks up later must be
-  validated at the route. `provider` in particular: an unknown one only
-  surfaces when the turn is set up, and for a queued prompt that is after the
-  202, in `dequeueAndStartQueuedMessage` — which removes the queued message
-  before the catalog lookup throws, so the prompt would be acknowledged and
-  then silently dropped.
+  validated in `control.ts`, not at the route — the agent-facing tools reach
+  the same functions. `provider` in particular: an unknown one only surfaces
+  when the turn is set up, and for a queued prompt that is after the 202, in
+  `dequeueAndStartQueuedMessage` — which removes the queued message before the
+  catalog lookup throws, so the prompt would be acknowledged and then silently
+  dropped.
 - Prompts are async: `POST /chats/:id/messages` answers 202 and the caller
   polls `GET /chats/:id`. A turn runs far longer than any HTTP client will
   wait. `queued: true` means it landed behind a running turn.
+- `POST /reload` re-reads the data dir into the running process, for editing
+  it underneath a live Kanna (moving a chat between projects, importing one)
+  without a restart. See `EventStore.reload` — it is deliberately *not*
+  `initialize()`: the boot path answers an unreadable snapshot or a foreign
+  store version by calling `clearStorage()`, which truncates every log, and
+  doing that to someone who was mid-edit would be unrecoverable. Everything is
+  validated first, a bad file is a 409 with the previous state still loaded,
+  and a `reloading` latch makes `clearStorage` throw rather than run. It also
+  goes through the write chain, so a turn appending mid-reload lands wholly
+  before or after. A chat that vanished from disk but still had a live harness
+  session is released (cancel + close) and named in `droppedChatIds`.
 - The route claims `/api/v1` even when the API is unmounted, answering a JSON
   404 — otherwise the SPA fallback returns index.html with a 200 and a client
   cannot tell the API is off (same reason `/__cloud` 404s explicitly).
@@ -109,6 +130,44 @@ React client (src/client)
   instance can tell that its flags will not take effect: it exits 1 asking for
   a restart when that instance has no API, and warns that this run's keys were
   not applied when it does.
+
+## Agents managing Kanna (`kanna-tools.ts` and friends)
+
+- Claude and Codex sessions get tools for Kanna itself: list/open projects,
+  list/read/create chats, send prompts, cancel turns, and `reload` (re-read
+  the data dir after editing it directly). `kanna-tools.ts` is the single
+  definition — names, descriptions and Zod shapes — and both transports read
+  from it, so the two agents see the same toolbox.
+- Two transports because the harnesses differ. Claude takes an in-process
+  server (`createSdkMcpServer`, in `kanna-mcp-claude.ts`) whose handlers call
+  `control.ts` directly: no HTTP, no child process, no key on disk. Codex has
+  no such hook, so its sessions spawn `kanna mcp <credentials>`
+  (`kanna-mcp-stdio.ts`) via `-c mcp_servers.kanna.*` overrides on
+  `codex app-server`, and that child calls back over `/api/v1`.
+- Schemas are Zod raw shapes because the Agent SDK's `tool()` rejects a plain
+  JSON Schema outright. The stdio bridge derives real JSON Schema from the
+  same shapes with `z.toJSONSchema`. Don't "simplify" one side into hand-
+  written JSON Schema; the SDK will throw at session start.
+- MCP tools are not filtered by the SDK's `tools` option — that selects
+  built-ins only — so nothing in `claudeToolset` gates these.
+- Credentials go in a 0600 file under `<dataDir>/mcp/`, one per chat, not in
+  argv or the environment: `ps` shows a child's command line to every user on
+  the machine, and codex passes its own environment to the servers it spawns.
+  `stopSession` deletes the file; shutdown removes the directory.
+- **Fan-out is bounded to one hop.** A chat an agent created carries
+  `ChatRecord.agentOrigin`, and a chat with it set may not create chats or
+  send messages (`assertMaySpawn`). An agent also cannot prompt its own chat.
+  The marker is persisted, not counted in memory, because boot resumes
+  interrupted turns and an in-memory depth would reset to zero; `forkChat`
+  copies it for the same reason.
+- `agentOrigin` is deliberately *not* a field on `ClientCommand` — it rides an
+  out-of-band options argument to `agent.send`, and over HTTP it comes from
+  `X-Kanna-Agent-Chat`, honoured only for the internal key. A browser must not
+  be able to label a chat it opened as agent work.
+- No delete tool, by design: removing a project or chat destroys work with no
+  undo in the UI. `DELETE /chats/:id` still exists for human API clients.
+- `kanna mcp` is not in `--help`. It takes a path to a file a running Kanna
+  wrote and is meaningless to type by hand.
 
 ## Cloud contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,14 @@ React client (src/client)
   a connected browser straight away. It deliberately does *not* reuse
   ws-router's `handleCommand`, which is bound to a socket — when you change
   the semantics of `chat.send`, `chat.delete` or `project.open` there, check
-  whether the matching route needs the same change.
+  whether the matching route needs the same change — including the analytics
+  event, which the routes emit to the same reporter.
+- Anything a request can name that the harness looks up later must be
+  validated at the route. `provider` in particular: an unknown one only
+  surfaces when the turn is set up, and for a queued prompt that is after the
+  202, in `dequeueAndStartQueuedMessage` — which removes the queued message
+  before the catalog lookup throws, so the prompt would be acknowledged and
+  then silently dropped.
 - Prompts are async: `POST /chats/:id/messages` answers 202 and the caller
   polls `GET /chats/:id`. A turn runs far longer than any HTTP client will
   wait. `queued: true` means it landed behind a running turn.
@@ -98,6 +105,10 @@ React client (src/client)
   every other `/api/` route still needs the cookie. Raw cloud-tunnel traffic
   (`requestClass === "untrusted"`) still sees nothing but `/health` and `/ws`,
   so the API is not reachable through a paired machine's tunnel by design.
+- `/health` reports `api`, so a second `kanna --api` against an already-running
+  instance can tell that its flags will not take effect: it exits 1 asking for
+  a restart when that instance has no API, and warns that this run's keys were
+  not applied when it does.
 
 ## Cloud contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,30 @@ React client (src/client)
   chat). When a bug report or request does not say which one it is about,
   ask before touching code. A fix on the wrong platform is wasted work.
 
+## Remote REST API (`src/server/api/`)
+
+- Off by default. `kanna --api --api-key=<k1,k2>` (or `--api-key-file=<path>`,
+  one key per line) mounts `/api/v1`. Pair with the existing `--remote` to
+  reach it off-loopback. `--api` without keys is a startup error — the API
+  has no session, origin check or login in front of it, so an unkeyed one
+  would be wide open.
+- `routes.ts` calls the same `EventStore` and `AgentCoordinator` the socket
+  does, then `broadcastSnapshots()`, so a chat created over HTTP shows up in
+  a connected browser straight away. It deliberately does *not* reuse
+  ws-router's `handleCommand`, which is bound to a socket — when you change
+  the semantics of `chat.send`, `chat.delete` or `project.open` there, check
+  whether the matching route needs the same change.
+- Prompts are async: `POST /chats/:id/messages` answers 202 and the caller
+  polls `GET /chats/:id`. A turn runs far longer than any HTTP client will
+  wait. `queued: true` means it landed behind a running turn.
+- The route claims `/api/v1` even when the API is unmounted, answering a JSON
+  404 — otherwise the SPA fallback returns index.html with a 200 and a client
+  cannot tell the API is off (same reason `/__cloud` 404s explicitly).
+- A valid key substitutes for the `--password` session on `/api/v1` only;
+  every other `/api/` route still needs the cookie. Raw cloud-tunnel traffic
+  (`requestClass === "untrusted"`) still sees nothing but `/health` and `/ws`,
+  so the API is not reachable through a paired machine's tunnel by design.
+
 ## Cloud contract
 
 - `src/shared/cloud-api.ts` is the wire contract with the hosted control

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "unified": "^11",
         "unist-util-visit": "^5",
         "uqr": "^0.1.3",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "remark-rehype": "^11",
     "unified": "^11",
     "unist-util-visit": "^5",
-    "uqr": "^0.1.3"
+    "uqr": "^0.1.3",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1,4 +1,4 @@
-import { query, type CanUseTool, type PermissionResult, type Query, type SDKUserMessage, type SlashCommand } from "@anthropic-ai/claude-agent-sdk"
+import { query, type CanUseTool, type McpServerConfig, type PermissionResult, type Query, type SDKUserMessage, type SlashCommand } from "@anthropic-ai/claude-agent-sdk"
 import { homedir } from "node:os"
 import type {
   AgentProvider,
@@ -22,6 +22,7 @@ import { STRUCTURED_RESULT_TOOL_KINDS } from "./events"
 import type { AnalyticsReporter } from "./analytics"
 import { NoopAnalyticsReporter } from "./analytics"
 import { CodexAppServerManager } from "./codex-app-server"
+import { KANNA_MCP_SERVER_NAME } from "./kanna-mcp-bridge"
 import { CursorCliManager } from "./cursor-cli"
 import { PiAgentManager, resolvePiConnection } from "./pi-agent"
 import { type GenerateChatTitleResult, generateTitleForChatDetailed } from "./generate-title"
@@ -204,6 +205,7 @@ interface AgentCoordinatorArgs {
     forkSession: boolean
     onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
     onRateLimitEvent?: (info: ClaudeRateLimitInfoRaw) => void
+    mcpServers?: Record<string, McpServerConfig>
   }) => Promise<ClaudeSessionHandle>
   /**
    * Probe whether a provider's native session artifact still exists on disk.
@@ -685,6 +687,12 @@ async function startClaudeSession(args: {
   forkSession: boolean
   onToolRequest: (request: HarnessToolRequest) => Promise<unknown>
   onRateLimitEvent?: (info: ClaudeRateLimitInfoRaw) => void
+  /**
+   * Kanna's own management tools, as an in-process MCP server built for this
+   * chat (kanna-mcp-claude.ts). Absent when the coordinator has no control
+   * deps — tests, mostly — and the session simply doesn't get them.
+   */
+  mcpServers?: Record<string, McpServerConfig>
 }): Promise<ClaudeSessionHandle> {
   const canUseTool: CanUseTool = async (toolName, input, options) => {
     if (toolName !== "AskUserQuestion" && toolName !== "ExitPlanMode") {
@@ -755,6 +763,9 @@ async function startClaudeSession(args: {
       permissionMode: args.planMode ? "plan" : "acceptEdits",
       canUseTool,
       tools: claudeToolset(args.autoPlan),
+      // MCP tools are not filtered by `tools` above — that option selects
+      // built-ins only — so these arrive callable without an allowlist entry.
+      ...(args.mcpServers ? { mcpServers: args.mcpServers } : {}),
       settingSources: ["user", "project", "local"],
       // Append-only: the claude_code preset stays intact, Kanna's git
       // attribution rides on the end of it (see attribution.ts).
@@ -857,6 +868,16 @@ export class AgentCoordinator {
   private readonly checkSessionArtifactFn: NonNullable<AgentCoordinatorArgs["checkSessionArtifact"]>
   private reportBackgroundError: ((message: string) => void) | null = null
   private onClaudeRateLimit: ((info: ClaudeRateLimitInfoRaw) => void) | null = null
+  /**
+   * Builds the in-process MCP server that gives a Claude session Kanna's own
+   * management tools, scoped to the chat that will call them.
+   *
+   * Injected after construction rather than through the constructor because
+   * those tools need to call back into this coordinator — server.ts can only
+   * close the loop once both halves exist. Null in tests, where sessions
+   * simply don't get the tools.
+   */
+  private buildKannaMcpServer: ((chatId: string) => McpServerConfig | null) | null = null
   private cursorModelCatalogApplied = false
   readonly activeTurns = new Map<string, ActiveTurn>()
   readonly drainingStreams = new Map<string, { turn: HarnessTurn }>()
@@ -877,6 +898,15 @@ export class AgentCoordinator {
 
   setBackgroundErrorReporter(report: ((message: string) => void) | null) {
     this.reportBackgroundError = report
+  }
+
+  /**
+   * Attach Kanna's management tools to Claude sessions. See
+   * {@link buildKannaMcpServer}; the factory is called per session, so a chat
+   * only ever sees a server scoped to itself.
+   */
+  setKannaMcpServerFactory(factory: ((chatId: string) => McpServerConfig | null) | null) {
+    this.buildKannaMcpServer = factory
   }
 
   /** Register a sink for pushed Claude rate-limit events (usage page). */
@@ -1573,6 +1603,7 @@ export class AgentCoordinator {
         this.claudeSessions.delete(args.chatId)
       }
 
+      const kannaMcpServer = this.buildKannaMcpServer?.(args.chatId) ?? null
       const started = await this.startClaudeSessionFn({
         localPath: args.localPath,
         model: args.model,
@@ -1584,6 +1615,7 @@ export class AgentCoordinator {
         forkSession: args.forkSession,
         onToolRequest: args.onToolRequest,
         onRateLimitEvent: (info) => this.onClaudeRateLimit?.(info),
+        ...(kannaMcpServer ? { mcpServers: { [KANNA_MCP_SERVER_NAME]: kannaMcpServer } } : {}),
       })
       this.refreshClaudeModelCatalog(started)
 
@@ -1633,7 +1665,17 @@ export class AgentCoordinator {
     }
   }
 
-  async send(command: Extract<ClientCommand, { type: "chat.send" }>) {
+  /**
+   * @param options Server-side only, never off the wire. `agentOrigin` marks a
+   * chat this send is creating as agent-started, which is what stops that chat
+   * from starting more of them (see `assertMaySpawn` in api/control.ts). It is
+   * deliberately not a field on `ClientCommand`: a browser must not be able to
+   * label a chat it opened as agent work.
+   */
+  async send(
+    command: Extract<ClientCommand, { type: "chat.send" }>,
+    options?: { agentOrigin?: { chatId: string } }
+  ) {
     let chatId = command.chatId
 
 
@@ -1641,7 +1683,7 @@ export class AgentCoordinator {
       if (!command.projectId) {
         throw new Error("Missing projectId for new chat")
       }
-      const created = await this.store.createChat(command.projectId)
+      const created = await this.store.createChat(command.projectId, { agentOrigin: options?.agentOrigin })
       chatId = created.id
       this.analytics.track("chat_created")
     }

--- a/src/server/api/control.test.ts
+++ b/src/server/api/control.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EventStore } from "../event-store"
+import {
+  addProject,
+  assertMaySpawn,
+  ControlError,
+  createChat,
+  listChats,
+  listProjects,
+  reloadFromDisk,
+  sendMessage,
+  type ControlDeps,
+} from "./control"
+
+async function withStore<T>(run: (store: EventStore, dataDir: string) => Promise<T>) {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-control-"))
+  const store = new EventStore(dataDir)
+  await store.initialize()
+  try {
+    return await run(store, dataDir)
+  } finally {
+    await rm(dataDir, { recursive: true, force: true })
+  }
+}
+
+interface SendCall {
+  chatId?: string
+  projectId?: string
+  content: string
+  agentOrigin?: { chatId: string }
+}
+
+function makeDeps(store: EventStore, options: { activeChatIds?: string[] } = {}) {
+  const sends: SendCall[] = []
+  const cancelled: string[] = []
+  const closed: string[] = []
+  const tracked: string[] = []
+  let broadcasts = 0
+
+  const deps: ControlDeps = {
+    store,
+    appSettings: { getSnapshot: () => ({ transcript: { windowAssistantMessages: 50 } }) as never },
+    agent: {
+      getActiveStatuses: () =>
+        new Map((options.activeChatIds ?? []).map((chatId) => [chatId, "running" as const])),
+      getDrainingChatIds: () => new Set(),
+      async send(command, options) {
+        let chatId = command.chatId
+        if (!chatId) {
+          const created = await store.createChat(command.projectId!, { agentOrigin: options?.agentOrigin })
+          chatId = created.id
+        }
+        sends.push({
+          chatId: command.chatId,
+          projectId: command.projectId,
+          content: command.content,
+          agentOrigin: options?.agentOrigin,
+        })
+        return { chatId }
+      },
+      async cancel(chatId) {
+        cancelled.push(chatId)
+      },
+      async closeChat(chatId) {
+        closed.push(chatId)
+      },
+    },
+    broadcast: () => {
+      broadcasts += 1
+    },
+    analytics: {
+      track: (event) => {
+        tracked.push(event)
+      },
+    },
+  }
+
+  return { deps, sends, cancelled, closed, tracked, broadcastCount: () => broadcasts }
+}
+
+describe("control", () => {
+  test("addProject reports whether the path was already open", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps } = makeDeps(store)
+      const projectPath = path.join(dataDir, "proj")
+
+      const first = await addProject(deps, { localPath: projectPath, title: "Proj" })
+      expect(first.created).toBe(true)
+
+      const second = await addProject(deps, { localPath: projectPath })
+      expect(second.created).toBe(false)
+      expect(second.project.id).toBe(first.project.id)
+      expect(listProjects(deps).projects).toHaveLength(1)
+    })
+  })
+
+  test("listChats scopes to a project and excludes archived chats by default", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps } = makeDeps(store)
+      const a = await store.openProject(path.join(dataDir, "a"))
+      const b = await store.openProject(path.join(dataDir, "b"))
+      const inA = await store.createChat(a.id)
+      await store.createChat(b.id)
+      const archived = await store.createChat(a.id)
+      await store.archiveChat(archived.id)
+
+      const listed = listChats(deps, { projectId: a.id })
+      expect(listed.chats.map((chat) => chat.id)).toEqual([inA.id])
+      expect(listChats(deps, { projectId: a.id, includeArchived: true }).total).toBe(2)
+      expect(listChats(deps, {}).total).toBe(2)
+    })
+  })
+
+  test("listChats rejects a non-positive limit and caps at the maximum", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps } = makeDeps(store)
+      const project = await store.openProject(path.join(dataDir, "a"))
+      await store.createChat(project.id)
+
+      expect(() => listChats(deps, { limit: 0 })).toThrow(ControlError)
+      expect(listChats(deps, { limit: 10_000 }).chats).toHaveLength(1)
+    })
+  })
+
+  test("an agent-created chat is marked with the chat that created it", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps, sends } = makeDeps(store)
+      const project = await store.openProject(path.join(dataDir, "a"))
+      const caller = await store.createChat(project.id)
+
+      const created = await createChat(
+        deps,
+        { projectId: project.id, content: "do the thing" },
+        { chatId: caller.id }
+      )
+
+      expect(created.started).toBe(true)
+      expect(created.chat.createdByChatId).toBe(caller.id)
+      expect(sends[0]?.agentOrigin).toEqual({ chatId: caller.id })
+      expect(store.getChat(created.chat.id)?.agentOrigin).toEqual({ chatId: caller.id })
+    })
+  })
+
+  test("an empty chat created by an agent is marked too", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps, sends } = makeDeps(store)
+      const project = await store.openProject(path.join(dataDir, "a"))
+      const caller = await store.createChat(project.id)
+
+      const created = await createChat(deps, { projectId: project.id }, { chatId: caller.id })
+
+      expect(created.started).toBe(false)
+      expect(sends).toHaveLength(0)
+      expect(created.chat.createdByChatId).toBe(caller.id)
+    })
+  })
+
+  test("a human caller leaves no agent origin", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps } = makeDeps(store)
+      const project = await store.openProject(path.join(dataDir, "a"))
+
+      const created = await createChat(deps, { projectId: project.id, content: "hi" })
+
+      expect(created.chat.createdByChatId).toBeNull()
+    })
+  })
+
+  describe("fan-out guard", () => {
+    test("an agent-created chat cannot create another", async () => {
+      await withStore(async (store, dataDir) => {
+        const { deps } = makeDeps(store)
+        const project = await store.openProject(path.join(dataDir, "a"))
+        const root = await store.createChat(project.id)
+        const spawned = await store.createChat(project.id, { agentOrigin: { chatId: root.id } })
+
+        await expect(
+          createChat(deps, { projectId: project.id, content: "go deeper" }, { chatId: spawned.id })
+        ).rejects.toThrow(/started by an agent/)
+      })
+    })
+
+    test("an agent-created chat cannot send to another chat", async () => {
+      await withStore(async (store, dataDir) => {
+        const { deps } = makeDeps(store)
+        const project = await store.openProject(path.join(dataDir, "a"))
+        const root = await store.createChat(project.id)
+        const spawned = await store.createChat(project.id, { agentOrigin: { chatId: root.id } })
+        const target = await store.createChat(project.id)
+
+        await expect(
+          sendMessage(deps, { chatId: target.id, content: "hi" }, { chatId: spawned.id })
+        ).rejects.toThrow(/started by an agent/)
+      })
+    })
+
+    test("an agent cannot send to its own chat", async () => {
+      await withStore(async (store, dataDir) => {
+        const { deps } = makeDeps(store)
+        const project = await store.openProject(path.join(dataDir, "a"))
+        const caller = await store.createChat(project.id)
+
+        await expect(
+          sendMessage(deps, { chatId: caller.id, content: "again" }, { chatId: caller.id })
+        ).rejects.toThrow(/its own chat/)
+      })
+    })
+
+    test("a human-created chat may spawn, and the guard is a no-op without a caller", async () => {
+      await withStore(async (store, dataDir) => {
+        const { deps, sends } = makeDeps(store)
+        const project = await store.openProject(path.join(dataDir, "a"))
+        const root = await store.createChat(project.id)
+        const target = await store.createChat(project.id)
+
+        const sent = await sendMessage(deps, { chatId: target.id, content: "hi" }, { chatId: root.id })
+        expect(sent.chatId).toBe(target.id)
+        expect(sends).toHaveLength(1)
+
+        expect(() => assertMaySpawn(deps, undefined, target.id)).not.toThrow()
+      })
+    })
+
+    test("forking an agent-created chat carries the marker over", async () => {
+      await withStore(async (store, dataDir) => {
+        const { deps } = makeDeps(store)
+        const project = await store.openProject(path.join(dataDir, "a"))
+        const root = await store.createChat(project.id)
+        const spawned = await store.createChat(project.id, { agentOrigin: { chatId: root.id } })
+        await store.setChatProvider(spawned.id, "claude")
+        await store.setSessionToken(spawned.id, "session-1")
+
+        const fork = await store.forkChat(spawned.id)
+
+        expect(fork.agentOrigin).toEqual({ chatId: root.id })
+        expect(() => assertMaySpawn(deps, { chatId: fork.id })).toThrow(ControlError)
+      })
+    })
+
+    test("the guard survives a restart, since the marker is persisted", async () => {
+      const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-control-restart-"))
+      try {
+        const first = new EventStore(dataDir)
+        await first.initialize()
+        const project = await first.openProject(path.join(dataDir, "a"))
+        const root = await first.createChat(project.id)
+        const spawned = await first.createChat(project.id, { agentOrigin: { chatId: root.id } })
+
+        const reloaded = new EventStore(dataDir)
+        await reloaded.initialize()
+        const { deps } = makeDeps(reloaded)
+
+        expect(reloaded.getChat(spawned.id)?.agentOrigin).toEqual({ chatId: root.id })
+        expect(() => assertMaySpawn(deps, { chatId: spawned.id })).toThrow(ControlError)
+      } finally {
+        await rm(dataDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  test("missing chats and projects surface as 404s", async () => {
+    await withStore(async (store) => {
+      const { deps } = makeDeps(store)
+      await expect(createChat(deps, { projectId: "nope", content: "hi" })).rejects.toMatchObject({ status: 404 })
+      await expect(sendMessage(deps, { chatId: "nope", content: "hi" })).rejects.toMatchObject({ status: 404 })
+    })
+  })
+})
+
+describe("reloadFromDisk", () => {
+  test("re-reads the store and pushes the result to clients", async () => {
+    await withStore(async (store, dataDir) => {
+      const { deps, broadcastCount } = makeDeps(store)
+      const project = await store.openProject(path.join(dataDir, "a"))
+
+      const other = new EventStore(dataDir)
+      await other.initialize()
+      const added = await other.createChat(project.id)
+
+      const result = await reloadFromDisk(deps)
+
+      expect(store.getChat(added.id)).not.toBeNull()
+      expect(result.chats).toBe(1)
+      expect(result.projects).toBe(1)
+      expect(broadcastCount()).toBe(1)
+    })
+  })
+
+  test("releases the harness session of a chat that vanished from disk", async () => {
+    await withStore(async (store, dataDir) => {
+      const project = await store.openProject(path.join(dataDir, "a"))
+      const kept = await store.createChat(project.id)
+      const vanished = await store.createChat(project.id)
+      await store.compact()
+
+      // Both are mid-turn when the reload lands.
+      const { deps, cancelled, closed } = makeDeps(store, { activeChatIds: [kept.id, vanished.id] })
+
+      const snapshotPath = path.join(dataDir, "snapshot.json")
+      const snapshot = JSON.parse(await Bun.file(snapshotPath).text()) as { chats: { id: string }[] }
+      snapshot.chats = snapshot.chats.filter((entry) => entry.id !== vanished.id)
+      await Bun.write(snapshotPath, JSON.stringify(snapshot))
+
+      const result = await reloadFromDisk(deps)
+
+      // The chat that is gone gets the same treatment deleting it would give:
+      // stop the turn, then release the session. The other is left running.
+      expect(result.droppedChatIds).toEqual([vanished.id])
+      expect(cancelled).toEqual([vanished.id])
+      expect(closed).toEqual([vanished.id])
+      expect(result.activeChatIds).toEqual([kept.id])
+    })
+  })
+
+  test("a refused reload is a 409 and changes nothing", async () => {
+    await withStore(async (store, dataDir) => {
+      const project = await store.openProject(path.join(dataDir, "a"))
+      const chat = await store.createChat(project.id)
+      await store.compact()
+      const { deps, cancelled, closed, broadcastCount } = makeDeps(store, { activeChatIds: [chat.id] })
+
+      await Bun.write(path.join(dataDir, "snapshot.json"), "{ not json")
+
+      await expect(reloadFromDisk(deps)).rejects.toMatchObject({ status: 409 })
+      expect(store.getChat(chat.id)).not.toBeNull()
+      // No session torn down, no snapshot pushed, on a reload that never ran.
+      expect(cancelled).toEqual([])
+      expect(closed).toEqual([])
+      expect(broadcastCount()).toBe(0)
+    })
+  })
+})

--- a/src/server/api/control.ts
+++ b/src/server/api/control.ts
@@ -1,0 +1,431 @@
+/**
+ * The operations Kanna exposes to something that is not a browser: the REST
+ * API (`routes.ts`) and the agent-facing MCP tools (`../kanna-tools.ts`).
+ *
+ * Both surfaces call the same functions here so they cannot drift — a change
+ * to what "create a chat" means lands on the HTTP route and the tool in one
+ * edit. The functions go through the same `EventStore` and `AgentCoordinator`
+ * the WebSocket uses, then `broadcast()` pushes fresh snapshots, so a chat
+ * created either way shows up in a connected browser straight away.
+ *
+ * Errors are `ControlError`, which carries the HTTP status the REST layer
+ * wants and a message the tool layer hands back to the model verbatim.
+ */
+
+import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../../shared/types"
+import type { ClientCommand } from "../../shared/protocol"
+import type { ChatRecord, ProjectRecord } from "../events"
+import type { EventStore } from "../event-store"
+import type { AnalyticsReporter } from "../analytics"
+import { initializeProjectDirectory } from "../paths"
+import { SERVER_PROVIDERS } from "../provider-catalog"
+import { deriveChatSnapshot, deriveStatus } from "../read-models"
+import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
+
+/** Cap on `listChats` so one call can't serialize an entire history. */
+export const DEFAULT_CHAT_LIMIT = 50
+export const MAX_CHAT_LIMIT = 200
+
+export class ControlError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message)
+  }
+}
+
+export interface ControlDeps extends ChatWindowRouteDeps {
+  store: ChatWindowRouteDeps["store"] &
+    Pick<EventStore, "getProject" | "openProject" | "createChat" | "deleteChat" | "reload">
+  agent: ChatWindowRouteDeps["agent"] & {
+    send: (
+      command: Extract<ClientCommand, { type: "chat.send" }>,
+      options?: { agentOrigin?: ControlCaller }
+    ) => Promise<{ chatId: string; queuedMessageId?: string; queued?: true }>
+    cancel: (chatId: string) => Promise<void>
+    closeChat: (chatId: string) => Promise<void>
+  }
+  /** Push fresh snapshots to connected sockets after a write. */
+  broadcast: () => Promise<void> | void
+  /**
+   * Same reporter the socket uses. Writes through here emit the same events as
+   * the equivalent `ClientCommand`, so metrics don't silently miss whatever is
+   * driven over HTTP or by an agent's tool call.
+   */
+  analytics: Pick<AnalyticsReporter, "track">
+}
+
+/**
+ * Reject a provider the server has no catalog entry for.
+ *
+ * This has to happen before `agent.send`. A bad provider is only discovered
+ * when the turn is set up — and for a prompt that lands behind a running turn
+ * that is long after the 202, in `dequeueAndStartQueuedMessage`, which removes
+ * the queued message *before* the catalog lookup throws. The prompt would be
+ * acknowledged and then silently dropped. Validating against SERVER_PROVIDERS
+ * (rather than a hand-written list) keeps this in step with what
+ * `getProviderSettings` will actually accept.
+ *
+ * Lives here rather than at the route so the agent-facing tools get the same
+ * check: the MCP schema constrains the enum, but a tool call is still model
+ * output arriving over a wire.
+ */
+export function assertKnownProvider(provider: AgentProvider | undefined) {
+  if (provider === undefined) return
+  if (SERVER_PROVIDERS.some((candidate) => candidate.id === provider)) return
+  const known = SERVER_PROVIDERS.map((candidate) => candidate.id).join(", ")
+  throw new ControlError(400, `Unknown provider "${provider}". Expected one of: ${known}`)
+}
+
+/** Prompt knobs shared by "create a chat and send" and "send to a chat". */
+export interface PromptFields {
+  provider?: AgentProvider
+  model?: string
+  effort?: string
+  modelOptions?: ModelOptions
+  planMode?: boolean
+  autoPlan?: boolean
+}
+
+/**
+ * Identifies the chat a request came from, when it came from an agent running
+ * inside Kanna. Absent for a human API client. Drives the fan-out guard in
+ * {@link assertMaySpawn}.
+ */
+export interface ControlCaller {
+  chatId: string
+}
+
+export interface SerializedProject {
+  id: string
+  title: string
+  localPath: string
+  createdAt: number
+  updatedAt: number
+  chatCount: number
+}
+
+export interface SerializedChat {
+  id: string
+  projectId: string
+  title: string
+  status: KannaStatus
+  provider: AgentProvider | null
+  createdAt: number
+  updatedAt: number
+  lastMessageAt: number | null
+  lastModel: string | null
+  hasMessages: boolean
+  unread: boolean
+  archived: boolean
+  /** Set when an agent created this chat — see `ChatRecord.agentOrigin`. */
+  createdByChatId: string | null
+}
+
+export function serializeProject(project: ProjectRecord, chatCount: number): SerializedProject {
+  return {
+    id: project.id,
+    title: project.sidebarTitle ?? project.title,
+    localPath: project.localPath,
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+    chatCount,
+  }
+}
+
+export function serializeChat(chat: ChatRecord, status: KannaStatus): SerializedChat {
+  return {
+    id: chat.id,
+    projectId: chat.projectId,
+    title: chat.title,
+    status,
+    provider: chat.provider,
+    createdAt: chat.createdAt,
+    updatedAt: chat.updatedAt,
+    lastMessageAt: chat.lastMessageAt ?? null,
+    lastModel: chat.lastModel ?? null,
+    hasMessages: Boolean(chat.hasMessages),
+    unread: chat.unread,
+    archived: Boolean(chat.archivedAt),
+    createdByChatId: chat.agentOrigin?.chatId ?? null,
+  }
+}
+
+function chatStatus(deps: ControlDeps, chat: ChatRecord): KannaStatus {
+  return deriveStatus(chat, deps.agent.getActiveStatuses().get(chat.id))
+}
+
+function liveChats(deps: ControlDeps) {
+  return [...deps.store.state.chatsById.values()].filter((chat) => !chat.deletedAt)
+}
+
+export function requireChat(deps: ControlDeps, chatId: string): ChatRecord {
+  const chat = deps.store.getChat(chatId)
+  if (!chat || chat.deletedAt) throw new ControlError(404, "Chat not found")
+  return chat
+}
+
+/**
+ * The fan-out guard for agent callers.
+ *
+ * An agent may start turns in *other* chats, but a chat that an agent itself
+ * created may not start any: one agent can hand work to a second, and there
+ * the chain stops. Without this a loop that ends in "spin up a chat to do the
+ * rest" recurses into unbounded billed turns, and nothing in the transcript
+ * makes that visible until the bill does.
+ *
+ * Depth is read off the persisted `agentOrigin` rather than an in-memory
+ * counter, so a restart (which resumes interrupted turns) doesn't reset it.
+ */
+export function assertMaySpawn(deps: ControlDeps, caller: ControlCaller | undefined, targetChatId?: string) {
+  if (!caller) return
+  if (targetChatId && targetChatId === caller.chatId) {
+    throw new ControlError(409, "An agent cannot send a message to its own chat")
+  }
+  const callerChat = deps.store.getChat(caller.chatId)
+  if (callerChat?.agentOrigin) {
+    throw new ControlError(
+      409,
+      "This chat was itself started by an agent, so it cannot start more agent work. Ask the person you are working with to do it."
+    )
+  }
+}
+
+// --- projects -------------------------------------------------------------
+
+export function listProjects(deps: ControlDeps) {
+  const chatCounts = new Map<string, number>()
+  for (const chat of liveChats(deps)) {
+    if (chat.archivedAt) continue
+    chatCounts.set(chat.projectId, (chatCounts.get(chat.projectId) ?? 0) + 1)
+  }
+  const projects = [...deps.store.state.projectsById.values()]
+    .filter((project) => !project.deletedAt)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((project) => serializeProject(project, chatCounts.get(project.id) ?? 0))
+  return { projects }
+}
+
+export async function addProject(deps: ControlDeps, input: { localPath: string; title?: string }) {
+  // Same call the UI's "new project" flow makes: create the directory if it is
+  // missing, and `git init` it when it is empty so chats there get diffs. An
+  // existing non-empty directory is left exactly as it is.
+  let resolvedPath: string
+  try {
+    resolvedPath = await initializeProjectDirectory(input.localPath)
+  } catch (error) {
+    throw new ControlError(400, error instanceof Error ? error.message : "Could not open project directory")
+  }
+
+  // openProject is idempotent on a path that is already open, so ask before
+  // rather than after: the returned record looks the same either way, and a
+  // caller told "created" about a project that was already there would go on
+  // to make a duplicate.
+  const existingId = deps.store.state.projectIdsByPath.get(resolvedPath)
+  const existing = existingId ? deps.store.state.projectsById.get(existingId) : undefined
+  const alreadyOpen = Boolean(existing && !existing.deletedAt)
+
+  const project = await deps.store.openProject(resolvedPath, input.title)
+  // Mirrors ws-router's `project.open`: only a path that wasn't already open
+  // counts as opening a project.
+  if (!alreadyOpen) deps.analytics.track("project_opened")
+  await deps.broadcast()
+  return { project: serializeProject(project, 0), created: !alreadyOpen }
+}
+
+// --- chats ----------------------------------------------------------------
+
+export function listChats(
+  deps: ControlDeps,
+  input: { projectId?: string; includeArchived?: boolean; limit?: number }
+) {
+  if (input.projectId && !deps.store.getProject(input.projectId)) {
+    throw new ControlError(404, "Project not found")
+  }
+  if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+    throw new ControlError(400, '"limit" must be a positive integer')
+  }
+  const limit = Math.min(input.limit ?? DEFAULT_CHAT_LIMIT, MAX_CHAT_LIMIT)
+
+  const matching = liveChats(deps)
+    .filter((chat) => (input.projectId ? chat.projectId === input.projectId : true))
+    .filter((chat) => (input.includeArchived ? true : !chat.archivedAt))
+    .sort((a, b) => (b.lastMessageAt ?? b.updatedAt) - (a.lastMessageAt ?? a.updatedAt))
+
+  return {
+    chats: matching.slice(0, limit).map((chat) => serializeChat(chat, chatStatus(deps, chat))),
+    total: matching.length,
+  }
+}
+
+export async function createChat(
+  deps: ControlDeps,
+  input: { projectId: string; content?: string } & PromptFields,
+  caller?: ControlCaller
+) {
+  if (!deps.store.getProject(input.projectId)) throw new ControlError(404, "Project not found")
+  assertKnownProvider(input.provider)
+
+  const content = input.content?.trim() ? input.content : undefined
+  // The guard is on starting turns, not on creating records: an empty chat
+  // runs nothing and costs nothing, and staging one for a person to prompt is
+  // a reasonable thing for any agent to do. Only `content` spends anything.
+  if (content) assertMaySpawn(deps, caller)
+
+  // With `content`, hand the whole thing to agent.send: it creates the chat
+  // and starts the first turn in one step, exactly as the composer does when
+  // you type into a project with no chat open.
+  if (content) {
+    const result = await deps.agent.send(
+      {
+        type: "chat.send",
+        projectId: input.projectId,
+        content,
+        provider: input.provider,
+        model: input.model,
+        effort: input.effort,
+        modelOptions: input.modelOptions,
+        planMode: input.planMode,
+        autoPlan: input.autoPlan,
+      },
+      { agentOrigin: caller }
+    )
+    await deps.broadcast()
+    const chat = requireChat(deps, result.chatId)
+    return { chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false, started: true }
+  }
+
+  // `agent.send` tracks this itself on the prompt path above, so it is only
+  // emitted here, where the chat is created on its own.
+  const chat = await deps.store.createChat(input.projectId, { agentOrigin: caller })
+  deps.analytics.track("chat_created")
+  await deps.broadcast()
+  return { chat: serializeChat(chat, chatStatus(deps, chat)), queued: false, started: false }
+}
+
+export function getChat(deps: ControlDeps, input: { chatId: string; full?: boolean }) {
+  const chat = requireChat(deps, input.chatId)
+  const snapshot: ChatSnapshot | null = input.full
+    ? deriveChatSnapshot(
+        deps.store.state,
+        deps.agent.getActiveStatuses(),
+        deps.agent.getDrainingChatIds(),
+        input.chatId,
+        (id) => deps.store.getClientTranscript(id)
+      )
+    : readChatWindow(input.chatId, deps)
+  if (!snapshot) throw new ControlError(404, "Chat not found")
+  return {
+    chat: serializeChat(chat, chatStatus(deps, chat)),
+    runtime: snapshot.runtime,
+    queuedMessages: snapshot.queuedMessages,
+    messages: snapshot.messages,
+    startIndex: snapshot.startIndex,
+  }
+}
+
+export async function sendMessage(
+  deps: ControlDeps,
+  input: { chatId: string; content: string } & PromptFields,
+  caller?: ControlCaller
+) {
+  requireChat(deps, input.chatId)
+  assertMaySpawn(deps, caller, input.chatId)
+  assertKnownProvider(input.provider)
+
+  const result = await deps.agent.send({
+    type: "chat.send",
+    chatId: input.chatId,
+    content: input.content,
+    provider: input.provider,
+    model: input.model,
+    effort: input.effort,
+    modelOptions: input.modelOptions,
+    planMode: input.planMode,
+    autoPlan: input.autoPlan,
+  })
+  await deps.broadcast()
+
+  const chat = requireChat(deps, result.chatId)
+  return {
+    chatId: result.chatId,
+    // True when a turn was already running: the prompt was queued behind it
+    // rather than starting one, and will run when the current turn ends.
+    queued: result.queued ?? false,
+    queuedMessageId: result.queuedMessageId ?? null,
+    status: chatStatus(deps, chat),
+  }
+}
+
+export async function cancelChat(deps: ControlDeps, input: { chatId: string }) {
+  requireChat(deps, input.chatId)
+  await deps.agent.cancel(input.chatId)
+  await deps.broadcast()
+  const chat = requireChat(deps, input.chatId)
+  return { chatId: input.chatId, status: chatStatus(deps, chat) }
+}
+
+/**
+ * Re-read the store from disk and bring the running process in line with it.
+ *
+ * For editing the data dir underneath a live Kanna — moving a chat between
+ * projects, importing one, fixing a record — and picking the result up without
+ * a restart. `EventStore.reload` validates everything first and refuses rather
+ * than resetting, so a bad edit surfaces as an error with the old state still
+ * loaded.
+ *
+ * Two loose ends the store cannot tie off on its own, both about chats that no
+ * longer exist on disk but still have something running in this process:
+ *
+ * - A chat with a live harness session is released the same way deleting one
+ *   would (cancel, then close). Left alone, its agent would keep appending to
+ *   a chat no snapshot mentions.
+ * - Chats that survived the reload but had a turn running are reported back
+ *   rather than touched. Their turn is still going and still writing; that is
+ *   usually fine, but the caller should know which ones were in flight.
+ */
+export async function reloadFromDisk(deps: ControlDeps) {
+  const activeBefore = [...deps.agent.getActiveStatuses().keys()]
+
+  let counts: { projects: number; chats: number }
+  try {
+    counts = await deps.store.reload()
+  } catch (error) {
+    // 409, not 500: the data dir is in a state this build will not load, and
+    // the caller is the one who can fix it.
+    throw new ControlError(409, `Reload refused: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  const stillLive = (chatId: string) => {
+    const chat = deps.store.getChat(chatId)
+    return Boolean(chat && !chat.deletedAt)
+  }
+
+  const droppedChatIds: string[] = []
+  for (const chatId of activeBefore) {
+    if (stillLive(chatId)) continue
+    await deps.agent.cancel(chatId)
+    await deps.agent.closeChat(chatId)
+    droppedChatIds.push(chatId)
+  }
+
+  await deps.broadcast()
+
+  return {
+    ...counts,
+    /** Chats whose turn was still running through the reload. */
+    activeChatIds: activeBefore.filter(stillLive),
+    /** Chats that vanished from disk; their harness session was released. */
+    droppedChatIds,
+  }
+}
+
+export async function deleteChat(deps: ControlDeps, input: { chatId: string }) {
+  requireChat(deps, input.chatId)
+  // Same order as the UI's chat.delete: stop the turn, release the harness
+  // session, then tombstone the record.
+  await deps.agent.cancel(input.chatId)
+  await deps.agent.closeChat(input.chatId)
+  await deps.store.deleteChat(input.chatId)
+  deps.analytics.track("chat_deleted")
+  await deps.broadcast()
+  return { chatId: input.chatId, deleted: true as const }
+}

--- a/src/server/api/keys.test.ts
+++ b/src/server/api/keys.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  createApiKeyVerifier,
+  extractApiKey,
+  parseApiKeyFile,
+  parseApiKeyList,
+  readApiKeyFile,
+} from "./keys"
+
+describe("parseApiKeyList", () => {
+  test("splits on commas and trims", () => {
+    expect(parseApiKeyList("a, b ,c")).toEqual(["a", "b", "c"])
+  })
+
+  test("drops empties and duplicates", () => {
+    expect(parseApiKeyList("a,,a, ,b")).toEqual(["a", "b"])
+  })
+
+  test("returns nothing for a blank value", () => {
+    expect(parseApiKeyList("   ")).toEqual([])
+  })
+
+  test("rejects a key past the length cap", () => {
+    expect(parseApiKeyList("x".repeat(513))).toEqual([])
+    expect(parseApiKeyList("x".repeat(512))).toHaveLength(1)
+  })
+})
+
+describe("parseApiKeyFile", () => {
+  test("reads one key per line", () => {
+    expect(parseApiKeyFile("alpha\nbravo\ncharlie")).toEqual(["alpha", "bravo", "charlie"])
+  })
+
+  test("skips blank lines and comments", () => {
+    expect(parseApiKeyFile("# for CI\nalpha\n\n  # laptop\nbravo\n")).toEqual(["alpha", "bravo"])
+  })
+
+  test("handles CRLF, since key files travel between machines", () => {
+    expect(parseApiKeyFile("alpha\r\nbravo\r\n")).toEqual(["alpha", "bravo"])
+  })
+
+  test("dedupes", () => {
+    expect(parseApiKeyFile("alpha\nalpha\n")).toEqual(["alpha"])
+  })
+})
+
+describe("readApiKeyFile", () => {
+  test("reads keys from disk", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-keys-"))
+    try {
+      const file = path.join(dir, "keys.txt")
+      await writeFile(file, "alpha\n# note\nbravo\n", "utf8")
+      expect(await readApiKeyFile(file)).toEqual(["alpha", "bravo"])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("names the missing file so the operator can fix it", async () => {
+    const missing = path.join(tmpdir(), `kanna-missing-${crypto.randomUUID()}.txt`)
+    await expect(readApiKeyFile(missing)).rejects.toThrow(missing)
+  })
+})
+
+describe("createApiKeyVerifier", () => {
+  test("accepts a configured key and rejects everything else", () => {
+    const verifier = createApiKeyVerifier(["alpha", "bravo"])
+    expect(verifier.isValid("alpha")).toBe(true)
+    expect(verifier.isValid("bravo")).toBe(true)
+    expect(verifier.isValid("charlie")).toBe(false)
+  })
+
+  test("rejects a prefix of a real key", () => {
+    const verifier = createApiKeyVerifier(["alphabet"])
+    expect(verifier.isValid("alpha")).toBe(false)
+    expect(verifier.isValid("alphabet")).toBe(true)
+  })
+
+  test("rejects empty and absent candidates", () => {
+    const verifier = createApiKeyVerifier(["alpha"])
+    expect(verifier.isValid(null)).toBe(false)
+    expect(verifier.isValid(undefined)).toBe(false)
+    expect(verifier.isValid("")).toBe(false)
+  })
+
+  test("an empty key list accepts nothing", () => {
+    const verifier = createApiKeyVerifier([])
+    expect(verifier.count).toBe(0)
+    expect(verifier.isValid("alpha")).toBe(false)
+  })
+
+  test("counts distinct usable keys", () => {
+    expect(createApiKeyVerifier(["alpha", "alpha", "", "bravo"]).count).toBe(2)
+  })
+
+  test("an oversized candidate is rejected without comparing", () => {
+    expect(createApiKeyVerifier(["alpha"]).isValid("x".repeat(513))).toBe(false)
+  })
+})
+
+describe("extractApiKey", () => {
+  const request = (headers: Record<string, string>) => new Request("http://localhost/api/v1", { headers })
+
+  test("reads a bearer token", () => {
+    expect(extractApiKey(request({ authorization: "Bearer alpha" }))).toBe("alpha")
+  })
+
+  test("accepts any case for the scheme", () => {
+    expect(extractApiKey(request({ authorization: "bearer alpha" }))).toBe("alpha")
+  })
+
+  test("reads X-Api-Key", () => {
+    expect(extractApiKey(request({ "x-api-key": "alpha" }))).toBe("alpha")
+  })
+
+  test("prefers the Authorization header when both are present", () => {
+    expect(extractApiKey(request({ authorization: "Bearer alpha", "x-api-key": "bravo" }))).toBe("alpha")
+  })
+
+  test("ignores other auth schemes", () => {
+    expect(extractApiKey(request({ authorization: "Basic alpha" }))).toBeNull()
+  })
+
+  test("returns null with no credential", () => {
+    expect(extractApiKey(request({}))).toBeNull()
+  })
+})

--- a/src/server/api/keys.ts
+++ b/src/server/api/keys.ts
@@ -1,0 +1,117 @@
+/**
+ * API keys for the remote REST API (`kanna --api`).
+ *
+ * Keys arrive either inline (`--api-key=a,b,c`) or from a file
+ * (`--api-key-file=path`, one key per line). Both forms end up as the same
+ * flat list, which the verifier compares against in constant time.
+ *
+ * The API key is the *only* credential on these routes — a caller with a key
+ * skips the `--password` session gate — so verification must not leak which
+ * prefix of a candidate matched.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+
+/** Longest key we will accept, so a huge header can't be used to burn CPU. */
+const MAX_KEY_LENGTH = 512
+
+function isUsableKey(value: string) {
+  return value.length > 0 && value.length <= MAX_KEY_LENGTH
+}
+
+function dedupe(keys: string[]) {
+  return [...new Set(keys)]
+}
+
+/**
+ * `--api-key=a,b,c` — comma separated. Whitespace around each key is trimmed,
+ * so `--api-key="a, b"` works as typed.
+ */
+export function parseApiKeyList(value: string): string[] {
+  return dedupe(
+    value
+      .split(",")
+      .map((key) => key.trim())
+      .filter(isUsableKey)
+  )
+}
+
+/**
+ * `--api-key-file` contents — one key per line. Blank lines are skipped and so
+ * are `#` comments, so a key file can be annotated with who each key is for.
+ * Handles CRLF, since a key file may well be edited on another machine.
+ */
+export function parseApiKeyFile(contents: string): string[] {
+  return dedupe(
+    contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => !line.startsWith("#"))
+      .filter(isUsableKey)
+  )
+}
+
+export async function readApiKeyFile(filePath: string): Promise<string[]> {
+  const file = Bun.file(filePath)
+  if (!(await file.exists())) {
+    throw new Error(`API key file not found: ${filePath}`)
+  }
+  return parseApiKeyFile(await file.text())
+}
+
+/**
+ * Compare without leaking length or content through timing.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so both sides are hashed to a
+ * fixed 32 bytes first. That also bounds the comparison cost for a candidate
+ * of any length.
+ */
+function constantTimeEquals(a: string, b: string) {
+  const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest()
+  return timingSafeEqual(hash(a), hash(b))
+}
+
+export interface ApiKeyVerifier {
+  /** How many keys are configured. Zero means the API must not be mounted. */
+  readonly count: number
+  isValid(candidate: string | null | undefined): boolean
+}
+
+export function createApiKeyVerifier(keys: string[]): ApiKeyVerifier {
+  const configured = dedupe(keys.filter(isUsableKey))
+
+  return {
+    get count() {
+      return configured.length
+    },
+    isValid(candidate) {
+      if (!candidate || candidate.length > MAX_KEY_LENGTH) return false
+      // No early return: every configured key is compared on every call, so a
+      // hit and a miss cost the same.
+      let matched = false
+      for (const key of configured) {
+        if (constantTimeEquals(candidate, key)) {
+          matched = true
+        }
+      }
+      return matched
+    },
+  }
+}
+
+/**
+ * The credential on an incoming request: `Authorization: Bearer <key>`, or
+ * `X-Api-Key: <key>` for callers that can't set an Authorization header.
+ */
+export function extractApiKey(req: Request): string | null {
+  const authorization = req.headers.get("authorization")
+  if (authorization) {
+    const [scheme, ...rest] = authorization.trim().split(/\s+/)
+    if (scheme?.toLowerCase() === "bearer" && rest.length > 0) {
+      return rest.join(" ")
+    }
+  }
+
+  const headerKey = req.headers.get("x-api-key")
+  return headerKey?.trim() || null
+}

--- a/src/server/api/local-request.test.ts
+++ b/src/server/api/local-request.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { isDirectLocalRequest, isLoopbackAddress } from "./local-request"
+
+const request = (headers: Record<string, string> = {}) =>
+  new Request("http://127.0.0.1:3210/api/v1/projects", { headers })
+
+describe("isLoopbackAddress", () => {
+  test("accepts the loopback forms Bun reports", () => {
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true)
+    expect(isLoopbackAddress("127.0.0.53")).toBe(true)
+    expect(isLoopbackAddress("::1")).toBe(true)
+    // Bun reports an IPv4 peer on a dual-stack socket in mapped form.
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true)
+  })
+
+  test("rejects everything else, including a missing address", () => {
+    expect(isLoopbackAddress("192.168.1.20")).toBe(false)
+    expect(isLoopbackAddress("10.0.0.5")).toBe(false)
+    expect(isLoopbackAddress("::ffff:192.168.1.20")).toBe(false)
+    expect(isLoopbackAddress(null)).toBe(false)
+    expect(isLoopbackAddress(undefined)).toBe(false)
+  })
+})
+
+describe("isDirectLocalRequest", () => {
+  test("a plain loopback request qualifies", () => {
+    expect(isDirectLocalRequest(request(), "127.0.0.1")).toBe(true)
+  })
+
+  test("a LAN peer does not — this is the --remote case", () => {
+    expect(isDirectLocalRequest(request(), "192.168.1.20")).toBe(false)
+  })
+
+  test("a relayed request does not, even from loopback", () => {
+    // cloudflared (`--share`) runs on this machine, so the peer address alone
+    // would let the whole public tunnel through.
+    expect(isDirectLocalRequest(request({ "x-forwarded-for": "203.0.113.7" }), "127.0.0.1")).toBe(false)
+    expect(isDirectLocalRequest(request({ "cf-connecting-ip": "203.0.113.7" }), "127.0.0.1")).toBe(false)
+    expect(isDirectLocalRequest(request({ "cf-ray": "abc123" }), "127.0.0.1")).toBe(false)
+    expect(isDirectLocalRequest(request({ forwarded: "for=203.0.113.7" }), "127.0.0.1")).toBe(false)
+    expect(isDirectLocalRequest(request({ "x-real-ip": "203.0.113.7" }), "127.0.0.1")).toBe(false)
+    expect(isDirectLocalRequest(request({ "x-forwarded-proto": "https" }), "127.0.0.1")).toBe(false)
+  })
+
+  test("header matching ignores case", () => {
+    expect(isDirectLocalRequest(request({ "X-Forwarded-For": "203.0.113.7" }), "127.0.0.1")).toBe(false)
+  })
+
+  test("an unrelated header is harmless", () => {
+    expect(isDirectLocalRequest(request({ "user-agent": "kanna-mcp" }), "127.0.0.1")).toBe(true)
+  })
+})

--- a/src/server/api/local-request.ts
+++ b/src/server/api/local-request.ts
@@ -1,0 +1,43 @@
+/**
+ * "Did this request come from a process on this machine, directly?"
+ *
+ * The one credential that must never travel is the internal API key Kanna
+ * mints for its own agent bridge (kanna-mcp-bridge.ts). It is accepted only on
+ * requests that pass this check, which is what keeps `/api/v1` — always
+ * mounted for the bridge — invisible to the network without `--api`.
+ *
+ * `CloudRequestClass` is not enough on its own. It answers "did this come
+ * through the kanna.sh proxy", and reports plain "local" for every request
+ * when no cloud runtime is attached — including one that arrived over the LAN
+ * because the user bound `--remote`. So the peer address is checked directly.
+ *
+ * The peer address alone is not enough either: under `--share`, cloudflared
+ * runs on this machine and connects to the server from 127.0.0.1, so every
+ * request off the public tunnel looks like loopback. What distinguishes them
+ * is the forwarding headers a tunnel or reverse proxy adds and a locally
+ * spawned child process never does — so any of those disqualifies a request,
+ * regardless of where it appears to come from.
+ */
+
+/** Headers that mean "this was relayed", whatever the socket says. */
+const FORWARDING_HEADERS = [
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-real-ip",
+  "forwarded",
+  "cf-connecting-ip",
+  "cf-ray",
+]
+
+export function isLoopbackAddress(address: string | null | undefined) {
+  if (!address) return false
+  // Bun reports IPv6-mapped IPv4 as ::ffff:127.0.0.1.
+  const normalized = address.startsWith("::ffff:") ? address.slice("::ffff:".length) : address
+  return normalized === "127.0.0.1" || normalized === "::1" || normalized.startsWith("127.")
+}
+
+export function isDirectLocalRequest(req: Request, peerAddress: string | null | undefined) {
+  if (!isLoopbackAddress(peerAddress)) return false
+  return !FORWARDING_HEADERS.some((header) => req.headers.has(header))
+}

--- a/src/server/api/routes.test.ts
+++ b/src/server/api/routes.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import type { AppSettingsSnapshot, KannaStatus } from "../../shared/types"
+import type { ClientCommand } from "../../shared/protocol"
+import { createEmptyState, type ChatRecord, type ProjectRecord } from "../events"
+import { createApiKeyVerifier } from "./keys"
+import { handleApiRequest, type ApiRouteDeps } from "./routes"
+
+const KEY = "test-key"
+
+function chatRecord(overrides: Partial<ChatRecord> & Pick<ChatRecord, "id" | "projectId">): ChatRecord {
+  return {
+    title: "Chat",
+    createdAt: 1,
+    updatedAt: 1,
+    unread: false,
+    provider: null,
+    planMode: false,
+    autoPlan: false,
+    sessionToken: null,
+    ...overrides,
+  } as ChatRecord
+}
+
+interface Calls {
+  sends: Array<Extract<ClientCommand, { type: "chat.send" }>>
+  cancels: string[]
+  closes: string[]
+  deletes: string[]
+  broadcasts: number
+}
+
+function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {}) {
+  const state = createEmptyState()
+  state.projectsById.set("project-1", {
+    id: "project-1",
+    localPath: "/tmp/project-1",
+    title: "Project One",
+    createdAt: 1,
+    updatedAt: 5,
+  } as ProjectRecord)
+  state.projectIdsByPath.set("/tmp/project-1", "project-1")
+  state.chatsById.set("chat-1", chatRecord({ id: "chat-1", projectId: "project-1", lastMessageAt: 10, hasMessages: true }))
+  state.chatsById.set("chat-2", chatRecord({ id: "chat-2", projectId: "project-1", lastMessageAt: 20 }))
+  state.chatsById.set("chat-archived", chatRecord({ id: "chat-archived", projectId: "project-1", archivedAt: 3 }))
+  state.chatsById.set("chat-deleted", chatRecord({ id: "chat-deleted", projectId: "project-1", deletedAt: 4 }))
+
+  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0 }
+  let created = 0
+
+  const store = {
+    state,
+    getChat: (chatId: string) => state.chatsById.get(chatId) ?? null,
+    getProject: (projectId: string) => state.projectsById.get(projectId) ?? null,
+    getClientTranscript: () => ({ messages: [], startIndex: 0, readAnchor: null }),
+    getInitialTranscriptWindowStart: () => 0,
+    openProject: async (localPath: string, title?: string) => {
+      const existingId = state.projectIdsByPath.get(localPath)
+      if (existingId) return state.projectsById.get(existingId)!
+      const project = {
+        id: `project-${state.projectsById.size + 1}`,
+        localPath,
+        title: title ?? path.basename(localPath),
+        createdAt: 1,
+        updatedAt: 1,
+      } as ProjectRecord
+      state.projectsById.set(project.id, project)
+      state.projectIdsByPath.set(localPath, project.id)
+      return project
+    },
+    createChat: async (projectId: string) => {
+      created += 1
+      const chat = chatRecord({ id: `new-chat-${created}`, projectId })
+      state.chatsById.set(chat.id, chat)
+      return chat
+    },
+    deleteChat: async (chatId: string) => {
+      calls.deletes.push(chatId)
+      const chat = state.chatsById.get(chatId)
+      if (chat) chat.deletedAt = Date.now()
+    },
+  }
+
+  const agent = {
+    getActiveStatuses: () => options.activeStatuses ?? new Map<string, KannaStatus>(),
+    getDrainingChatIds: () => new Set<string>(),
+    send: async (command: Extract<ClientCommand, { type: "chat.send" }>) => {
+      calls.sends.push(command)
+      if (command.chatId) return { chatId: command.chatId }
+      const chat = await store.createChat(command.projectId!)
+      return { chatId: chat.id }
+    },
+    cancel: async (chatId: string) => {
+      calls.cancels.push(chatId)
+    },
+    closeChat: async (chatId: string) => {
+      calls.closes.push(chatId)
+    },
+  }
+
+  const deps = {
+    store,
+    agent,
+    appSettings: {
+      getSnapshot: () => ({ transcript: { windowAssistantMessages: 50 } } as unknown as AppSettingsSnapshot),
+    },
+    verifier: createApiKeyVerifier([KEY]),
+    broadcast: () => {
+      calls.broadcasts += 1
+    },
+    version: "1.2.3",
+  } as unknown as ApiRouteDeps
+
+  return { deps, calls, state }
+}
+
+function call(
+  deps: ApiRouteDeps,
+  pathname: string,
+  init: { method?: string; body?: unknown; key?: string | null } = {}
+) {
+  const url = new URL(`http://localhost${pathname}`)
+  const headers: Record<string, string> = {}
+  const key = init.key === undefined ? KEY : init.key
+  if (key) headers.authorization = `Bearer ${key}`
+  if (init.body !== undefined) headers["content-type"] = "application/json"
+  const req = new Request(url, {
+    method: init.method ?? "GET",
+    headers,
+    body: init.body === undefined ? undefined : typeof init.body === "string" ? init.body : JSON.stringify(init.body),
+  })
+  return handleApiRequest(req, url, deps)
+}
+
+/** Test-local: response bodies are asserted field by field, not typed. */
+async function json(response: Response | null): Promise<Record<string, any>> {
+  expect(response).not.toBeNull()
+  return (await response!.json()) as Record<string, any>
+}
+
+describe("routing", () => {
+  test("ignores requests outside the API prefix", async () => {
+    const { deps } = createDeps()
+    expect(await call(deps, "/api/chats/chat-1/window")).toBeNull()
+    expect(await call(deps, "/")).toBeNull()
+  })
+
+  test("claims the prefix even for an unknown path", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/nope")
+    expect(response?.status).toBe(404)
+  })
+
+  test("reports version and capabilities at the root", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1")
+    expect(response?.status).toBe(200)
+    expect(await json(response)).toMatchObject({ name: "kanna", version: "1.2.3", api: 1 })
+  })
+
+  test("answers 405 with an Allow header on the wrong method", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "GET" })
+    expect(response?.status).toBe(405)
+    expect(response?.headers.get("Allow")).toBe("POST")
+  })
+
+  test("never caches a response", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats")
+    expect(response?.headers.get("Cache-Control")).toBe("no-store")
+  })
+})
+
+describe("authentication", () => {
+  test("rejects a request with no key", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { key: null })
+    expect(response?.status).toBe(401)
+    expect(response?.headers.get("WWW-Authenticate")).toContain("Bearer")
+  })
+
+  test("rejects a wrong key", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats", { key: "nope" }))?.status).toBe(401)
+  })
+
+  test("accepts X-Api-Key as well as Bearer", async () => {
+    const { deps } = createDeps()
+    const url = new URL("http://localhost/api/v1/chats")
+    const req = new Request(url, { headers: { "x-api-key": KEY } })
+    expect((await handleApiRequest(req, url, deps))?.status).toBe(200)
+  })
+
+  test("checks the key before doing any work", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" }, key: null })
+    expect(calls.sends).toHaveLength(0)
+  })
+})
+
+describe("projects", () => {
+  test("lists projects with a live chat count", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/projects"))
+    expect(body.projects).toHaveLength(1)
+    // chat-1 and chat-2 only: archived and deleted chats don't count.
+    expect(body.projects[0]).toMatchObject({ id: "project-1", localPath: "/tmp/project-1", chatCount: 2 })
+  })
+
+  test("adds an existing directory as a project", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await Bun.write(path.join(dir, "README.md"), "# existing\n")
+      const response = await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir, title: "Added" } })
+      expect(response?.status).toBe(201)
+      const body = await json(response)
+      expect(body.project).toMatchObject({ localPath: dir, title: "Added" })
+      expect(calls.broadcasts).toBe(1)
+      // A directory with content is adopted as-is, not turned into a repo.
+      expect(await Bun.file(path.join(dir, ".git", "HEAD")).exists()).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("creates and git-inits a directory that does not exist yet", async () => {
+    const { deps } = createDeps()
+    const parent = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    const target = path.join(parent, "fresh")
+    try {
+      const response = await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: target } })
+      expect(response?.status).toBe(201)
+      expect(await Bun.file(path.join(target, ".git", "HEAD")).exists()).toBe(true)
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects a path that is a file, not a directory", async () => {
+    const { deps } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    const file = path.join(dir, "not-a-dir.txt")
+    try {
+      await Bun.write(file, "hello")
+      expect((await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: file } }))?.status).toBe(400)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("re-adding the same path returns the project already open there", async () => {
+    const { deps } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      const first = await json(await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } }))
+      const second = await json(await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } }))
+      expect(second.project.id).toBe(first.project.id)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("requires localPath", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/projects", { method: "POST", body: {} })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("localPath")
+  })
+
+  test("rejects a body that is not JSON", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/projects", { method: "POST", body: "{" }))?.status).toBe(400)
+  })
+})
+
+describe("listing chats", () => {
+  test("hides archived and deleted chats by default, newest first", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats"))
+    expect(body.chats.map((chat: { id: string }) => chat.id)).toEqual(["chat-2", "chat-1"])
+    expect(body.total).toBe(2)
+  })
+
+  test("includes archived chats on request, still never deleted ones", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats?includeArchived=true"))
+    const ids = body.chats.map((chat: { id: string }) => chat.id)
+    expect(ids).toContain("chat-archived")
+    expect(ids).not.toContain("chat-deleted")
+  })
+
+  test("filters by project", async () => {
+    const { deps, state } = createDeps()
+    state.projectsById.set("project-2", { id: "project-2", localPath: "/tmp/p2", title: "Two", createdAt: 1, updatedAt: 1 } as ProjectRecord)
+    state.chatsById.set("chat-other", chatRecord({ id: "chat-other", projectId: "project-2" }))
+    const body = await json(await call(deps, "/api/v1/chats?projectId=project-2"))
+    expect(body.chats.map((chat: { id: string }) => chat.id)).toEqual(["chat-other"])
+  })
+
+  test("404s an unknown project rather than returning an empty list", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats?projectId=nope"))?.status).toBe(404)
+  })
+
+  test("honours limit and reports the untruncated total", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats?limit=1"))
+    expect(body.chats).toHaveLength(1)
+    expect(body.total).toBe(2)
+  })
+
+  test("rejects a nonsense limit", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats?limit=0"))?.status).toBe(400)
+    expect((await call(deps, "/api/v1/chats?limit=abc"))?.status).toBe(400)
+  })
+
+  test("reports the live turn status", async () => {
+    const { deps } = createDeps({ activeStatuses: new Map([["chat-1", "running" as KannaStatus]]) })
+    const body = await json(await call(deps, "/api/v1/chats"))
+    const chat = body.chats.find((entry: { id: string }) => entry.id === "chat-1")
+    expect(chat).toMatchObject({ status: "running" })
+  })
+})
+
+describe("creating chats", () => {
+  test("creates an empty chat", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1" } })
+    expect(response?.status).toBe(201)
+    expect((await json(response)).chat).toMatchObject({ projectId: "project-1" })
+    expect(calls.sends).toHaveLength(0)
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("creates and prompts in one call when content is given", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "build it", model: "opus", planMode: true },
+    })
+    expect(response?.status).toBe(202)
+    expect(calls.sends).toEqual([
+      {
+        type: "chat.send",
+        projectId: "project-1",
+        content: "build it",
+        provider: undefined,
+        model: "opus",
+        effort: undefined,
+        modelOptions: undefined,
+        planMode: true,
+        autoPlan: undefined,
+      },
+    ])
+  })
+
+  test("treats whitespace-only content as no content", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1", content: "   " } })
+    expect(response?.status).toBe(201)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("404s an unknown project", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "nope" } }))?.status).toBe(404)
+  })
+})
+
+describe("reading a chat", () => {
+  test("returns the chat with its transcript window", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats/chat-1"))
+    expect(body.chat).toMatchObject({ id: "chat-1", projectId: "project-1" })
+    expect(body.messages).toEqual([])
+    expect(body.runtime).toBeDefined()
+  })
+
+  test("404s an unknown chat", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope"))?.status).toBe(404)
+  })
+
+  test("404s a deleted chat", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/chats/chat-deleted"))?.status).toBe(404)
+  })
+})
+
+describe("sending a prompt", () => {
+  test("accepts the prompt and answers 202 without waiting for the turn", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hello" } })
+    expect(response?.status).toBe(202)
+    expect(await json(response)).toMatchObject({ chatId: "chat-1", queued: false })
+    expect(calls.sends[0]).toMatchObject({ type: "chat.send", chatId: "chat-1", content: "hello" })
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("reports a prompt that landed behind a running turn", async () => {
+    const { deps } = createDeps()
+    deps.agent.send = async () => ({ chatId: "chat-1", queued: true as const, queuedMessageId: "queued-1" })
+    const body = await json(await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hello" } }))
+    expect(body).toMatchObject({ queued: true, queuedMessageId: "queued-1" })
+  })
+
+  test("requires content", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: {} })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("content")
+  })
+
+  test("rejects a non-object modelOptions", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", modelOptions: "nope" },
+    })
+    expect(response?.status).toBe(400)
+  })
+
+  test("404s an unknown chat before sending", async () => {
+    const { deps, calls } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope/messages", { method: "POST", body: { content: "hi" } }))?.status).toBe(404)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("surfaces an agent failure as 500", async () => {
+    const { deps } = createDeps()
+    deps.agent.send = async () => {
+      throw new Error("provider is not configured")
+    }
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
+    expect(response?.status).toBe(500)
+    expect((await json(response)).error).toBe("provider is not configured")
+  })
+})
+
+describe("cancel and delete", () => {
+  test("cancels a running turn", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/cancel", { method: "POST" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("deletes a chat, stopping its turn first", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.closes).toEqual(["chat-1"])
+    expect(calls.deletes).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("404s deleting an unknown chat", async () => {
+    const { deps, calls } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope", { method: "DELETE" }))?.status).toBe(404)
+    expect(calls.deletes).toHaveLength(0)
+  })
+})

--- a/src/server/api/routes.test.ts
+++ b/src/server/api/routes.test.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import type { AppSettingsSnapshot, KannaStatus } from "../../shared/types"
 import type { ClientCommand } from "../../shared/protocol"
 import { createEmptyState, type ChatRecord, type ProjectRecord } from "../events"
+import { SERVER_PROVIDERS } from "../provider-catalog"
 import { createApiKeyVerifier } from "./keys"
 import { handleApiRequest, type ApiRouteDeps } from "./routes"
 
@@ -30,6 +31,7 @@ interface Calls {
   closes: string[]
   deletes: string[]
   broadcasts: number
+  events: string[]
 }
 
 function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {}) {
@@ -47,7 +49,7 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
   state.chatsById.set("chat-archived", chatRecord({ id: "chat-archived", projectId: "project-1", archivedAt: 3 }))
   state.chatsById.set("chat-deleted", chatRecord({ id: "chat-deleted", projectId: "project-1", deletedAt: 4 }))
 
-  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0 }
+  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0, events: [] }
   let created = 0
 
   const store = {
@@ -109,6 +111,11 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
     verifier: createApiKeyVerifier([KEY]),
     broadcast: () => {
       calls.broadcasts += 1
+    },
+    analytics: {
+      track: (eventName: string) => {
+        calls.events.push(eventName)
+      },
     },
     version: "1.2.3",
   } as unknown as ApiRouteDeps
@@ -439,6 +446,128 @@ describe("sending a prompt", () => {
     const response = await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
     expect(response?.status).toBe(500)
     expect((await json(response)).error).toBe("provider is not configured")
+  })
+})
+
+describe("provider validation", () => {
+  // An unknown provider is only noticed when the turn is set up. For a prompt
+  // that queues behind a running turn that happens after the 202, in
+  // dequeueAndStartQueuedMessage, which removes the queued message before the
+  // catalog lookup throws — so an accepted prompt would vanish.
+  test("rejects an unknown provider instead of accepting the prompt", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", provider: "bogus" },
+    })
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("bogus")
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("names the providers it will accept", async () => {
+    const { deps } = createDeps()
+    const body = await json(await call(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "hi", provider: "bogus" },
+    }))
+    expect(body.error).toContain("claude")
+  })
+
+  test("rejects an unknown provider on create-and-prompt too", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "hi", provider: "bogus" },
+    })
+    expect(response?.status).toBe(400)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("accepts every provider the server has a catalog entry for", async () => {
+    for (const provider of SERVER_PROVIDERS.map((entry) => entry.id)) {
+      const { deps, calls } = createDeps()
+      const response = await call(deps, "/api/v1/chats/chat-1/messages", {
+        method: "POST",
+        body: { content: "hi", provider },
+      })
+      expect(response?.status).toBe(202)
+      expect(calls.sends[0]).toMatchObject({ provider })
+    }
+  })
+
+  test("a missing provider stays undefined so the chat's own is used", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1/messages", { method: "POST", body: { content: "hi" } })
+    expect(calls.sends[0]?.provider).toBeUndefined()
+  })
+})
+
+describe("malformed paths", () => {
+  test("answers 400, not 500, on bad percent-encoding", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/chats/%ZZ")
+    expect(response?.status).toBe(400)
+    expect((await json(response)).error).toContain("percent-encoding")
+  })
+
+  test("still decodes a legitimately encoded id", async () => {
+    const { deps, state } = createDeps()
+    state.chatsById.set("chat/with slash", chatRecord({ id: "chat/with slash", projectId: "project-1" }))
+    const response = await call(deps, `/api/v1/chats/${encodeURIComponent("chat/with slash")}`)
+    expect(response?.status).toBe(200)
+  })
+})
+
+describe("analytics", () => {
+  test("creating a chat reports chat_created", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1" } })
+    expect(calls.events).toEqual(["chat_created"])
+  })
+
+  test("create-and-prompt leaves the event to agent.send, so it is not doubled", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats", { method: "POST", body: { projectId: "project-1", content: "hi" } })
+    expect(calls.events).toEqual([])
+  })
+
+  test("deleting a chat reports chat_deleted", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
+    expect(calls.events).toEqual(["chat_deleted"])
+  })
+
+  test("adding a new project reports project_opened", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      expect(calls.events).toEqual(["project_opened"])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("re-adding an already-open project reports nothing", async () => {
+    const { deps, calls } = createDeps()
+    const dir = await mkdtemp(path.join(tmpdir(), "kanna-api-project-"))
+    try {
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      calls.events.length = 0
+      await call(deps, "/api/v1/projects", { method: "POST", body: { localPath: dir } })
+      expect(calls.events).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("reads report nothing", async () => {
+    const { deps, calls } = createDeps()
+    await call(deps, "/api/v1/chats")
+    await call(deps, "/api/v1/projects")
+    await call(deps, "/api/v1/chats/chat-1")
+    expect(calls.events).toEqual([])
   })
 })
 

--- a/src/server/api/routes.test.ts
+++ b/src/server/api/routes.test.ts
@@ -27,10 +27,13 @@ function chatRecord(overrides: Partial<ChatRecord> & Pick<ChatRecord, "id" | "pr
 
 interface Calls {
   sends: Array<Extract<ClientCommand, { type: "chat.send" }>>
+  /** The out-of-band agent origin passed alongside each send, if any. */
+  sendOrigins: Array<{ chatId: string } | undefined>
   cancels: string[]
   closes: string[]
   deletes: string[]
   broadcasts: number
+  /** Analytics event names, in order, so a write can't silently stop reporting. */
   events: string[]
 }
 
@@ -49,7 +52,7 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
   state.chatsById.set("chat-archived", chatRecord({ id: "chat-archived", projectId: "project-1", archivedAt: 3 }))
   state.chatsById.set("chat-deleted", chatRecord({ id: "chat-deleted", projectId: "project-1", deletedAt: 4 }))
 
-  const calls: Calls = { sends: [], cancels: [], closes: [], deletes: [], broadcasts: 0, events: [] }
+  const calls: Calls = { sends: [], sendOrigins: [], cancels: [], closes: [], deletes: [], broadcasts: 0, events: [] }
   let created = 0
 
   const store = {
@@ -72,12 +75,16 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
       state.projectIdsByPath.set(localPath, project.id)
       return project
     },
-    createChat: async (projectId: string) => {
+    createChat: async (projectId: string, options?: { agentOrigin?: { chatId: string } }) => {
       created += 1
-      const chat = chatRecord({ id: `new-chat-${created}`, projectId })
+      const chat = chatRecord({ id: `new-chat-${created}`, projectId, agentOrigin: options?.agentOrigin })
       state.chatsById.set(chat.id, chat)
       return chat
     },
+    reload: async () => ({
+      projects: state.projectsById.size,
+      chats: [...state.chatsById.values()].filter((chat) => !chat.deletedAt).length,
+    }),
     deleteChat: async (chatId: string) => {
       calls.deletes.push(chatId)
       const chat = state.chatsById.get(chatId)
@@ -88,10 +95,14 @@ function createDeps(options: { activeStatuses?: Map<string, KannaStatus> } = {})
   const agent = {
     getActiveStatuses: () => options.activeStatuses ?? new Map<string, KannaStatus>(),
     getDrainingChatIds: () => new Set<string>(),
-    send: async (command: Extract<ClientCommand, { type: "chat.send" }>) => {
+    send: async (
+      command: Extract<ClientCommand, { type: "chat.send" }>,
+      options?: { agentOrigin?: { chatId: string } }
+    ) => {
       calls.sends.push(command)
+      calls.sendOrigins.push(options?.agentOrigin)
       if (command.chatId) return { chatId: command.chatId }
-      const chat = await store.createChat(command.projectId!)
+      const chat = await store.createChat(command.projectId!, { agentOrigin: options?.agentOrigin })
       return { chatId: chat.id }
     },
     cancel: async (chatId: string) => {
@@ -449,6 +460,190 @@ describe("sending a prompt", () => {
   })
 })
 
+describe("cancel and delete", () => {
+  test("cancels a running turn", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1/cancel", { method: "POST" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("deletes a chat, stopping its turn first", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
+    expect(response?.status).toBe(200)
+    expect(calls.cancels).toEqual(["chat-1"])
+    expect(calls.closes).toEqual(["chat-1"])
+    expect(calls.deletes).toEqual(["chat-1"])
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("404s deleting an unknown chat", async () => {
+    const { deps, calls } = createDeps()
+    expect((await call(deps, "/api/v1/chats/nope", { method: "DELETE" }))?.status).toBe(404)
+    expect(calls.deletes).toHaveLength(0)
+  })
+})
+
+describe("agent callers", () => {
+  /** Like `call`, but sets the agent-chat header the MCP bridge sends. */
+  function agentCall(
+    deps: ApiRouteDeps,
+    pathname: string,
+    init: { method?: string; body?: unknown; agentChatId: string }
+  ) {
+    const url = new URL(`http://localhost${pathname}`)
+    const req = new Request(url, {
+      method: init.method ?? "GET",
+      headers: {
+        authorization: `Bearer ${KEY}`,
+        "content-type": "application/json",
+        "x-kanna-agent-chat": init.agentChatId,
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    })
+    return handleApiRequest(req, url, deps)
+  }
+
+  test("the header is ignored unless the key is the internal one", async () => {
+    // A human `--api` client can set any header it likes; without the internal
+    // key it is still just a human client, and its chats are not agent work.
+    const { deps, calls, state } = createDeps()
+    const response = await agentCall(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "hi" },
+      agentChatId: "chat-1",
+    })
+
+    expect(response?.status).toBe(202)
+    expect(calls.sendOrigins).toEqual([undefined])
+    expect((await json(response)).chat.createdByChatId).toBeNull()
+    expect(state.chatsById.get("new-chat-1")?.agentOrigin).toBeUndefined()
+  })
+
+  test("with the internal key, a created chat records who created it", async () => {
+    const { deps, calls } = createDeps()
+    deps.isInternalKey = () => true
+
+    const response = await agentCall(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "hi" },
+      agentChatId: "chat-1",
+    })
+
+    expect(response?.status).toBe(202)
+    expect(calls.sendOrigins).toEqual([{ chatId: "chat-1" }])
+    expect((await json(response)).chat.createdByChatId).toBe("chat-1")
+  })
+
+  test("a chat an agent created cannot start more work", async () => {
+    const { deps, state, calls } = createDeps()
+    deps.isInternalKey = () => true
+    state.chatsById.set(
+      "spawned",
+      chatRecord({ id: "spawned", projectId: "project-1", agentOrigin: { chatId: "chat-1" } })
+    )
+
+    const created = await agentCall(deps, "/api/v1/chats", {
+      method: "POST",
+      body: { projectId: "project-1", content: "go deeper" },
+      agentChatId: "spawned",
+    })
+    const sent = await agentCall(deps, "/api/v1/chats/chat-2/messages", {
+      method: "POST",
+      body: { content: "go deeper" },
+      agentChatId: "spawned",
+    })
+
+    expect(created?.status).toBe(409)
+    expect(sent?.status).toBe(409)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("an agent cannot prompt its own chat", async () => {
+    const { deps, calls } = createDeps()
+    deps.isInternalKey = () => true
+
+    const response = await agentCall(deps, "/api/v1/chats/chat-1/messages", {
+      method: "POST",
+      body: { content: "again" },
+      agentChatId: "chat-1",
+    })
+
+    expect(response?.status).toBe(409)
+    expect(calls.sends).toHaveLength(0)
+  })
+
+  test("reading is never gated by the guard", async () => {
+    const { deps, state } = createDeps()
+    deps.isInternalKey = () => true
+    state.chatsById.set(
+      "spawned",
+      chatRecord({ id: "spawned", projectId: "project-1", agentOrigin: { chatId: "chat-1" } })
+    )
+
+    expect((await agentCall(deps, "/api/v1/projects", { agentChatId: "spawned" }))?.status).toBe(200)
+    expect((await agentCall(deps, "/api/v1/chats", { agentChatId: "spawned" }))?.status).toBe(200)
+    expect((await agentCall(deps, "/api/v1/chats/chat-1", { agentChatId: "spawned" }))?.status).toBe(200)
+  })
+})
+
+describe("reload", () => {
+  test("re-reads the store and reports what it found", async () => {
+    const { deps, calls } = createDeps()
+    const response = await call(deps, "/api/v1/reload", { method: "POST" })
+
+    expect(response?.status).toBe(200)
+    expect(await json(response)).toMatchObject({ chats: 3, droppedChatIds: [], activeChatIds: [] })
+    expect(calls.broadcasts).toBe(1)
+  })
+
+  test("names the chats that were mid-turn, and drops ones that vanished", async () => {
+    const activeStatuses = new Map<KannaStatus, KannaStatus>() as Map<string, KannaStatus>
+    activeStatuses.set("chat-1", "running")
+    activeStatuses.set("chat-gone", "running")
+    const { deps, calls } = createDeps({ activeStatuses })
+
+    const body = await json(await call(deps, "/api/v1/reload", { method: "POST" }))
+
+    expect(body.activeChatIds).toEqual(["chat-1"])
+    expect(body.droppedChatIds).toEqual(["chat-gone"])
+    expect(calls.cancels).toEqual(["chat-gone"])
+    expect(calls.closes).toEqual(["chat-gone"])
+  })
+
+  test("a store that refuses to reload answers 409, not 500", async () => {
+    const { deps, calls } = createDeps()
+    deps.store.reload = async () => {
+      throw new Error("snapshot.json is not valid JSON")
+    }
+
+    const response = await call(deps, "/api/v1/reload", { method: "POST" })
+
+    expect(response?.status).toBe(409)
+    expect((await json(response)).error).toContain("snapshot.json is not valid JSON")
+    expect(calls.broadcasts).toBe(0)
+  })
+
+  test("only POST", async () => {
+    const { deps } = createDeps()
+    const response = await call(deps, "/api/v1/reload")
+    expect(response?.status).toBe(405)
+    expect(response?.headers.get("Allow")).toBe("POST")
+  })
+
+  test("still needs a key", async () => {
+    const { deps } = createDeps()
+    expect((await call(deps, "/api/v1/reload", { method: "POST", key: null }))?.status).toBe(401)
+  })
+
+  test("is listed in the root capabilities", async () => {
+    const { deps } = createDeps()
+    expect((await json(await call(deps, "/api/v1"))).capabilities).toContain("reload")
+  })
+})
+
 describe("provider validation", () => {
   // An unknown provider is only noticed when the turn is set up. For a prompt
   // that queues behind a running turn that happens after the 202, in
@@ -568,31 +763,5 @@ describe("analytics", () => {
     await call(deps, "/api/v1/projects")
     await call(deps, "/api/v1/chats/chat-1")
     expect(calls.events).toEqual([])
-  })
-})
-
-describe("cancel and delete", () => {
-  test("cancels a running turn", async () => {
-    const { deps, calls } = createDeps()
-    const response = await call(deps, "/api/v1/chats/chat-1/cancel", { method: "POST" })
-    expect(response?.status).toBe(200)
-    expect(calls.cancels).toEqual(["chat-1"])
-    expect(calls.broadcasts).toBe(1)
-  })
-
-  test("deletes a chat, stopping its turn first", async () => {
-    const { deps, calls } = createDeps()
-    const response = await call(deps, "/api/v1/chats/chat-1", { method: "DELETE" })
-    expect(response?.status).toBe(200)
-    expect(calls.cancels).toEqual(["chat-1"])
-    expect(calls.closes).toEqual(["chat-1"])
-    expect(calls.deletes).toEqual(["chat-1"])
-    expect(calls.broadcasts).toBe(1)
-  })
-
-  test("404s deleting an unknown chat", async () => {
-    const { deps, calls } = createDeps()
-    expect((await call(deps, "/api/v1/chats/nope", { method: "DELETE" }))?.status).toBe(404)
-    expect(calls.deletes).toHaveLength(0)
   })
 })

--- a/src/server/api/routes.ts
+++ b/src/server/api/routes.ts
@@ -16,7 +16,9 @@ import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../
 import type { ClientCommand } from "../../shared/protocol"
 import type { ChatRecord, ProjectRecord } from "../events"
 import type { EventStore } from "../event-store"
+import type { AnalyticsReporter } from "../analytics"
 import { initializeProjectDirectory } from "../paths"
+import { SERVER_PROVIDERS } from "../provider-catalog"
 import { deriveChatSnapshot, deriveStatus } from "../read-models"
 import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
 import { extractApiKey, type ApiKeyVerifier } from "./keys"
@@ -38,6 +40,12 @@ export interface ApiRouteDeps extends ChatWindowRouteDeps {
   verifier: ApiKeyVerifier
   /** Push fresh snapshots to connected sockets after a write. */
   broadcast: () => Promise<void> | void
+  /**
+   * Same reporter the socket uses. API writes emit the same events as the
+   * equivalent `ClientCommand`, so metrics don't silently miss whatever is
+   * driven over HTTP.
+   */
+  analytics: Pick<AnalyticsReporter, "track">
   version: string
 }
 
@@ -125,6 +133,28 @@ function serializeChat(chat: ChatRecord, status: KannaStatus) {
 }
 
 /**
+ * Reject a provider the server has no catalog entry for.
+ *
+ * This has to happen before `agent.send`. A bad provider is only discovered
+ * when the turn is set up — and for a prompt that lands behind a running turn
+ * that is long after the 202, in `dequeueAndStartQueuedMessage`, which removes
+ * the queued message *before* the catalog lookup throws. The prompt would be
+ * acknowledged and then silently dropped. Validating against SERVER_PROVIDERS
+ * (rather than a hand-written list) keeps this in step with what
+ * `getProviderSettings` will actually accept.
+ */
+function readProvider(body: Record<string, unknown>): AgentProvider | undefined {
+  const value = optionalString(body, "provider")
+  if (value === undefined) return undefined
+  const entry = SERVER_PROVIDERS.find((candidate) => candidate.id === value)
+  if (!entry) {
+    const known = SERVER_PROVIDERS.map((candidate) => candidate.id).join(", ")
+    throw new ApiError(400, `Unknown provider "${value}". Expected one of: ${known}`)
+  }
+  return entry.id
+}
+
+/**
  * The prompt fields shared by "create a chat and send" and "send to an
  * existing chat". Kept in one place so the two routes can't drift.
  */
@@ -134,7 +164,7 @@ function readPromptFields(body: Record<string, unknown>) {
     throw new ApiError(400, '"modelOptions" must be an object')
   }
   return {
-    provider: optionalString(body, "provider") as AgentProvider | undefined,
+    provider: readProvider(body),
     model: optionalString(body, "model"),
     effort: optionalString(body, "effort"),
     modelOptions: modelOptions as ModelOptions | undefined,
@@ -206,7 +236,11 @@ async function handleCreateProject(req: Request, deps: ApiRouteDeps) {
     throw new ApiError(400, error instanceof Error ? error.message : "Could not open project directory")
   }
 
+  // Mirrors ws-router's `project.open`: only a path that wasn't already open
+  // counts as opening a project.
+  const alreadyOpen = deps.store.state.projectIdsByPath.get(resolvedPath)
   const project = await deps.store.openProject(resolvedPath, title)
+  if (!alreadyOpen) deps.analytics.track("project_opened")
   await deps.broadcast()
   return json({ project: serializeProject(project, 0) }, 201)
 }
@@ -259,7 +293,10 @@ async function handleCreateChat(req: Request, deps: ApiRouteDeps) {
     return json({ chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false }, 202)
   }
 
+  // `agent.send` tracks this itself on the prompt path above, so it is only
+  // emitted here, where the chat is created on its own.
   const chat = await deps.store.createChat(projectId)
+  deps.analytics.track("chat_created")
   await deps.broadcast()
   return json({ chat: serializeChat(chat, chatStatus(deps, chat)) }, 201)
 }
@@ -320,6 +357,7 @@ async function handleDeleteChat(chatId: string, deps: ApiRouteDeps) {
   await deps.agent.cancel(chatId)
   await deps.agent.closeChat(chatId)
   await deps.store.deleteChat(chatId)
+  deps.analytics.track("chat_deleted")
   await deps.broadcast()
   return json({ chatId, deleted: true })
 }
@@ -343,7 +381,14 @@ export function hasValidApiKey(req: Request, verifier: ApiKeyVerifier | null) {
 
 async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response> {
   const rest = url.pathname.slice(API_ROUTE_PREFIX.length).replace(/^\/+|\/+$/g, "")
-  const segments = rest ? rest.split("/").map(decodeURIComponent) : []
+  let segments: string[]
+  try {
+    segments = rest ? rest.split("/").map(decodeURIComponent) : []
+  } catch {
+    // decodeURIComponent throws URIError on malformed input like `%ZZ`. That
+    // is a bad request, not a server fault, so it must not reach the 500 path.
+    throw new ApiError(400, "Malformed percent-encoding in path")
+  }
 
   if (segments.length === 0) {
     if (req.method !== "GET") return methodNotAllowed("GET")

--- a/src/server/api/routes.ts
+++ b/src/server/api/routes.ts
@@ -1,58 +1,56 @@
 /**
- * `/api/v1/*` — the remote REST API, mounted only when the server is started
- * with `--api` (see cli-runtime.ts).
+ * `/api/v1/*` — the remote REST API.
  *
- * Everything here goes through the same EventStore and AgentCoordinator the
- * WebSocket uses, so a chat created over HTTP shows up in a connected browser
- * immediately and is written to the normal data dir. After any write the
- * caller-supplied `broadcast` pushes fresh snapshots to connected sockets.
+ * Two kinds of caller reach this. A person or script with a key from `--api`
+ * (see cli-runtime.ts), and Kanna's own agent-facing MCP bridge, which runs as
+ * a child process of a codex session and holds a loopback-only internal key
+ * (see ../kanna-mcp-stdio.ts). The bridge additionally sends
+ * `X-Kanna-Agent-Chat`, naming the chat whose agent is calling, which is what
+ * the fan-out guard in control.ts keys off.
+ *
+ * The operations themselves live in control.ts, shared with the in-process
+ * tools Claude gets, so HTTP and MCP cannot drift.
  *
  * Prompts are asynchronous: a send returns 202 with the chat id, and the
  * caller polls `GET /api/v1/chats/:id` for status and new messages. A turn can
  * run for many minutes, which no HTTP client or proxy would sit through.
  */
 
-import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../../shared/types"
-import type { ClientCommand } from "../../shared/protocol"
-import type { ChatRecord, ProjectRecord } from "../events"
-import type { EventStore } from "../event-store"
-import type { AnalyticsReporter } from "../analytics"
-import { initializeProjectDirectory } from "../paths"
-import { SERVER_PROVIDERS } from "../provider-catalog"
-import { deriveChatSnapshot, deriveStatus } from "../read-models"
-import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
+import type { AgentProvider, ModelOptions } from "../../shared/types"
+import {
+  addProject,
+  cancelChat,
+  ControlError,
+  createChat,
+  deleteChat,
+  getChat,
+  listChats,
+  listProjects,
+  reloadFromDisk,
+  sendMessage,
+  type ControlCaller,
+  type ControlDeps,
+  type PromptFields,
+} from "./control"
 import { extractApiKey, type ApiKeyVerifier } from "./keys"
 
 export const API_ROUTE_PREFIX = "/api/v1"
 
-/** Cap on `GET /chats` so one call can't serialize an entire history. */
-const DEFAULT_CHAT_LIMIT = 50
-const MAX_CHAT_LIMIT = 200
+/**
+ * Header the MCP bridge sets to identify the chat its agent is running in.
+ * Only honoured for callers holding the internal key — a human API client
+ * setting it would only restrict itself, but there is no reason to let it.
+ */
+export const AGENT_CHAT_HEADER = "x-kanna-agent-chat"
 
-export interface ApiRouteDeps extends ChatWindowRouteDeps {
-  store: ChatWindowRouteDeps["store"] &
-    Pick<EventStore, "getProject" | "openProject" | "createChat" | "deleteChat">
-  agent: ChatWindowRouteDeps["agent"] & {
-    send: (command: Extract<ClientCommand, { type: "chat.send" }>) => Promise<{ chatId: string; queuedMessageId?: string; queued?: true }>
-    cancel: (chatId: string) => Promise<void>
-    closeChat: (chatId: string) => Promise<void>
-  }
+export interface ApiRouteDeps extends ControlDeps {
   verifier: ApiKeyVerifier
-  /** Push fresh snapshots to connected sockets after a write. */
-  broadcast: () => Promise<void> | void
   /**
-   * Same reporter the socket uses. API writes emit the same events as the
-   * equivalent `ClientCommand`, so metrics don't silently miss whatever is
-   * driven over HTTP.
+   * True when the request's key was the internal one Kanna mints for its own
+   * agent bridge. Only such a request may claim an agent chat id.
    */
-  analytics: Pick<AnalyticsReporter, "track">
+  isInternalKey?: (req: Request) => boolean
   version: string
-}
-
-class ApiError extends Error {
-  constructor(readonly status: number, message: string) {
-    super(message)
-  }
 }
 
 function json(body: unknown, status = 200) {
@@ -70,10 +68,10 @@ async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
   try {
     parsed = JSON.parse(raw)
   } catch {
-    throw new ApiError(400, "Body must be valid JSON")
+    throw new ControlError(400, "Body must be valid JSON")
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new ApiError(400, "Body must be a JSON object")
+    throw new ControlError(400, "Body must be a JSON object")
   }
   return parsed as Record<string, unknown>
 }
@@ -81,7 +79,7 @@ async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
 function requireString(body: Record<string, unknown>, field: string): string {
   const value = body[field]
   if (typeof value !== "string" || !value.trim()) {
-    throw new ApiError(400, `Missing or empty "${field}"`)
+    throw new ControlError(400, `Missing or empty "${field}"`)
   }
   return value
 }
@@ -89,14 +87,14 @@ function requireString(body: Record<string, unknown>, field: string): string {
 function optionalString(body: Record<string, unknown>, field: string): string | undefined {
   const value = body[field]
   if (value === undefined || value === null) return undefined
-  if (typeof value !== "string") throw new ApiError(400, `"${field}" must be a string`)
+  if (typeof value !== "string") throw new ControlError(400, `"${field}" must be a string`)
   return value
 }
 
 function optionalBoolean(body: Record<string, unknown>, field: string): boolean | undefined {
   const value = body[field]
   if (value === undefined || value === null) return undefined
-  if (typeof value !== "boolean") throw new ApiError(400, `"${field}" must be a boolean`)
+  if (typeof value !== "boolean") throw new ControlError(400, `"${field}" must be a boolean`)
   return value
 }
 
@@ -104,67 +102,17 @@ function isTruthyParam(value: string | null) {
   return value === "" || value === "1" || value === "true"
 }
 
-function serializeProject(project: ProjectRecord, chatCount: number) {
-  return {
-    id: project.id,
-    title: project.sidebarTitle ?? project.title,
-    localPath: project.localPath,
-    createdAt: project.createdAt,
-    updatedAt: project.updatedAt,
-    chatCount,
-  }
-}
-
-function serializeChat(chat: ChatRecord, status: KannaStatus) {
-  return {
-    id: chat.id,
-    projectId: chat.projectId,
-    title: chat.title,
-    status,
-    provider: chat.provider,
-    createdAt: chat.createdAt,
-    updatedAt: chat.updatedAt,
-    lastMessageAt: chat.lastMessageAt ?? null,
-    lastModel: chat.lastModel ?? null,
-    hasMessages: Boolean(chat.hasMessages),
-    unread: chat.unread,
-    archived: Boolean(chat.archivedAt),
-  }
-}
-
-/**
- * Reject a provider the server has no catalog entry for.
- *
- * This has to happen before `agent.send`. A bad provider is only discovered
- * when the turn is set up — and for a prompt that lands behind a running turn
- * that is long after the 202, in `dequeueAndStartQueuedMessage`, which removes
- * the queued message *before* the catalog lookup throws. The prompt would be
- * acknowledged and then silently dropped. Validating against SERVER_PROVIDERS
- * (rather than a hand-written list) keeps this in step with what
- * `getProviderSettings` will actually accept.
- */
-function readProvider(body: Record<string, unknown>): AgentProvider | undefined {
-  const value = optionalString(body, "provider")
-  if (value === undefined) return undefined
-  const entry = SERVER_PROVIDERS.find((candidate) => candidate.id === value)
-  if (!entry) {
-    const known = SERVER_PROVIDERS.map((candidate) => candidate.id).join(", ")
-    throw new ApiError(400, `Unknown provider "${value}". Expected one of: ${known}`)
-  }
-  return entry.id
-}
-
 /**
  * The prompt fields shared by "create a chat and send" and "send to an
  * existing chat". Kept in one place so the two routes can't drift.
  */
-function readPromptFields(body: Record<string, unknown>) {
+function readPromptFields(body: Record<string, unknown>): PromptFields {
   const modelOptions = body.modelOptions
   if (modelOptions !== undefined && (typeof modelOptions !== "object" || modelOptions === null || Array.isArray(modelOptions))) {
-    throw new ApiError(400, '"modelOptions" must be an object')
+    throw new ControlError(400, '"modelOptions" must be an object')
   }
   return {
-    provider: readProvider(body),
+    provider: optionalString(body, "provider") as AgentProvider | undefined,
     model: optionalString(body, "model"),
     effort: optionalString(body, "effort"),
     modelOptions: modelOptions as ModelOptions | undefined,
@@ -173,28 +121,12 @@ function readPromptFields(body: Record<string, unknown>) {
   }
 }
 
-function chatStatus(deps: ApiRouteDeps, chat: ChatRecord): KannaStatus {
-  return deriveStatus(chat, deps.agent.getActiveStatuses().get(chat.id))
-}
-
-function liveChats(deps: ApiRouteDeps) {
-  return [...deps.store.state.chatsById.values()].filter((chat) => !chat.deletedAt)
-}
-
-function requireChat(deps: ApiRouteDeps, chatId: string): ChatRecord {
-  const chat = deps.store.getChat(chatId)
-  if (!chat || chat.deletedAt) throw new ApiError(404, "Chat not found")
-  return chat
-}
-
-function readFullChatSnapshot(chatId: string, deps: ApiRouteDeps): ChatSnapshot | null {
-  return deriveChatSnapshot(
-    deps.store.state,
-    deps.agent.getActiveStatuses(),
-    deps.agent.getDrainingChatIds(),
-    chatId,
-    (id) => deps.store.getClientTranscript(id)
-  )
+/** The agent chat behind this request, or undefined for a human caller. */
+function readCaller(req: Request, deps: ApiRouteDeps): ControlCaller | undefined {
+  const chatId = req.headers.get(AGENT_CHAT_HEADER)?.trim()
+  if (!chatId) return undefined
+  if (!deps.isInternalKey?.(req)) return undefined
+  return { chatId }
 }
 
 // --- routes ---------------------------------------------------------------
@@ -204,162 +136,65 @@ function handleRoot(deps: ApiRouteDeps) {
     name: "kanna",
     version: deps.version,
     api: 1,
-    capabilities: ["projects", "chats", "messages", "cancel"],
+    capabilities: ["projects", "chats", "messages", "cancel", "reload"],
   })
-}
-
-function handleListProjects(deps: ApiRouteDeps) {
-  const chatCounts = new Map<string, number>()
-  for (const chat of liveChats(deps)) {
-    if (chat.archivedAt) continue
-    chatCounts.set(chat.projectId, (chatCounts.get(chat.projectId) ?? 0) + 1)
-  }
-  const projects = [...deps.store.state.projectsById.values()]
-    .filter((project) => !project.deletedAt)
-    .sort((a, b) => b.updatedAt - a.updatedAt)
-    .map((project) => serializeProject(project, chatCounts.get(project.id) ?? 0))
-  return json({ projects })
 }
 
 async function handleCreateProject(req: Request, deps: ApiRouteDeps) {
   const body = await readJsonBody(req)
-  const localPath = requireString(body, "localPath")
-  const title = optionalString(body, "title")
-
-  // Same call the UI's "new project" flow makes: create the directory if it is
-  // missing, and `git init` it when it is empty so chats there get diffs. An
-  // existing non-empty directory is left exactly as it is.
-  let resolvedPath: string
-  try {
-    resolvedPath = await initializeProjectDirectory(localPath)
-  } catch (error) {
-    throw new ApiError(400, error instanceof Error ? error.message : "Could not open project directory")
-  }
-
-  // Mirrors ws-router's `project.open`: only a path that wasn't already open
-  // counts as opening a project.
-  const alreadyOpen = deps.store.state.projectIdsByPath.get(resolvedPath)
-  const project = await deps.store.openProject(resolvedPath, title)
-  if (!alreadyOpen) deps.analytics.track("project_opened")
-  await deps.broadcast()
-  return json({ project: serializeProject(project, 0) }, 201)
+  const result = await addProject(deps, {
+    localPath: requireString(body, "localPath"),
+    title: optionalString(body, "title"),
+  })
+  // Always 201, including for a path that was already open: opening is
+  // idempotent and existing clients treat any 2xx that isn't 201 as a
+  // surprise. `created` in the body is how a caller tells the two apart.
+  return json({ project: result.project, created: result.created }, 201)
 }
 
 function handleListChats(url: URL, deps: ApiRouteDeps) {
-  const projectId = url.searchParams.get("projectId")
-  if (projectId && !deps.store.getProject(projectId)) {
-    throw new ApiError(404, "Project not found")
-  }
-  const includeArchived = isTruthyParam(url.searchParams.get("includeArchived"))
-
   const rawLimit = url.searchParams.get("limit")
-  let limit = DEFAULT_CHAT_LIMIT
+  let limit: number | undefined
   if (rawLimit !== null) {
     const parsed = Number(rawLimit)
-    if (!Number.isInteger(parsed) || parsed < 1) throw new ApiError(400, '"limit" must be a positive integer')
-    limit = Math.min(parsed, MAX_CHAT_LIMIT)
+    if (!Number.isInteger(parsed) || parsed < 1) throw new ControlError(400, '"limit" must be a positive integer')
+    limit = parsed
   }
-
-  const matching = liveChats(deps)
-    .filter((chat) => (projectId ? chat.projectId === projectId : true))
-    .filter((chat) => (includeArchived ? true : !chat.archivedAt))
-    .sort((a, b) => (b.lastMessageAt ?? b.updatedAt) - (a.lastMessageAt ?? a.updatedAt))
-
-  return json({
-    chats: matching.slice(0, limit).map((chat) => serializeChat(chat, chatStatus(deps, chat))),
-    total: matching.length,
-  })
+  return json(listChats(deps, {
+    projectId: url.searchParams.get("projectId") ?? undefined,
+    includeArchived: isTruthyParam(url.searchParams.get("includeArchived")),
+    limit,
+  }))
 }
 
 async function handleCreateChat(req: Request, deps: ApiRouteDeps) {
   const body = await readJsonBody(req)
-  const projectId = requireString(body, "projectId")
-  if (!deps.store.getProject(projectId)) throw new ApiError(404, "Project not found")
-
-  const content = optionalString(body, "content")
-
-  // With `content`, hand the whole thing to agent.send: it creates the chat
-  // and starts the first turn in one step, exactly as the composer does when
-  // you type into a project with no chat open.
-  if (content?.trim()) {
-    const result = await deps.agent.send({
-      type: "chat.send",
-      projectId,
-      content,
+  const result = await createChat(
+    deps,
+    {
+      projectId: requireString(body, "projectId"),
+      content: optionalString(body, "content"),
       ...readPromptFields(body),
-    })
-    await deps.broadcast()
-    const chat = requireChat(deps, result.chatId)
-    return json({ chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false }, 202)
-  }
-
-  // `agent.send` tracks this itself on the prompt path above, so it is only
-  // emitted here, where the chat is created on its own.
-  const chat = await deps.store.createChat(projectId)
-  deps.analytics.track("chat_created")
-  await deps.broadcast()
-  return json({ chat: serializeChat(chat, chatStatus(deps, chat)) }, 201)
+    },
+    readCaller(req, deps)
+  )
+  return result.started
+    ? json({ chat: result.chat, queued: result.queued }, 202)
+    : json({ chat: result.chat }, 201)
 }
 
 function handleGetChat(url: URL, chatId: string, deps: ApiRouteDeps) {
-  const chat = requireChat(deps, chatId)
-  const full = isTruthyParam(url.searchParams.get("full"))
-  const snapshot = full ? readFullChatSnapshot(chatId, deps) : readChatWindow(chatId, deps)
-  if (!snapshot) throw new ApiError(404, "Chat not found")
-  return json({
-    chat: serializeChat(chat, chatStatus(deps, chat)),
-    runtime: snapshot.runtime,
-    queuedMessages: snapshot.queuedMessages,
-    messages: snapshot.messages,
-    startIndex: snapshot.startIndex,
-  })
+  return json(getChat(deps, { chatId, full: isTruthyParam(url.searchParams.get("full")) }))
 }
 
 async function handleSendMessage(req: Request, chatId: string, deps: ApiRouteDeps) {
-  requireChat(deps, chatId)
   const body = await readJsonBody(req)
-  const content = requireString(body, "content")
-
-  const result = await deps.agent.send({
-    type: "chat.send",
-    chatId,
-    content,
-    ...readPromptFields(body),
-  })
-  await deps.broadcast()
-
-  const chat = requireChat(deps, result.chatId)
-  return json(
-    {
-      chatId: result.chatId,
-      // True when a turn was already running: the prompt was queued behind it
-      // rather than starting one, and will run when the current turn ends.
-      queued: result.queued ?? false,
-      queuedMessageId: result.queuedMessageId ?? null,
-      status: chatStatus(deps, chat),
-    },
-    202
+  const result = await sendMessage(
+    deps,
+    { chatId, content: requireString(body, "content"), ...readPromptFields(body) },
+    readCaller(req, deps)
   )
-}
-
-async function handleCancelChat(chatId: string, deps: ApiRouteDeps) {
-  requireChat(deps, chatId)
-  await deps.agent.cancel(chatId)
-  await deps.broadcast()
-  const chat = requireChat(deps, chatId)
-  return json({ chatId, status: chatStatus(deps, chat) })
-}
-
-async function handleDeleteChat(chatId: string, deps: ApiRouteDeps) {
-  requireChat(deps, chatId)
-  // Same order as the UI's chat.delete: stop the turn, release the harness
-  // session, then tombstone the record.
-  await deps.agent.cancel(chatId)
-  await deps.agent.closeChat(chatId)
-  await deps.store.deleteChat(chatId)
-  deps.analytics.track("chat_deleted")
-  await deps.broadcast()
-  return json({ chatId, deleted: true })
+  return json(result, 202)
 }
 
 // --- dispatch -------------------------------------------------------------
@@ -387,7 +222,7 @@ async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Respon
   } catch {
     // decodeURIComponent throws URIError on malformed input like `%ZZ`. That
     // is a bad request, not a server fault, so it must not reach the 500 path.
-    throw new ApiError(400, "Malformed percent-encoding in path")
+    throw new ControlError(400, "Malformed percent-encoding in path")
   }
 
   if (segments.length === 0) {
@@ -395,8 +230,13 @@ async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Respon
     return handleRoot(deps)
   }
 
+  if (segments[0] === "reload" && segments.length === 1) {
+    if (req.method !== "POST") return methodNotAllowed("POST")
+    return json(await reloadFromDisk(deps))
+  }
+
   if (segments[0] === "projects" && segments.length === 1) {
-    if (req.method === "GET") return handleListProjects(deps)
+    if (req.method === "GET") return json(listProjects(deps))
     if (req.method === "POST") return await handleCreateProject(req, deps)
     return methodNotAllowed("GET, POST")
   }
@@ -411,7 +251,7 @@ async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Respon
     const chatId = segments[1]!
     if (segments.length === 2) {
       if (req.method === "GET") return handleGetChat(url, chatId, deps)
-      if (req.method === "DELETE") return await handleDeleteChat(chatId, deps)
+      if (req.method === "DELETE") return json(await deleteChat(deps, { chatId }))
       return methodNotAllowed("GET, DELETE")
     }
 
@@ -422,7 +262,7 @@ async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Respon
 
     if (segments.length === 3 && segments[2] === "cancel") {
       if (req.method !== "POST") return methodNotAllowed("POST")
-      return await handleCancelChat(chatId, deps)
+      return json(await cancelChat(deps, { chatId }))
     }
   }
 
@@ -450,7 +290,7 @@ export async function handleApiRequest(req: Request, url: URL, deps: ApiRouteDep
   try {
     return await route(req, url, deps)
   } catch (error) {
-    if (error instanceof ApiError) {
+    if (error instanceof ControlError) {
       return json({ error: error.message }, error.status)
     }
     // Store and agent failures surface as 500 with their message: this API is

--- a/src/server/api/routes.ts
+++ b/src/server/api/routes.ts
@@ -1,0 +1,416 @@
+/**
+ * `/api/v1/*` — the remote REST API, mounted only when the server is started
+ * with `--api` (see cli-runtime.ts).
+ *
+ * Everything here goes through the same EventStore and AgentCoordinator the
+ * WebSocket uses, so a chat created over HTTP shows up in a connected browser
+ * immediately and is written to the normal data dir. After any write the
+ * caller-supplied `broadcast` pushes fresh snapshots to connected sockets.
+ *
+ * Prompts are asynchronous: a send returns 202 with the chat id, and the
+ * caller polls `GET /api/v1/chats/:id` for status and new messages. A turn can
+ * run for many minutes, which no HTTP client or proxy would sit through.
+ */
+
+import type { AgentProvider, ChatSnapshot, KannaStatus, ModelOptions } from "../../shared/types"
+import type { ClientCommand } from "../../shared/protocol"
+import type { ChatRecord, ProjectRecord } from "../events"
+import type { EventStore } from "../event-store"
+import { initializeProjectDirectory } from "../paths"
+import { deriveChatSnapshot, deriveStatus } from "../read-models"
+import { readChatWindow, type ChatWindowRouteDeps } from "../chat-window-route"
+import { extractApiKey, type ApiKeyVerifier } from "./keys"
+
+export const API_ROUTE_PREFIX = "/api/v1"
+
+/** Cap on `GET /chats` so one call can't serialize an entire history. */
+const DEFAULT_CHAT_LIMIT = 50
+const MAX_CHAT_LIMIT = 200
+
+export interface ApiRouteDeps extends ChatWindowRouteDeps {
+  store: ChatWindowRouteDeps["store"] &
+    Pick<EventStore, "getProject" | "openProject" | "createChat" | "deleteChat">
+  agent: ChatWindowRouteDeps["agent"] & {
+    send: (command: Extract<ClientCommand, { type: "chat.send" }>) => Promise<{ chatId: string; queuedMessageId?: string; queued?: true }>
+    cancel: (chatId: string) => Promise<void>
+    closeChat: (chatId: string) => Promise<void>
+  }
+  verifier: ApiKeyVerifier
+  /** Push fresh snapshots to connected sockets after a write. */
+  broadcast: () => Promise<void> | void
+  version: string
+}
+
+class ApiError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message)
+  }
+}
+
+function json(body: unknown, status = 200) {
+  return Response.json(body, { status, headers: { "Cache-Control": "no-store" } })
+}
+
+function methodNotAllowed(allow: string) {
+  return new Response(null, { status: 405, headers: { Allow: allow, "Cache-Control": "no-store" } })
+}
+
+async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
+  const raw = await req.text()
+  if (!raw.trim()) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new ApiError(400, "Body must be valid JSON")
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ApiError(400, "Body must be a JSON object")
+  }
+  return parsed as Record<string, unknown>
+}
+
+function requireString(body: Record<string, unknown>, field: string): string {
+  const value = body[field]
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ApiError(400, `Missing or empty "${field}"`)
+  }
+  return value
+}
+
+function optionalString(body: Record<string, unknown>, field: string): string | undefined {
+  const value = body[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "string") throw new ApiError(400, `"${field}" must be a string`)
+  return value
+}
+
+function optionalBoolean(body: Record<string, unknown>, field: string): boolean | undefined {
+  const value = body[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "boolean") throw new ApiError(400, `"${field}" must be a boolean`)
+  return value
+}
+
+function isTruthyParam(value: string | null) {
+  return value === "" || value === "1" || value === "true"
+}
+
+function serializeProject(project: ProjectRecord, chatCount: number) {
+  return {
+    id: project.id,
+    title: project.sidebarTitle ?? project.title,
+    localPath: project.localPath,
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+    chatCount,
+  }
+}
+
+function serializeChat(chat: ChatRecord, status: KannaStatus) {
+  return {
+    id: chat.id,
+    projectId: chat.projectId,
+    title: chat.title,
+    status,
+    provider: chat.provider,
+    createdAt: chat.createdAt,
+    updatedAt: chat.updatedAt,
+    lastMessageAt: chat.lastMessageAt ?? null,
+    lastModel: chat.lastModel ?? null,
+    hasMessages: Boolean(chat.hasMessages),
+    unread: chat.unread,
+    archived: Boolean(chat.archivedAt),
+  }
+}
+
+/**
+ * The prompt fields shared by "create a chat and send" and "send to an
+ * existing chat". Kept in one place so the two routes can't drift.
+ */
+function readPromptFields(body: Record<string, unknown>) {
+  const modelOptions = body.modelOptions
+  if (modelOptions !== undefined && (typeof modelOptions !== "object" || modelOptions === null || Array.isArray(modelOptions))) {
+    throw new ApiError(400, '"modelOptions" must be an object')
+  }
+  return {
+    provider: optionalString(body, "provider") as AgentProvider | undefined,
+    model: optionalString(body, "model"),
+    effort: optionalString(body, "effort"),
+    modelOptions: modelOptions as ModelOptions | undefined,
+    planMode: optionalBoolean(body, "planMode"),
+    autoPlan: optionalBoolean(body, "autoPlan"),
+  }
+}
+
+function chatStatus(deps: ApiRouteDeps, chat: ChatRecord): KannaStatus {
+  return deriveStatus(chat, deps.agent.getActiveStatuses().get(chat.id))
+}
+
+function liveChats(deps: ApiRouteDeps) {
+  return [...deps.store.state.chatsById.values()].filter((chat) => !chat.deletedAt)
+}
+
+function requireChat(deps: ApiRouteDeps, chatId: string): ChatRecord {
+  const chat = deps.store.getChat(chatId)
+  if (!chat || chat.deletedAt) throw new ApiError(404, "Chat not found")
+  return chat
+}
+
+function readFullChatSnapshot(chatId: string, deps: ApiRouteDeps): ChatSnapshot | null {
+  return deriveChatSnapshot(
+    deps.store.state,
+    deps.agent.getActiveStatuses(),
+    deps.agent.getDrainingChatIds(),
+    chatId,
+    (id) => deps.store.getClientTranscript(id)
+  )
+}
+
+// --- routes ---------------------------------------------------------------
+
+function handleRoot(deps: ApiRouteDeps) {
+  return json({
+    name: "kanna",
+    version: deps.version,
+    api: 1,
+    capabilities: ["projects", "chats", "messages", "cancel"],
+  })
+}
+
+function handleListProjects(deps: ApiRouteDeps) {
+  const chatCounts = new Map<string, number>()
+  for (const chat of liveChats(deps)) {
+    if (chat.archivedAt) continue
+    chatCounts.set(chat.projectId, (chatCounts.get(chat.projectId) ?? 0) + 1)
+  }
+  const projects = [...deps.store.state.projectsById.values()]
+    .filter((project) => !project.deletedAt)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((project) => serializeProject(project, chatCounts.get(project.id) ?? 0))
+  return json({ projects })
+}
+
+async function handleCreateProject(req: Request, deps: ApiRouteDeps) {
+  const body = await readJsonBody(req)
+  const localPath = requireString(body, "localPath")
+  const title = optionalString(body, "title")
+
+  // Same call the UI's "new project" flow makes: create the directory if it is
+  // missing, and `git init` it when it is empty so chats there get diffs. An
+  // existing non-empty directory is left exactly as it is.
+  let resolvedPath: string
+  try {
+    resolvedPath = await initializeProjectDirectory(localPath)
+  } catch (error) {
+    throw new ApiError(400, error instanceof Error ? error.message : "Could not open project directory")
+  }
+
+  const project = await deps.store.openProject(resolvedPath, title)
+  await deps.broadcast()
+  return json({ project: serializeProject(project, 0) }, 201)
+}
+
+function handleListChats(url: URL, deps: ApiRouteDeps) {
+  const projectId = url.searchParams.get("projectId")
+  if (projectId && !deps.store.getProject(projectId)) {
+    throw new ApiError(404, "Project not found")
+  }
+  const includeArchived = isTruthyParam(url.searchParams.get("includeArchived"))
+
+  const rawLimit = url.searchParams.get("limit")
+  let limit = DEFAULT_CHAT_LIMIT
+  if (rawLimit !== null) {
+    const parsed = Number(rawLimit)
+    if (!Number.isInteger(parsed) || parsed < 1) throw new ApiError(400, '"limit" must be a positive integer')
+    limit = Math.min(parsed, MAX_CHAT_LIMIT)
+  }
+
+  const matching = liveChats(deps)
+    .filter((chat) => (projectId ? chat.projectId === projectId : true))
+    .filter((chat) => (includeArchived ? true : !chat.archivedAt))
+    .sort((a, b) => (b.lastMessageAt ?? b.updatedAt) - (a.lastMessageAt ?? a.updatedAt))
+
+  return json({
+    chats: matching.slice(0, limit).map((chat) => serializeChat(chat, chatStatus(deps, chat))),
+    total: matching.length,
+  })
+}
+
+async function handleCreateChat(req: Request, deps: ApiRouteDeps) {
+  const body = await readJsonBody(req)
+  const projectId = requireString(body, "projectId")
+  if (!deps.store.getProject(projectId)) throw new ApiError(404, "Project not found")
+
+  const content = optionalString(body, "content")
+
+  // With `content`, hand the whole thing to agent.send: it creates the chat
+  // and starts the first turn in one step, exactly as the composer does when
+  // you type into a project with no chat open.
+  if (content?.trim()) {
+    const result = await deps.agent.send({
+      type: "chat.send",
+      projectId,
+      content,
+      ...readPromptFields(body),
+    })
+    await deps.broadcast()
+    const chat = requireChat(deps, result.chatId)
+    return json({ chat: serializeChat(chat, chatStatus(deps, chat)), queued: result.queued ?? false }, 202)
+  }
+
+  const chat = await deps.store.createChat(projectId)
+  await deps.broadcast()
+  return json({ chat: serializeChat(chat, chatStatus(deps, chat)) }, 201)
+}
+
+function handleGetChat(url: URL, chatId: string, deps: ApiRouteDeps) {
+  const chat = requireChat(deps, chatId)
+  const full = isTruthyParam(url.searchParams.get("full"))
+  const snapshot = full ? readFullChatSnapshot(chatId, deps) : readChatWindow(chatId, deps)
+  if (!snapshot) throw new ApiError(404, "Chat not found")
+  return json({
+    chat: serializeChat(chat, chatStatus(deps, chat)),
+    runtime: snapshot.runtime,
+    queuedMessages: snapshot.queuedMessages,
+    messages: snapshot.messages,
+    startIndex: snapshot.startIndex,
+  })
+}
+
+async function handleSendMessage(req: Request, chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  const body = await readJsonBody(req)
+  const content = requireString(body, "content")
+
+  const result = await deps.agent.send({
+    type: "chat.send",
+    chatId,
+    content,
+    ...readPromptFields(body),
+  })
+  await deps.broadcast()
+
+  const chat = requireChat(deps, result.chatId)
+  return json(
+    {
+      chatId: result.chatId,
+      // True when a turn was already running: the prompt was queued behind it
+      // rather than starting one, and will run when the current turn ends.
+      queued: result.queued ?? false,
+      queuedMessageId: result.queuedMessageId ?? null,
+      status: chatStatus(deps, chat),
+    },
+    202
+  )
+}
+
+async function handleCancelChat(chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  await deps.agent.cancel(chatId)
+  await deps.broadcast()
+  const chat = requireChat(deps, chatId)
+  return json({ chatId, status: chatStatus(deps, chat) })
+}
+
+async function handleDeleteChat(chatId: string, deps: ApiRouteDeps) {
+  requireChat(deps, chatId)
+  // Same order as the UI's chat.delete: stop the turn, release the harness
+  // session, then tombstone the record.
+  await deps.agent.cancel(chatId)
+  await deps.agent.closeChat(chatId)
+  await deps.store.deleteChat(chatId)
+  await deps.broadcast()
+  return json({ chatId, deleted: true })
+}
+
+// --- dispatch -------------------------------------------------------------
+
+/** True when this request is for the REST API, whoever it turns out to be. */
+export function isApiRoute(url: URL) {
+  return url.pathname === API_ROUTE_PREFIX || url.pathname.startsWith(`${API_ROUTE_PREFIX}/`)
+}
+
+/**
+ * True when the request carries a key valid for this server. `server.ts` uses
+ * this to let an API caller past the `--password` session gate, which exists
+ * for browsers and which an API client has no way to satisfy.
+ */
+export function hasValidApiKey(req: Request, verifier: ApiKeyVerifier | null) {
+  if (!verifier || verifier.count === 0) return false
+  return verifier.isValid(extractApiKey(req))
+}
+
+async function route(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response> {
+  const rest = url.pathname.slice(API_ROUTE_PREFIX.length).replace(/^\/+|\/+$/g, "")
+  const segments = rest ? rest.split("/").map(decodeURIComponent) : []
+
+  if (segments.length === 0) {
+    if (req.method !== "GET") return methodNotAllowed("GET")
+    return handleRoot(deps)
+  }
+
+  if (segments[0] === "projects" && segments.length === 1) {
+    if (req.method === "GET") return handleListProjects(deps)
+    if (req.method === "POST") return await handleCreateProject(req, deps)
+    return methodNotAllowed("GET, POST")
+  }
+
+  if (segments[0] === "chats") {
+    if (segments.length === 1) {
+      if (req.method === "GET") return handleListChats(url, deps)
+      if (req.method === "POST") return await handleCreateChat(req, deps)
+      return methodNotAllowed("GET, POST")
+    }
+
+    const chatId = segments[1]!
+    if (segments.length === 2) {
+      if (req.method === "GET") return handleGetChat(url, chatId, deps)
+      if (req.method === "DELETE") return await handleDeleteChat(chatId, deps)
+      return methodNotAllowed("GET, DELETE")
+    }
+
+    if (segments.length === 3 && segments[2] === "messages") {
+      if (req.method !== "POST") return methodNotAllowed("POST")
+      return await handleSendMessage(req, chatId, deps)
+    }
+
+    if (segments.length === 3 && segments[2] === "cancel") {
+      if (req.method !== "POST") return methodNotAllowed("POST")
+      return await handleCancelChat(chatId, deps)
+    }
+  }
+
+  return json({ error: "Not found" }, 404)
+}
+
+/**
+ * Returns null when the request is not for the API, so `server.ts` can keep
+ * this in its chain of fall-through handlers.
+ */
+export async function handleApiRequest(req: Request, url: URL, deps: ApiRouteDeps): Promise<Response | null> {
+  if (!isApiRoute(url)) return null
+
+  if (!hasValidApiKey(req, deps.verifier)) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "WWW-Authenticate": 'Bearer realm="kanna"',
+      },
+    })
+  }
+
+  try {
+    return await route(req, url, deps)
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return json({ error: error.message }, error.status)
+    }
+    // Store and agent failures surface as 500 with their message: this API is
+    // key-gated and operator-facing, so the detail is useful, not a leak.
+    const message = error instanceof Error ? error.message : "Internal error"
+    return json({ error: message }, 500)
+  }
+}

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -147,6 +147,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -163,6 +166,9 @@ describe("parseArgs", () => {
         strictPort: true,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -179,6 +185,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -195,6 +204,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -211,6 +223,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -227,6 +242,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -253,6 +271,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -269,6 +290,9 @@ describe("parseArgs", () => {
         strictPort: false,
         noCloud: false,
         directCloud: false,
+        api: false,
+        apiKeys: [],
+        apiKeyFile: null,
       },
     })
   })
@@ -631,6 +655,64 @@ describe("parseArgs pair subcommand", () => {
     expect(() => parseArgs(["--cloud", "--cloudflared", "tok"])).toThrow("--cloudflared")
     expect(() => parseArgs(["--cloud", "--host", "10.0.0.5"])).toThrow("--host")
     expect(() => parseArgs(["--cloud", "--remote"])).toThrow("--remote")
+  })
+
+  test("--api collects inline keys in either flag form", () => {
+    const equals = parseArgs(["--api", "--api-key=alpha,bravo"])
+    expect(equals).toMatchObject({ kind: "run", options: { api: true, apiKeys: ["alpha", "bravo"], apiKeyFile: null } })
+
+    const spaced = parseArgs(["--api", "--api-key", "alpha,bravo"])
+    expect(spaced).toMatchObject({ kind: "run", options: { api: true, apiKeys: ["alpha", "bravo"] } })
+  })
+
+  test("repeating --api-key accumulates without duplicates", () => {
+    expect(parseArgs(["--api", "--api-key=alpha", "--api-key=bravo,alpha"])).toMatchObject({
+      kind: "run",
+      options: { apiKeys: ["alpha", "bravo"] },
+    })
+  })
+
+  test("--api-key-file is recorded for startup to read", () => {
+    expect(parseArgs(["--api", "--api-key-file=/tmp/keys.txt"])).toMatchObject({
+      kind: "run",
+      options: { api: true, apiKeys: [], apiKeyFile: "/tmp/keys.txt" },
+    })
+    expect(parseArgs(["--api", "--api-key-file", "/tmp/keys.txt"])).toMatchObject({
+      kind: "run",
+      options: { apiKeyFile: "/tmp/keys.txt" },
+    })
+  })
+
+  test("--api-key-file is not swallowed by --api-key", () => {
+    const parsed = parseArgs(["--api", "--api-key-file=/tmp/keys.txt"])
+    expect(parsed).toMatchObject({ kind: "run", options: { apiKeys: [], apiKeyFile: "/tmp/keys.txt" } })
+  })
+
+  test("--api without any key flag is refused", () => {
+    expect(() => parseArgs(["--api"])).toThrow("--api-key")
+  })
+
+  test("key flags without --api are refused", () => {
+    expect(() => parseArgs(["--api-key=alpha"])).toThrow("--api")
+    expect(() => parseArgs(["--api-key-file=/tmp/keys.txt"])).toThrow("--api")
+  })
+
+  test("key flags need a value", () => {
+    expect(() => parseArgs(["--api", "--api-key="])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key"])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key", "--no-open"])).toThrow("Missing value for --api-key")
+    expect(() => parseArgs(["--api", "--api-key-file"])).toThrow("Missing value for --api-key-file")
+  })
+
+  test("--api composes with --remote", () => {
+    expect(parseArgs(["--remote", "--api", "--api-key=alpha"])).toMatchObject({
+      kind: "run",
+      options: { host: "0.0.0.0", api: true, apiKeys: ["alpha"] },
+    })
+  })
+
+  test("a blank inline key list is treated as no keys", () => {
+    expect(() => parseArgs(["--api", "--api-key= , "])).toThrow("--api-key")
   })
 })
 

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -913,6 +913,52 @@ describe("runCli single-instance guard + hosted open", () => {
     expect(calls.openUrl).toEqual([])
   })
 
+  // This run starts no server, so its --api flags cannot take effect. Exiting
+  // 0 would tell a script the API is up when the running instance has no
+  // /api/v1 at all.
+  test("--api against an instance without the API → exit 1, say to restart", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: false }),
+    })
+
+    const result = await runCli(["--api", "--api-key=alpha"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 1 })
+    expect(calls.startServer).toEqual([])
+    expect(calls.openUrl).toEqual([])
+    expect(calls.warn.some((line) => line.includes("without the API"))).toBe(true)
+    expect(calls.warn.some((line) => line.includes("--api"))).toBe(true)
+  })
+
+  test("an instance predating the health field is treated as having no API", async () => {
+    const { deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210 }),
+    })
+
+    expect(await runCli(["--api", "--api-key=alpha"], deps)).toEqual({ kind: "exited", code: 1 })
+  })
+
+  test("--api against an instance already serving it → exit 0, but say the keys were not applied", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: true }),
+    })
+
+    const result = await runCli(["--api", "--api-key=alpha", "--no-open"], deps)
+
+    expect(result).toEqual({ kind: "exited", code: 0 })
+    expect(calls.startServer).toEqual([])
+    expect(calls.warn.some((line) => line.includes("was not applied"))).toBe(true)
+  })
+
+  test("without --api an existing instance is unaffected by the new check", async () => {
+    const { calls, deps } = createDeps({
+      probeExistingInstanceImpl: async () => ({ localUrl: "http://localhost:3210", port: 3210, api: false }),
+    })
+
+    expect(await runCli(["--no-open"], deps)).toEqual({ kind: "exited", code: 0 })
+    expect(calls.warn).toEqual([])
+  })
+
   test("paired start opens the hosted URL when the tunnel connects (not localhost)", async () => {
     const fake = createFakeCloudRuntime()
     let capturedOnTunnelUp: ((kind: "started" | "recovered") => void) | undefined

--- a/src/server/cli-runtime.test.ts
+++ b/src/server/cli-runtime.test.ts
@@ -608,6 +608,22 @@ describe("parseArgs slim-transcripts subcommand", () => {
   })
 })
 
+describe("parseArgs mcp subcommand", () => {
+  test("takes exactly one credentials path", () => {
+    expect(parseArgs(["mcp", "/data/mcp/chat-1.json"])).toEqual({
+      kind: "mcp",
+      credentialsPath: "/data/mcp/chat-1.json",
+    })
+    expect(() => parseArgs(["mcp"])).toThrow("credentials-file")
+    expect(() => parseArgs(["mcp", "a", "b"])).toThrow("credentials-file")
+  })
+
+  test("does not shadow a normal run", () => {
+    expect(parseArgs([]).kind).toBe("run")
+    expect(parseArgs(["--port", "1234"]).kind).toBe("run")
+  })
+})
+
 describe("parseArgs pair subcommand", () => {
   test("pair with a code", () => {
     expect(parseArgs(["pair", "ABC123XYZ"])).toEqual({

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -526,6 +526,21 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
   // fingerprint (e.g. dev profile) keeps the try-next-port behavior.
   const existing = await (deps.probeExistingInstanceImpl ?? probeExistingInstance)(runOptions.port)
   if (existing) {
+    // This run is not going to start a server, so its --api flags cannot take
+    // effect. Saying nothing would exit 0 and leave the caller believing the
+    // API is up: a script would go straight on to a /api/v1 request and get a
+    // 404 from an instance that never had the API mounted.
+    if (runOptions.api) {
+      if (!existing.api) {
+        deps.warn(`${LOG_PREFIX} kanna is already running at ${existing.localUrl} without the API`)
+        deps.warn(`${LOG_PREFIX} restart that instance with --api to serve ${API_ROUTE_PREFIX}`)
+        return { kind: "exited", code: 1 }
+      }
+      // It does serve the API, but with the key set it was started with —
+      // this run's keys were never loaded, so don't imply otherwise.
+      deps.warn(`${LOG_PREFIX} kanna is already running with the API enabled; it kept its own keys, and this run's --api-key was not applied`)
+    }
+
     const hostedUrl = identity?.enabled ? identity.appOrigin : null
     deps.log(`${LOG_PREFIX} kanna is already running at ${existing.localUrl}${hostedUrl ? ` (and ${hostedUrl})` : ""}`)
     if (hostedUrl) {

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -105,6 +105,12 @@ type ParsedArgs =
   | { kind: "run"; options: CliOptions }
   | { kind: "pair"; args: PairCommandArgs }
   | { kind: "slim-transcripts" }
+  /**
+   * `kanna mcp <credentials>` — the stdio MCP server a codex session spawns
+   * to reach Kanna's management tools. Not a command anyone types: the path
+   * points at a 0600 file a running Kanna wrote for one chat.
+   */
+  | { kind: "mcp"; credentialsPath: string }
   | { kind: "help" }
   | { kind: "version" }
 
@@ -221,6 +227,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
   if (argv[0] === "slim-transcripts") {
     if (argv.length > 1) throw new Error(`Unexpected argument for ${CLI_COMMAND} slim-transcripts: ${argv[1]}`)
     return { kind: "slim-transcripts" }
+  }
+  if (argv[0] === "mcp") {
+    if (argv.length !== 2) throw new Error(`Usage: ${CLI_COMMAND} mcp <credentials-file>`)
+    return { kind: "mcp", credentialsPath: argv[1]! }
   }
 
   let port = PROD_SERVER_PORT
@@ -449,6 +459,25 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     // connects. From then on any plain `kanna` does the same (sticky).
     deps.log(`${LOG_PREFIX} starting ${CLI_COMMAND}…`)
     parsedArgs = parseArgs([])
+  }
+
+  if (parsedArgs.kind === "mcp") {
+    // stdout is the MCP channel from here on: anything written to it that
+    // isn't a JSON-RPC message desynchronizes the client, so diagnostics go
+    // to stderr and nothing calls deps.log.
+    const { parseBridgeConfig, runMcpStdioServer } = await import("./kanna-mcp-stdio")
+    try {
+      const config = parseBridgeConfig(await Bun.file(parsedArgs.credentialsPath).text())
+      await runMcpStdioServer(config, {
+        input: Bun.stdin.stream(),
+        write: (line) => process.stdout.write(`${line}\n`),
+        warn: (message) => process.stderr.write(`${message}\n`),
+      })
+      return { kind: "exited", code: 0 }
+    } catch (error) {
+      process.stderr.write(`${LOG_PREFIX} mcp: ${error instanceof Error ? error.message : String(error)}\n`)
+      return { kind: "exited", code: 1 }
+    }
   }
 
   if (parsedArgs.kind === "slim-transcripts") {

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -14,6 +14,8 @@ import type { AnalyticsReporter } from "./analytics"
 import { createCloudRuntime, type CloudRuntime } from "./cloud"
 import { readCloudIdentity, type CloudIdentity } from "./cloud/identity"
 import { runPairCommand, type PairCommandArgs, type PairAction } from "./cloud/pair-command"
+import { parseApiKeyList, readApiKeyFile } from "./api/keys"
+import { API_ROUTE_PREFIX } from "./api/routes"
 
 export interface CliOptions {
   port: number
@@ -31,6 +33,12 @@ export interface CliOptions {
    * ingress can reach the server. Hook for future dev-box-only features.
    */
   directCloud: boolean
+  /** Mount the remote REST API at /api/v1 (`--api`). Always needs keys. */
+  api: boolean
+  /** Keys given inline with `--api-key`. Merged with `apiKeyFile` at startup. */
+  apiKeys: string[]
+  /** Path from `--api-key-file`; read at startup, one key per line. */
+  apiKeyFile: string | null
 }
 
 export interface CliUpdateOptions {
@@ -83,6 +91,7 @@ export interface CliRuntimeDeps {
   createCloudRuntimeImpl?: (identity: CloudIdentity) => CloudRuntime
   probeExistingInstanceImpl?: (port: number) => Promise<ExistingInstance | null>
   slimTranscriptsImpl?: (log: (message: string) => void) => Promise<SlimTranscriptsStats>
+  readApiKeyFileImpl?: (filePath: string) => Promise<string[]>
 }
 
 export interface UpdateInstallAttemptResult {
@@ -125,6 +134,29 @@ function throwShareConflict(share: Exclude<ShareMode, false>, hostFlag: "--host"
   throw new Error(`${getShareCliFlag(share)} cannot be used with ${hostFlag}`)
 }
 
+/**
+ * Read `--flag=value` or `--flag value`. Every other flag here takes the
+ * space-separated form only; the API key flags accept both because `=` is what
+ * you reach for when the value is a secret being pasted in.
+ *
+ * Returns the value plus how many argv entries it consumed.
+ */
+function readFlagValue(argv: string[], index: number, flag: string): { value: string; consumed: number } {
+  const arg = argv[index]!
+  if (arg.startsWith(`${flag}=`)) {
+    const value = arg.slice(flag.length + 1)
+    if (!value) throw new Error(`Missing value for ${flag}`)
+    return { value, consumed: 0 }
+  }
+  const next = argv[index + 1]
+  if (!next || next.startsWith("-")) throw new Error(`Missing value for ${flag}`)
+  return { value: next, consumed: 1 }
+}
+
+function matchesFlag(arg: string, flag: string) {
+  return arg === flag || arg.startsWith(`${flag}=`)
+}
+
 function printHelp() {
   console.log(`${APP_NAME} — local-only project chat UI
 
@@ -144,6 +176,10 @@ Options:
   --cloudflared <token>
                        Run a named Cloudflare tunnel from a token
   --password <secret>  Require a password before loading the app
+  --api                Serve the remote REST API at /api/v1 (needs a key flag)
+  --api-key=<k1,k2>    API keys, comma separated
+  --api-key-file=<path>
+                       Read API keys from a file, one per line
   --strict-port        Fail instead of trying another port
   --no-open            Don't open browser automatically
   --no-cloud           Skip bringing a paired machine online for this run
@@ -197,6 +233,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let strictPort = false
   let noCloud = false
   let directCloud = false
+  let api = false
+  let apiKeys: string[] = []
+  let apiKeyFile: string | null = null
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -268,7 +307,34 @@ export function parseArgs(argv: string[]): ParsedArgs {
       strictPort = true
       continue
     }
+    if (arg === "--api") {
+      api = true
+      continue
+    }
+    if (matchesFlag(arg, "--api-key-file")) {
+      const { value, consumed } = readFlagValue(argv, index, "--api-key-file")
+      apiKeyFile = value
+      index += consumed
+      continue
+    }
+    if (matchesFlag(arg, "--api-key")) {
+      const { value, consumed } = readFlagValue(argv, index, "--api-key")
+      // Repeating the flag adds to the set rather than replacing it.
+      apiKeys = [...new Set([...apiKeys, ...parseApiKeyList(value)])]
+      index += consumed
+      continue
+    }
     if (!arg.startsWith("-")) throw new Error(`Unexpected positional argument: ${arg}`)
+  }
+
+  // The API is credential-only — there is no session, origin check or browser
+  // login in front of it — so refuse to mount it without keys rather than
+  // quietly serving an open one.
+  if (api && apiKeys.length === 0 && !apiKeyFile) {
+    throw new Error("--api requires --api-key=<key[,key]> or --api-key-file=<path>")
+  }
+  if (!api && (apiKeys.length > 0 || apiKeyFile)) {
+    throw new Error("--api-key and --api-key-file require --api")
   }
 
   if (directCloud) {
@@ -290,6 +356,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       strictPort,
       noCloud,
       directCloud,
+      api,
+      apiKeys,
+      apiKeyFile,
     },
   }
 }
@@ -413,6 +482,25 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
     return { kind: "exited", code: 1 }
   }
 
+  // Resolve API keys before anything slow: a bad key file is a config error
+  // and should fail on the spot, not after a self-update round trip.
+  let apiKeys = runOptions.apiKeys
+  if (runOptions.api) {
+    if (runOptions.apiKeyFile) {
+      try {
+        const fromFile = await (deps.readApiKeyFileImpl ?? readApiKeyFile)(runOptions.apiKeyFile)
+        apiKeys = [...new Set([...apiKeys, ...fromFile])]
+      } catch (error) {
+        deps.warn(`${LOG_PREFIX} ${error instanceof Error ? error.message : String(error)}`)
+        return { kind: "exited", code: 1 }
+      }
+    }
+    if (apiKeys.length === 0) {
+      deps.warn(`${LOG_PREFIX} --api needs at least one key; none were found`)
+      return { kind: "exited", code: 1 }
+    }
+  }
+
   const shouldRestart = await maybeSelfUpdate(argv, deps)
   if (shouldRestart !== null) {
     return { kind: "restarting", reason: shouldRestart }
@@ -463,6 +551,7 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   const started = await deps.startServer({
     ...runOptions,
+    apiKeys,
     trustProxy: isShareEnabled(runOptions.share) || cloudRuntime !== null,
     cloud: cloudRuntime,
     // Unpaired but cloud-capable: the sidebar can claim this machine in one
@@ -486,6 +575,16 @@ export async function runCli(argv: string[], deps: CliRuntimeDeps): Promise<CliR
 
   deps.log(`${LOG_PREFIX} listening on http://${bindHost}:${port}`)
   deps.log(`${LOG_PREFIX} data dir: ${getDataDirDisplay()}`)
+
+  if (runOptions.api) {
+    const keyCount = `${apiKeys.length} key${apiKeys.length === 1 ? "" : "s"}`
+    deps.log(`${LOG_PREFIX} REST API on http://${bindHost}:${port}${API_ROUTE_PREFIX} (${keyCount})`)
+    if (bindHost !== "127.0.0.1") {
+      // Worth saying out loud: bound off loopback, the only thing between the
+      // network and full read/write on every chat is the key.
+      deps.warn(`${LOG_PREFIX} the API is reachable from the network — the API key is its only protection`)
+    }
+  }
 
   if (isShareEnabled(runOptions.share)) {
     try {

--- a/src/server/codex-app-server.test.ts
+++ b/src/server/codex-app-server.test.ts
@@ -2002,3 +2002,80 @@ describe("CodexAppServerManager", () => {
     expect(resultEvent?.entry.result).toContain("fatal: app-server crashed")
   })
 })
+
+describe("Kanna management tools", () => {
+  function respondToHandshake(message: any, child: FakeCodexProcess) {
+    if (message.method === "initialize") {
+      child.writeServerMessage({ id: message.id, result: { userAgent: "codex-test" } })
+    } else if (message.method === "thread/start") {
+      child.writeServerMessage({
+        id: message.id,
+        result: { thread: { id: "thread-1" }, model: "gpt-5.4", reasoningEffort: "high" },
+      })
+    }
+  }
+
+  test("the MCP overrides for this chat are passed to the spawn", async () => {
+    const process = new FakeCodexProcess(respondToHandshake)
+    const spawns: { cwd: string; extraArgs?: string[] }[] = []
+    const requested: string[] = []
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: (cwd, extraArgs) => {
+        spawns.push({ cwd, extraArgs })
+        return process as never
+      },
+      resolveMcpArgs: async (chatId) => {
+        requested.push(chatId)
+        return ["-c", `mcp_servers.kanna.args=["cli.ts", "mcp", "/creds/${chatId}.json"]`]
+      },
+    })
+
+    await manager.startSession({ chatId: "chat-1", cwd: "/tmp/project", model: "gpt-5.4", sessionToken: null })
+
+    expect(requested).toEqual(["chat-1"])
+    expect(spawns[0]?.extraArgs).toEqual([
+      "-c",
+      'mcp_servers.kanna.args=["cli.ts", "mcp", "/creds/chat-1.json"]',
+    ])
+  })
+
+  test("a session still starts when the bridge cannot be prepared", async () => {
+    const process = new FakeCodexProcess(respondToHandshake)
+    const spawns: (string[] | undefined)[] = []
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: (_cwd, extraArgs) => {
+        spawns.push(extraArgs)
+        return process as never
+      },
+      resolveMcpArgs: async () => {
+        throw new Error("data dir is read-only")
+      },
+    })
+
+    await manager.startSession({ chatId: "chat-1", cwd: "/tmp/project", model: "gpt-5.4", sessionToken: null })
+
+    // No tools, but the user's turn is not lost to a bridge problem.
+    expect(spawns[0]).toEqual([])
+  })
+
+  test("stopping a session releases its credentials", async () => {
+    const process = new FakeCodexProcess(respondToHandshake)
+    const released: string[] = []
+
+    const manager = new CodexAppServerManager({
+      spawnProcess: () => process as never,
+      resolveMcpArgs: async () => [],
+      releaseMcp: async (chatId) => {
+        released.push(chatId)
+      },
+    })
+
+    await manager.startSession({ chatId: "chat-1", cwd: "/tmp/project", model: "gpt-5.4", sessionToken: null })
+    manager.stopSession("chat-1")
+    await Bun.sleep(0)
+
+    expect(released).toEqual(["chat-1"])
+  })
+})

--- a/src/server/codex-app-server.ts
+++ b/src/server/codex-app-server.ts
@@ -10,6 +10,7 @@ import type {
   TodoItem,
   TranscriptEntry,
 } from "../shared/types"
+import { LOG_PREFIX } from "../shared/branding"
 import type { HarnessEvent, HarnessToolRequest, HarnessTurn } from "./harness-types"
 import { appendSystemMessageBlock, buildSkillSystemMessage } from "./harness-skills"
 import { buildKannaAgentId, buildKannaAttributionInstructions } from "./attribution"
@@ -77,7 +78,12 @@ interface CodexAppServerProcess {
   once(event: "error", listener: (error: Error) => void): this
 }
 
-type SpawnCodexAppServer = (cwd: string) => CodexAppServerProcess
+/**
+ * @param extraArgs Leading `codex` arguments, before `app-server`. Used for
+ * the `-c mcp_servers.kanna.…` overrides that give the session Kanna's own
+ * management tools (see kanna-mcp-bridge.ts).
+ */
+type SpawnCodexAppServer = (cwd: string, extraArgs?: string[]) => CodexAppServerProcess
 
 interface PendingRequest<TResult> {
   method: string
@@ -697,9 +703,24 @@ export class CodexAppServerManager {
   private readonly spawnProcess: SpawnCodexAppServer
   private onRateLimits: ((snapshot: CodexRateLimitSnapshot) => void) | null = null
 
-  constructor(args: { spawnProcess?: SpawnCodexAppServer } = {}) {
-    this.spawnProcess = args.spawnProcess ?? ((cwd) =>
-      spawn("codex", ["app-server"], {
+  /**
+   * Resolves the `-c` overrides that attach Kanna's management MCP server to
+   * a chat's session, or null when the bridge is unavailable. Async because
+   * it writes the session's credentials file first.
+   */
+  private readonly resolveMcpArgs: ((chatId: string) => Promise<string[]>) | null
+  /** Drops a stopped session's MCP credentials file. */
+  private readonly releaseMcp: ((chatId: string) => Promise<void>) | null
+
+  constructor(args: {
+    spawnProcess?: SpawnCodexAppServer
+    resolveMcpArgs?: (chatId: string) => Promise<string[]>
+    releaseMcp?: (chatId: string) => Promise<void>
+  } = {}) {
+    this.resolveMcpArgs = args.resolveMcpArgs ?? null
+    this.releaseMcp = args.releaseMcp ?? null
+    this.spawnProcess = args.spawnProcess ?? ((cwd, extraArgs) =>
+      spawn("codex", [...(extraArgs ?? []), "app-server"], {
         cwd,
         stdio: ["pipe", "pipe", "pipe"],
         env: process.env,
@@ -778,7 +799,18 @@ export class CodexAppServerManager {
       this.stopSession(args.chatId)
     }
 
-    const child = this.spawnProcess(args.cwd)
+    // A bridge failure (unwritable data dir, say) must not cost the user their
+    // turn: the session starts without the management tools instead.
+    let mcpArgs: string[] = []
+    if (this.resolveMcpArgs) {
+      try {
+        mcpArgs = await this.resolveMcpArgs(args.chatId)
+      } catch (error) {
+        console.warn(`${LOG_PREFIX} codex: kanna tools unavailable for this session:`, error)
+      }
+    }
+
+    const child = this.spawnProcess(args.cwd, mcpArgs)
     const context: SessionContext = {
       chatId: args.chatId,
       cwd: args.cwd,
@@ -1030,6 +1062,10 @@ export class CodexAppServerManager {
     } catch {
       // ignore kill failures
     }
+    // The MCP child dies with its parent; its credentials file does not, so
+    // drop it here rather than leaving a live key on disk. Fire-and-forget:
+    // a failed unlink must not stop a session from closing.
+    void this.releaseMcp?.(chatId).catch(() => undefined)
   }
 
   stopAll() {

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -1611,3 +1611,152 @@ describe("getClientTranscript window and outline", () => {
     await rm(dataDir, { recursive: true, force: true })
   })
 })
+
+describe("reload", () => {
+  test("picks up a chat another process appended", async () => {
+    const dir = await createTempDataDir()
+    const store = new EventStore(dir)
+    await store.initialize()
+    const project = await store.openProject(join(dir, "proj"))
+
+    // A second store on the same data dir stands in for whatever edited it.
+    const other = new EventStore(dir)
+    await other.initialize()
+    const added = await other.createChat(project.id)
+
+    expect(store.getChat(added.id)).toBeNull()
+    const result = await store.reload()
+
+    expect(store.getChat(added.id)?.projectId).toBe(project.id)
+    expect(result.chats).toBe(1)
+    expect(result.projects).toBe(1)
+  })
+
+  test("picks up a chat moved to another project on disk", async () => {
+    const dir = await createTempDataDir()
+    const store = new EventStore(dir)
+    await store.initialize()
+    const from = await store.openProject(join(dir, "from"))
+    const to = await store.openProject(join(dir, "to"))
+    const chat = await store.createChat(from.id)
+    // Compact so the move is a snapshot edit, which is how a person would do it.
+    await store.compact()
+
+    const snapshotPath = join(dir, "snapshot.json")
+    const snapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as SnapshotFile
+    snapshot.chats.find((entry) => entry.id === chat.id)!.projectId = to.id
+    await writeFile(snapshotPath, JSON.stringify(snapshot))
+
+    expect(store.getChat(chat.id)?.projectId).toBe(from.id)
+    await store.reload()
+    expect(store.getChat(chat.id)?.projectId).toBe(to.id)
+  })
+
+  test("drops a chat removed from disk", async () => {
+    const dir = await createTempDataDir()
+    const store = new EventStore(dir)
+    await store.initialize()
+    const project = await store.openProject(join(dir, "proj"))
+    const kept = await store.createChat(project.id)
+    const removed = await store.createChat(project.id)
+    await store.compact()
+
+    const snapshotPath = join(dir, "snapshot.json")
+    const snapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as SnapshotFile
+    snapshot.chats = snapshot.chats.filter((entry) => entry.id !== removed.id)
+    await writeFile(snapshotPath, JSON.stringify(snapshot))
+
+    await store.reload()
+    expect(store.getChat(kept.id)).not.toBeNull()
+    expect(store.getChat(removed.id)).toBeNull()
+  })
+
+  test("re-reads a transcript edited on disk rather than serving the cache", async () => {
+    const dir = await createTempDataDir()
+    const store = new EventStore(dir)
+    await store.initialize()
+    const project = await store.openProject(join(dir, "proj"))
+    const chat = await store.createChat(project.id)
+    await store.appendMessage(chat.id, entry("user_prompt", 1, { content: "before" }))
+    // Warm the transcript cache, so a stale read would show up here.
+    expect(store.getMessages(chat.id)).toHaveLength(1)
+
+    const transcriptPath = join(dir, "transcripts", `${chat.id}.jsonl`)
+    const edited = { _id: "user_prompt-1", createdAt: 1, kind: "user_prompt", content: "after" }
+    await writeFile(transcriptPath, `${JSON.stringify(edited)}\n`)
+
+    await store.reload()
+    const messages = store.getMessages(chat.id)
+    expect(messages).toHaveLength(1)
+    expect((messages[0] as { content: string }).content).toBe("after")
+  })
+
+  describe("refuses rather than resetting", () => {
+    async function storeWithOneChat() {
+      const dir = await createTempDataDir()
+      const store = new EventStore(dir)
+      await store.initialize()
+      const project = await store.openProject(join(dir, "proj"))
+      const chat = await store.createChat(project.id)
+      await store.compact()
+      return { dir, store, chat }
+    }
+
+    test("a corrupt snapshot leaves the loaded state alone", async () => {
+      const { dir, store, chat } = await storeWithOneChat()
+      await writeFile(join(dir, "snapshot.json"), "{ not json")
+
+      await expect(store.reload()).rejects.toThrow(/snapshot\.json is not valid JSON/)
+      // The whole point: history is still loaded, and nothing on disk was
+      // truncated on the way out — including the bad file, so it can be fixed.
+      expect(store.getChat(chat.id)).not.toBeNull()
+      expect(await readFile(join(dir, "snapshot.json"), "utf8")).toBe("{ not json")
+    })
+
+    test("a snapshot from another store version leaves the loaded state alone", async () => {
+      const { dir, store, chat } = await storeWithOneChat()
+      const snapshotPath = join(dir, "snapshot.json")
+      const snapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as SnapshotFile
+      await writeFile(snapshotPath, JSON.stringify({ ...snapshot, v: 1 }))
+
+      await expect(store.reload()).rejects.toThrow(/store version 1/)
+      expect(store.getChat(chat.id)).not.toBeNull()
+    })
+
+    test("a corrupt log line leaves the loaded state alone", async () => {
+      const { dir, store, chat } = await storeWithOneChat()
+      // Mid-file, so it is a bad edit rather than a torn final append.
+      await writeFile(join(dir, "chats.jsonl"), `{ not json\n${JSON.stringify({ v: 2, type: "noop", timestamp: 1 })}\n`)
+
+      await expect(store.reload()).rejects.toThrow(/chats\.jsonl line 1 is not valid JSON/)
+      expect(store.getChat(chat.id)).not.toBeNull()
+      // The snapshot still holds the chat: nothing was reset behind the error.
+      const snapshot = JSON.parse(await readFile(join(dir, "snapshot.json"), "utf8")) as SnapshotFile
+      expect(snapshot.chats.map((entry) => entry.id)).toContain(chat.id)
+    })
+
+    test("a torn final line is tolerated, the same as on boot", async () => {
+      const { dir, store } = await storeWithOneChat()
+      const chatsLog = join(dir, "chats.jsonl")
+      await writeFile(chatsLog, `${await readFile(chatsLog, "utf8")}{"v":2,"type":"chat_cre`)
+
+      await expect(store.reload()).resolves.toMatchObject({ chats: 1 })
+    })
+  })
+
+  test("is serialized against in-flight writes", async () => {
+    const dir = await createTempDataDir()
+    const store = new EventStore(dir)
+    await store.initialize()
+    const project = await store.openProject(join(dir, "proj"))
+    const chat = await store.createChat(project.id)
+
+    // Start an append and a reload without awaiting between them: both go
+    // through the write chain, so the append must land whole.
+    const append = store.appendMessage(chat.id, entry("user_prompt", 1, { content: "hello" }))
+    const reload = store.reload()
+    await Promise.all([append, reload])
+
+    expect(store.getMessages(chat.id)).toHaveLength(1)
+  })
+})

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -248,6 +248,8 @@ export class EventStore {
   readonly state: StoreState = createEmptyState()
   private writeChain = Promise.resolve()
   private storageReset = false
+  /** True while {@link reload} runs, which makes `clearStorage` refuse. */
+  private reloading = false
   private readonly snapshotPath: string
   private readonly projectsLogPath: string
   private readonly chatsLogPath: string
@@ -323,6 +325,125 @@ export class EventStore {
   }
 
   /**
+   * Re-read the whole store from disk, discarding in-memory state and caches.
+   *
+   * For editing the data dir underneath a running Kanna — moving a chat
+   * between projects, importing a transcript, fixing a record by hand — and
+   * then having the running process pick it up instead of restarting.
+   *
+   * Two things make this different from `initialize()`, and both matter:
+   *
+   * 1. **It cannot destroy anything.** The boot path treats an unreadable
+   *    snapshot or a log line from another store version as "this data dir is
+   *    unusable, start fresh", and `clearStorage()` truncates every log. That
+   *    is right on boot and catastrophic here — the whole point of this method
+   *    is that someone has been editing those files, so a mistake in one is
+   *    the expected failure, not an unthinkable one. Everything is validated
+   *    first and the reload is refused outright if anything is wrong, with the
+   *    live state left exactly as it was.
+   * 2. **It is serialized against writes.** The body runs on the write chain,
+   *    so a turn appending mid-reload lands wholly before or wholly after,
+   *    never interleaved with the rebuild.
+   *
+   * No compaction: this runs right after a person edited these files by hand,
+   * and rewriting them on the way out would be a poor way to repay that.
+   */
+  async reload(): Promise<{ projects: number; chats: number }> {
+    await this.assertReloadable()
+
+    // Latch: the validation above means no load path should reach
+    // `clearStorage`, and this makes sure a path that somehow does can't
+    // truncate the logs anyway. Belt and braces, because the failure mode is
+    // "every chat is gone" with no undo.
+    this.reloading = true
+    this.writeChain = this.writeChain.then(async () => {
+      this.resetState()
+      this.clearLegacyTranscriptState()
+      await this.loadSnapshot()
+      await this.replayLogs()
+      await this.hydrateChatMetadataFromTranscripts()
+      await this.loadSidebarProjectOrder()
+    }).finally(() => {
+      this.reloading = false
+    })
+    await this.writeChain
+
+    return {
+      projects: [...this.state.projectsById.values()].filter((project) => !project.deletedAt).length,
+      chats: [...this.state.chatsById.values()].filter((chat) => !chat.deletedAt).length,
+    }
+  }
+
+  /**
+   * Throws unless every file the reload will read is one this store version
+   * can load. Read-only: it exists so a bad file is a refusal rather than a
+   * reset. The tolerances match the boot path — an absent or empty file is
+   * fine, and so is a single corrupt line at the end of a log, which is what a
+   * process killed mid-append leaves behind.
+   */
+  private async assertReloadable() {
+    const snapshot = Bun.file(this.snapshotPath)
+    if (await snapshot.exists()) {
+      const text = await snapshot.text()
+      if (text.trim()) {
+        let parsed: SnapshotFile
+        try {
+          parsed = JSON.parse(text) as SnapshotFile
+        } catch (error) {
+          throw new Error(`snapshot.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+        }
+        if (parsed.v !== STORE_VERSION) {
+          throw new Error(`snapshot.json is store version ${parsed.v}, this build reads ${STORE_VERSION}`)
+        }
+      }
+    }
+
+    for (const filePath of [
+      this.projectsLogPath,
+      this.chatsLogPath,
+      this.messagesLogPath,
+      this.queuedMessagesLogPath,
+      this.turnsLogPath,
+    ]) {
+      await this.assertLogReloadable(filePath)
+    }
+  }
+
+  private async assertLogReloadable(filePath: string) {
+    const file = Bun.file(filePath)
+    if (!(await file.exists())) return
+    const text = await file.text()
+    if (!text.trim()) return
+
+    const name = path.basename(filePath)
+    const lines = text.split("\n")
+    let lastNonEmpty = -1
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (lines[index].trim()) {
+        lastNonEmpty = index
+        break
+      }
+    }
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index].trim()
+      if (!line) continue
+      let event: Partial<StoreEvent>
+      try {
+        event = JSON.parse(line) as Partial<StoreEvent>
+      } catch (error) {
+        // A half-written last line is what a crash leaves; boot skips it, so
+        // this does too. Anywhere else it is an edit that went wrong.
+        if (index === lastNonEmpty) continue
+        throw new Error(`${name} line ${index + 1} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+      }
+      if (event.v !== STORE_VERSION) {
+        throw new Error(`${name} line ${index + 1} is store version ${String(event.v)}, this build reads ${STORE_VERSION}`)
+      }
+    }
+  }
+
+  /**
    * Chat metadata derived from transcript entries (lastMessageAt, hasMessages,
    * message previews) is applied in memory on append and only persisted when a
    * snapshot compaction runs. Rebuild it from the transcript files on boot so
@@ -385,6 +506,12 @@ export class EventStore {
   }
 
   private async clearStorage() {
+    // A reload validated every file before starting, so nothing here should be
+    // reachable from one. If it ever is, the answer is to fail the reload, not
+    // to truncate history the user was in the middle of editing.
+    if (this.reloading) {
+      throw new Error("Refusing to reset local history during a reload")
+    }
     if (this.storageReset) return
     this.storageReset = true
     this.resetState()
@@ -683,6 +810,7 @@ export class EventStore {
           // Forks carry the source's turn-end timestamp on the create event
           // (they have no turn events of their own to replay).
           ...(event.lastTurnEndedAt != null ? { lastTurnEndedAt: event.lastTurnEndedAt } : {}),
+          ...(event.agentOrigin ? { agentOrigin: event.agentOrigin } : {}),
         }
         this.state.chatsById.set(chat.id, chat)
         break
@@ -1127,7 +1255,11 @@ export class EventStore {
     return this.writeChain
   }
 
-  async createChat(projectId: string) {
+  /**
+   * @param options `agentOrigin` marks the chat as created by the agent
+   * running in another chat. Server-side only — see `ChatRecord.agentOrigin`.
+   */
+  async createChat(projectId: string, options?: { agentOrigin?: { chatId: string } }) {
     const project = this.state.projectsById.get(projectId)
     if (!project || project.deletedAt) {
       throw new Error("Project not found")
@@ -1140,6 +1272,7 @@ export class EventStore {
       chatId,
       projectId,
       title: "New Chat",
+      ...(options?.agentOrigin ? { agentOrigin: options.agentOrigin } : {}),
     }
     await this.append(this.chatsLogPath, event)
     return this.state.chatsById.get(chatId)!
@@ -1165,6 +1298,10 @@ export class EventStore {
       // no turn events of its own it would otherwise read as brand new and sort
       // by creation time alone.
       ...(sourceChat.lastTurnEndedAt != null ? { lastTurnEndedAt: sourceChat.lastTurnEndedAt } : {}),
+      // The fan-out marker comes along too. Forking is a human action and no
+      // agent has a tool for it, but a fork that dropped the marker would be a
+      // way to launder an agent-started chat into one that may spawn again.
+      ...(sourceChat.agentOrigin ? { agentOrigin: sourceChat.agentOrigin } : {}),
     }
     await this.append(this.chatsLogPath, createEvent)
     // The fork carries the same conversation, so it carries the same claim on

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -48,6 +48,17 @@ export interface ChatRecord {
    */
   readAnchor?: ChatReadAnchor | null
   provider: AgentProvider | null
+  /**
+   * Set when an agent created this chat through the Kanna management tools,
+   * naming the chat whose agent did it.
+   *
+   * Load-bearing rather than informational: a chat with this set is not
+   * allowed to create chats or send messages of its own, which is what bounds
+   * agent fan-out to a single hop (see `assertMaySpawn` in api/control.ts).
+   * Persisted so a restart — which resumes interrupted turns — can't reset the
+   * depth back to zero.
+   */
+  agentOrigin?: { chatId: string }
   planMode: boolean
   /** "Auto Plan": the harness keeps its EnterPlanMode tool. Claude only. */
   autoPlan: boolean
@@ -205,6 +216,12 @@ export type ChatEvent =
        * every plain chat_created, including old logs.
        */
       lastTurnEndedAt?: number
+      /**
+       * Set when an agent created this chat, naming the chat it was running
+       * in. Absent on every human-created chat, including old logs — which is
+       * the right default, since an unmarked chat is one that may spawn.
+       */
+      agentOrigin?: { chatId: string }
     }
   | {
       v: 2

--- a/src/server/instance.test.ts
+++ b/src/server/instance.test.ts
@@ -31,7 +31,8 @@ describe("probeExistingInstance", () => {
     stops.push(server.stop)
 
     const match = await probeExistingInstance(server.port, dataDir)
-    expect(match).toEqual({ localUrl: `http://localhost:${server.port}`, port: server.port })
+    // `api` is false: this server was started without --api.
+    expect(match).toEqual({ localUrl: `http://localhost:${server.port}`, port: server.port, api: false })
 
     // Same server, different expected data dir (e.g. dev profile) → no match.
     const mismatch = await probeExistingInstance(server.port, "/somewhere/else")

--- a/src/server/instance.ts
+++ b/src/server/instance.ts
@@ -22,6 +22,12 @@ export function instanceFingerprint(dataDir: string = getDataDir(homedir())) {
 export interface ExistingInstance {
   localUrl: string
   port: number
+  /**
+   * Whether that instance serves the REST API. Absent from an instance older
+   * than this field, which is indistinguishable from "no API" here — either
+   * way `--api` cannot take effect without restarting it.
+   */
+  api?: boolean
 }
 
 /**
@@ -39,10 +45,10 @@ export async function probeExistingInstance(
       signal: AbortSignal.timeout(700),
     })
     if (!response.ok) return null
-    const payload = await response.json() as { ok?: unknown; instance?: unknown }
+    const payload = await response.json() as { ok?: unknown; instance?: unknown; api?: unknown }
     if (payload.ok !== true || typeof payload.instance !== "string") return null
     if (payload.instance !== instanceFingerprint(dataDir)) return null
-    return { localUrl: `http://localhost:${port}`, port }
+    return { localUrl: `http://localhost:${port}`, port, api: payload.api === true }
   } catch {
     return null
   }

--- a/src/server/kanna-control-local.ts
+++ b/src/server/kanna-control-local.ts
@@ -1,0 +1,99 @@
+/**
+ * In-process executor for the Kanna management tools: maps a tool name onto
+ * the matching control.ts call, in the server process that owns the store.
+ *
+ * Used by the Claude in-process MCP server. The stdio bridge Codex uses has
+ * its own executor that goes over HTTP but hits the same control functions on
+ * the other end, so the two agents get identical behaviour.
+ */
+
+import {
+  addProject,
+  cancelChat,
+  createChat,
+  getChat,
+  listChats,
+  listProjects,
+  reloadFromDisk,
+  sendMessage,
+  type ControlCaller,
+  type ControlDeps,
+  type PromptFields,
+} from "./api/control"
+import type { KannaToolContext, KannaToolOperation } from "./kanna-tools"
+
+function str(input: Record<string, unknown>, field: string): string {
+  const value = input[field]
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Missing or empty "${field}"`)
+  return value
+}
+
+function optionalStr(input: Record<string, unknown>, field: string): string | undefined {
+  const value = input[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "string") throw new Error(`"${field}" must be a string`)
+  return value
+}
+
+function optionalBool(input: Record<string, unknown>, field: string): boolean | undefined {
+  const value = input[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "boolean") throw new Error(`"${field}" must be a boolean`)
+  return value
+}
+
+function optionalNum(input: Record<string, unknown>, field: string): number | undefined {
+  const value = input[field]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`"${field}" must be a number`)
+  return value
+}
+
+function promptFields(input: Record<string, unknown>): PromptFields {
+  return {
+    provider: optionalStr(input, "provider") as PromptFields["provider"],
+    model: optionalStr(input, "model"),
+    effort: optionalStr(input, "effort"),
+    planMode: optionalBool(input, "planMode"),
+  }
+}
+
+export function createLocalKannaControl(deps: ControlDeps, caller: ControlCaller): KannaToolContext {
+  return {
+    async call(operation: KannaToolOperation, input: Record<string, unknown>) {
+      switch (operation) {
+        case "list_projects":
+          return listProjects(deps)
+        case "add_project":
+          return await addProject(deps, {
+            localPath: str(input, "localPath"),
+            title: optionalStr(input, "title"),
+          })
+        case "list_chats":
+          return listChats(deps, {
+            projectId: optionalStr(input, "projectId"),
+            includeArchived: optionalBool(input, "includeArchived"),
+            limit: optionalNum(input, "limit"),
+          })
+        case "get_chat":
+          return getChat(deps, { chatId: str(input, "chatId"), full: optionalBool(input, "full") })
+        case "create_chat":
+          return await createChat(
+            deps,
+            { projectId: str(input, "projectId"), content: optionalStr(input, "content"), ...promptFields(input) },
+            caller
+          )
+        case "send_message":
+          return await sendMessage(
+            deps,
+            { chatId: str(input, "chatId"), content: str(input, "content"), ...promptFields(input) },
+            caller
+          )
+        case "cancel_chat":
+          return await cancelChat(deps, { chatId: str(input, "chatId") })
+        case "reload":
+          return await reloadFromDisk(deps)
+      }
+    },
+  }
+}

--- a/src/server/kanna-mcp-bridge.test.ts
+++ b/src/server/kanna-mcp-bridge.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { createKannaMcpBridge } from "./kanna-mcp-bridge"
+import { parseBridgeConfig } from "./kanna-mcp-stdio"
+
+async function withBridge<T>(
+  run: (bridge: ReturnType<typeof createKannaMcpBridge>, dataDir: string) => Promise<T>,
+  overrides: { entryPath?: string; execPath?: string; port?: number } = {}
+) {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-bridge-"))
+  const bridge = createKannaMcpBridge({
+    dataDir,
+    baseUrl: () => `http://127.0.0.1:${overrides.port ?? 3210}`,
+    entryPath: overrides.entryPath ?? "/opt/kanna/src/server/cli.ts",
+    execPath: overrides.execPath ?? "/usr/local/bin/bun",
+  })
+  try {
+    return await run(bridge, dataDir)
+  } finally {
+    await rm(dataDir, { recursive: true, force: true })
+  }
+}
+
+describe("createKannaMcpBridge", () => {
+  test("mints a long random key that only matches itself", async () => {
+    await withBridge(async (bridge) => {
+      expect(bridge.apiKey).toMatch(/^[0-9a-f]{64}$/)
+      expect(bridge.isInternalKey(bridge.apiKey)).toBe(true)
+      expect(bridge.isInternalKey("nope")).toBe(false)
+      expect(bridge.isInternalKey(null)).toBe(false)
+      expect(bridge.isInternalKey(undefined)).toBe(false)
+    })
+  })
+
+  test("two bridges never share a key", async () => {
+    await withBridge(async (first) => {
+      await withBridge(async (second) => {
+        expect(second.apiKey).not.toBe(first.apiKey)
+        expect(first.isInternalKey(second.apiKey)).toBe(false)
+      })
+    })
+  })
+
+  test("credentials name the chat and are readable only by the owner", async () => {
+    await withBridge(async (bridge, dataDir) => {
+      const filePath = await bridge.ensureCredentials("chat-1")
+
+      expect(filePath).toBe(path.join(dataDir, "mcp", "chat-1.json"))
+      const config = parseBridgeConfig(await Bun.file(filePath).text())
+      expect(config).toEqual({ baseUrl: "http://127.0.0.1:3210", apiKey: bridge.apiKey, chatId: "chat-1" })
+      // 0600: the key in here is a full-access credential for this instance.
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+    })
+  })
+
+  test("rewriting credentials keeps the restricted mode", async () => {
+    await withBridge(async (bridge) => {
+      const filePath = await bridge.ensureCredentials("chat-1")
+      await Bun.write(filePath, "clobbered")
+      await bridge.ensureCredentials("chat-1")
+
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+      expect(parseBridgeConfig(await Bun.file(filePath).text()).chatId).toBe("chat-1")
+    })
+  })
+
+  test("release drops one chat's file and is safe to repeat", async () => {
+    await withBridge(async (bridge) => {
+      const kept = await bridge.ensureCredentials("keep")
+      const dropped = await bridge.ensureCredentials("drop")
+
+      await bridge.release("drop")
+      await bridge.release("drop")
+
+      expect(await Bun.file(kept).exists()).toBe(true)
+      expect(await Bun.file(dropped).exists()).toBe(false)
+    })
+  })
+
+  test("dispose clears the directory", async () => {
+    await withBridge(async (bridge, dataDir) => {
+      const filePath = await bridge.ensureCredentials("chat-1")
+      await bridge.dispose()
+      expect(await Bun.file(filePath).exists()).toBe(false)
+      expect(await Bun.file(path.join(dataDir, "mcp")).exists()).toBe(false)
+      // Idempotent, since shutdown can race a failed start.
+      await bridge.dispose()
+    })
+  })
+
+  test("codex overrides are TOML the CLI can parse", async () => {
+    await withBridge(async (bridge) => {
+      const args = bridge.codexConfigArgs("/data/mcp/chat-1.json")
+
+      expect(args).toEqual([
+        "-c",
+        'mcp_servers.kanna.command="/usr/local/bin/bun"',
+        "-c",
+        'mcp_servers.kanna.args=["/opt/kanna/src/server/cli.ts", "mcp", "/data/mcp/chat-1.json"]',
+      ])
+    })
+  })
+
+  test("paths with quotes or backslashes stay valid TOML", async () => {
+    await withBridge(
+      async (bridge) => {
+        const args = bridge.codexConfigArgs('/data/we"ird\\path.json')
+        expect(args[1]).toBe('mcp_servers.kanna.command="C:\\\\Program Files\\\\bun.exe"')
+        expect(args[3]).toContain('\\"ird\\\\path.json')
+      },
+      { execPath: "C:\\Program Files\\bun.exe" }
+    )
+  })
+
+  test("the base url is read when credentials are written, not when the bridge is built", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-bridge-port-"))
+    try {
+      let port = 0
+      const bridge = createKannaMcpBridge({ dataDir, baseUrl: () => `http://127.0.0.1:${port}` })
+      port = 3999
+      const filePath = await bridge.ensureCredentials("chat-1")
+      expect(parseBridgeConfig(await Bun.file(filePath).text()).baseUrl).toBe("http://127.0.0.1:3999")
+    } finally {
+      await rm(dataDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/kanna-mcp-bridge.ts
+++ b/src/server/kanna-mcp-bridge.ts
@@ -1,0 +1,106 @@
+/**
+ * Plumbing that lets a Codex session reach the Kanna management tools.
+ *
+ * Claude gets them in-process (kanna-mcp-claude.ts). Codex has no such hook,
+ * so each session spawns `kanna mcp <credentials>` as a stdio MCP server and
+ * that child calls back into `/api/v1` on loopback. This module owns the three
+ * things that makes necessary: the internal API key, the per-chat credentials
+ * file, and the `-c` overrides that point `codex app-server` at the child.
+ *
+ * The key is minted per run and never written to the user's config. It is
+ * accepted only on loopback requests (see server.ts), so a paired machine's
+ * tunnel cannot reach the API with it even though the API is now always
+ * mounted for local callers.
+ *
+ * Credentials go in a 0600 file rather than argv or the environment: `ps`
+ * shows a child's command line to every user on the machine, and codex passes
+ * its own environment through to the MCP servers it spawns.
+ */
+
+import path from "node:path"
+import { randomBytes } from "node:crypto"
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises"
+import { serializeBridgeConfig } from "./kanna-mcp-stdio"
+
+/** Server name codex will prefix onto the tool names it reports. */
+export const KANNA_MCP_SERVER_NAME = "kanna"
+
+export interface KannaMcpBridge {
+  readonly apiKey: string
+  /** True for a key that is this run's internal one. */
+  isInternalKey: (candidate: string | null | undefined) => boolean
+  /** Write (or refresh) the credentials for one chat; returns the file path. */
+  ensureCredentials: (chatId: string) => Promise<string>
+  /** Drop a chat's credentials once its session is gone. */
+  release: (chatId: string) => Promise<void>
+  /** Remove the whole credentials directory (shutdown). */
+  dispose: () => Promise<void>
+  /** `-c key=value` overrides pointing `codex app-server` at the bridge. */
+  codexConfigArgs: (credentialsPath: string) => string[]
+}
+
+/** TOML basic string, for a `-c key=value` whose value is parsed as TOML. */
+function tomlString(value: string) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+function tomlStringArray(values: string[]) {
+  return `[${values.map(tomlString).join(", ")}]`
+}
+
+export function createKannaMcpBridge(args: {
+  dataDir: string
+  /** Read late: the port is only known once Bun.serve has picked one. */
+  baseUrl: () => string
+  /** Absolute path to the `kanna mcp` entry point. Injectable for tests. */
+  entryPath?: string
+  /** Executable that runs it. Defaults to the Bun running this process. */
+  execPath?: string
+}): KannaMcpBridge {
+  const apiKey = randomBytes(32).toString("hex")
+  const directory = path.join(args.dataDir, "mcp")
+  // src/server/cli.ts sits next to this file in both the repo and the
+  // published package (`files` ships all of src/server/).
+  const entryPath = args.entryPath ?? path.join(import.meta.dir, "cli.ts")
+  const execPath = args.execPath ?? process.execPath
+
+  const credentialsPath = (chatId: string) => path.join(directory, `${chatId}.json`)
+
+  return {
+    apiKey,
+    isInternalKey: (candidate) => typeof candidate === "string" && candidate === apiKey,
+
+    async ensureCredentials(chatId: string) {
+      const filePath = credentialsPath(chatId)
+      await mkdir(directory, { recursive: true, mode: 0o700 })
+      await writeFile(
+        filePath,
+        serializeBridgeConfig({ baseUrl: args.baseUrl(), apiKey, chatId }),
+        { mode: 0o600 }
+      )
+      // Explicit chmod as well as the open mode: writeFile's mode only applies
+      // when it creates the file, and this rewrites an existing one whenever a
+      // session restarts on a new port.
+      await chmod(filePath, 0o600)
+      return filePath
+    },
+
+    async release(chatId: string) {
+      await rm(credentialsPath(chatId), { force: true })
+    },
+
+    async dispose() {
+      await rm(directory, { recursive: true, force: true })
+    },
+
+    codexConfigArgs(path: string) {
+      const prefix = `mcp_servers.${KANNA_MCP_SERVER_NAME}`
+      return [
+        "-c",
+        `${prefix}.command=${tomlString(execPath)}`,
+        "-c",
+        `${prefix}.args=${tomlStringArray([entryPath, "mcp", path])}`,
+      ]
+    },
+  }
+}

--- a/src/server/kanna-mcp-claude.test.ts
+++ b/src/server/kanna-mcp-claude.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EventStore } from "./event-store"
+import type { ControlDeps } from "./api/control"
+import { createClaudeKannaMcpServer } from "./kanna-mcp-claude"
+import { createLocalKannaControl } from "./kanna-control-local"
+import { KANNA_TOOLS } from "./kanna-tools"
+
+async function withDeps<T>(run: (deps: ControlDeps, store: EventStore, dataDir: string) => Promise<T>) {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "kanna-claude-mcp-"))
+  const store = new EventStore(dataDir)
+  await store.initialize()
+  const deps: ControlDeps = {
+    store,
+    appSettings: { getSnapshot: () => ({ transcript: { windowAssistantMessages: 50 } }) as never },
+    agent: {
+      getActiveStatuses: () => new Map(),
+      getDrainingChatIds: () => new Set(),
+      async send(command, options) {
+        const chatId =
+          command.chatId ?? (await store.createChat(command.projectId!, { agentOrigin: options?.agentOrigin })).id
+        return { chatId }
+      },
+      async cancel() {},
+      async closeChat() {},
+    },
+    broadcast: () => {},
+    analytics: { track: () => {} },
+  }
+  try {
+    return await run(deps, store, dataDir)
+  } finally {
+    await rm(dataDir, { recursive: true, force: true })
+  }
+}
+
+describe("createClaudeKannaMcpServer", () => {
+  test("builds an SDK server the Agent SDK accepts", async () => {
+    await withDeps(async (deps) => {
+      const server = createClaudeKannaMcpServer(deps, "caller-chat")
+      expect(server.type).toBe("sdk")
+      expect(server.name).toBe("kanna")
+    })
+  })
+
+  test("the Zod shapes every tool declares are valid SDK tool schemas", async () => {
+    // The SDK rejects a plain JSON Schema outright, so this is what catches a
+    // tool whose shape stopped being Zod.
+    await withDeps(async (deps) => {
+      expect(() => createClaudeKannaMcpServer(deps, "caller-chat")).not.toThrow()
+      expect(KANNA_TOOLS.length).toBeGreaterThan(0)
+    })
+  })
+})
+
+describe("createLocalKannaControl", () => {
+  test("dispatches each tool onto the matching control call", async () => {
+    await withDeps(async (deps, store, dataDir) => {
+      const caller = { chatId: "caller" }
+      const ctx = createLocalKannaControl(deps, caller)
+
+      const added = (await ctx.call("add_project", { localPath: path.join(dataDir, "proj") })) as {
+        project: { id: string }
+        created: boolean
+      }
+      expect(added.created).toBe(true)
+
+      const listed = (await ctx.call("list_projects", {})) as { projects: unknown[] }
+      expect(listed.projects).toHaveLength(1)
+
+      const created = (await ctx.call("create_chat", { projectId: added.project.id })) as {
+        chat: { id: string; createdByChatId: string | null }
+      }
+      expect(created.chat.createdByChatId).toBe("caller")
+
+      const chats = (await ctx.call("list_chats", { projectId: added.project.id })) as { total: number }
+      expect(chats.total).toBe(1)
+
+      const read = (await ctx.call("get_chat", { chatId: created.chat.id })) as { chat: { id: string } }
+      expect(read.chat.id).toBe(created.chat.id)
+
+      const cancelled = (await ctx.call("cancel_chat", { chatId: created.chat.id })) as { chatId: string }
+      expect(cancelled.chatId).toBe(created.chat.id)
+
+      expect(store.getChat(created.chat.id)?.agentOrigin).toEqual(caller)
+    })
+  })
+
+  test("a missing required argument is refused before the store is touched", async () => {
+    await withDeps(async (deps) => {
+      const ctx = createLocalKannaControl(deps, { chatId: "caller" })
+      await expect(ctx.call("get_chat", {})).rejects.toThrow(/Missing or empty "chatId"/)
+      await expect(ctx.call("add_project", { localPath: "   " })).rejects.toThrow(/Missing or empty "localPath"/)
+    })
+  })
+
+  test("a wrongly typed optional argument is refused rather than coerced", async () => {
+    await withDeps(async (deps) => {
+      const ctx = createLocalKannaControl(deps, { chatId: "caller" })
+      await expect(ctx.call("list_chats", { limit: "5" })).rejects.toThrow(/"limit" must be a number/)
+      await expect(ctx.call("list_chats", { includeArchived: "yes" })).rejects.toThrow(/must be a boolean/)
+    })
+  })
+})
+
+describe("reload through the tools", () => {
+  test("re-reads the store and reports the counts", async () => {
+    await withDeps(async (deps, store, dataDir) => {
+      const ctx = createLocalKannaControl(deps, { chatId: "caller" })
+      const project = await store.openProject(path.join(dataDir, "proj"))
+
+      const other = new EventStore(dataDir)
+      await other.initialize()
+      const added = await other.createChat(project.id)
+
+      const result = (await ctx.call("reload", {})) as { chats: number; droppedChatIds: string[] }
+
+      expect(store.getChat(added.id)).not.toBeNull()
+      expect(result.chats).toBe(1)
+      expect(result.droppedChatIds).toEqual([])
+    })
+  })
+
+  test("a bad data dir surfaces as an error the model can read, not a wipe", async () => {
+    await withDeps(async (deps, store, dataDir) => {
+      const ctx = createLocalKannaControl(deps, { chatId: "caller" })
+      const project = await store.openProject(path.join(dataDir, "proj"))
+      const chat = await store.createChat(project.id)
+      await store.compact()
+
+      await Bun.write(path.join(dataDir, "snapshot.json"), "{ not json")
+
+      await expect(ctx.call("reload", {})).rejects.toThrow(/Reload refused/)
+      expect(store.getChat(chat.id)).not.toBeNull()
+    })
+  })
+})

--- a/src/server/kanna-mcp-claude.ts
+++ b/src/server/kanna-mcp-claude.ts
@@ -1,0 +1,57 @@
+/**
+ * The Kanna management tools as an in-process MCP server for Claude.
+ *
+ * The Agent SDK can host a server that lives in this process
+ * (`createSdkMcpServer`), so Claude's calls land straight on control.ts — no
+ * HTTP hop, no child process, no key on disk, and nothing on a socket. Codex
+ * has no equivalent hook and goes the long way round (kanna-mcp-stdio.ts).
+ *
+ * The server is built per turn because the tools need to know *which* chat is
+ * calling: that is what bounds agent fan-out (see `assertMaySpawn`).
+ *
+ * MCP tools are not subject to the SDK's `tools` allowlist — that option only
+ * selects built-ins — so nothing in agent.ts's toolset needs to change for
+ * these to be callable.
+ */
+
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk"
+import {
+  KANNA_TOOLS,
+  KANNA_TOOLS_INSTRUCTIONS,
+  type KannaToolContext,
+} from "./kanna-tools"
+import { createLocalKannaControl } from "./kanna-control-local"
+import { KANNA_MCP_SERVER_NAME } from "./kanna-mcp-bridge"
+import type { ControlDeps } from "./api/control"
+
+/** Tools reach the model as `mcp__kanna__<tool>`, matching the codex bridge. */
+export function createClaudeKannaMcpServer(deps: ControlDeps, callerChatId: string) {
+  const ctx: KannaToolContext = createLocalKannaControl(deps, { chatId: callerChatId })
+
+  return createSdkMcpServer({
+    name: KANNA_MCP_SERVER_NAME,
+    version: "1",
+    instructions: KANNA_TOOLS_INSTRUCTIONS,
+    tools: KANNA_TOOLS.map((definition) =>
+      tool(
+        definition.name,
+        definition.description,
+        definition.inputShape,
+        async (input: Record<string, unknown>) => {
+          try {
+            const result = await ctx.call(definition.name, input ?? {})
+            return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] }
+          } catch (error) {
+            // Reported as a tool error rather than thrown: a refused spawn or
+            // a missing chat is something the model should read and adjust to,
+            // not something that should fail the turn.
+            return {
+              content: [{ type: "text" as const, text: error instanceof Error ? error.message : String(error) }],
+              isError: true,
+            }
+          }
+        }
+      )
+    ),
+  })
+}

--- a/src/server/kanna-mcp-stdio.test.ts
+++ b/src/server/kanna-mcp-stdio.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test"
+import { AGENT_CHAT_HEADER } from "./api/routes"
+import {
+  callTool,
+  handleMessage,
+  parseBridgeConfig,
+  runMcpStdioServer,
+  serializeBridgeConfig,
+  type McpBridgeConfig,
+} from "./kanna-mcp-stdio"
+import { KANNA_TOOLS } from "./kanna-tools"
+
+const config: McpBridgeConfig = {
+  baseUrl: "http://127.0.0.1:1234",
+  apiKey: "secret-key",
+  chatId: "caller-chat",
+}
+
+interface Captured {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body: unknown
+}
+
+function stubFetch(response: { status?: number; body: unknown }, captured: Captured[] = []) {
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {}
+    for (const [key, value] of Object.entries((init?.headers ?? {}) as Record<string, string>)) {
+      headers[key.toLowerCase()] = value
+    }
+    captured.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers,
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    })
+    return new Response(JSON.stringify(response.body), { status: response.status ?? 200 })
+  }) as unknown as typeof fetch
+  return { impl, captured }
+}
+
+describe("bridge credentials", () => {
+  test("round-trip", () => {
+    expect(parseBridgeConfig(serializeBridgeConfig(config))).toEqual(config)
+  })
+
+  test("a file missing any field is rejected rather than half-used", () => {
+    expect(() => parseBridgeConfig(JSON.stringify({ baseUrl: "x", apiKey: "y" }))).toThrow(/Malformed/)
+  })
+})
+
+describe("callTool", () => {
+  test("every call carries the key and the calling chat", async () => {
+    const { impl, captured } = stubFetch({ body: { projects: [] } })
+    await callTool(config, "list_projects", {}, impl)
+
+    expect(captured[0]?.url).toBe("http://127.0.0.1:1234/api/v1/projects")
+    expect(captured[0]?.headers.authorization).toBe("Bearer secret-key")
+    expect(captured[0]?.headers[AGENT_CHAT_HEADER]).toBe("caller-chat")
+  })
+
+  test("list_chats maps its filters onto the query string", async () => {
+    const { impl, captured } = stubFetch({ body: { chats: [], total: 0 } })
+    await callTool(config, "list_chats", { projectId: "p1", includeArchived: true, limit: 5 }, impl)
+
+    const url = new URL(captured[0]!.url)
+    expect(url.pathname).toBe("/api/v1/chats")
+    expect(url.searchParams.get("projectId")).toBe("p1")
+    expect(url.searchParams.get("includeArchived")).toBe("true")
+    expect(url.searchParams.get("limit")).toBe("5")
+  })
+
+  test("send_message posts only the fields the API knows", async () => {
+    const { impl, captured } = stubFetch({ status: 202, body: { chatId: "c1" } })
+    await callTool(
+      config,
+      "send_message",
+      { chatId: "c1", content: "hello", model: "opus", nonsense: "drop me" },
+      impl
+    )
+
+    expect(captured[0]?.method).toBe("POST")
+    expect(captured[0]?.url).toBe("http://127.0.0.1:1234/api/v1/chats/c1/messages")
+    expect(captured[0]?.body).toEqual({ content: "hello", model: "opus" })
+  })
+
+  test("reload posts to the reload route", async () => {
+    const { impl, captured } = stubFetch({ body: { projects: 1, chats: 2 } })
+    await callTool(config, "reload", {}, impl)
+
+    expect(captured[0]?.method).toBe("POST")
+    expect(captured[0]?.url).toBe("http://127.0.0.1:1234/api/v1/reload")
+  })
+
+  test("a chat id is escaped into the path", async () => {
+    const { impl, captured } = stubFetch({ body: {} })
+    await callTool(config, "cancel_chat", { chatId: "a/b" }, impl)
+    expect(captured[0]?.url).toBe("http://127.0.0.1:1234/api/v1/chats/a%2Fb/cancel")
+  })
+
+  test("an unknown tool is refused before any request goes out", async () => {
+    const { impl, captured } = stubFetch({ body: {} })
+    await expect(callTool(config, "delete_everything", {}, impl)).rejects.toThrow(/Unknown tool/)
+    expect(captured).toHaveLength(0)
+  })
+})
+
+describe("MCP protocol", () => {
+  test("initialize advertises tools and the instructions", async () => {
+    const response = await handleMessage(config, { jsonrpc: "2.0", id: 1, method: "initialize" })
+    expect(response?.id).toBe(1)
+    const result = response?.result as Record<string, unknown>
+    expect(result.capabilities).toEqual({ tools: {} })
+    expect(String(result.instructions)).toContain("Kanna instance you are running inside")
+  })
+
+  test("notifications get no reply", async () => {
+    expect(await handleMessage(config, { jsonrpc: "2.0", method: "notifications/initialized" })).toBeNull()
+  })
+
+  test("tools/list advertises every tool with a JSON Schema", async () => {
+    const response = await handleMessage(config, { jsonrpc: "2.0", id: 2, method: "tools/list" })
+    const tools = (response?.result as { tools: { name: string; inputSchema: Record<string, unknown> }[] }).tools
+
+    expect(tools.map((tool) => tool.name).sort()).toEqual(KANNA_TOOLS.map((tool) => tool.name).sort())
+    const sendMessage = tools.find((tool) => tool.name === "send_message")!
+    expect(sendMessage.inputSchema.type).toBe("object")
+    expect(sendMessage.inputSchema.required).toEqual(["chatId", "content"])
+  })
+
+  test("no delete tool is exposed", async () => {
+    const response = await handleMessage(config, { jsonrpc: "2.0", id: 2, method: "tools/list" })
+    const names = (response?.result as { tools: { name: string }[] }).tools.map((tool) => tool.name)
+    expect(names.some((name) => name.includes("delete") || name.includes("remove"))).toBe(false)
+  })
+
+  test("a refused call comes back as a tool error, not a protocol error", async () => {
+    const { impl } = stubFetch({ status: 409, body: { error: "This chat was itself started by an agent" } })
+    const response = await handleMessage(
+      config,
+      { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "create_chat", arguments: { projectId: "p" } } },
+      impl
+    )
+
+    expect(response?.error).toBeUndefined()
+    const result = response?.result as { isError: boolean; content: { text: string }[] }
+    expect(result.isError).toBe(true)
+    expect(result.content[0]?.text).toContain("409")
+    expect(result.content[0]?.text).toContain("started by an agent")
+  })
+
+  test("a successful call returns the API body as text", async () => {
+    const { impl } = stubFetch({ body: { projects: [{ id: "p1" }] } })
+    const response = await handleMessage(
+      config,
+      { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "list_projects", arguments: {} } },
+      impl
+    )
+    const result = response?.result as { isError: boolean; content: { text: string }[] }
+    expect(result.isError).toBe(false)
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ projects: [{ id: "p1" }] })
+  })
+
+  test("an unknown request method gets method-not-found; an unknown notification is ignored", async () => {
+    const request = await handleMessage(config, { jsonrpc: "2.0", id: 9, method: "resources/list" })
+    expect((request?.error as { code: number }).code).toBe(-32601)
+    expect(await handleMessage(config, { jsonrpc: "2.0", method: "notifications/cancelled" })).toBeNull()
+  })
+})
+
+describe("stdio loop", () => {
+  function streamOf(lines: string[]) {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const line of lines) controller.enqueue(new TextEncoder().encode(line))
+        controller.close()
+      },
+    })
+  }
+
+  test("reads newline-delimited requests and answers each one", async () => {
+    const written: string[] = []
+    await runMcpStdioServer(config, {
+      input: streamOf([
+        `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`,
+        `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+        `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "ping" })}\n`,
+      ]),
+      write: (line) => written.push(line),
+      warn: () => {},
+    })
+
+    expect(written.map((line) => JSON.parse(line).id)).toEqual([1, 2])
+  })
+
+  test("a request split across chunks is still handled once", async () => {
+    const written: string[] = []
+    const message = JSON.stringify({ jsonrpc: "2.0", id: 7, method: "ping" })
+    await runMcpStdioServer(config, {
+      input: streamOf([message.slice(0, 10), `${message.slice(10)}\n`]),
+      write: (line) => written.push(line),
+      warn: () => {},
+    })
+
+    expect(written).toHaveLength(1)
+    expect(JSON.parse(written[0]!).id).toBe(7)
+  })
+
+  test("a malformed line gets a parse error and does not stop the loop", async () => {
+    const written: string[] = []
+    await runMcpStdioServer(config, {
+      input: streamOf(["not json\n", `${JSON.stringify({ jsonrpc: "2.0", id: 5, method: "ping" })}\n`]),
+      write: (line) => written.push(line),
+      warn: () => {},
+    })
+
+    expect(JSON.parse(written[0]!).error.code).toBe(-32700)
+    expect(JSON.parse(written[1]!).id).toBe(5)
+  })
+})

--- a/src/server/kanna-mcp-stdio.ts
+++ b/src/server/kanna-mcp-stdio.ts
@@ -1,0 +1,305 @@
+/**
+ * `kanna mcp` — the Kanna management tools as a stdio MCP server.
+ *
+ * Codex has no in-process tool hook the way the Claude Agent SDK does, so its
+ * sessions get these tools by spawning this as a child process
+ * (`codex app-server -c mcp_servers.kanna.…`, wired up in codex-app-server.ts).
+ * It speaks MCP over stdin/stdout and turns each `tools/call` into one request
+ * to `/api/v1` on loopback, where control.ts does the same work Claude's
+ * in-process server does directly.
+ *
+ * MCP is hand-rolled rather than pulled from a package: this speaks exactly
+ * four methods, all of them a few lines, and the alternative is a dependency
+ * in the install path of every Kanna user for the sake of a JSON-RPC loop.
+ *
+ * Credentials come from a file, not argv and not the environment: `ps` shows a
+ * child's command line to every user on the machine, and codex passes its own
+ * environment through to MCP servers it spawns. The file is written 0600 in
+ * the data dir by the server that spawned this.
+ */
+
+import { AGENT_CHAT_HEADER } from "./api/routes"
+import { KANNA_TOOLS, KANNA_TOOLS_INSTRUCTIONS, toolInputJsonSchema } from "./kanna-tools"
+
+/** MCP revision we implement. Clients that ask for another get told this one. */
+const PROTOCOL_VERSION = "2024-11-05"
+
+export interface McpBridgeConfig {
+  /** Base URL of the Kanna server, e.g. http://127.0.0.1:3210 */
+  baseUrl: string
+  /** Internal API key minted by that server for this run. */
+  apiKey: string
+  /** The chat whose agent is calling, for the fan-out guard. */
+  chatId: string
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0"
+  id?: string | number | null
+  method: string
+  params?: Record<string, unknown>
+}
+
+/**
+ * The credentials file the server writes and this process reads. Its own
+ * format rather than reusing the `--api-key-file` list format: that one is a
+ * bare list of keys, and this needs the URL and the calling chat too.
+ */
+export function serializeBridgeConfig(config: McpBridgeConfig) {
+  return JSON.stringify(config)
+}
+
+export function parseBridgeConfig(contents: string): McpBridgeConfig {
+  const parsed = JSON.parse(contents) as Partial<McpBridgeConfig>
+  if (!parsed.baseUrl || !parsed.apiKey || !parsed.chatId) {
+    throw new Error("Malformed Kanna MCP credentials file")
+  }
+  return { baseUrl: parsed.baseUrl, apiKey: parsed.apiKey, chatId: parsed.chatId }
+}
+
+// --- the REST calls behind each tool --------------------------------------
+
+interface HttpResult {
+  ok: boolean
+  status: number
+  body: unknown
+}
+
+async function request(
+  config: McpBridgeConfig,
+  method: string,
+  path: string,
+  body?: unknown,
+  fetchImpl: typeof fetch = fetch
+): Promise<HttpResult> {
+  const response = await fetchImpl(`${config.baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      [AGENT_CHAT_HEADER]: config.chatId,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+  const text = await response.text()
+  let parsed: unknown = text
+  try {
+    parsed = text ? JSON.parse(text) : null
+  } catch {
+    // Leave it as text — a non-JSON body from the API means something is off
+    // and the raw response is the most useful thing to show.
+  }
+  return { ok: response.ok, status: response.status, body: parsed }
+}
+
+function query(params: Record<string, string | number | boolean | undefined>) {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue
+    search.set(key, String(value))
+  }
+  const rendered = search.toString()
+  return rendered ? `?${rendered}` : ""
+}
+
+function requireString(input: Record<string, unknown>, field: string): string {
+  const value = input[field]
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Missing or empty "${field}"`)
+  return value
+}
+
+function pick(input: Record<string, unknown>, fields: string[]) {
+  const out: Record<string, unknown> = {}
+  for (const field of fields) {
+    if (input[field] !== undefined && input[field] !== null) out[field] = input[field]
+  }
+  return out
+}
+
+const PROMPT_FIELDS = ["provider", "model", "effort", "planMode"]
+
+export async function callTool(
+  config: McpBridgeConfig,
+  name: string,
+  input: Record<string, unknown>,
+  fetchImpl: typeof fetch = fetch
+): Promise<HttpResult> {
+  switch (name) {
+    case "list_projects":
+      return await request(config, "GET", "/api/v1/projects", undefined, fetchImpl)
+    case "add_project":
+      return await request(config, "POST", "/api/v1/projects", pick(input, ["localPath", "title"]), fetchImpl)
+    case "list_chats":
+      return await request(
+        config,
+        "GET",
+        `/api/v1/chats${query({
+          projectId: input.projectId as string | undefined,
+          includeArchived: input.includeArchived as boolean | undefined,
+          limit: input.limit as number | undefined,
+        })}`,
+        undefined,
+        fetchImpl
+      )
+    case "get_chat":
+      return await request(
+        config,
+        "GET",
+        `/api/v1/chats/${encodeURIComponent(requireString(input, "chatId"))}${query({ full: input.full as boolean | undefined })}`,
+        undefined,
+        fetchImpl
+      )
+    case "create_chat":
+      return await request(
+        config,
+        "POST",
+        "/api/v1/chats",
+        pick(input, ["projectId", "content", ...PROMPT_FIELDS]),
+        fetchImpl
+      )
+    case "send_message":
+      return await request(
+        config,
+        "POST",
+        `/api/v1/chats/${encodeURIComponent(requireString(input, "chatId"))}/messages`,
+        pick(input, ["content", ...PROMPT_FIELDS]),
+        fetchImpl
+      )
+    case "cancel_chat":
+      return await request(
+        config,
+        "POST",
+        `/api/v1/chats/${encodeURIComponent(requireString(input, "chatId"))}/cancel`,
+        {},
+        fetchImpl
+      )
+    case "reload":
+      return await request(config, "POST", "/api/v1/reload", {}, fetchImpl)
+    default:
+      throw new Error(`Unknown tool: ${name}`)
+  }
+}
+
+// --- MCP protocol ---------------------------------------------------------
+
+function toolsListResult() {
+  return {
+    tools: KANNA_TOOLS.map((definition) => ({
+      name: definition.name,
+      description: definition.description,
+      inputSchema: toolInputJsonSchema(definition),
+    })),
+  }
+}
+
+/**
+ * Handles one JSON-RPC message. Returns the response to write, or null for a
+ * notification (which by JSON-RPC takes no reply).
+ */
+export async function handleMessage(
+  config: McpBridgeConfig,
+  message: JsonRpcRequest,
+  fetchImpl: typeof fetch = fetch
+): Promise<Record<string, unknown> | null> {
+  const respond = (result: unknown) => ({ jsonrpc: "2.0" as const, id: message.id ?? null, result })
+  const fail = (code: number, msg: string) => ({
+    jsonrpc: "2.0" as const,
+    id: message.id ?? null,
+    error: { code, message: msg },
+  })
+
+  switch (message.method) {
+    case "initialize":
+      return respond({
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: "kanna", version: "1" },
+        instructions: KANNA_TOOLS_INSTRUCTIONS,
+      })
+    case "notifications/initialized":
+      return null
+    case "ping":
+      return respond({})
+    case "tools/list":
+      return respond(toolsListResult())
+    case "tools/call": {
+      const params = message.params ?? {}
+      const name = typeof params.name === "string" ? params.name : ""
+      const args = (params.arguments ?? {}) as Record<string, unknown>
+      try {
+        const result = await callTool(config, name, args, fetchImpl)
+        const text =
+          typeof result.body === "string" ? result.body : JSON.stringify(result.body, null, 2)
+        // A refused spawn or a missing chat comes back as an MCP tool error,
+        // not a protocol error: the model should read it and adjust, not have
+        // its turn fail.
+        return respond({
+          content: [{ type: "text", text: result.ok ? text : `Kanna API error ${result.status}: ${text}` }],
+          isError: !result.ok,
+        })
+      } catch (error) {
+        return respond({
+          content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }],
+          isError: true,
+        })
+      }
+    }
+    default:
+      // A notification we don't implement is ignored; a request gets the
+      // standard "method not found" so the client isn't left waiting.
+      if (message.id === undefined || message.id === null) return null
+      return fail(-32601, `Method not found: ${message.method}`)
+  }
+}
+
+/**
+ * Reads newline-delimited JSON-RPC off stdin and writes replies to stdout,
+ * until stdin closes. Anything diagnostic goes to stderr — stdout is the
+ * protocol channel and a stray log there desynchronizes the client.
+ */
+export async function runMcpStdioServer(
+  config: McpBridgeConfig,
+  io: {
+    input: ReadableStream<Uint8Array>
+    write: (line: string) => void
+    warn: (message: string) => void
+    fetchImpl?: typeof fetch
+  }
+) {
+  const decoder = new TextDecoder()
+  const reader = io.input.getReader()
+  let buffer = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    let newline = buffer.indexOf("\n")
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      newline = buffer.indexOf("\n")
+      if (!line) continue
+
+      let message: JsonRpcRequest
+      try {
+        message = JSON.parse(line) as JsonRpcRequest
+      } catch {
+        io.write(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } }))
+        continue
+      }
+
+      try {
+        const response = await handleMessage(config, message, io.fetchImpl)
+        if (response) io.write(JSON.stringify(response))
+      } catch (error) {
+        io.warn(`kanna mcp: ${error instanceof Error ? error.message : String(error)}`)
+        if (message.id !== undefined && message.id !== null) {
+          io.write(
+            JSON.stringify({ jsonrpc: "2.0", id: message.id, error: { code: -32603, message: "Internal error" } })
+          )
+        }
+      }
+    }
+  }
+}

--- a/src/server/kanna-tools.ts
+++ b/src/server/kanna-tools.ts
@@ -1,0 +1,159 @@
+/**
+ * The Kanna management tools an agent running inside Kanna gets: list and open
+ * projects, list, read and create chats, send prompts, cancel a running turn.
+ *
+ * One definition, two transports. Claude sees these through an in-process SDK
+ * MCP server (`kanna-mcp-claude.ts`) that calls straight into the EventStore
+ * and AgentCoordinator. Codex sees them through a stdio MCP child process
+ * (`kanna-mcp-stdio.ts`) that reaches the same operations over `/api/v1` on
+ * loopback. Names, schemas and descriptions are shared, so the two agents are
+ * looking at the same toolbox.
+ *
+ * Schemas are Zod raw shapes because that is what the Agent SDK's `tool()`
+ * takes — it rejects a plain JSON Schema. The stdio bridge, which has to
+ * advertise real JSON Schema on the wire, derives it with `z.toJSONSchema`.
+ *
+ * Deliberately no delete: removing a project or a chat destroys a person's
+ * work with no undo in the UI, and nothing an agent does here is worth that.
+ * `/api/v1` still has `DELETE /chats/:id` for human clients.
+ *
+ * Every mutating tool routes through `assertMaySpawn`, so a chat an agent
+ * started cannot start more (see api/control.ts).
+ */
+
+import { z } from "zod"
+
+export type KannaToolOperation =
+  | "list_projects"
+  | "add_project"
+  | "list_chats"
+  | "get_chat"
+  | "create_chat"
+  | "send_message"
+  | "cancel_chat"
+  | "reload"
+
+export interface KannaToolContext {
+  /**
+   * Runs one operation. Backed either by direct control.ts calls or by an
+   * HTTP round trip, depending on which transport built this context.
+   */
+  call: (operation: KannaToolOperation, input: Record<string, unknown>) => Promise<unknown>
+}
+
+export interface KannaToolDefinition {
+  name: KannaToolOperation
+  description: string
+  /** Zod raw shape — the form `tool()` wants. */
+  inputShape: z.ZodRawShape
+}
+
+/**
+ * The model-facing knobs on a prompt. All optional: omitting them means
+ * "whatever this chat already uses", which is nearly always what an agent
+ * wants and what the person watching would expect to see happen.
+ */
+const PROMPT_SHAPE = {
+  provider: z
+    .enum(["claude", "codex", "cursor", "pi"])
+    .optional()
+    .describe("Which coding agent runs the turn. Defaults to the chat's current provider."),
+  model: z
+    .string()
+    .optional()
+    .describe('Model id for the turn (e.g. "opus", "gpt-5.3-codex"). Defaults to the chat\'s last model.'),
+  effort: z
+    .string()
+    .optional()
+    .describe("Reasoning effort, where the provider supports one: low, medium, high, or max."),
+  planMode: z
+    .boolean()
+    .optional()
+    .describe("Start the turn in plan mode, so it proposes a plan instead of editing files."),
+} satisfies z.ZodRawShape
+
+export const KANNA_TOOLS: KannaToolDefinition[] = [
+  {
+    name: "list_projects",
+    description:
+      "List the projects open in this Kanna instance, most recently active first, with each one's local path and how many unarchived chats it has.",
+    inputShape: {},
+  },
+  {
+    name: "add_project",
+    description:
+      "Open a local directory as a Kanna project. Creates the directory if it does not exist, and runs `git init` when it is empty so chats there produce diffs; an existing non-empty directory is left untouched. Opening a path that is already a project returns the existing project with created:false.",
+    inputShape: {
+      localPath: z.string().describe("Absolute path to the project directory. `~` is expanded."),
+      title: z.string().optional().describe("Display name. Defaults to the directory name."),
+    },
+  },
+  {
+    name: "list_chats",
+    description:
+      "List chats, most recently active first, with their status (running, waiting_for_user, idle…) and provider. Filter to one project with projectId.",
+    inputShape: {
+      projectId: z.string().optional().describe("Only chats in this project. Omit for every project."),
+      includeArchived: z.boolean().optional().describe("Include archived chats. Defaults to false."),
+      limit: z.number().optional().describe("Maximum chats to return (default 50, max 200)."),
+    },
+  },
+  {
+    name: "get_chat",
+    description:
+      "Read one chat: its status, its queued messages, and its transcript. Returns the recent window by default; pass full to get the whole conversation, which on a long chat is very large.",
+    inputShape: {
+      chatId: z.string(),
+      full: z.boolean().optional().describe("Return the entire transcript instead of the recent window."),
+    },
+  },
+  {
+    name: "create_chat",
+    description:
+      "Create a chat in a project. With `content`, the chat is created and its first turn starts immediately — that spends model credits and runs a real agent with file access in that project, so only do it when you have been asked to. Without `content`, an empty chat is created for a person to prompt. Returns as soon as the turn starts, not when it finishes; poll get_chat for status and output.",
+    inputShape: {
+      projectId: z.string(),
+      content: z
+        .string()
+        .optional()
+        .describe("Opening prompt. Starts a turn. Omit to create an empty chat instead."),
+      ...PROMPT_SHAPE,
+    },
+  },
+  {
+    name: "send_message",
+    description:
+      "Send a prompt to an existing chat, starting a turn. Spends model credits and runs a real agent with file access — only do it when you have been asked to. If a turn is already running the prompt is queued behind it and `queued` comes back true. Returns as soon as the prompt lands, not when the turn finishes; poll get_chat for the result. You cannot send to your own chat.",
+    inputShape: {
+      chatId: z.string(),
+      content: z.string(),
+      ...PROMPT_SHAPE,
+    },
+  },
+  {
+    name: "cancel_chat",
+    description: "Stop the turn running in a chat, the same way the stop button does. Safe on an idle chat.",
+    inputShape: { chatId: z.string() },
+  },
+  {
+    name: "reload",
+    description:
+      "Re-read every project and chat from Kanna's data directory, discarding what is held in memory, and push the result to any open browser. Use this after editing that directory directly — moving a chat between projects, importing one, fixing a record — so the running Kanna picks the change up without a restart. Nothing is written and nothing is deleted: if a file is unreadable or from another store version the reload is refused and the previous state stays loaded. A chat that has disappeared from disk but still had an agent running has that agent stopped, and comes back in droppedChatIds.",
+    inputShape: {},
+  },
+]
+
+/** JSON Schema for one tool, for transports that advertise schema on the wire. */
+export function toolInputJsonSchema(definition: KannaToolDefinition) {
+  return z.toJSONSchema(z.object(definition.inputShape))
+}
+
+/**
+ * Instructions surfaced alongside the tools, so the model knows what this
+ * server is before it reads any tool name.
+ */
+export const KANNA_TOOLS_INSTRUCTIONS = [
+  "These tools manage the Kanna instance you are running inside: its projects and its chats.",
+  "create_chat and send_message start real agent turns that cost money and can edit files — treat them as actions you take on request, not as a way to delegate work you could do yourself.",
+  "There is no delete: removing a project or chat is left to the person at the keyboard.",
+].join(" ")

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,6 +30,8 @@ import { clearGitHubRepoCache } from "./github"
 import { readLlmProviderSnapshot, validateLlmProviderCredentials, writeLlmProviderSnapshot } from "./llm-provider"
 import { handleTranscribe } from "./transcribe"
 import { handleChatWindow } from "./chat-window-route"
+import { createApiKeyVerifier } from "./api/keys"
+import { handleApiRequest, hasValidApiKey, isApiRoute } from "./api/routes"
 import { applyPiFaveModels } from "./provider-catalog"
 import { createProcessAuthDeps, ProviderAuthManager } from "./provider-auth"
 import { fetchLatestPackageVersion } from "./cli-runtime"
@@ -125,6 +127,13 @@ export interface StartKannaServerOptions {
    * through the app-settings snapshot to unlock dev-box-only UI.
    */
   directCloud?: boolean
+  /**
+   * Mount the remote REST API at /api/v1 (`kanna --api`). Requires `apiKeys`;
+   * with an empty list the API stays unmounted rather than serving openly.
+   */
+  api?: boolean
+  /** Keys accepted on /api/v1 as `Authorization: Bearer` or `X-Api-Key`. */
+  apiKeys?: string[]
   onMigrationProgress?: (message: string) => void
   update?: {
     version: string
@@ -140,6 +149,11 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const strictPort = options.strictPort ?? false
   const runtimeProfile = getRuntimeProfile()
   const auth = options.password ? createAuthManager(options.password, { trustProxy: options.trustProxy ?? false }) : null
+  // Null unless --api was passed with at least one key. Every /api/v1 request
+  // is checked against it, and nothing else on the server consults it.
+  const apiKeyVerifier = options.api && (options.apiKeys?.length ?? 0) > 0
+    ? createApiKeyVerifier(options.apiKeys ?? [])
+    : null
   const store = new EventStore(options.dataDir)
   const diffStore = new DiffStore(store.dataDir)
   const machineDisplayName = getMachineDisplayName()
@@ -505,7 +519,14 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
                   return withOriginAgentCluster(new Response("Unauthorized", { status: 401 }))
                 }
               }
-            } else if (url.pathname.startsWith("/api/") && !auth.isAuthenticated(req)) {
+            } else if (
+              url.pathname.startsWith("/api/") &&
+              !auth.isAuthenticated(req) &&
+              // A valid API key stands in for the browser session on /api/v1.
+              // The password gate is a cookie flow an API client cannot do,
+              // and the key is the stronger credential of the two.
+              !(isApiRoute(url) && hasValidApiKey(req, apiKeyVerifier))
+            ) {
               return withOriginAgentCluster(Response.json({ error: "Unauthorized" }, { status: 401 }))
             }
           }
@@ -565,6 +586,29 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             }
             const payload: CloudWsEndpointResponse = { wsUrl: null }
             return withOriginAgentCluster(Response.json(payload, { headers: { "Cache-Control": "no-store" } }))
+          }
+
+          if (isApiRoute(url)) {
+            // Claim the prefix whether or not the API is mounted: without
+            // this, an unmounted /api/v1 falls through to the SPA and answers
+            // index.html with a 200, which a client reads as success.
+            if (!apiKeyVerifier) {
+              return withOriginAgentCluster(Response.json({ error: "Not found" }, { status: 404 }))
+            }
+            const apiResponse = await handleApiRequest(req, url, {
+              store,
+              agent,
+              appSettings,
+              verifier: apiKeyVerifier,
+              // API writes are rare next to socket traffic, so a full
+              // broadcast is the safe choice: every topic an API call can
+              // touch gets refreshed without enumerating them here.
+              broadcast: () => router.broadcastSnapshots(),
+              version: options.update?.version ?? "0.0.0",
+            })
+            if (apiResponse) {
+              return withOriginAgentCluster(apiResponse)
+            }
           }
 
           const uploadResponse = await handleProjectUpload(req, url, store)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,8 +30,12 @@ import { clearGitHubRepoCache } from "./github"
 import { readLlmProviderSnapshot, validateLlmProviderCredentials, writeLlmProviderSnapshot } from "./llm-provider"
 import { handleTranscribe } from "./transcribe"
 import { handleChatWindow } from "./chat-window-route"
-import { createApiKeyVerifier } from "./api/keys"
+import { createApiKeyVerifier, extractApiKey } from "./api/keys"
 import { handleApiRequest, hasValidApiKey, isApiRoute } from "./api/routes"
+import { isDirectLocalRequest } from "./api/local-request"
+import type { ControlDeps } from "./api/control"
+import { createKannaMcpBridge } from "./kanna-mcp-bridge"
+import { createClaudeKannaMcpServer } from "./kanna-mcp-claude"
 import { applyPiFaveModels } from "./provider-catalog"
 import { createProcessAuthDeps, ProviderAuthManager } from "./provider-auth"
 import { fetchLatestPackageVersion } from "./cli-runtime"
@@ -149,9 +153,17 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
   const strictPort = options.strictPort ?? false
   const runtimeProfile = getRuntimeProfile()
   const auth = options.password ? createAuthManager(options.password, { trustProxy: options.trustProxy ?? false }) : null
-  // Null unless --api was passed with at least one key. Every /api/v1 request
-  // is checked against it, and nothing else on the server consults it.
-  const apiKeyVerifier = options.api && (options.apiKeys?.length ?? 0) > 0
+  // Two verifiers, because two very different callers hold keys.
+  //
+  // `remoteApiKeyVerifier` is the user's own `--api` keys, and is null without
+  // that flag — off the machine, no key means no API, exactly as before.
+  //
+  // `localApiKeyVerifier` additionally accepts the key Kanna mints for its own
+  // agent bridge, and is consulted only for requests that came straight off
+  // loopback with no forwarding headers (see api/local-request.ts). That is
+  // what lets `/api/v1` be always-on for the tools an agent uses without
+  // opening it to the network, a share tunnel, or a paired machine.
+  const remoteApiKeyVerifier = options.api && (options.apiKeys?.length ?? 0) > 0
     ? createApiKeyVerifier(options.apiKeys ?? [])
     : null
   const store = new EventStore(options.dataDir)
@@ -240,7 +252,30 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
       trackEvent: analytics.track.bind(analytics),
     })
     : null
-  const codexManager = new CodexAppServerManager()
+  // Gives agent sessions Kanna's own management tools. Claude reaches them
+  // in-process; codex spawns `kanna mcp` per session, which is what needs the
+  // credentials file and the `-c` overrides below.
+  const mcpBridge = createKannaMcpBridge({
+    dataDir: store.dataDir,
+    // Read late, inside the closure: `actualPort` is only settled once
+    // Bun.serve has bound one, which is long before any session starts.
+    baseUrl: () => `http://127.0.0.1:${actualPort}`,
+  })
+  const codexManager = new CodexAppServerManager({
+    resolveMcpArgs: async (chatId) => mcpBridge.codexConfigArgs(await mcpBridge.ensureCredentials(chatId)),
+    releaseMcp: (chatId) => mcpBridge.release(chatId),
+  })
+  const localApiKeyVerifier = createApiKeyVerifier([
+    ...(remoteApiKeyVerifier ? options.apiKeys ?? [] : []),
+    mcpBridge.apiKey,
+  ])
+  /**
+   * Which keys count for this request. A request that came straight off
+   * loopback — the agent bridge, in practice — may also use the internal key;
+   * anything relayed, tunnelled or off the network is held to `--api`.
+   */
+  const apiKeyVerifierFor = (req: Request, peerAddress: string | null | undefined) =>
+    isDirectLocalRequest(req, peerAddress) ? localApiKeyVerifier : remoteApiKeyVerifier
   const agent = new AgentCoordinator({
     store,
     analytics,
@@ -307,6 +342,24 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     updateManager,
     providerAuth,
   })
+  // The operations the REST API and the agent-facing tools share. Built here
+  // rather than at either call site because it closes the loop between the
+  // store, the coordinator and the router's broadcast — none of which can name
+  // all three on its own.
+  const controlDeps: ControlDeps = {
+    store,
+    agent,
+    appSettings,
+    // API and tool writes are rare next to socket traffic, so a full broadcast
+    // is the safe choice: every topic one can touch gets refreshed without
+    // enumerating them here.
+    broadcast: () => router.broadcastSnapshots(),
+    analytics,
+  }
+  // Claude calls the tools in-process; codex reaches the same functions over
+  // the loopback API through `kanna mcp`.
+  agent.setKannaMcpServerFactory((chatId) => createClaudeKannaMcpServer(controlDeps, chatId))
+
   // Overlay the account's live Cursor model list on the static catalog
   // (no-op when cursor-agent is missing or logged out); broadcasts on change.
   void agent.refreshCursorModelCatalog()
@@ -436,6 +489,9 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
           const requestClass: CloudRequestClass = cloud
             ? classifyCloudRequest(req, cloud.identity.proxySecret)
             : "local"
+          // Peer address, for the one decision that turns on where a request
+          // physically came from: whether it may use the internal agent key.
+          const peerAddress = serverInstance.requestIP(req)?.address ?? null
 
           // The proxy answers /__cloud/* itself and never forwards it; the
           // machine 404s the prefix explicitly so the client can
@@ -525,7 +581,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
               // A valid API key stands in for the browser session on /api/v1.
               // The password gate is a cookie flow an API client cannot do,
               // and the key is the stronger credential of the two.
-              !(isApiRoute(url) && hasValidApiKey(req, apiKeyVerifier))
+              !(isApiRoute(url) && hasValidApiKey(req, apiKeyVerifierFor(req, peerAddress)))
             ) {
               return withOriginAgentCluster(Response.json({ error: "Unauthorized" }, { status: 401 }))
             }
@@ -548,7 +604,10 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
               ok: true,
               port: actualPort,
               instance: instanceFingerprint(store.dataDir),
-              api: apiKeyVerifier !== null,
+              // The `--api` verifier specifically: the bridge's internal key is
+              // always present, so asking whether *any* key exists would answer
+              // true on every instance and tell a second invocation nothing.
+              api: remoteApiKeyVerifier !== null,
             }))
           }
 
@@ -598,22 +657,24 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
           }
 
           if (isApiRoute(url)) {
+            const verifier = apiKeyVerifierFor(req, peerAddress)
             // Claim the prefix whether or not the API is mounted: without
             // this, an unmounted /api/v1 falls through to the SPA and answers
             // index.html with a 200, which a client reads as success.
-            if (!apiKeyVerifier) {
+            //
+            // Loopback always has a verifier (the internal agent key), so this
+            // 404 is what a remote caller sees without `--api` — the API is
+            // still invisible from the network unless the user asked for it.
+            if (!verifier) {
               return withOriginAgentCluster(Response.json({ error: "Not found" }, { status: 404 }))
             }
             const apiResponse = await handleApiRequest(req, url, {
-              store,
-              agent,
-              appSettings,
-              verifier: apiKeyVerifier,
-              // API writes are rare next to socket traffic, so a full
-              // broadcast is the safe choice: every topic an API call can
-              // touch gets refreshed without enumerating them here.
-              broadcast: () => router.broadcastSnapshots(),
-              analytics,
+              ...controlDeps,
+              verifier,
+              // Only the bridge's own key may claim to be an agent, and only
+              // from loopback — the header is otherwise ignored.
+              isInternalKey: (request) =>
+                isDirectLocalRequest(request, peerAddress) && mcpBridge.isInternalKey(extractApiKey(request)),
               version: options.update?.version ?? "0.0.0",
             })
             if (apiResponse) {
@@ -724,6 +785,9 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
     appSettings.dispose()
     keybindings.dispose()
     terminals.closeAll()
+    // The internal key dies with this process, so leaving credential files
+    // behind would only leave stale ones for the next run to ignore.
+    await mcpBridge.dispose().catch(() => undefined)
     await store.compact()
     server.stop(true)
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -540,7 +540,16 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
             // data dir is already being served (single-instance guard). Only
             // exposed on local/proxied requests — the raw-tunnel /health
             // above stays minimal.
-            return withOriginAgentCluster(Response.json({ ok: true, port: actualPort, instance: instanceFingerprint(store.dataDir) }))
+            // `api` lets a second `kanna --api` invocation see whether the
+            // instance already running on this data dir serves /api/v1, so it
+            // can report that the flag needs a restart instead of exiting as
+            // though it had taken effect.
+            return withOriginAgentCluster(Response.json({
+              ok: true,
+              port: actualPort,
+              instance: instanceFingerprint(store.dataDir),
+              api: apiKeyVerifier !== null,
+            }))
           }
 
           if (url.pathname === CLOUD_PAIR_SESSION_PATH) {
@@ -604,6 +613,7 @@ export async function startKannaServer(options: StartKannaServerOptions = {}) {
               // broadcast is the safe choice: every topic an API call can
               // touch gets refreshed without enumerating them here.
               broadcast: () => router.broadcastSnapshots(),
+              analytics,
               version: options.update?.version ?? "0.0.0",
             })
             if (apiResponse) {


### PR DESCRIPTION
> **Stacks on #106.** GitHub shows that PR's two commits here too, because its
> branch only exists on the fork. The commit to review is the last one,
> `Add Kanna management tools for Claude and Codex sessions`.

An agent running inside Kanna can list and open projects, list/read/create
chats, send prompts, cancel turns, and `reload` the data dir — the same
operations the REST API exposes, reached as MCP tools.

### One definition, two transports

`kanna-tools.ts` holds the names, descriptions and Zod shapes; both transports
read from it, so Claude and Codex see the same toolbox.

- **Claude** takes an in-process server (`createSdkMcpServer`, in
  `kanna-mcp-claude.ts`) whose handlers call `control.ts` directly — no HTTP,
  no child process, no key on disk.
- **Codex** has no such hook, so its sessions spawn `kanna mcp <credentials>`
  (`kanna-mcp-stdio.ts`) through `-c mcp_servers.kanna.*` overrides on
  `codex app-server`, and that child calls back over `/api/v1`.

Schemas stay Zod raw shapes because the Agent SDK's `tool()` rejects a plain
JSON Schema outright; the stdio bridge derives real JSON Schema from the same
shapes with `z.toJSONSchema`.

### routes.ts becomes a shell over control.ts

The API operations move out of `routes.ts` into `control.ts` so HTTP and the
tools cannot drift — a change to what "create a chat" means lands on both in
one edit. #106's provider validation and analytics events move there with
them, so a tool call gets the same checks a request does.

### Reaching the API without opening it

The routes are now always mounted for exactly one caller: Kanna's own bridge,
holding a per-run key minted at startup. `api/local-request.ts` accepts that
key only on requests that arrived straight off loopback with no forwarding
headers. Peer address alone is not enough — cloudflared runs on this machine
under `--share`, so every tunnelled request looks like loopback — and
`requestClass` alone is not enough either, since it reports "local" for a LAN
peer when no cloud runtime is attached. Without `--api`, anything relayed
still gets the JSON 404 it got before.

Credentials go in a 0600 file under `<dataDir>/mcp/`, one per chat, rather
than in argv or the environment: `ps` shows a child's command line to every
user on the machine, and codex passes its own environment to the servers it
spawns.

### Fan-out is bounded to one hop

A chat an agent created carries `ChatRecord.agentOrigin`, and a chat with it
set may not create chats or send messages. An agent also cannot prompt its own
chat. The marker is persisted rather than counted in memory because boot
resumes interrupted turns, and an in-memory depth would reset to zero;
`forkChat` copies it for the same reason. `agentOrigin` is deliberately not a
field on `ClientCommand` — it rides an out-of-band options argument to
`agent.send`, and over HTTP comes from `X-Kanna-Agent-Chat`, honoured only for
the internal key, so a browser cannot label a chat it opened as agent work.

There is no delete tool by design: removing a project or chat destroys work
with no undo in the UI. `DELETE /chats/:id` still exists for human API
clients.

### Testing

`bun run check` passes. `bun test`: 1870 pass, 4 fail — the same four `runCli`
self-update tests that already fail on this branch's base.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/opus[1m]`.