### PR TITLE
feat(codex): add GPT-6 Astra to the model picker

### DIFF
--- a/src/server/read-models.test.ts
+++ b/src/server/read-models.test.ts
@@ -296,6 +296,7 @@ describe("read models", () => {
     expect(chat?.queuedMessages.map((message) => message.content)).toEqual(["follow up"])
     expect(chat?.availableProviders.length).toBeGreaterThan(1)
     expect(chat?.availableProviders.find((provider) => provider.id === "codex")?.models.map((model) => model.id)).toEqual([
+      "gpt-6-astra",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",

--- a/src/shared/types.test.ts
+++ b/src/shared/types.test.ts
@@ -66,6 +66,20 @@ describe("shared model normalization", () => {
     expect(normalizeCodexModelId("not-a-real-model")).toBe("gpt-5.6-sol")
   })
 
+  test("keeps GPT-6 Astra selectable with its own effort range and default", () => {
+    // The catalog is the gate: an id it doesn't list is silently replaced with
+    // the default model server-side, so a new release is unusable until added.
+    expect(normalizeCodexModelId("gpt-6-astra")).toBe("gpt-6-astra")
+    expect(getCodexReasoningOptions("gpt-6-astra").map((option) => option.id)).toEqual([
+      "low", "medium", "high", "xhigh", "max", "ultra",
+    ])
+    // Recommended default for this model is high, not the 5.6 family's medium.
+    expect(normalizeCodexReasoningEffort("gpt-6-astra", "unknown")).toBe("high")
+    // Astra is not the catalog default: access rolled out gradually, so
+    // everyone would otherwise be moved onto a model they may not have.
+    expect(normalizeCodexModelId()).toBe("gpt-5.6-sol")
+  })
+
   test("exposes model-specific GPT-5.6 reasoning efforts", () => {
     expect(getCodexReasoningOptions("gpt-5.6-sol").map((option) => option.id)).toEqual([
       "low", "medium", "high", "xhigh", "max", "ultra",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -569,6 +569,16 @@ export const PROVIDERS: ProviderCatalogEntry[] = [
     supportsAutoPlanMode: false,
     models: [
       {
+        id: "gpt-6-astra",
+        label: "GPT-6 Astra",
+        supportsEffort: true,
+        supportedReasoningEfforts: GPT_5_6_REASONING_OPTIONS,
+        // OpenAI's Codex docs recommend high as the everyday default for this
+        // model, where the 5.6 family defaults to medium.
+        defaultReasoningEffort: "high",
+        supportsFastMode: true,
+      },
+      {
         id: "gpt-5.6-sol",
         label: "GPT-5.6 Sol",
         supportsEffort: true,


### PR DESCRIPTION
GPT-6 Astra (`gpt-6-astra`) can't be selected in Kanna. Codex models are hardcoded in `shared/types.ts`, unlike Cursor, Claude and Pi, which get theirs from the harness at runtime — and `normalizeServerModel` replaces any codex id the catalog doesn't list with the default model, so the model is unreachable even if it's set in `~/.codex/config.toml`.

Adds it as the first codex entry: efforts match the 5.6 family (`low`…`ultra`), Fast mode supported, default effort `high` — what [OpenAI's docs](https://learn.chatgpt.com/docs/models) recommend for this model, where the 5.6 family defaults to `medium`.

Deliberately **not** the catalog default. Access rolled out gradually after the Sep 3 release, so defaulting to it would move everyone onto a model they may not have; `gpt-5.6-sol` stays the default.

Requires Codex CLI v0.153.1+ on the machine — older CLIs don't know the id.

Full suite, typecheck and both builds pass.

🌸 Shipped with [Kanna](https://kanna.sh) — an open-source workspace for all your coding agents. Written by `claude/fable`.
