### PR TITLE
Performance: measured wins across boot, broadcast path, and client bundle

### DIFF
--- a/src/client/app/App.tsx
+++ b/src/client/app/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom"
 import { Flower } from "lucide-react"
 import { StandaloneShareDialog } from "../components/chat-ui/StandaloneShareDialog"
@@ -20,7 +20,9 @@ import { KannaSidebar } from "./KannaSidebar"
 import { ChatPage } from "./ChatPage"
 import { LocalProjectsPage } from "./LocalProjectsPage"
 import { OpenRouterCallbackPage } from "./OpenRouterCallbackPage"
-import { SettingsPage } from "./SettingsPage"
+// Code-split: its own route, with 8 settings sections and a second
+// react-markdown instance behind the changelog.
+const SettingsPage = lazy(() => import("./SettingsPage").then((m) => ({ default: m.SettingsPage })))
 import { TerminalPage } from "./TerminalPage"
 import { useKannaState } from "./useKannaState"
 import { useSidebarStore } from "../stores/sidebarStore"
@@ -442,7 +444,7 @@ export function App() {
             <Route path="/" element={<div className="hidden md:contents"><LocalProjectsPage /></div>} />
             <Route path="/home" element={<LocalProjectsPage />} />
             <Route path="/settings" element={<Navigate to="/settings/general" replace />} />
-            <Route path="/settings/:sectionId" element={<SettingsPage />} />
+            <Route path="/settings/:sectionId" element={<Suspense fallback={null}><SettingsPage /></Suspense>} />
             <Route path="/chat/:chatId" element={<ChatPage />} />
             <Route path="/terminal" element={<TerminalPage />} />
           </Route>

--- a/src/client/app/ChatPage/ChatTranscriptViewport.tsx
+++ b/src/client/app/ChatPage/ChatTranscriptViewport.tsx
@@ -129,6 +129,69 @@ function rowLightsItself(row: ResolvedTranscriptRow): boolean {
   return row.kind === "single" && row.message.kind === "user_prompt"
 }
 
+type TranscriptRowItemProps = Pick<
+  ComponentProps<typeof KannaTranscriptRow>,
+  "row" | "toolGroupExpanded" | "onToolGroupExpandedChange" | "onAskUserQuestionSubmit" | "onExitPlanModeConfirm"
+> & { flashBox: boolean; flashRow: boolean }
+
+/**
+ * One row, memoized at the wrapper rather than only at `KannaTranscriptRow`.
+ *
+ * Without this, a push re-created the `MessageScrollerItem`, the box `<div>` and
+ * the `cn()` call for every row in the window before React reached the inner
+ * memo - so showing one new message walked all N rows through three component
+ * invocations and two deep compares. `row` identity is already stabilized by
+ * `useStableResolvedRows` and every callback below is a `useCallback(…, [])`,
+ * so a default shallow memo bails here and React never descends.
+ *
+ * The two flash flags are passed as booleans, not as `flashRowId`, so a flash
+ * on one row does not invalidate the other N-1.
+ */
+const TranscriptRowItem = memo(function TranscriptRowItem({
+  row,
+  flashBox,
+  flashRow,
+  toolGroupExpanded,
+  onToolGroupExpandedChange,
+  onAskUserQuestionSubmit,
+  onExitPlanModeConfirm,
+}: TranscriptRowItemProps) {
+  return (
+    <MessageScrollerItem
+      messageId={row.id}
+      // Deliberately not a scroll anchor. Marking turn starts makes
+      // the scroller pull each new one to the top of the viewport —
+      // its "new turn begins here" behaviour. Sending should land
+      // at the bottom, where the reply arrives, and the read
+      // position is taken from the visible rows rather than from
+      // anchors.
+    >
+      {/* The row's own padding is what gives the jump highlight its
+          breathing room, so it has to be uniform and inside the
+          box. The gap between messages used to be 20px of bottom
+          padding and is now 8 of padding either side plus 4 of
+          margin, so the rhythm is unchanged. `max-w` grew by the
+          padding to keep the text column itself at 800px. */}
+      <div
+        className={cn(
+          "mx-auto mb-1 w-full max-w-[816px] rounded-xl p-2",
+          flashBox && "kanna-jump-flash",
+        )}
+        data-transcript-row-id={row.id}
+      >
+        <KannaTranscriptRow
+          row={row}
+          flash={flashRow}
+          toolGroupExpanded={toolGroupExpanded}
+          onToolGroupExpandedChange={onToolGroupExpandedChange}
+          onAskUserQuestionSubmit={onAskUserQuestionSubmit}
+          onExitPlanModeConfirm={onExitPlanModeConfirm}
+        />
+      </div>
+    </MessageScrollerItem>
+  )
+})
+
 
 
 
@@ -1005,39 +1068,16 @@ const TranscriptScrollerBody = memo(function TranscriptScrollerBody({
             <MessageScrollerContent style={contentContainerStyle}>
               {listHeader}
               {resolvedRows.map((row) => (
-                <MessageScrollerItem
+                <TranscriptRowItem
                   key={row.id}
-                  messageId={row.id}
-                  // Deliberately not a scroll anchor. Marking turn starts makes
-                  // the scroller pull each new one to the top of the viewport —
-                  // its "new turn begins here" behaviour. Sending should land
-                  // at the bottom, where the reply arrives, and the read
-                  // position is taken from the visible rows rather than from
-                  // anchors.
-                >
-                  {/* The row's own padding is what gives the jump highlight its
-                      breathing room, so it has to be uniform and inside the
-                      box. The gap between messages used to be 20px of bottom
-                      padding and is now 8 of padding either side plus 4 of
-                      margin, so the rhythm is unchanged. `max-w` grew by the
-                      padding to keep the text column itself at 800px. */}
-                  <div
-                    className={cn(
-                      "mx-auto mb-1 w-full max-w-[816px] rounded-xl p-2",
-                      flashRowId === row.id && !rowLightsItself(row) && "kanna-jump-flash",
-                    )}
-                    data-transcript-row-id={row.id}
-                  >
-                    <KannaTranscriptRow
-                      row={row}
-                      flash={flashRowId === row.id && rowLightsItself(row)}
-                      toolGroupExpanded={row.kind === "tool-group" ? (toolGroupExpanded[row.id] ?? false) : undefined}
-                      onToolGroupExpandedChange={handleToolGroupExpandedChange}
-                      onAskUserQuestionSubmit={onAskUserQuestionSubmit}
-                      onExitPlanModeConfirm={onExitPlanModeConfirm}
-                    />
-                  </div>
-                </MessageScrollerItem>
+                  row={row}
+                  flashBox={flashRowId === row.id && !rowLightsItself(row)}
+                  flashRow={flashRowId === row.id && rowLightsItself(row)}
+                  toolGroupExpanded={row.kind === "tool-group" ? (toolGroupExpanded[row.id] ?? false) : undefined}
+                  onToolGroupExpandedChange={handleToolGroupExpandedChange}
+                  onAskUserQuestionSubmit={onAskUserQuestionSubmit}
+                  onExitPlanModeConfirm={onExitPlanModeConfirm}
+                />
               ))}
               {listFooter}
             </MessageScrollerContent>

--- a/src/client/app/ChatPage/TerminalWorkspaceShell.tsx
+++ b/src/client/app/ChatPage/TerminalWorkspaceShell.tsx
@@ -1,5 +1,9 @@
-import { memo } from "react"
-import { TerminalWorkspace } from "../../components/chat-ui/TerminalWorkspace"
+import { lazy, memo, Suspense } from "react"
+// Code-split: pulls @xterm/xterm + webgl, web-links, serialize and unicode11.
+// The terminal is a toggle, so none of it belongs in the entry chunk.
+const TerminalWorkspace = lazy(() =>
+  import("../../components/chat-ui/TerminalWorkspace").then((m) => ({ default: m.TerminalWorkspace }))
+)
 import { useTerminalLayoutStore } from "../../stores/terminalLayoutStore"
 import type { KannaState } from "../useKannaState"
 
@@ -40,6 +44,7 @@ export const TerminalWorkspaceShell = memo(function TerminalWorkspaceShell({
 }: TerminalWorkspaceShellProps) {
   return (
     <div style={fixedTerminalHeight > 0 ? { height: `${fixedTerminalHeight}px` } : undefined}>
+      <Suspense fallback={null}>
       <TerminalWorkspace
         projectId={projectId}
         layout={terminalLayout}
@@ -57,6 +62,7 @@ export const TerminalWorkspaceShell = memo(function TerminalWorkspaceShell({
         onRemoveTerminal={onRemoveTerminal}
         onTerminalLayout={onTerminalLayout}
       />
+      </Suspense>
     </div>
   )
 })

--- a/src/client/app/ChatPage/index.tsx
+++ b/src/client/app/ChatPage/index.tsx
@@ -1,10 +1,19 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentProps, type CSSProperties, type DragEvent, type ReactNode, type RefObject } from "react"
+import { lazy, memo, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentProps, type CSSProperties, type DragEvent, type ReactNode, type RefObject } from "react"
 import type { GroupImperativeHandle } from "react-resizable-panels"
 import { useOutletContext } from "react-router-dom"
 import type { ChatInputHandle } from "../../components/chat-ui/ChatInput"
 import { ChatNavbar } from "../../components/chat-ui/ChatNavbar"
-import { BrowserPanel } from "../../components/chat-ui/BrowserPanel"
-import { GitPanel } from "../../components/chat-ui/GitPanel"
+// Code-split: a sidebar panel, not first paint.
+const BrowserPanel = lazy(() =>
+  import("../../components/chat-ui/BrowserPanel").then((m) => ({ default: m.BrowserPanel }))
+)
+// Code-split: GitPanel pulls @pierre/diffs, which pulls shiki core and ~300
+// language grammars. The git tab is a sidebar panel, not first paint, so none
+// of that belongs in the entry chunk. Type-only import keeps the prop types.
+import type { GitPanel as GitPanelComponent } from "../../components/chat-ui/GitPanel"
+const GitPanel = lazy(() =>
+  import("../../components/chat-ui/GitPanel").then((m) => ({ default: m.GitPanel }))
+)
 import { useAppDialog } from "../../components/ui/app-dialog"
 import { Card, CardContent } from "../../components/ui/card"
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../../components/ui/resizable"
@@ -22,7 +31,7 @@ import { useProjectRepoUrl } from "../../stores/sidebarStore"
 import { DEFAULT_PROJECT_TERMINAL_LAYOUT, useTerminalLayoutStore } from "../../stores/terminalLayoutStore"
 import { useTerminalPreferencesStore } from "../../stores/terminalPreferencesStore"
 import { shouldCloseTerminalPane } from "../terminalLayoutResize"
-import { disposeCachedTerminal } from "../../components/chat-ui/TerminalPane"
+
 import { TERMINAL_TOGGLE_ANIMATION_DURATION_MS } from "../terminalToggleAnimation"
 import { useRightSidebarToggleAnimation } from "../useRightSidebarToggleAnimation"
 import { useStickyChatFocus } from "../useStickyChatFocus"
@@ -302,14 +311,16 @@ interface ChatWorkspaceProps {
   onLayoutChanged: (layout: Record<string, number>) => void
 }
 
-type ChatSidebarContentProps = ComponentProps<typeof GitPanel>
+type ChatSidebarContentProps = ComponentProps<typeof GitPanelComponent>
 
 const ChatSidebarContent = memo(function ChatSidebarContent(props: ChatSidebarContentProps) {
   return (
-    <GitPanel
-      {...props}
-      diffs={props.diffs ?? EMPTY_DIFF_SNAPSHOT}
-    />
+    <Suspense fallback={<div className="h-full w-full" />}>
+      <GitPanel
+        {...props}
+        diffs={props.diffs ?? EMPTY_DIFF_SNAPSHOT}
+      />
+    </Suspense>
   )
 })
 
@@ -771,6 +782,11 @@ export function ChatPage() {
     void state.handleShareChat(state.activeChatId)
   }, [state.activeChatId, state.handleShareChat])
 
+  // Same rule, for ChatInputDock: every other prop it takes is already stable,
+  // so an inline arrow here was the one thing defeating its memo - and then
+  // ChatInput's memo below it - on every streamed entry.
+  const handleEditModels = useCallback(() => setDefaultModelsDialogOpen(true), [])
+
   const handleRemoveTerminal = useCallback((currentProjectId: string, terminalId: string) => {
     const paneCount = useTerminalLayoutStore.getState().projects[currentProjectId]?.terminals.length ?? 0
     if (paneCount <= 1) {
@@ -784,7 +800,10 @@ export function ChatPage() {
     // A split pane is unreachable once removed, so closing it does kill it.
     void state.socket.command({ type: "terminal.close", terminalId }).catch(() => {})
     removeTerminal(currentProjectId, terminalId)
-    disposeCachedTerminal(terminalId)
+    // Dynamic so this one helper does not pin the five xterm packages into the
+    // entry chunk. Removing a terminal implies the module is already loaded, so
+    // this resolves from cache.
+    void import("../../components/chat-ui/TerminalPane").then((m) => m.disposeCachedTerminal(terminalId))
   }, [hideTerminals, removeTerminal, state.socket])
 
   const clearShowScrollTimeout = useCallback(() => {
@@ -1081,7 +1100,7 @@ export function ChatPage() {
         contextWindowSnapshot={contextWindowSnapshot}
         onSubmit={handleChatSubmit}
         onCancel={handleCancel}
-        onEditModels={() => setDefaultModelsDialogOpen(true)}
+        onEditModels={handleEditModels}
         onListSkills={handleListSkills}
       />
       <DefaultModelsDialog
@@ -1191,7 +1210,11 @@ export function ChatPage() {
     wrapDiffLines,
   ])
   const rightPanelContent = activeRightPanel === "browser" && projectId
-    ? <BrowserPanel projectId={projectId} socket={state.socket} onClose={handleCloseRightSidebar} onRunQuickAction={handleRunQuickAction} />
+    ? (
+      <Suspense fallback={<div className="h-full w-full" />}>
+        <BrowserPanel projectId={projectId} socket={state.socket} onClose={handleCloseRightSidebar} onRunQuickAction={handleRunQuickAction} />
+      </Suspense>
+    )
     : gitPanelContentProps
       ? <ChatSidebarContent {...gitPanelContentProps} />
       : null

--- a/src/client/app/TerminalPage.tsx
+++ b/src/client/app/TerminalPage.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect } from "react"
+import { lazy, Suspense, useCallback, useEffect } from "react"
 import { Navigate, useOutletContext } from "react-router-dom"
-import { TerminalWorkspace } from "../components/chat-ui/TerminalWorkspace"
+const TerminalWorkspace = lazy(() =>
+  import("../components/chat-ui/TerminalWorkspace").then((m) => ({ default: m.TerminalWorkspace }))
+)
 import { useAppSettingsStore } from "../stores/appSettingsStore"
 import { useTerminalLayoutStore } from "../stores/terminalLayoutStore"
 import { useTerminalPreferencesStore } from "../stores/terminalPreferencesStore"
@@ -57,6 +59,7 @@ export function TerminalPage() {
   return (
     <div className="flex-1 flex min-h-0 min-w-0 flex-col pt-14 md:pt-0">
       {layout && hasTerminals ? (
+        <Suspense fallback={null}>
         <TerminalWorkspace
           projectId={HOME_TERMINAL_LAYOUT_KEY}
           paneProjectId={null}
@@ -70,6 +73,7 @@ export function TerminalPage() {
           onRemoveTerminal={handleRemoveTerminal}
           onTerminalLayout={setTerminalSizes}
         />
+        </Suspense>
       ) : null}
     </div>
   )

--- a/src/client/components/auth/SetupWizard.tsx
+++ b/src/client/components/auth/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { Check, ChevronLeft, Cloud, Flower } from "lucide-react"
 import { AUTH_SERVICE_LABELS, type AuthServiceId } from "../../../shared/types"
@@ -100,7 +100,10 @@ function StepFooter({
  * satisfied are skipped on open, and skippable steps auto-advance the moment
  * they connect.
  */
-export function SetupWizard() {
+// Takes no props, so memo bails unconditionally whenever the app shell
+// re-renders - which is every streamed transcript entry. Its zustand
+// subscriptions still drive it normally.
+export const SetupWizard = memo(function SetupWizard() {
   const open = useProviderAuthStore((store) => store.setupWizardOpen)
   const socket = useProviderAuthStore((store) => store.socket)
   const snapshot = useProviderAuthStore((store) => store.snapshot)
@@ -386,4 +389,4 @@ export function SetupWizard() {
       </div>
     </div>
   )
-}
+})

--- a/src/server/agent.ts
+++ b/src/server/agent.ts
@@ -1330,8 +1330,18 @@ export class AgentCoordinator {
     await this.store.setPlanMode(args.chatId, args.planMode)
     await this.store.setAutoPlan(args.chatId, args.autoPlan)
 
-    const existingMessages = this.store.getMessages(args.chatId)
-    const shouldGenerateTitle = args.appendUserPrompt && chat.title === "New Chat" && existingMessages.length === 0
+    // Lazy: `getMessages` reads the whole payload sidecar (its own docstring
+    // says it is "for export, handoff and fork, not for anything that runs per
+    // push"), which measures 3 ms on a short chat and ~45 ms on a 2,300-entry
+    // one. Only the handoff and session-restore paths below actually need it;
+    // the empty-chat check just needs a count.
+    let existingMessagesCache: ReturnType<typeof this.store.getMessages> | null = null
+    const existingMessages = () => (existingMessagesCache ??= this.store.getMessages(args.chatId))
+    // `chat.title === "New Chat"` short-circuits first, and it is only true for
+    // a chat that has never been titled - whose sidecar is empty. So on every
+    // later message the sidecar is never read at all.
+    const shouldGenerateTitle = args.appendUserPrompt && chat.title === "New Chat"
+      && existingMessages().length === 0
     const optimisticTitle = shouldGenerateTitle ? fallbackTitleFromMessage(args.content) : null
 
     if (optimisticTitle) {
@@ -1349,7 +1359,7 @@ export class AgentCoordinator {
     // transcript, and build the wire-only handoff context from the entries
     // that precede this turn's prompt.
     const handoff = previousProvider !== null && previousProvider !== args.provider
-      ? await this.prepareProviderHandoff(args.chatId, previousProvider, args.provider, existingMessages)
+      ? await this.prepareProviderHandoff(args.chatId, previousProvider, args.provider, existingMessages())
       : null
 
     // Same-provider session recovery: when we're NOT switching harnesses but
@@ -1369,7 +1379,7 @@ export class AgentCoordinator {
         sessionToken: chat.sessionToken,
         pendingForkSessionToken: chat.pendingForkSessionToken,
       })
-      ? await this.prepareSessionRestore(args.chatId, args.provider, existingMessages)
+      ? await this.prepareSessionRestore(args.chatId, args.provider, existingMessages())
       : null
 
     if (args.appendUserPrompt) {

--- a/src/server/cli-runtime.ts
+++ b/src/server/cli-runtime.ts
@@ -564,7 +564,12 @@ export function openUrl(url: string) {
 }
 
 export async function fetchLatestPackageVersion(packageName: string) {
-  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`)
+  // Timeout, because this is awaited before the server's port opens: a VPN or
+  // captive portal that blackholes the registry would otherwise hang startup
+  // indefinitely on "checking for updates". UpdateManager re-checks post-listen.
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`, {
+    signal: AbortSignal.timeout(5000),
+  })
   if (!response.ok) {
     throw new Error(`registry returned ${response.status}`)
   }

--- a/src/server/event-store.test.ts
+++ b/src/server/event-store.test.ts
@@ -1611,3 +1611,55 @@ describe("getClientTranscript window and outline", () => {
     await rm(dataDir, { recursive: true, force: true })
   })
 })
+
+
+describe("stateVersion", () => {
+  /**
+   * `stateVersion` is the sidebar memo key in ws-router. A transcript append
+   * must bump it only when it moved something the sidebar can actually show,
+   * otherwise a streaming turn re-derives and re-serializes the whole sidebar
+   * many times a second for bytes that come out identical.
+   */
+  test("agent entries inside one activity bucket do not bump it", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject(dataDir, "proj")
+    const chat = await store.createChat(project.id)
+
+    const at = Date.now()
+    await store.appendMessage(chat.id, entry("user_prompt", at, { content: "go" }))
+
+    const before = store.stateVersion
+    for (let i = 0; i < 20; i++) {
+      // 20ms apart, so every one lands in the same 15s quantization bucket.
+      await store.appendMessage(chat.id, entry("assistant_text", at + 100 + i * 20, { text: `step ${i}` }))
+    }
+    // The first one moves lastAgentMessageAt into a bucket; the rest are free.
+    expect(store.stateVersion - before).toBe(1)
+  })
+
+  test("still bumps when a sidebar-visible field moves", async () => {
+    const dataDir = await createTempDataDir()
+    const store = new EventStore(dataDir)
+    await store.initialize()
+    const project = await store.openProject(dataDir, "proj")
+    const chat = await store.createChat(project.id)
+
+    const at = Date.now()
+    // hasMessages false -> true, and lastMessageAt is the sidebar sort key.
+    const afterFirstPrompt = store.stateVersion
+    await store.appendMessage(chat.id, entry("user_prompt", at, { content: "one" }))
+    expect(store.stateVersion).toBeGreaterThan(afterFirstPrompt)
+
+    // A later user prompt moves lastMessageAt, so it must bump again.
+    const beforeSecond = store.stateVersion
+    await store.appendMessage(chat.id, entry("user_prompt", at + 1_000, { content: "two" }))
+    expect(store.stateVersion).toBeGreaterThan(beforeSecond)
+
+    // Crossing into the next 15s activity bucket must bump.
+    const beforeBucketCross = store.stateVersion
+    await store.appendMessage(chat.id, entry("assistant_text", at + 40_000, { text: "much later" }))
+    expect(store.stateVersion).toBeGreaterThan(beforeBucketCross)
+  })
+})

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -10,6 +10,7 @@ import type { AgentProvider, QueuedChatMessage, ResolvedChatReadAnchor, Transcri
 import { STORE_VERSION } from "../shared/types"
 import {
   type ChatEvent,
+  type ChatRecord,
   type ProjectEvent,
   type QueuedMessageEvent,
   type SnapshotFile,
@@ -22,6 +23,9 @@ import {
   createEmptyState,
 } from "./events"
 import { resolveLocalPath } from "./paths"
+// The sidebar's own quantization, imported rather than duplicated so the two
+// cannot drift: if the wire resolution changes, this bump condition follows.
+import { SIDEBAR_ACTIVITY_RESOLUTION_MS } from "./read-models"
 import { slimTranscriptFile } from "./transcript-slim"
 import {
   mergeTranscriptPayload,
@@ -625,8 +629,10 @@ export class EventStore {
 
   /**
    * Bumped on every change that can move a sidebar row: applied events,
-   * transcript metadata, project order, a reset. Read models memoize on it,
-   * so a broadcast that changed nothing here skips the derive entirely.
+   * project order, a reset, and transcript appends — the last only when they
+   * moved something the sidebar can actually show (`sidebarVisibleSignature`).
+   * Read models memoize on it, so a broadcast that changed nothing here skips
+   * the derive entirely.
    */
   stateVersion = 0
 
@@ -878,10 +884,35 @@ export class EventStore {
     }
   }
 
+  /**
+   * The part of a chat the sidebar snapshot can actually show.
+   *
+   * `applyMessageMetadata` touches seven fields, but the sidebar reads only
+   * three: `hasMessages` (its archived-chat filter), `lastMessageAt` (sort key,
+   * row field, recent/older bucket) and `lastAgentMessageAt` — the last one
+   * quantized, so sub-15s movement is invisible on the wire. The previews and
+   * `updatedAt` never reach the sidebar at all; the hover card fetches previews
+   * through a separate command.
+   */
+  private sidebarVisibleSignature(chat: ChatRecord) {
+    const activityBucket = chat.lastAgentMessageAt == null
+      ? ""
+      : Math.floor(chat.lastAgentMessageAt / SIDEBAR_ACTIVITY_RESOLUTION_MS)
+    return `${chat.hasMessages}|${chat.lastMessageAt ?? ""}|${activityBucket}`
+  }
+
   private applyMessageMetadata(chatId: string, entry: TranscriptEntry) {
-    this.stateVersion += 1
     const chat = this.state.chatsById.get(chatId)
-    if (!chat) return
+    if (!chat) {
+      // No chat to compare against; keep the unconditional bump.
+      this.stateVersion += 1
+      return
+    }
+    // `stateVersion` has exactly one consumer: the sidebar memo key in
+    // ws-router. Bumping it per appended entry made a streaming turn re-derive
+    // the whole sidebar and stringify the whole snapshot many times a second,
+    // only for the signature compare to drop the push as byte-identical.
+    const sidebarBefore = this.sidebarVisibleSignature(chat)
     chat.hasMessages = true
     if (entry.kind === "user_prompt") {
       // Monotonic, like `lastAgentMessageAt` below and like the logged stamp
@@ -911,6 +942,9 @@ export class EventStore {
       chat.lastAgentMessageAt = Math.max(chat.lastAgentMessageAt ?? 0, entry.createdAt)
     }
     chat.updatedAt = Math.max(chat.updatedAt, entry.createdAt)
+    if (this.sidebarVisibleSignature(chat) !== sidebarBefore) {
+      this.stateVersion += 1
+    }
   }
 
   private append<TEvent extends StoreEvent>(filePath: string, event: TEvent) {

--- a/src/server/pi-agent.ts
+++ b/src/server/pi-agent.ts
@@ -1,16 +1,24 @@
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
-import {
+import type {
   AuthStorage,
   DefaultResourceLoader,
   ModelRegistry,
-  SessionManager,
-  SettingsManager,
-  createAgentSession,
-  type AgentSession,
-  type AgentSessionEvent,
+  AgentSession,
+  AgentSessionEvent,
 } from "@mariozechner/pi-coding-agent"
+
+/**
+ * The pi SDK is loaded on first use, not at import time. Its module graph
+ * pulls the AWS Bedrock, Google GenAI and Mistral clients and measures ~170 ms
+ * to evaluate — paid on every boot, by every user, including the ones who
+ * only ever pick Claude. Both runtime call sites below are already async.
+ */
+let piSdkPromise: Promise<typeof import("@mariozechner/pi-coding-agent")> | null = null
+function loadPiSdk() {
+  return (piSdkPromise ??= import("@mariozechner/pi-coding-agent"))
+}
 import type { Model } from "@mariozechner/pi-ai"
 import type { ContextWindowUsageSnapshot, HarnessSkill, LlmProviderKind, PiReasoningEffort } from "../shared/types"
 import { getDataRootDir } from "../shared/branding"
@@ -352,6 +360,7 @@ export class PiAgentManager {
     if (existing && existing.cwd === args.cwd) {
       return collectPiSkills(existing.resourceLoader)
     }
+    const { DefaultResourceLoader, SettingsManager } = await loadPiSdk()
     const loader = new DefaultResourceLoader({
       cwd: args.cwd,
       agentDir: this.agentDir,
@@ -412,6 +421,7 @@ export class PiAgentManager {
 
     // All state is Kanna-owned: in-memory credentials/settings, sessions under
     // Kanna's data root, and no discovery of the user's ~/.pi setup.
+    const { AuthStorage, ModelRegistry, SettingsManager, DefaultResourceLoader, SessionManager, createAgentSession } = await loadPiSdk()
     const authStorage = AuthStorage.inMemory()
     authStorage.setRuntimeApiKey(args.connection.provider, args.connection.apiKey)
     const modelRegistry = ModelRegistry.inMemory(authStorage)

--- a/src/server/process-utils.ts
+++ b/src/server/process-utils.ts
@@ -74,6 +74,17 @@ function findInUserBinDirs(command: string, homeDir: string): string | null {
  */
 export function resolveCommandPath(command: string, homeDir = homedir()): string | null {
   if (!/^[\w.-]+$/.test(command)) return null
+
+  // Fast path: the login shell below is a synchronous spawn that blocks the
+  // event loop for ~5 ms (up to 24 ms observed here), and callers like
+  // diff-store's `gh` runner hit this per invocation. `Bun.which` is ~0.045 ms.
+  // It only sees the server's own PATH — which is exactly the gap the login
+  // shell exists to cover — so it is a fast path, not a replacement.
+  // Deliberately not memoized: callers that need to re-resolve after an install
+  // (provider-auth's `fresh` option) must not be served a stale path.
+  const direct = Bun.which(command)
+  if (direct) return direct
+
   const result = spawnSync("sh", ["-lc", `command -v -- ${command}`], {
     stdio: ["ignore", "pipe", "ignore"],
     encoding: "utf8",

--- a/src/server/ws-router.ts
+++ b/src/server/ws-router.ts
@@ -336,10 +336,12 @@ export function createWsRouter({
       const pendingTool = agent.getPendingTool(chatId)
       if (pendingTool) pendingToolKinds.set(chatId, pendingTool.toolKind)
     }
-    // Every input to the derive, in one string. A streaming turn bumps
-    // `stateVersion` per appended entry, so this still re-derives per entry;
-    // what it stops is the derive-and-stringify for broadcasts that changed
-    // nothing sidebar-visible (terminal, git, settings, read anchors).
+    // Every input to the derive, in one string. `stateVersion` now moves only
+    // when an append changed something the sidebar can show (see
+    // `sidebarVisibleSignature` in event-store), so a streaming turn re-derives
+    // on the 15 s activity bucket rather than per entry — on top of skipping
+    // broadcasts that changed nothing sidebar-visible (terminal, git,
+    // settings, read anchors).
     const memoKey = [
       store.stateVersion,
       sidebarInputsVersion,
@@ -1023,7 +1025,12 @@ export function createWsRouter({
       send(ws, { v: PROTOCOL_VERSION, type: "ack", id, result })
     }
     if (changed) {
-      void broadcastSnapshots()
+      // Scoped, not a full broadcast: a git command can move this project's
+      // diff snapshot and the sidebar (branch label, uncommitted-work dot).
+      // It cannot move terminal snapshots, whose serializer walks the whole
+      // scrollback (~15 ms and ~350 KB at max scrollback) — and the 5 s diff
+      // poll lands here, so an unfiltered broadcast paid that every poll.
+      void broadcastFilteredSnapshots({ includeSidebar: true, projectIds: new Set([project.id]) })
     }
   }
 


### PR DESCRIPTION
Performance pass across boot, the sidebar broadcast path, and the client bundle. Every number below is measured on this machine, not estimated — commands and methodology in each commit body.

## Results

| Metric | Before | After |
|---|---|---|
| Entry chunk | 2,180 KB / 626 KB gzip | 1,183 KB / 356 KB gzip (−43%) |
| Cold start (median, warm cache) | 518 ms | ~270 ms |
| Sidebar re-derives per streaming turn | 1 per transcript entry | 1 per 15s activity bucket |
| Tests | 1730 pass | 1732 pass (+2 new, covering the sidebar-bump change) |

## What's here

- **Boot**: pi SDK now loads on first use instead of at every startup (measured 170ms import cost for a provider most users never touch); the startup update-check fetch is bounded at 5s instead of unbounded.
- **Send latency**: `chat.send` no longer reads the entire payload sidecar just to check if a chat is empty (3ms → 45ms depending on chat size, now skipped almost always).
- **Sidebar broadcast**: `stateVersion` was bumped on every appended transcript entry, forcing a full sidebar re-derive + whole-snapshot stringify per entry — even though the dedupe signature discarded almost all of it as unchanged bytes. Now bumps only when an entry actually moves something the sidebar shows.
- **Git broadcast**: a git command triggered an unfiltered broadcast to every socket, including a full terminal snapshot (the serializer walks the whole scrollback — measured 3.7–14.9ms and 72–347KB depending on scrollback size), paid every 5s while the diff panel polls. Scoped to just the affected project + sidebar, matching every other broadcast call site in the file.
- **Command resolution**: `resolveCommandPath` always spawned a synchronous login shell (~5ms, up to 24ms observed); `Bun.which` now covers the common case first (~0.045ms), with the login shell staying as fallback for PATH entries only it can see.
- **Client bundle**: GitPanel, TerminalWorkspace, BrowserPanel and SettingsPage were statically imported into the entry chunk despite being sidebar panels or a separate route. GitPanel alone pulls `@pierre/diffs` → shiki → ~300 language grammar chunks. Code-split all four.
- **Re-renders**: the transcript's per-row wrapper wasn't memoized, so every streamed entry walked all N visible rows through three component invocations before React's inner memo could bail. Extracted and memoized it.

## Known trade-offs

- **Scoped git broadcast**: two projects pointing at the same repo (e.g. a monorepo opened as separate projects at different subpaths), or the local-projects "last modified" timestamp, now update on the next 5s poll instead of instantly. Self-healing, low-frequency edge case.
- **Terminal dispose is now a dynamic import**: `disposeCachedTerminal` moved behind `import()` so the 500KB xterm bundle isn't pinned into the entry chunk by one cleanup helper. This lands a microtask later than before; only matters if a new terminal reused the exact same id in that window, which doesn't happen since ids are freshly generated.

## Verification

- `bun test`: 1732 pass, 0 fail (baseline was 1730; +2 new tests locking the sidebar-bump semantics — verified they fail without the fix)
- `bun run check`: typecheck + both production builds clean
- Cold-start and broadcast-cost numbers measured directly against this repo's dependencies (real `@xterm/headless` serialization, real `EventStore`), not estimated
